### PR TITLE
feat: fully implement catalog/jpl and catalog/vizier (v1.0.0 blockers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Catalog Providers: full `catalog/jpl` and `catalog/vizier` implementations
+- `catalog/jpl`: `ResolveObject` now parses Horizons' free-text `result` field for all three recognized response shapes (verified against live Horizons traffic) instead of always returning `ErrNotImplemented`:
+  - Ambiguous major-body matches (planets, satellites, spacecraft, barycenters) via a fixed-width table parser, ported from `ephemeris/jpl/spk`'s production-proven `parseHorizonsResult` and hardened with a COSPAR-designation regex (`cosparDesignationRe`) so a body name that overflows its nominal column width no longer corrupts the following Designation field
+  - Ambiguous small-body matches (comets/asteroids) via a new parser for Horizons' structurally different JPL/DASTCOM "Small-body Index Search Results" table
+  - Unambiguous single matches (major or small body) via Horizons' stable "Target body name: `<name>` (`<id-or-designation>`)" header line — deliberately not the orbital-elements printout body that follows, which has no stable, verified schema
+  - A genuinely novel/unrecognized non-blank response shape still returns `ErrNotImplemented`, preserving the honest-error-over-fabricated-Target policy from the prior audit
+  - Added the missing `cache.Set` call before yielding (every sibling provider does this; `catalog/jpl` previously never cached a result)
+- `catalog/vizier`: `resolve.ConeRequest` gains a `Table` field selecting which VizieR table to query, backed by a new schema registry (`tables.go`) mapping table name → RA/Dec/designation column names + `resolve.Kind`. An empty `Table` preserves the exact previous behavior (2MASS `II/246/out`). A table not in the registry returns the new `ErrUnknownTable` rather than guessing column names. Registered today: `II/246/out` (2MASS, default), `I/239/hip_main` (Hipparcos), `I/355/gaiadr3` (Gaia DR3)
+- `catalog/vizier`: the cache key now includes the table name (previously only ra/dec/radius/limit — two different tables queried over the same cone would have collided on one cache entry once table selection existed)
+- `catalog/vizier`: `parseCSV` now tags each row with the queried table's `resolve.Kind` instead of always `resolve.KindStar`, and sets `Target.HasCoord = true` (previously never set despite `Coord` always being populated)
+
+### Documentation
+- `catalog/jpl/doc.go`, `catalog/vizier/doc.go`: rewritten to describe the now-real capability
+- `README.md`, `docs/ROADMAP.md`: both v1.0.0-blocking catalog providers are now fully implemented; Implementation Status table updated, "Path to v1.0.0" section updated
+
 ## [0.2.0] — 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ AOS: 19:45:03 UTC  Max El: 73.1°  LOS: 19:51:47 UTC  Duration: 6m44s
 | **Atmosphere** | SOFA-rigorous refraction by default at all altitudes, Pickering (2002) airmass down to 0°, pluggable `RefractionModel` |
 | **Ephemerides** | Sun/Moon/planets (SOFA), multi-kernel JPL SPK with on-demand Horizons fetching, SGP4 satellite propagation |
 | **Magnitude** | Planets (Mallama & Hilton 2018), asteroids (HG/HG1G2/**sHG1G2**), comets, satellites, stars — validated 100% within 0.025 mag against the FINK/ZTF production pipeline |
-| **Catalogs** | Unified `resolve.Provider` over SIMBAD, MAST, Gaia, VizieR, JPL SBDB, OpenNGC, NORAD, FINK — streaming `iter.Seq2`, Arrow caching, retry/backoff |
+| **Catalogs** | Unified `resolve.Provider` over SIMBAD, MAST, Gaia, VizieR, JPL Horizons & SBDB, OpenNGC, NORAD, FINK — streaming `iter.Seq2`, Arrow caching, retry/backoff |
 | **FITS & WCS** | Image/BinTable/ASCII HDUs, gzip streams, mmap, TAN projection, Arrow export |
 | **Sky Brightness** | Moonlight (Krisciunas & Schaefer 1991), zodiacal light (Leinert 1998), airglow, light-pollution floor — folds into observability scoring |
 | **Planning** | Sub-second Chandrupatla/Brent boundary refinement, constraint-based scoring, `Greedy`/`Priority`/`SwapOptimized` scheduling strategies |
@@ -613,8 +613,8 @@ flowchart TD
 | `ephemeris/satellite` | SGP4 propagation, TEME→GCRS, look angles, ground track | ✅ Stable |
 | `catalog/resolve` | Provider interface, HTTP client, Arrow cache | ✅ Stable |
 | `catalog/{simbad,mast,gaia,sbdb,openngc,norad,fink}` | Fully-implemented catalog providers | ✅ Stable |
-| `catalog/vizier` | ConeSearch works against a single hardcoded 2MASS table (see `doc.go`) | 🟡 Partial |
-| `catalog/jpl` | Name lookup only — result-text parsing not yet implemented (see `doc.go`) | 🟡 Partial |
+| `catalog/vizier` | ConeSearch against any registered VizieR table (2MASS, Hipparcos, Gaia DR3; extensible via `tables.go`) | ✅ Stable |
+| `catalog/jpl` | Horizons name resolution — ambiguous major/small-body match tables and unambiguous exact matches | ✅ Stable |
 | `magnitude` | Apparent magnitude (planets, asteroids, comets, satellites, stars) | ✅ Stable |
 | `fits` | FITS I/O, WCS (TAN projection), mmap, Arrow export | ✅ Stable |
 | `fits/plan` | FITS↔plan bridge (`SiteFromFITS`, `TargetFromFITS`) | ✅ Stable |
@@ -639,7 +639,7 @@ These are wrapped internally to ensure:
 ---
 
 > [!IMPORTANT]
-> astrogo is pre-1.0 (currently **v0.2.0**) — the public API may still change. This release includes an extensive correctness/robustness/release-readiness audit (see [CHANGELOG.md](CHANGELOG.md)); a v1.0.0 API-stability commitment is planned once `catalog/jpl` and `catalog/vizier` (currently 🟡 partial, see Implementation Status below) are fully implemented.
+> astrogo is pre-1.0 (currently **v0.2.0**) — the public API may still change. This release includes an extensive correctness/robustness/release-readiness audit (see [CHANGELOG.md](CHANGELOG.md)). `catalog/jpl` and `catalog/vizier` — the two providers that were gating a v1.0.0 API-stability commitment — are now fully implemented (see Implementation Status above); see [`docs/ROADMAP.md`](docs/ROADMAP.md) for what's left before v1.0.0.
 
 ---
 
@@ -679,10 +679,6 @@ Sub-arcsecond topocentric accuracy and sub-second UT1 timing require IERS EOP da
 | Rise/set timing | ≤0.6 min vs USNO | ≤0.7 min vs USNO |
 
 The library logs a one-time warning when EOP data is unavailable (users who redirect or suppress logs won't see it — call `iers.Coverage()` to check proactively). The IERS data is bundled via `go:generate`.
-
-### Catalog Provider Coverage
-
-`catalog/vizier` and `catalog/jpl` are the two providers still marked 🟡 in the table above — see their package docs for exactly what's implemented today. Every other catalog provider is fully functional.
 
 ### TDB Precision
 

--- a/catalog/jpl/doc.go
+++ b/catalog/jpl/doc.go
@@ -3,15 +3,28 @@
 //
 // # Current status
 //
-// [Provider.ResolveObject] reaches the live horizons.api endpoint and
-// decodes its JSON envelope, but does not yet parse the "result" field —
-// Horizons has no stable schema for that field (it ranges from a
-// major-body match table to a full small-body orbital-elements printout,
-// and even the match-table header wording has been observed to differ
-// across responses). Rather than guess at a shape and risk silently
-// extracting the wrong identifier, every successful, decodable response
-// currently returns [ErrNotImplemented]. [Provider.Resolve] and
-// [Provider.Search] surface this as ok=false / an empty result.
+// [Provider.ResolveObject] reaches the live horizons.api endpoint and parses
+// its JSON-enveloped "result" field for the three recognized response
+// shapes, verified against live Horizons traffic:
+//
+//   - An ambiguous major-body match (planets, satellites, spacecraft,
+//     barycenters) — a fixed-width table, yielding one [resolve.Target] per
+//     row.
+//   - An ambiguous small-body match (comets/asteroids) — JPL/DASTCOM's
+//     "Small-body Index Search Results" index table, a structurally
+//     different table from the major-body one above, yielding one
+//     [resolve.Target] per row.
+//   - An unambiguous single match (major or small body) — Horizons' stable
+//     "Target body name: <name> (<id-or-designation>)" identifying header
+//     line, yielding exactly one [resolve.Target].
+//
+// A response matching none of these shapes but carrying non-blank result
+// text returns [ErrNotImplemented] rather than a guessed/fabricated Target.
+// In particular, this provider deliberately does not parse the body of a
+// single-match response beyond its identifying header line — the physical
+// parameters / orbital elements printout that follows has no stable,
+// verified schema. Use [ephemeris/jpl] or [catalog/sbdb] for orbital
+// elements and physical parameters.
 //
 // This package is exclusively for resolving static object identities. For
 // resolving actual time-dependent position states and astrometric

--- a/catalog/jpl/jpl.go
+++ b/catalog/jpl/jpl.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
 )
@@ -15,13 +16,13 @@ import (
 var ErrAPIError = errors.New("jpl: API error")
 
 // ErrNotImplemented indicates a successful Horizons response whose free-text
-// "result" block this provider does not yet parse. Horizons has no stable
-// schema for this field — it ranges from a major-body match table to a full
-// small-body orbital-elements printout, and the exact table header wording
-// has been observed to differ across API responses — so a best-effort
-// heuristic parse here risks silently returning wrong data. Until a
-// dedicated parser is verified against live responses for every shape,
-// callers get this explicit error instead of a fabricated placeholder Target.
+// "result" block matches none of the recognized shapes: the major-body
+// ambiguous-match table, the small-body DASTCOM index table, or the
+// single-match "Target body name:" header line. This provider deliberately
+// does not attempt to parse a full orbital-elements printout body — that
+// portion of Horizons' output has no stable, verified schema — so a
+// genuinely novel response shape surfaces this explicit error instead of a
+// guessed/fabricated Target.
 var ErrNotImplemented = errors.New("jpl: Horizons result parsing not implemented for this response")
 
 const horizonsAPI = "https://ssd.jpl.nasa.gov/api/horizons.api"
@@ -127,6 +128,33 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 			return
 		}
 
-		yield(resolve.Target{}, fmt.Errorf("%w: query %q", ErrNotImplemented, req.Query))
+		var (
+			targets []resolve.Target
+			matched bool
+		)
+
+		if ts, ok := parseSmallBodyIndexTable(payload.Result); ok {
+			targets, matched = ts, true
+		} else if ts, ok := parseMajorBodyMatchTable(payload.Result); ok {
+			targets, matched = ts, true
+		} else if t, ok := parseExactMatch(payload.Result); ok {
+			targets, matched = []resolve.Target{t}, true
+		}
+
+		if !matched && strings.TrimSpace(payload.Result) != "" {
+			yield(resolve.Target{}, fmt.Errorf("%w: query %q", ErrNotImplemented, req.Query))
+			return
+		}
+
+		if err := p.cache.Set(cacheKey, targets); err != nil {
+			yield(resolve.Target{}, err)
+			return
+		}
+
+		for _, t := range targets {
+			if !yield(t, nil) {
+				return
+			}
+		}
 	}
 }

--- a/catalog/jpl/jpl_network_test.go
+++ b/catalog/jpl/jpl_network_test.go
@@ -5,7 +5,6 @@ package jpl
 
 import (
 	"context"
-	"errors"
 	"net"
 	"testing"
 	"time"
@@ -28,9 +27,8 @@ func requireHorizons(t *testing.T) {
 }
 
 // TestJPLNetworkResolve confirms the provider reaches the live Horizons API
-// and — since result-text parsing isn't implemented (see ErrNotImplemented)
-// — surfaces that explicitly rather than fabricating a Target. This is a
-// live-service reachability check, not a "resolution works" check.
+// and resolves an ambiguous major-body query ("Mars" matches the planet,
+// its barycenter, and several spacecraft) into real resolve.Targets.
 func TestJPLNetworkResolve(t *testing.T) {
 	requireHorizons(t)
 
@@ -38,16 +36,84 @@ func TestJPLNetworkResolve(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	req := resolve.ObjectRequest{Query: "Mars", Limit: 1}
+	req := resolve.ObjectRequest{Query: "Mars"}
 	iter := prov.ResolveObject(ctx, req)
 
-	var gotErr error
-	iter(func(_ resolve.Target, err error) bool {
-		gotErr = err
-		return false
+	var (
+		got    []resolve.Target
+		gotErr error
+	)
+
+	iter(func(t resolve.Target, err error) bool {
+		if err != nil {
+			gotErr = err
+			return false
+		}
+
+		got = append(got, t)
+
+		return true
 	})
 
-	if !errors.Is(gotErr, ErrNotImplemented) {
-		t.Fatalf("expected ErrNotImplemented from a reachable, decodable live response, got: %v", gotErr)
+	if gotErr != nil {
+		t.Fatalf("expected a resolved response, got error: %v", gotErr)
+	}
+
+	if len(got) == 0 {
+		t.Fatal("expected at least one match for ambiguous query \"Mars\"")
+	}
+
+	found := false
+
+	for _, tg := range got {
+		if tg.Name == "Mars" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected a target named \"Mars\" among matches, got: %+v", got)
+	}
+}
+
+// TestJPLNetworkResolveExact confirms an unambiguous small-body query
+// resolves to exactly one Target via the "Target body name:" header parse.
+func TestJPLNetworkResolveExact(t *testing.T) {
+	requireHorizons(t)
+
+	prov := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req := resolve.ObjectRequest{Query: "Ceres"}
+	iter := prov.ResolveObject(ctx, req)
+
+	var (
+		got    []resolve.Target
+		gotErr error
+	)
+
+	iter(func(t resolve.Target, err error) bool {
+		if err != nil {
+			gotErr = err
+			return false
+		}
+
+		got = append(got, t)
+
+		return true
+	})
+
+	if gotErr != nil {
+		t.Fatalf("expected a resolved response, got error: %v", gotErr)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 target for unambiguous query \"Ceres\", got %d: %+v", len(got), got)
+	}
+
+	if got[0].SPKID == "" {
+		t.Errorf("expected a non-empty SPKID, got: %+v", got[0])
 	}
 }

--- a/catalog/jpl/jpl_test.go
+++ b/catalog/jpl/jpl_test.go
@@ -2,6 +2,7 @@ package jpl
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,51 +14,204 @@ import (
 	"github.com/TuSKan/astrogo/internal/testutil"
 )
 
-func TestJPLResolveMock(t *testing.T) {
-	jsonPayload := `{
-  "signature": {"version": "1.2", "source": "NASA/JPL Horizons API"},
-  "result": "Multiple major-bodies match string \"Mars*\"\n\n  Number  Name                           Designation  IAU/aliases/other   \n  ------  -----------------------------  -----------  ------------------- \n     401  Mars Barycenter                                                 \n     499  Mars                                                            \n"
-}`
+// jsonResultPayload builds a minimal Horizons JSON envelope carrying the
+// given free-text "result" body, escaping it via encoding/json to avoid
+// hand-rolled string-literal escaping bugs.
+func jsonResultPayload(t *testing.T, result string) string {
+	t.Helper()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	b, err := json.Marshal(struct {
+		Result string `json:"result"`
+	}{Result: result})
+	testutil.AssertNoError(t, err)
 
-		if _, err := fmt.Fprint(w, jsonPayload); err != nil {
-			t.Errorf("failed to write response: %v", err)
-		}
-	}))
-	defer server.Close()
-
-	prov := New()
-	// Override transport
-	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
-
-	// The provider does not parse Horizons' free-text result block (see
-	// ErrNotImplemented) — a successful, decodable API response with data it
-	// can't parse must surface as an explicit error, not a fabricated Target.
-	_, ok := prov.Resolve("Mars")
-	testutil.AssertEqual(t, "Resolve Ok", ok, false)
+	return string(b)
 }
 
-func TestJPLResolveObjectNotImplemented(t *testing.T) {
-	jsonPayload := `{
-  "signature": {"version": "1.2", "source": "NASA/JPL Horizons API"},
-  "result": "Multiple major-bodies match string \"Mars*\"\n\n  Number  Name                           Designation  IAU/aliases/other   \n  ------  -----------------------------  -----------  ------------------- \n     401  Mars Barycenter                                                 \n     499  Mars                                                            \n"
-}`
-
+// newMockProvider spins up an httptest.Server always returning jsonPayload
+// and wires it into a fresh Provider's transport, bypassing real network I/O.
+func newMockProvider(jsonPayload string) *Provider {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-
-		if _, err := fmt.Fprint(w, jsonPayload); err != nil {
-			t.Errorf("failed to write response: %v", err)
-		}
+		fmt.Fprint(w, jsonPayload) //nolint:errcheck // test server, write failure would fail the test via response assertions
 	}))
-	defer server.Close()
 
 	prov := New()
 	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
 
-	iter := prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: "Mars"})
+	return prov
+}
+
+// TestJPLResolveObject_AmbiguousMajorBody uses a real Horizons "Multiple
+// major-bodies match string" response (verified live for query "Mars",
+// trimmed to 3 of the 10 real matches) — including a body whose name
+// overflows into the designation column, the exact case that motivated
+// cosparDesignationRe over fixed-offset slicing.
+func TestJPLResolveObject_AmbiguousMajorBody(t *testing.T) {
+	result := "*******************************************************************************\n" +
+		" Multiple major-bodies match string \"MARS*\"\n\n" +
+		"  ID#      Name                               Designation  IAU/aliases/other   \n" +
+		"  -------  ---------------------------------- -----------  ------------------- \n" +
+		"        4  Mars Barycenter                                                      \n" +
+		"      499  Mars                                                                 \n" +
+		"      -74  Mars Reconnaissance Orbiter (spacec2005-029A    MRO                  \n" +
+		" \n" +
+		"   Number of matches =  3. Use ID# to make unique selection.\n" +
+		"*******************************************************************************\n"
+
+	prov := newMockProvider(jsonResultPayload(t, result))
+
+	var got []resolve.Target
+
+	prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: "Mars"})(func(tg resolve.Target, err error) bool {
+		testutil.AssertNoError(t, err)
+
+		got = append(got, tg)
+
+		return true
+	})
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 targets, got %d: %+v", len(got), got)
+	}
+
+	testutil.AssertEqual(t, "target[0] ID", got[0].ID, "4")
+	testutil.AssertEqual(t, "target[0] Name", got[0].Name, "Mars Barycenter")
+	testutil.AssertEqual(t, "target[1] ID", got[1].ID, "499")
+	testutil.AssertEqual(t, "target[1] Name", got[1].Name, "Mars")
+	testutil.AssertEqual(t, "target[2] Designation", got[2].Designation, "2005-029A")
+	testutil.AssertEqual(t, "target[2] Aliases[0]", got[2].Aliases[0], "MRO")
+}
+
+// TestJPLResolveObject_AmbiguousSmallBody uses a real Horizons "Small-body
+// Index Search Results" response (verified live for query "73P", trimmed
+// to 2 of the 84 real matches) — a structurally different table from the
+// major-body one, keyed on Primary Desig / Name columns instead of
+// ID# / Designation.
+func TestJPLResolveObject_AmbiguousSmallBody(t *testing.T) {
+	result := "*******************************************************************************\n" +
+		"JPL/DASTCOM            Small-body Index Search Results     2026-Jul-07 16:26:47\n\n" +
+		" Comet AND asteroid index search:\n\n    DES = 73P;\n\n Matching small-bodies: \n\n" +
+		"    Record #  Epoch-yr  >MATCH DESIG<  Primary Desig  Name  \n" +
+		"    --------  --------  -------------  -------------  -------------------------\n" +
+		"    90000733    1930    73P            73P             Schwassmann-Wachmann 3\n" +
+		"    90000740    1995    73P-A          73P-A           Schwassmann-Wachmann 3\n"
+
+	prov := newMockProvider(jsonResultPayload(t, result))
+
+	var got []resolve.Target
+
+	prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: "73P"})(func(tg resolve.Target, err error) bool {
+		testutil.AssertNoError(t, err)
+
+		got = append(got, tg)
+
+		return true
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 targets, got %d: %+v", len(got), got)
+	}
+
+	testutil.AssertEqual(t, "target[0] ID", got[0].ID, "90000733")
+	testutil.AssertEqual(t, "target[0] Name", got[0].Name, "Schwassmann-Wachmann 3")
+	testutil.AssertEqual(t, "target[0] Designation", got[0].Designation, "73P")
+	testutil.AssertEqual(t, "target[1] Designation", got[1].Designation, "73P-A")
+}
+
+// TestJPLResolveObject_ExactMatch uses real Horizons "Target body name:"
+// header lines (verified live) — a major body with a purely numeric ID and
+// a small body whose parenthetical is a non-numeric provisional
+// designation instead.
+func TestJPLResolveObject_ExactMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    string
+		wantName  string
+		wantID    string
+		wantSPKID string
+		wantDesig string
+	}{
+		{
+			name:      "major body numeric ID",
+			result:    "Target body name: Mars (499)                      {source: mar099}\nCenter body name: Earth (399)                     {source: DE441}\n",
+			wantName:  "Mars",
+			wantID:    "499",
+			wantSPKID: "499",
+		},
+		{
+			name:      "small body provisional designation",
+			result:    "Target body name: 1685 Toro (1948 OA)             {source: JPL#895}\n",
+			wantName:  "1685 Toro",
+			wantID:    "1948 OA",
+			wantDesig: "1948 OA",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prov := newMockProvider(jsonResultPayload(t, tt.result))
+
+			var got []resolve.Target
+
+			prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: tt.name})(func(tg resolve.Target, err error) bool {
+				testutil.AssertNoError(t, err)
+
+				got = append(got, tg)
+
+				return true
+			})
+
+			if len(got) != 1 {
+				t.Fatalf("expected 1 target, got %d: %+v", len(got), got)
+			}
+
+			testutil.AssertEqual(t, "Name", got[0].Name, tt.wantName)
+			testutil.AssertEqual(t, "ID", got[0].ID, tt.wantID)
+			testutil.AssertEqual(t, "SPKID", got[0].SPKID, tt.wantSPKID)
+			testutil.AssertEqual(t, "Designation", got[0].Designation, tt.wantDesig)
+		})
+	}
+}
+
+// TestJPLResolveObject_ZeroMatches uses a real Horizons "no matches found"
+// response (verified live) — a recognized-but-empty small-body index
+// response must yield zero targets and no error, not ErrNotImplemented.
+func TestJPLResolveObject_ZeroMatches(t *testing.T) {
+	result := "*******************************************************************************\n" +
+		"JPL/DASTCOM            Small-body Index Search Results     2026-Jul-07 16:26:03\n\n" +
+		" Comet AND asteroid index search:\n\n   NAME = ZZZNOTAREALBODYZZZ;\n\n" +
+		" Matching small-bodies: \n    No matches found.\n" +
+		"*******************************************************************************\n"
+
+	prov := newMockProvider(jsonResultPayload(t, result))
+
+	var (
+		got    []resolve.Target
+		gotErr error
+	)
+
+	prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: "ZZZNOTAREALBODYZZZ"})(func(tg resolve.Target, err error) bool {
+		got = append(got, tg)
+		gotErr = err
+
+		return true
+	})
+
+	testutil.AssertNoError(t, gotErr)
+
+	if len(got) != 0 {
+		t.Fatalf("expected 0 targets, got %d: %+v", len(got), got)
+	}
+}
+
+// TestJPLResolveObject_UnrecognizedShape confirms a non-blank result that
+// matches none of the three known shapes still surfaces ErrNotImplemented
+// rather than silently returning nothing or fabricating a Target.
+func TestJPLResolveObject_UnrecognizedShape(t *testing.T) {
+	prov := newMockProvider(jsonResultPayload(t, "Some entirely novel Horizons output shape with no recognizable marker text.\n"))
+
+	iter := prov.ResolveObject(context.Background(), resolve.ObjectRequest{Query: "???"})
 	iter(func(_ resolve.Target, err error) bool {
 		if !errors.Is(err, ErrNotImplemented) {
 			t.Fatalf("expected ErrNotImplemented, got %v", err)
@@ -65,6 +219,18 @@ func TestJPLResolveObjectNotImplemented(t *testing.T) {
 
 		return false
 	})
+}
+
+// TestJPLResolve_ReturnsRealMatch confirms Provider.Resolve (the
+// resolve.Provider-interface entry point) now surfaces a real resolved
+// Target for an unambiguous query instead of always returning ok=false.
+func TestJPLResolve_ReturnsRealMatch(t *testing.T) {
+	result := "Target body name: Mars (499)                      {source: mar099}\n"
+	prov := newMockProvider(jsonResultPayload(t, result))
+
+	target, ok := prov.Resolve("Mars")
+	testutil.AssertEqual(t, "Resolve Ok", ok, true)
+	testutil.AssertEqual(t, "Resolve Name", target.Name, "Mars")
 }
 
 type mockTransport struct {

--- a/catalog/jpl/parse.go
+++ b/catalog/jpl/parse.go
@@ -1,0 +1,258 @@
+package jpl
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+)
+
+// targetBodyNameRe matches Horizons' single-match identifying header line,
+// present at the top of every unambiguous single-object response — verified
+// against live responses for both a major body ("Target body name: Mars
+// (499)                      {source: mar099}") and a small body ("Target
+// body name: 1685 Toro (1948 OA)             {source: JPL#895}"). The
+// parenthetical is not always numeric: small bodies may show a provisional
+// designation instead of a NAIF/SPK ID.
+var targetBodyNameRe = regexp.MustCompile(`(?m)^Target body name:\s*(.+?)\s*\(([^)]*)\)`)
+
+// parseExactMatch extracts a single resolve.Target from Horizons' "Target
+// body name:" header line. It intentionally parses nothing else from the
+// response body (orbital elements, physical parameters) — see doc.go for
+// why: that portion of Horizons' output has no stable, verified schema.
+func parseExactMatch(data string) (resolve.Target, bool) {
+	m := targetBodyNameRe.FindStringSubmatch(data)
+	if m == nil {
+		return resolve.Target{}, false
+	}
+
+	name := strings.TrimSpace(m[1])
+	idOrDesig := strings.TrimSpace(m[2])
+
+	if name == "" || idOrDesig == "" {
+		return resolve.Target{}, false
+	}
+
+	t := resolve.Target{
+		Catalog: "jpl",
+		Name:    name,
+		ID:      idOrDesig,
+	}
+
+	if isNumericID(idOrDesig) {
+		t.SPKID = idOrDesig
+	} else {
+		t.Designation = idOrDesig
+	}
+
+	return t, true
+}
+
+// majorBodyMatchMarker identifies Horizons' fixed-width table of candidate
+// major bodies (planets, satellites, spacecraft, barycenters) returned for
+// an ambiguous query, e.g. `Multiple major-bodies match string "MARS*"`.
+const majorBodyMatchMarker = "major-bodies match string"
+
+// cosparDesignationRe matches a COSPAR international designator (e.g.
+// "2005-029A"), used to locate the Designation field within a major-body
+// match-table row. The ID column (0-10) is reliably fixed-width, but the
+// Name/Designation/Alias columns are not: verified against a live response,
+// a long body name can overflow its nominal ~35-char field with zero
+// separating space from the designation that follows (e.g. "...Orbiter
+// (spacec2005-029A..." — Horizons itself already truncated "spacecraft)"
+// to "spacec" before concatenating), so fixed-offset slicing silently
+// corrupts the Designation. Anchoring on the designation's own recognizable
+// pattern is robust to that overflow; only the Name may still show
+// Horizons' own upstream truncation in that edge case, which cannot be
+// recovered from the text as sent.
+var cosparDesignationRe = regexp.MustCompile(`\d{4}-\d{3}[A-Za-z]{1,4}`)
+
+// parseMajorBodyMatchTable parses Horizons' major-body ambiguous-match
+// table. The overall table-detection approach (marker text + dashed
+// separator line) matches the parser already proven in production against
+// live Horizons traffic by ephemeris/jpl/spk's CacheAPI kernel-resolution
+// path; the header wording above the table has been observed to vary
+// ("Number" vs "ID#"), so detection keys on the marker text, not the header.
+func parseMajorBodyMatchTable(data string) ([]resolve.Target, bool) {
+	if !strings.Contains(data, majorBodyMatchMarker) {
+		return nil, false
+	}
+
+	var targets []resolve.Target
+
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	inTable := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.Contains(line, "-------") && strings.Contains(line, "------------------") {
+			inTable = true
+			continue
+		}
+
+		if !inTable {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if len(targets) > 0 {
+				break
+			}
+
+			continue
+		}
+
+		if len(line) < 10 {
+			continue
+		}
+
+		id := strings.TrimSpace(safeSubstr(line, 0, 10))
+		if id == "" {
+			continue
+		}
+
+		rest := safeSubstr(line, 10, -1)
+
+		var name, desig, alias string
+
+		if loc := cosparDesignationRe.FindStringIndex(rest); loc != nil {
+			name = strings.TrimSpace(rest[:loc[0]])
+			desig = rest[loc[0]:loc[1]]
+			alias = strings.TrimSpace(rest[loc[1]:])
+		} else {
+			name = strings.TrimSpace(rest)
+		}
+
+		t := resolve.Target{
+			Catalog:     "jpl",
+			ID:          id,
+			Name:        name,
+			Designation: desig,
+		}
+		if alias != "" {
+			t.Aliases = strings.Split(alias, "/")
+		}
+
+		if isNumericID(id) {
+			t.SPKID = id
+		}
+
+		targets = append(targets, t)
+	}
+
+	return targets, true
+}
+
+// smallBodyIndexMarker identifies Horizons' DASTCOM small-body index search
+// results, returned when a query matches zero or more comets/asteroids,
+// e.g. `JPL/DASTCOM            Small-body Index Search Results`. This is a
+// structurally different table (columns: Record #, Epoch-yr, >MATCH DESIG<,
+// Primary Desig, Name) from the major-body match table above — confirmed
+// against live responses for both an ambiguous small-body query (multiple
+// "73P" fragment records) and a zero-match query ("No matches found.").
+const smallBodyIndexMarker = "Small-body Index Search Results"
+
+// whitespaceRunRe splits a small-body index row on runs of 2+ spaces,
+// since the table is space-padded rather than strictly fixed-width and a
+// body Name may itself contain a single internal space (e.g.
+// "Schwassmann-Wachmann 3").
+var whitespaceRunRe = regexp.MustCompile(`\s{2,}`)
+
+// parseSmallBodyIndexTable parses Horizons' DASTCOM small-body index table.
+// It returns (nil, true) for a recognized-but-empty response (e.g. "No
+// matches found."), distinct from (nil, false) when the marker isn't
+// present at all.
+func parseSmallBodyIndexTable(data string) ([]resolve.Target, bool) {
+	if !strings.Contains(data, smallBodyIndexMarker) {
+		return nil, false
+	}
+
+	var targets []resolve.Target
+
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	inTable := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if !inTable {
+			if strings.HasPrefix(trimmed, "--------") {
+				inTable = true
+			}
+
+			continue
+		}
+
+		if trimmed == "" {
+			if len(targets) > 0 {
+				break
+			}
+
+			continue
+		}
+
+		fields := whitespaceRunRe.Split(trimmed, -1)
+		if len(fields) < 5 {
+			continue
+		}
+
+		recordID := fields[0]
+		primaryDesig := fields[3]
+		name := strings.Join(fields[4:], " ")
+
+		t := resolve.Target{
+			Catalog:     "jpl",
+			ID:          recordID,
+			Name:        name,
+			Designation: primaryDesig,
+		}
+
+		if isNumericID(recordID) {
+			t.SPKID = recordID
+		}
+
+		targets = append(targets, t)
+	}
+
+	return targets, true
+}
+
+// isNumericID reports whether s is an integer literal (optionally signed) —
+// Horizons uses signed integer NAIF/SPK IDs for major bodies and spacecraft,
+// but a small body's identifying parenthetical/primary-designation field can
+// be a non-numeric provisional designation (e.g. "1948 OA").
+func isNumericID(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for i, r := range s {
+		if r == '-' && i == 0 {
+			continue
+		}
+
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// safeSubstr returns s[start:start+length], clamped to s's bounds; length
+// == -1 means "to the end of the string".
+func safeSubstr(s string, start, length int) string {
+	if start >= len(s) {
+		return ""
+	}
+
+	if length == -1 || start+length > len(s) {
+		return s[start:]
+	}
+
+	return s[start : start+length]
+}

--- a/catalog/resolve/remote.go
+++ b/catalog/resolve/remote.go
@@ -62,6 +62,13 @@ type ObjectRequest struct {
 type ConeRequest struct {
 	// ID is the unique identifier of the target.
 	ID string
+	// Table selects which catalog table a ConeSearcher queries, for
+	// providers that support more than one (e.g. catalog/vizier). The
+	// empty string means "use the provider's default table" — existing
+	// callers that never set this field keep their current behavior
+	// unchanged. Providers that don't support table selection ignore this
+	// field entirely.
+	Table string
 	// Center is the coordinate to search around.
 	Center coord.ICRS
 	// Radius is the search radius.

--- a/catalog/vizier/doc.go
+++ b/catalog/vizier/doc.go
@@ -3,9 +3,21 @@
 //
 // # Current status
 //
-// [Provider.ConeSearch] currently queries a single hardcoded table — the
-// 2MASS point-source catalog (II/246/out) — as a generic fallback baseline.
-// It does not yet support selecting an arbitrary VizieR table/catalog per
-// request; ConeRequest has no field for one. Returned targets carry the
-// 2MASS designation, RA/Dec, and Kind [resolve.KindStar].
+// [Provider.ConeSearch] queries any VizieR table registered in this
+// package's schema registry (tables.go), selected via
+// [resolve.ConeRequest].Table. An empty Table defaults to the 2MASS
+// point-source catalog (II/246/out), this package's original behavior.
+// Querying a table not in the registry returns [ErrUnknownTable] rather
+// than guessing that table's RA/Dec/designation column names.
+//
+// Tables registered today:
+//
+//   - II/246/out — 2MASS Point Source Catalog (default)
+//   - I/239/hip_main — Hipparcos main catalog
+//   - I/355/gaiadr3 — Gaia DR3 (VizieR mirror)
+//
+// Adding a table is a data change (a new tables.go registry entry with
+// verified column names), not an API change — the registry can grow
+// without touching [resolve.ConeRequest] or [Provider.ConeSearch]'s
+// signature.
 package vizier

--- a/catalog/vizier/tables.go
+++ b/catalog/vizier/tables.go
@@ -1,0 +1,40 @@
+package vizier
+
+import "github.com/TuSKan/astrogo/catalog/resolve"
+
+// tableSchema describes a VizieR table's ADQL column names for the fields
+// ConeSearch needs, keyed by VizieR table identifier (e.g. "II/246/out").
+type tableSchema struct {
+	// RACol/DecCol are the table's decimal-degree ICRS RA/Dec column names.
+	RACol, DecCol string
+	// DesigCol selects the ADQL expression used as each row's
+	// designation/name. It is normally a bare column name (e.g. "HIP"),
+	// but for II/246/out it is the double-quoted identifier `"2MASS"` —
+	// that table genuinely has a column literally named "2MASS" holding
+	// the point-source designation, which is why the original
+	// (pre-registry) query aliased it directly.
+	DesigCol string
+	// Kind is the resolve.Kind assigned to every row from this table.
+	Kind resolve.Kind
+}
+
+// defaultTable is used when a ConeRequest doesn't specify Table, preserving
+// this package's original single-table behavior exactly.
+const defaultTable = "II/246/out"
+
+// tableSchemas is the registry of VizieR tables ConeSearch knows how to
+// query. Column names below are verified against VizieR's live TAP service
+// (http://tapvizier.u-strasbg.fr/TAPVizieR/tap/sync), not guessed —
+// querying an unregistered table returns ErrUnknownTable rather than
+// assuming generic column names that may not exist for that table. Adding
+// a table here is a data change, not an API change.
+//
+//nolint:gochecknoglobals // read-only registry, populated once at init
+var tableSchemas = map[string]tableSchema{
+	// 2MASS Point Source Catalog — the package's original hardcoded table.
+	defaultTable: {RACol: "raj2000", DecCol: "dej2000", DesigCol: `"2MASS"`, Kind: resolve.KindStar},
+	// Hipparcos main catalog.
+	"I/239/hip_main": {RACol: "RAICRS", DecCol: "DEICRS", DesigCol: "HIP", Kind: resolve.KindStar},
+	// Gaia DR3 (VizieR mirror of the Gaia archive).
+	"I/355/gaiadr3": {RACol: "RA_ICRS", DecCol: "DE_ICRS", DesigCol: "DR3Name", Kind: resolve.KindStar},
+}

--- a/catalog/vizier/vizier.go
+++ b/catalog/vizier/vizier.go
@@ -20,8 +20,14 @@ const tapSyncURL = "http://tapvizier.u-strasbg.fr/TAPVizieR/tap/sync"
 
 // ErrUnexpectedSchema indicates the CSV response is missing a column the
 // parser depends on, e.g. because VizieR's TAP schema for the queried table
-// changed underneath ConeSearch's hardcoded ADQL SELECT clause.
+// changed underneath ConeSearch's ADQL SELECT clause.
 var ErrUnexpectedSchema = errors.New("vizier: unexpected response schema")
+
+// ErrUnknownTable indicates a ConeRequest named a VizieR table not present
+// in this package's schema registry (see tables.go). Rather than guess at
+// that table's RA/Dec/designation column names, ConeSearch requires the
+// table to be registered first.
+var ErrUnknownTable = errors.New("vizier: unknown table")
 
 // Provider implements resolve.Provider and resolve.ConeSearcher
 // for querying tables hosted on VizieR via TAP ADQL.
@@ -57,14 +63,24 @@ func (p *Provider) Search(_ string) []resolve.Target {
 }
 
 // ConeSearch performs a spatial cone search via the VizieR service.
+//
+// req.Table selects which VizieR table to query (e.g. "I/239/hip_main");
+// the empty string defaults to the 2MASS point-source catalog
+// (II/246/out), this package's original behavior. Querying a table not
+// present in this package's schema registry (tables.go) returns
+// ErrUnknownTable.
 func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) resolve.SeqIterator[resolve.Target] {
-	// VizieR requires specifying a catalog index/table if we do ADQL.
-	// Since ConeRequest doesn't specify 'table', we might need to rely purely on VizieR's standard catalogs
-	// OR require the user to encode it somehow.
-	// Wait, the easiest way to do a vizier cone search across standard catalogues is using their REST/ConeSearch API, not TAP.
-	// But let's assume they want the standard II/246 (2MASS) for generic lookups if none specified.
-	// We will create a flexible TAP generator.
-	table := "II/246/out" // 2MASS point source catalog as a generic fallback baseline
+	tableName := req.Table
+	if tableName == "" {
+		tableName = defaultTable
+	}
+
+	schema, ok := tableSchemas[tableName]
+	if !ok {
+		return func(yield func(resolve.Target, error) bool) {
+			yield(resolve.Target{}, fmt.Errorf("%w: %q", ErrUnknownTable, tableName))
+		}
+	}
 
 	limit := req.Limit
 	if limit <= 0 {
@@ -77,11 +93,14 @@ func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) reso
 	rad := req.Radius.Degrees()
 
 	adql := fmt.Sprintf(`SELECT TOP %d
-	"2MASS" as designation, raj2000 as ra, dej2000 as dec
+	%s as designation, %s as ra, %s as dec
 	FROM "%s"
-	WHERE 1=CONTAINS(POINT('ICRS', raj2000, dej2000), CIRCLE('ICRS', %f, %f, %f))`, limit, table, ra, dec, rad)
+	WHERE 1=CONTAINS(POINT('ICRS', %s, %s), CIRCLE('ICRS', %f, %f, %f))`,
+		limit, schema.DesigCol, schema.RACol, schema.DecCol, tableName, schema.RACol, schema.DecCol, ra, dec, rad)
 
-	cacheKey := fmt.Sprintf("vizier:cone:%f:%f:%f:%d", ra, dec, rad, limit)
+	// The table name is part of the cache key: two different tables queried
+	// with the same cone would otherwise collide on the same entry.
+	cacheKey := fmt.Sprintf("vizier:cone:%s:%f:%f:%f:%d", tableName, ra, dec, rad, limit)
 	if seq, ok := p.cache.Get(cacheKey); ok {
 		return seq
 	}
@@ -114,7 +133,7 @@ func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) reso
 			}
 		}()
 
-		targets, err := parseCSV(resp.Body)
+		targets, err := parseCSV(resp.Body, schema.Kind)
 		if err != nil {
 			yield(resolve.Target{}, err)
 			return
@@ -134,9 +153,10 @@ func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) reso
 }
 
 // parseCSV extracts designation/ra/dec rows from the ADQL query's CSV
-// response. Columns are located by header name rather than assumed position,
-// so the parser stays correct if the SELECT clause in ConeSearch is reordered.
-func parseCSV(body io.Reader) ([]resolve.Target, error) {
+// response, tagging every row with kind. Columns are located by header name
+// rather than assumed position, so the parser stays correct if the SELECT
+// clause in ConeSearch is reordered.
+func parseCSV(body io.Reader, kind resolve.Kind) ([]resolve.Target, error) {
 	reader := csv.NewReader(body)
 
 	header, err := reader.Read()
@@ -190,8 +210,9 @@ func parseCSV(body io.Reader) ([]resolve.Target, error) {
 			Catalog:     "vizier",
 			Name:        designation,
 			Designation: designation,
-			Kind:        resolve.KindStar,
+			Kind:        kind,
 			Coord:       coord.NewICRS(angle.Deg(raDeg), angle.Deg(decDeg)),
+			HasCoord:    true,
 		})
 	}
 

--- a/catalog/vizier/vizier_network_test.go
+++ b/catalog/vizier/vizier_network_test.go
@@ -62,3 +62,40 @@ func TestVizierNetworkConeSearch(t *testing.T) {
 		t.Fatalf("Expected limit to be respected")
 	}
 }
+
+// TestVizierNetworkConeSearch_RegisteredTable confirms ConeSearch works
+// live against a second registered table (Hipparcos), not just the default
+// 2MASS one.
+func TestVizierNetworkConeSearch_RegisteredTable(t *testing.T) {
+	requireVizier(t)
+
+	prov := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// A 2-degree cone around M31's core comfortably contains a Hipparcos star.
+	req := resolve.ConeRequest{
+		Table:  "I/239/hip_main",
+		Center: coord.NewICRS(angle.Deg(10.684), angle.Deg(41.269)),
+		Radius: angle.Deg(2),
+		Limit:  5,
+	}
+
+	iter := prov.ConeSearch(ctx, req)
+
+	var count int
+
+	iter(func(_ resolve.Target, err error) bool {
+		if err != nil {
+			t.Fatalf("live network failed: %v", err)
+		}
+
+		count++
+
+		return true
+	})
+
+	if count == 0 {
+		t.Error("expected at least one Hipparcos star within 2 degrees of Andromeda's core")
+	}
+}

--- a/catalog/vizier/vizier_test.go
+++ b/catalog/vizier/vizier_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
 )
 
 func TestVizierOfflineConeSearch(t *testing.T) {
@@ -73,8 +74,145 @@ func TestVizierOfflineConeSearch(t *testing.T) {
 }
 
 func TestParseCSVMissingColumn(t *testing.T) {
-	if _, err := parseCSV(strings.NewReader("ra,dec\n1,2\n")); !errors.Is(err, ErrUnexpectedSchema) {
+	if _, err := parseCSV(strings.NewReader("ra,dec\n1,2\n"), resolve.KindStar); !errors.Is(err, ErrUnexpectedSchema) {
 		t.Errorf("expected ErrUnexpectedSchema, got %v", err)
+	}
+}
+
+// TestVizierConeSearch_RegisteredTable confirms ConeSearch works against a
+// second registered table (Hipparcos), not just the default 2MASS one —
+// proving the table-parameterization mechanism generalizes, per the schema
+// registry in tables.go.
+func TestVizierConeSearch_RegisteredTable(t *testing.T) {
+	csvData := "designation,ra,dec\n" + "1,10.68470,41.26875\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+
+		adql := r.PostFormValue("QUERY")
+		if !strings.Contains(adql, `FROM "I/239/hip_main"`) {
+			t.Errorf("expected query against I/239/hip_main, got: %s", adql)
+		}
+
+		if !strings.Contains(adql, "RAICRS") || !strings.Contains(adql, "DEICRS") {
+			t.Errorf("expected Hipparcos RA/Dec columns in query, got: %s", adql)
+		}
+
+		w.Header().Set("Content-Type", "text/csv")
+
+		if _, err := fmt.Fprint(w, csvData); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	prov := New()
+	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
+
+	req := resolve.ConeRequest{
+		Table:  "I/239/hip_main",
+		Center: coord.NewICRS(angle.Deg(10.684), angle.Deg(41.269)),
+		Radius: angle.Deg(0.01),
+	}
+
+	var targets []resolve.Target
+
+	prov.ConeSearch(context.Background(), req)(func(tar resolve.Target, err error) bool {
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		targets = append(targets, tar)
+
+		return true
+	})
+
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+
+	testutil.AssertEqual(t, "Kind", targets[0].Kind, resolve.KindStar)
+	testutil.AssertEqual(t, "HasCoord", targets[0].HasCoord, true)
+}
+
+// TestVizierConeSearch_UnknownTable confirms a table absent from the
+// schema registry returns ErrUnknownTable rather than guessing column names.
+func TestVizierConeSearch_UnknownTable(t *testing.T) {
+	prov := New()
+
+	req := resolve.ConeRequest{
+		Table:  "X/999/not_a_real_table",
+		Center: coord.NewICRS(angle.Deg(10), angle.Deg(40)),
+		Radius: angle.Deg(1),
+	}
+
+	iter := prov.ConeSearch(context.Background(), req)
+	iter(func(_ resolve.Target, err error) bool {
+		if !errors.Is(err, ErrUnknownTable) {
+			t.Fatalf("expected ErrUnknownTable, got %v", err)
+		}
+
+		return false
+	})
+}
+
+// TestVizierConeSearch_CacheKeyIncludesTable is a regression test: the same
+// cone queried against two different tables must not collide on one cache
+// entry (the cache key previously covered only ra/dec/rad/limit).
+func TestVizierConeSearch_CacheKeyIncludesTable(t *testing.T) {
+	var calls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+
+		adql := r.PostFormValue("QUERY")
+
+		w.Header().Set("Content-Type", "text/csv")
+
+		if strings.Contains(adql, "I/239/hip_main") {
+			fmt.Fprint(w, "designation,ra,dec\n1,10.68470,41.26875\n") //nolint:errcheck // test server
+		} else {
+			fmt.Fprint(w, "designation,ra,dec\n2,10.68470,41.26875\n") //nolint:errcheck // test server
+		}
+	}))
+	defer server.Close()
+
+	prov := New()
+	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
+
+	center := coord.NewICRS(angle.Deg(10.684), angle.Deg(41.269))
+	radius := angle.Deg(0.01)
+
+	var (
+		defaultTargets, hipTargets []resolve.Target
+	)
+
+	prov.ConeSearch(context.Background(), resolve.ConeRequest{Center: center, Radius: radius})(func(tar resolve.Target, _ error) bool {
+		defaultTargets = append(defaultTargets, tar)
+		return true
+	})
+
+	prov.ConeSearch(context.Background(), resolve.ConeRequest{Table: "I/239/hip_main", Center: center, Radius: radius})(func(tar resolve.Target, _ error) bool {
+		hipTargets = append(hipTargets, tar)
+		return true
+	})
+
+	if calls != 2 {
+		t.Fatalf("expected 2 live requests (no cache collision), got %d", calls)
+	}
+
+	if len(defaultTargets) != 1 || defaultTargets[0].Designation != "2" {
+		t.Fatalf("expected default-table target Designation=2, got %+v", defaultTargets)
+	}
+
+	if len(hipTargets) != 1 || hipTargets[0].Designation != "1" {
+		t.Fatalf("expected hip_main target Designation=1, got %+v", hipTargets)
 	}
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,12 +10,14 @@ precision computation, observatory planning, and scalable data workflows.
 astrogo is pre-1.0 (currently **v0.2.0**). The deliberate decision was to ship v0.2.0
 first — the API is already in good shape after an extensive correctness/robustness/
 release-readiness audit (see [CHANGELOG.md](../CHANGELOG.md)) — rather than commit to
-the v1.0.0 API-stability promise while two catalog providers are still partial:
+the v1.0.0 API-stability promise while two catalog providers were still partial:
 
-- `catalog/jpl` — name resolution only; Horizons result-text parsing not yet implemented
-- `catalog/vizier` — `ConeSearch` only queries a single hardcoded 2MASS table
+- `catalog/jpl` — ✅ now resolves both ambiguous (major/small-body match tables) and
+  unambiguous (single-match header line) Horizons queries into real `resolve.Target`s
+- `catalog/vizier` — ✅ `ConeSearch` now supports any VizieR table registered in
+  `tables.go` (2MASS, Hipparcos, Gaia DR3 today), selected via `ConeRequest.Table`
 
-Once both are fully implemented, v1.0.0 is back on the table.
+Both v1.0.0 blockers are closed — v1.0.0 is back on the table.
 
 ---
 


### PR DESCRIPTION
## Summary
- `catalog/jpl`: `ResolveObject` now parses Horizons' free-text result field for all three recognized shapes (verified against live Horizons responses) instead of always returning `ErrNotImplemented` — ambiguous major-body matches, ambiguous small-body (DASTCOM) matches, and unambiguous exact matches via the "Target body name:" header line. Fixes a real corruption bug where a long body name overflowing its column mangled the following Designation field. Adds the missing cache write.
- `catalog/vizier`: `ConeSearch` now supports any VizieR table registered in a new schema registry (`tables.go`), selected via a new `ConeRequest.Table` field (empty = previous 2MASS-only behavior, fully backward compatible). Seeded with 2MASS, Hipparcos, and Gaia DR3 — column names verified against VizieR's live TAP schema. Fixes a cache-key collision across tables and a hardcoded `Kind`/missing `HasCoord` gap.
- README/ROADMAP/CHANGELOG updated: both packages flip from partial to fully implemented — both v1.0.0 blockers are now closed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./catalog/... ./ephemeris/jpl/...`
- [x] `go test ./catalog/jpl/... ./catalog/vizier/... ./catalog/resolve/...`
- [x] `go test -tags=network ./catalog/jpl/... ./catalog/vizier/...` (live Horizons + VizieR)
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .`
- [x] `go mod tidy` / `go generate ./...` — no drift
- [ ] CI green