### PR TITLE
DX improvements: provider guide, NewSite options, lpmap rename, plan doc index, download progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `remote.WithProgress(func(downloaded, total int64))` — a `ReadOption` reporting a `GetFile` download's progress as it streams, on both the buffered (`WithValidate`) and direct-to-disk paths. Independent of whether a caller supplies it, `GetFile` now logs one line (via the stdlib `log` package) at the start of an actual download showing the endpoint and its registered `ApproxSize` — never logged on a cache hit.
+- `ephemeris` package doc: a "Choosing a Provider" section comparing `Default()` against the JPL kernel family (de440s/de440/de442/de441) on accuracy, size, and offline-friendliness — previously only a size table existed, with no guidance on which provider to reach for.
+- `plan` package doc: a "Finding what you need" task-oriented symbol index (site setup, targets, rise/set/twilight, observability scoring, geometric events, phases/eclipses, crescent visibility, scheduling, satellite passes, low-level solving) — previously prose-only with no way to locate a symbol among the package's ~150 exported names short of scanning godoc alphabetically.
+
+### Changed — BREAKING
+- **`lightpollution` moved to `skybrightness/lpmap`** (package name `lightpollution` → `lpmap`). It's a live-API sibling of `skybrightness/atlas` — both resolve the same World Atlas artificial-brightness data for a `skybrightness.Floor`, just from a downloaded file (`atlas`) versus a live per-request query (`lpmap`) — and the old top-level package name didn't make that relationship, or the live-client-vs-physics-model distinction from core `skybrightness`, visible. Update `import "github.com/TuSKan/astrogo/lightpollution"` to `import "github.com/TuSKan/astrogo/skybrightness/lpmap"`; `lightpollution.New()` is now `lpmap.New()`. `remote.LightPollution` (the endpoint registry key) is unchanged.
+- **`plan.NewSite`'s `horizon angle.Angle` parameter is now the optional `WithHorizon(angle.Angle)` `SiteOption`, defaulting to `angle.Zero()`.** The signature changes from `NewSite(name, loc, horizon, tz)` to `NewSite(name, loc, tz, opts...)` — the overwhelming majority of call sites passed a zero horizon anyway, so most callers now drop the argument entirely (`NewSite("Site", loc, tz)`); a non-zero horizon becomes `NewSite("Site", loc, tz, plan.WithHorizon(angle.Deg(20)))`. Matches the `WithX`-functional-option convention already used by `Asteroid`/`Comet`/`DeepSkyObject`/`Satellite`/`Star` in this package. `Site.WithHorizon` (the copy-with-new-horizon method) is unchanged.
+
+### Changed
+- Every `plan.NewSite` call site across examples, docs, and tests now spells a zero horizon limit as `angle.Zero()` (or omits it entirely now that it's optional — see above) — previously a mix of `angle.Zero()`, a bare `0`, and `angle.Deg(0)` (all numerically identical, but inconsistent to read).
+
 ## [0.5.0] — 2026-07-16
 
 ### Changed — BREAKING

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,14 +59,14 @@ Strictly layered, unidirectional imports (no cycles). Lower layers never import 
 ```
 plan, catalog, fits/plan                         ← orchestration (observability, scheduling, events, resolvers, FITS↔plan bridge)
 ephemeris, coord, atmosphere, fits, skybrightness ← scientific engines
-iers, lightpollution                             ← data providers (Earth orientation params, live light-pollution API)
+iers, skybrightness/lpmap                        ← data providers (Earth orientation params, live light-pollution API)
 time, angle, vector, unit, constants, remote      ← primitives
 ```
 
 - **`coord`** is the transform core. `coord.Context` (in [coord/context.go](coord/context.go)) caches the expensive SOFA `Apco13` matrix computation (~91 µs) once per epoch so each subsequent transform is ~325 ns. **Hot paths must create one `Context` per epoch and reuse it** — never one per transform. The scheduler shares a single `Context` per time step across constraints via the `ConstraintCtx` interface; built-in `Altitude`/`Airmass` implement it.
 - **`ephemeris`** provides Sun/Moon/planet positions (SOFA + JPL SPK). `ephemeris/jpl` is the multi-kernel SPK provider with on-demand Horizons fetching (`Provider.AddKernel`/`State`/`FindSegment`/`SupportedBodies` are guarded by an internal `sync.RWMutex` — safe to call concurrently); `ephemeris/satellite` is SGP4 (TEME→GCRS, ground track, look angles).
 - **`plan`** is the planning/event engine: `Observable` targets, `Constraint`s, the Chandrupatla/Brent `Solver` (rise/set/transit, phases, seasons, eclipses, conjunctions), and the `Strategy`-based scheduler (`Greedy`/`Priority`/`SwapOptimized`). `plan` has no dependency on `fits` or Apache Arrow — the FITS↔plan bridge (`SiteFromFITS`/`TargetFromFITS`) lives in the separate `fits/plan` package.
-- **`skybrightness`** (+ `skybrightness/atlas`) models night-sky surface brightness (moonlight, zodiacal light, airglow, light-pollution floor) as additive linear-flux components; `lightpollution` is a live client for the lightpollutionmap.info API feeding `skybrightness.Floor`. `plan.LimitingMagnitudeConstraint`/`ScoreObservableSky` wire this into observability scoring.
+- **`skybrightness`** (+ `skybrightness/atlas`, `skybrightness/lpmap`) models night-sky surface brightness (moonlight, zodiacal light, airglow, light-pollution floor) as additive linear-flux components; `atlas` decodes offline light-pollution atlas files, `lpmap` is a live client for the lightpollutionmap.info API — both feed `skybrightness.Floor` and neither is ever imported back by core `skybrightness` (enforced by an import-graph test). `plan.LimitingMagnitudeConstraint`/`ScoreObservableSky` wire this into observability scoring.
 - **`catalog`** + `catalog/resolve` expose unified `resolve.Provider` interfaces over SIMBAD/MAST/Gaia/VizieR/JPL/SBDB/OpenNGC/NORAD/FINK, with Apache Arrow columnar caching. All network access goes through `remote.Client`.
 - **`internal/gofaext`** wraps [github.com/hebl/gofa](https://github.com/hebl/gofa) (SOFA-derived algorithms). All low-level SOFA calls go through here to keep public APIs clean and the backend swappable.
 - **`internal/testutil`** holds float/error test helpers used across packages.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import (
 
 func main() {
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760) // São Paulo
-	site, _ := plan.NewSite("Backyard", loc, angle.Zero(), nil)
+	site, _ := plan.NewSite("Backyard", loc, nil)
 	sirius := plan.NewStar("Sirius", angle.Hour(6.7525), angle.Deg(-16.7161))
 
 	tonight := time.Date(2026, 4, 15, 22, 0, 0, 0, time.LocationUTC)
@@ -121,7 +121,7 @@ const layout = "2006-01-02 15:04 MST"
 func main() {
 	// ── Observer Setup: São Paulo ──
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, angle.Zero(), nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// ── Night boundaries ──
 	eph := ephemeris.Default()
@@ -488,14 +488,14 @@ AOS: 19:45:03 UTC  Max El: 73.1°  LOS: 19:51:47 UTC  Duration: 6m44s
     - **`SwapOptimizedStrategy`** — local search with adjacent swaps + gap insertion (monotonic improvement)
   - Linear scaling benchmarked to 100 blocks
 
-### Sky Brightness & Light Pollution (`skybrightness`, `lightpollution`)
+### Sky Brightness & Light Pollution (`skybrightness`, `skybrightness/lpmap`)
 - Night-sky surface brightness decomposed into additive components, summed in linear flux space and converted to V mag/arcsec² only at the boundary:
   - `Moonlight` — scattered moonlight, Krisciunas & Schaefer (1991) closed form
   - `ZodiacalLight` — Leinert et al. (1998) Table 17, bilinear interpolation
   - `Airglow` — dark-sky floor (Noll et al. 2012 / Patat 2008)
   - `Floor` — light-pollution baseline from scalar SQM, directional `SQMGrid`, or `FloorFromBortle`
 - `skybrightness/atlas` — offline, pure-Go artificial-brightness atlas providers (Falchi et al. 2016 World Atlas GeoTIFF, VIIRS-DNB)
-- `lightpollution` — live client for the lightpollutionmap.info QueryRaster API, with retry/backoff on transient failures
+- `skybrightness/lpmap` — live client for the lightpollutionmap.info QueryRaster API, with retry/backoff on transient failures
 - `plan.LimitingMagnitudeConstraint` / `ScoreObservableSky` — folds sky-brightness-derived limiting magnitude into observability constraints and scoring
 
 ### Event Solver
@@ -538,7 +538,7 @@ flowchart TD
 
     %% Data Providers
     iers[iers]
-    lightpollution[lightpollution]
+    lpmap["skybrightness/lpmap"]
 
     %% Primitive Foundation
     subgraph Primitives
@@ -575,7 +575,7 @@ flowchart TD
     plan --> satellite
 
     skybrightness --> angle
-    lightpollution --> skybrightness
+    lpmap --> skybrightness
 
     coord --> iers
     coord --> atmosphere
@@ -621,7 +621,7 @@ flowchart TD
 | `fits/plan` | FITS↔plan bridge (`SiteFromFITS`, `TargetFromFITS`) | ✅ Stable |
 | `plan` | Observability, constraints, events, scheduling, satellite passes | ✅ Stable |
 | `skybrightness`, `skybrightness/atlas` | Sky brightness model (moonlight, zodiacal light, airglow, light-pollution floor) | ✅ Stable |
-| `lightpollution` | Live lightpollutionmap.info client | ✅ Stable |
+| `skybrightness/lpmap` | Live lightpollutionmap.info client | ✅ Stable |
 | `unit` | Physical unit and quantity system | ✅ Stable |
 
 See [`VALIDATION.md`](docs/VALIDATION.md) for scientific validation status, [`USNO.md`](docs/USNO.md) for the U.S. Naval Observatory accuracy report (41/41 tests passing, ≤0.6 min rise/set accuracy across 3 continents + polar/equatorial/8849m edge cases), and the FINK/ZTF sHG1G2 validation (100% match at 0.025 mag against the phunk production pipeline).
@@ -647,13 +647,17 @@ happens.
 | IERS Earth-orientation data | `remote.IERSFinals2000A` | ~3.7 MB | `iers.FetchNow`/`FetchIfStale` |
 | OpenNGC catalog CSVs | `remote.OpenNGC` | ~2 MB combined | `catalog.NewResolver(catalog.OpenNGC, ...)` |
 
+For an accuracy/offline tradeoff comparison across `ephemeris.Default()` and the
+JPL kernels above, see the [`ephemeris` package doc](ephemeris/doc.go)'s
+"Choosing a Provider" section.
+
 Both IERS and OpenNGC skip the download entirely when the upstream content hasn't
 changed since the last fetch — a HEAD-request content check (ETag/Content-Length)
 against what was cached, not a wall-clock expiration window, since the two sources
 mutate on their own schedules rather than yours.
 
 Catalog resolvers (`catalog/simbad`, `catalog/gaia`, `catalog/vizier`, `catalog/mast`,
-`catalog/sbdb`, `catalog/norad`, `catalog/fink`) and `lightpollution` make small
+`catalog/sbdb`, `catalog/norad`, `catalog/fink`) and `skybrightness/lpmap` make small
 request/response API calls, not bulk downloads — those are gated by endpoint
 enable/disable and offline mode, not by download-size consent (the network call itself
 is the explicit purpose of the method you're calling).

--- a/catalog/example_test.go
+++ b/catalog/example_test.go
@@ -32,7 +32,7 @@ func TestIntegration(t *testing.T) {
 	// Let's create an Observatory on Earth (e.g. at Mauna Kea)
 	loc, _ := coord.NewGeodetic(angle.Deg(-155.4681), angle.Deg(19.8206), 4205.0)
 
-	obs, err := plan.NewSite("Mauna Kea", loc, angle.Deg(0), nil)
+	obs, err := plan.NewSite("Mauna Kea", loc, nil)
 	if err != nil {
 		t.Fatalf("Failed to create site: %v", err)
 	}

--- a/docs/JESUS.md
+++ b/docs/JESUS.md
@@ -582,7 +582,7 @@ glowing with a dull reddish-copper hue.
 ```go
 // Compute moonrise over Jerusalem on April 3, AD 33
 loc, _ := coord.NewGeodetic(angle.Deg(31.7683), angle.Deg(35.2137), 780.0)
-site, _ := plan.NewSite("Jerusalem", loc, angle.Deg(0), time.LocationUTC)
+site, _ := plan.NewSite("Jerusalem", loc, time.LocationUTC)
 
 dayStart := time.Date(33, time.April, 3, 12, 0, 0, 0, time.LocationUTC)
 dayEnd   := time.Date(33, time.April, 3, 20, 0, 0, 0, time.LocationUTC)

--- a/docs/PLANET_PARADE.md
+++ b/docs/PLANET_PARADE.md
@@ -117,7 +117,7 @@ prov, _ := eph.NewProvider(eph.Planets, "de442")
 defer prov.Close()
 
 loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-site, _ := plan.NewSite("São Paulo", loc, angle.Zero(), brtz)
+site, _ := plan.NewSite("São Paulo", loc, brtz)
 
 day := time.Date(2025, 2, 28, 0, 0, 0, 0, brtz)
 next := day.Add(24 * time.Hour)

--- a/ephemeris/doc.go
+++ b/ephemeris/doc.go
@@ -33,6 +33,28 @@
 //   - Sun: IAU 2000 Earth ephemeris (Epv00), providing ~0.1″ solar accuracy.
 //   - Moon: Meeus 1998 algorithm (Moon98), providing geocentric GCRS-like state.
 //
+// # Choosing a Provider
+//
+// [Default] needs no download and no [context.Context] consent step, at the
+// cost of accuracy. A JPL kernel via [NewProvider] is sub-arcsecond (validated
+// against JPL Horizons, see docs/VALIDATION.md) but requires a one-time,
+// consent-gated download (see the remote package doc for the consent gate).
+// de440s/de440/de442/de441 do not differ from each other in accuracy — only
+// in time-span coverage and file size; the real accuracy jump is
+// [Default] versus any JPL kernel:
+//
+//	Provider                    Accuracy                    Size         Download
+//	Default()                   ~0.1″ solar (Sun); Moon      built-in     not needed
+//	                             via Meeus 1998, not JPL-grade
+//	NewProvider(…, "de440s")     sub-arcsecond vs. Horizons   ~32 MB       one-time
+//	NewProvider(…, "de440")      same fidelity, wider span    ~115 MB      one-time
+//	NewProvider(…, "de442")      same fidelity, wider span    ~115 MB      one-time
+//	NewProvider(…, "de441_…")    same fidelity, millennia     multi-GB/part one-time
+//
+// Default to de440s once JPL-grade positions are needed; reach for de440/de442
+// only when a request spans centuries beyond de440s's coverage, and de441
+// only for millennia-scale work.
+//
 // # Coordinates and Frames
 //
 // Providers return [State] vectors (position and velocity) in astronomical units

--- a/ephemeris/ephemeris_test.go
+++ b/ephemeris/ephemeris_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSunAltitudeMovement(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := plan.NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := plan.NewSite("Test", loc, nil)
 	p := eph.Default()
 
 	// Noon (roughly) at long 0

--- a/examples/02_target_visibility/main.go
+++ b/examples/02_target_visibility/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	// 1. Setup Observatory (São Paulo, Brazil)
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// 2. Define Constraints: The target must be above 30 degrees altitude
 	constraints := []plan.Constraint{

--- a/examples/03_rise_transit_set/main.go
+++ b/examples/03_rise_transit_set/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	// 1. Setup Observatory (São Paulo, Brazil)
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// 2. Set a Deep Space Target
 	sirius, err := catalog.NewResolver(catalog.SIMBAD).Resolve("Sirius")

--- a/examples/06_tiny_plan/main.go
+++ b/examples/06_tiny_plan/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	// 1. Setup Observatory (São Paulo, Brazil)
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// Ensure targets are at least 20 degrees above the horizon
 	planner, _ := plan.NewPlanner(site, []plan.Constraint{plan.Altitude{Threshold: angle.Deg(20)}})

--- a/examples/07_slew_time/main.go
+++ b/examples/07_slew_time/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	// 1. Setup Observatory (São Paulo, Brazil)
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// 2. Define our Transition Model representing the telescope's physical properties
 	model := &plan.BasicTransitionModel{

--- a/examples/09_geometry_events/main.go
+++ b/examples/09_geometry_events/main.go
@@ -48,7 +48,7 @@ func main() {
 	// Geocentric Events (like Full Moon syzygy) do not depend on the observer to occur,
 	// but we can map the generated event timestamp against an observer to see if the event is visible locally!
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760) // São Paulo
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// ----------------------------------------------------
 	// Conjunction: Mars and Venus having the same Right Ascension

--- a/examples/10_jesus_christ/eclipse/main.go
+++ b/examples/10_jesus_christ/eclipse/main.go
@@ -47,7 +47,7 @@ func main() {
 		panic(err)
 	}
 
-	site, err := plan.NewSite("Jerusalem", loc, angle.Deg(0), time.LocationUTC)
+	site, err := plan.NewSite("Jerusalem", loc, time.LocationUTC)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/10_jesus_christ/herod/main.go
+++ b/examples/10_jesus_christ/herod/main.go
@@ -44,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	site, err := plan.NewSite("Jerusalem", loc, angle.Deg(0), time.LocationUTC)
+	site, err := plan.NewSite("Jerusalem", loc, time.LocationUTC)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/13_crescent_visibility/main.go
+++ b/examples/13_crescent_visibility/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	// ── Observer: São Paulo, Brazil ──────────────────────────────────────
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	prov := eph.Default()
 

--- a/examples/14_target_scoring/main.go
+++ b/examples/14_target_scoring/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	// ── Observatory: São Paulo (-23.5505°, -46.6333°, 760m) ─────────────
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, nil)
+	site, _ := plan.NewSite("São Paulo", loc, nil)
 
 	// ── Observation epoch: 2026-04-15 at local midnight ──────────────────
 	tz, _ := time.LoadLocation("America/Sao_Paulo")

--- a/examples/16_planet_parade/main.go
+++ b/examples/16_planet_parade/main.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
@@ -60,7 +59,7 @@ func main() {
 	}
 
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, angle.Zero(), brtz)
+	site, _ := plan.NewSite("São Paulo", loc, brtz)
 	atm := atmosphere.AtAltitude(760)
 
 	planets := []planetDef{

--- a/examples/17_equinox_prediction/main.go
+++ b/examples/17_equinox_prediction/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
@@ -210,7 +209,7 @@ func main() {
 	moonTarget := plan.NewMoon(prov)
 	now := events26[0].Time // Use the actual vernal equinox moment
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760.0)
-	site, _ := plan.NewSite("São Paulo", loc, angle.Zero(), brtz)
+	site, _ := plan.NewSite("São Paulo", loc, brtz)
 	atm := atmosphere.AtAltitude(760)
 	ctx := coord.NewContext(now, loc, atm)
 

--- a/examples/18_sky_brightness/main.go
+++ b/examples/18_sky_brightness/main.go
@@ -19,10 +19,10 @@ import (
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
-	"github.com/TuSKan/astrogo/lightpollution"
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/skybrightness/lpmap"
 	"github.com/TuSKan/astrogo/time"
 )
 
@@ -30,7 +30,7 @@ func main() {
 	// ── Observatory: São Paulo ───────────────────────────────────────────
 	tz, _ := time.LoadLocation("America/Sao_Paulo")
 	loc, _ := coord.NewEarthLocation(-23.5505, -46.6333, 760)
-	site, _ := plan.NewSite("São Paulo", loc, 0, tz)
+	site, _ := plan.NewSite("São Paulo", loc, tz)
 
 	// JPL kernel downloads are opt-in — see README "Data downloads &
 	// offline usage". de442 is ~115 MB; naif0012.tls (leap seconds) ~5 KB.
@@ -83,7 +83,7 @@ func main() {
 		skybrightness.NewZodiacalLight(provider),
 	}
 
-	if floor, err := lightpollution.New().Floor(context.Background(), -23.5505, -46.6333); err == nil {
+	if floor, err := lpmap.New().Floor(context.Background(), -23.5505, -46.6333); err == nil {
 		sqm, _ := floor.Radiance(coord.NewAltAz(angle.Deg(90), angle.Deg(0)), nil)
 		fmt.Printf("\n  Discovered São Paulo light-pollution floor: %.2f V mag/arcsec² (Falchi 2015)\n",
 			float64(sqm.SurfaceBrightnessV()))

--- a/fits/plan/plan.go
+++ b/fits/plan/plan.go
@@ -35,7 +35,7 @@ func SiteFromFITS(h *fits.Header) (*plan.Site, error) {
 	}
 
 	// Assuming 0 horizon limitation as standard ingestion
-	site, err := plan.NewSite(obsName, geodetic, angle.Deg(0), nil)
+	site, err := plan.NewSite(obsName, geodetic, nil)
 	if err != nil {
 		return nil, fmt.Errorf("fits/plan: new site: %w", err)
 	}

--- a/plan/bench_test.go
+++ b/plan/bench_test.go
@@ -29,7 +29,7 @@ func (m benchMock) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, er
 
 func BenchmarkVisibleIntervals(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(0), angle.Deg(45))}
 	start := atime.FromJD(2460000.0, atime.UTC)
 	end := start.AddDays(1.0)
@@ -43,7 +43,7 @@ func BenchmarkVisibleIntervals(b *testing.B) {
 
 func BenchmarkVisibleIntervals_1MinStep(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(0), angle.Deg(45))}
 	start := atime.FromJD(2460000.0, atime.UTC)
 	end := start.AddDays(1.0)
@@ -59,7 +59,7 @@ func BenchmarkVisibleIntervals_1MinStep(b *testing.B) {
 
 func BenchmarkEventSolver_Visibility(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(0))
 	start := atime.FromJD(2451545.0, atime.UTC)
 	end := start.Add(24 * atime.Hour)
@@ -83,7 +83,7 @@ func BenchmarkEventSolver_Visibility(b *testing.B) {
 
 func BenchmarkObservableWindows(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
 	start := atime.FromJD(2451545.0, atime.UTC)
 	end := start.Add(12 * atime.Hour)
@@ -117,7 +117,7 @@ func benchScheduler(b *testing.B, n int, strategy Strategy) {
 	b.Helper()
 
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Bench", loc, angle.Zero(), nil)
+	site, _ := NewSite("Bench", loc, nil)
 	planner, _ := NewPlanner(site, nil)
 	tm := &BasicTransitionModel{BaseSetup: 0}
 	blocks := makeBlocks(n)
@@ -172,7 +172,7 @@ func BenchmarkSwapOptimized_100(b *testing.B) {
 
 func BenchmarkTransitEstimate(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(100), angle.Deg(20))}
 	start := atime.FromJD(2460000.0, atime.UTC)
 	end := start.AddDays(0.5)

--- a/plan/constraint_test.go
+++ b/plan/constraint_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestConstraints(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	// Equinox 2000
 	tm := time.FromJD(2451545.0, time.UTC)
 
@@ -58,7 +58,7 @@ func TestConstraints(t *testing.T) {
 
 func TestSunMoonConstraints(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	// Night time (Sun below horizon)
 	tmNight := time.FromJD(2451545.5, time.UTC)

--- a/plan/details.go
+++ b/plan/details.go
@@ -289,7 +289,7 @@ func applyProps(d *TargetDetails, props []string) {
 // fillRiseSetTransit finds the next rise, set, and transit events within
 // ±12/+24 hours of the context time.
 func fillRiseSetTransit(d *TargetDetails, obs Observable, ctx *coord.Context) {
-	site, err := NewSite("Observer", ctx.Site(), angle.Deg(0), nil)
+	site, err := NewSite("Observer", ctx.Site(), nil)
 	if err != nil {
 		// No valid location to compute rise/set/transit against; leave
 		// those fields unset rather than proceed with a broken Observer.

--- a/plan/details_test.go
+++ b/plan/details_test.go
@@ -21,7 +21,7 @@ func TestGetDetails_Star(t *testing.T) {
 	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	testutil.AssertNoError(t, err)
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	testutil.AssertNoError(t, err)
 
 	tm := time.FromJD(2451545.0, time.UTC) // J2000
@@ -81,7 +81,7 @@ func TestGetDetails_DeepSkyObject(t *testing.T) {
 	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	testutil.AssertNoError(t, err)
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	testutil.AssertNoError(t, err)
 
 	tm := time.FromJD(2451545.0, time.UTC)
@@ -107,7 +107,7 @@ func TestGetDetails_MovingBody(t *testing.T) {
 	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	testutil.AssertNoError(t, err)
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	testutil.AssertNoError(t, err)
 
 	tm := time.FromJD(2451545.0, time.UTC)
@@ -145,7 +145,7 @@ func TestGetDetails_String(t *testing.T) {
 	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	testutil.AssertNoError(t, err)
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	testutil.AssertNoError(t, err)
 
 	tm := time.FromJD(2451545.0, time.UTC)

--- a/plan/doc.go
+++ b/plan/doc.go
@@ -7,6 +7,41 @@
 // It also features a full scheduling engine for generating observation timelines
 // subject to constraints, slew transitions, and dynamical block prioritizations.
 //
+// # Finding what you need
+//
+// The exported surface is large; here's a task-oriented index instead of an
+// alphabetical one:
+//
+//   - Site & observatory setup — [NewSite], [Site]
+//   - Targets to observe — [Planet] (via [NewSun]...[NewPluto], [NewPlanet]),
+//     [Star] (via [NewStar]), [Asteroid] (via [NewAsteroid]), [Comet] (via
+//     [NewComet]), [DeepSkyObject] (via [NewDeepSkyObject]), [Satellite] (via
+//     [NewSatellite]), [GenericBody] (via [NewGenericBody]), [FromCatalog];
+//     all implement [Observable]/[MovingBody]/[MagnitudeComputer]
+//   - Rise/set/twilight times — [SunEvents]/[SunriseSunset],
+//     [MoonEvents]/[MoonriseMoonset], [TwilightEvents], [CivilDawnDusk],
+//     [NauticalDawnDusk], [AstronomicalDawnDusk]
+//   - Observability windows & scoring — [VisibilityEvents], [IsObservable],
+//     [ScoreObservable], [RankObservables], [ObservableWindows],
+//     [Constraint] ([Altitude], [Airmass], [Sun], [MoonSep]),
+//     [LimitingMagnitudeConstraint], [ScoreObservableSky]
+//   - Geometric events — [Conjunctions], [ConjunctionsEcliptic], [Appulses],
+//     [Oppositions], [GreatestElongations], [FullMoonOppositions]
+//   - Moon phases, seasons, eclipses — [MoonPhases], [MoonIllumination],
+//     [Seasons], [Apsides], [LunarEclipses], [SolarEclipses], [NextNewMoon],
+//     [NextFullMoon]
+//   - Lunar crescent visibility — [NewCrescentParams]/[CrescentParams], whose
+//     methods (Yallop, Odeh, Qureshi, Fotheringham, Danjon, MABIMS1995,
+//     MABIMS2021, and more) implement the 20 published criteria;
+//     [CrescentParams.EvaluateAll] runs all of them at once into a
+//     [CrescentResult]
+//   - Scheduling — [Scheduler]/[NewScheduler], [Strategy]
+//     ([GreedyStrategy]/[PriorityStrategy]/[SwapOptimizedStrategy]),
+//     [TransitionModel], [Block]/[Schedule]
+//   - Satellite passes — [SatellitePasses], [LookAngle]
+//   - Low-level event solving (for custom event families) — [EventSolver],
+//     [Solver]/[DefaultSolver], [CrossesTarget]/[CrossesIncreasing]
+//
 // # Refinement
 //
 // The EventSolver uses a two-stage approach: a coarse sampling pass followed

--- a/plan/events_convenience_test.go
+++ b/plan/events_convenience_test.go
@@ -166,7 +166,7 @@ func TestVisibilityEvents_Star(t *testing.T) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	site, err := NewSite("São Paulo", loc, angle.Zero(), nil)
+	site, err := NewSite("São Paulo", loc, nil)
 	if err != nil {
 		t.Fatalf("NewSite: %v", err)
 	}

--- a/plan/events_test.go
+++ b/plan/events_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestEventSolver_Visibility_Fixed(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(0))
 
 	start := time.FromJD(2451545.0, time.UTC)
@@ -53,7 +53,7 @@ func TestEventSolver_Visibility_Fixed(t *testing.T) {
 
 func TestEventSolver_Visibility_Circumpolar(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(80))
 
 	start := time.FromJD(2451545.0, time.UTC)
@@ -78,7 +78,7 @@ func TestEventSolver_Visibility_Circumpolar(t *testing.T) {
 
 func TestEventSolver_Visibility_NeverVisible(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(-80))
 
 	start := time.FromJD(2451545.0, time.UTC)
@@ -105,7 +105,7 @@ func TestEventSolver_Visibility_NeverVisible(t *testing.T) {
 
 func TestSunEvents(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(40), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451544.5, time.UTC)
@@ -138,7 +138,7 @@ func TestSunEvents(t *testing.T) {
 
 func TestSunEvents_Polar(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(80), 0)
-	site, _ := NewSite("Arctic", loc, angle.Zero(), nil)
+	site, _ := NewSite("Arctic", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451727.5, time.UTC)
@@ -156,7 +156,7 @@ func TestSunEvents_Polar(t *testing.T) {
 
 func TestMoonEvents(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(40), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451545.0, time.UTC)
@@ -174,7 +174,7 @@ func TestMoonEvents(t *testing.T) {
 
 func TestSunriseSunset(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(40), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451544.5, time.UTC)
@@ -192,7 +192,7 @@ func TestSunriseSunset(t *testing.T) {
 
 func TestTwilightEvents(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(40), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451544.5, time.UTC)
@@ -228,7 +228,7 @@ func TestTwilightEvents(t *testing.T) {
 
 func TestTwilight_Sequence(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(40), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451544.5, time.UTC)
@@ -266,7 +266,7 @@ func TestTwilight_Sequence(t *testing.T) {
 
 func TestTwilight_HighLat(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(51.5), 0)
-	site, _ := NewSite("London", loc, angle.Zero(), nil)
+	site, _ := NewSite("London", loc, nil)
 	eph := eph.Default()
 
 	start := time.FromJD(2451727.5, time.UTC)
@@ -284,7 +284,7 @@ func TestTwilight_HighLat(t *testing.T) {
 
 func BenchmarkEventSolver(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(0))
 	start := time.FromJD(2451545.0, time.UTC)
 	end := start.Add(24 * time.Hour)

--- a/plan/example_test.go
+++ b/plan/example_test.go
@@ -13,7 +13,7 @@ import (
 func ExamplePlanner_Observable() {
 	// Setup observatory
 	loc, _ := coord.NewGeodetic(angle.Deg(-70), angle.Deg(-30), 2400) // Chile
-	site, _ := NewSite("Paranal", loc, angle.Zero(), nil)
+	site, _ := NewSite("Paranal", loc, nil)
 
 	// Constraints
 	constraints := []Constraint{
@@ -42,7 +42,7 @@ func ExamplePlanner_Observable() {
 
 func ExampleObservableWindows() {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Greenwich", loc, angle.Zero(), nil)
+	site, _ := NewSite("Greenwich", loc, nil)
 
 	// Target at Zenith initially (J2000 Noon LST ~18.69h)
 	obj := NewStar("ZenithTarget", angle.Hour(18.69), angle.Zero())
@@ -66,7 +66,7 @@ func ExampleObservableWindows() {
 
 func ExampleRankObservables() {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	tm := time.FromJD(2451545.0, time.UTC) // J2000 Noon
 
 	obj1 := NewStar("NearZenith", angle.Hour(18.69), angle.Deg(0))

--- a/plan/moving_bodies_test.go
+++ b/plan/moving_bodies_test.go
@@ -61,7 +61,7 @@ func testContext(t *testing.T) *coord.Context {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	if err != nil {
 		t.Fatalf("NewSite: %v", err)
 	}

--- a/plan/observatory.go
+++ b/plan/observatory.go
@@ -28,26 +28,41 @@ type Site struct {
 	horizon  angle.Angle
 }
 
+// SiteOption configures optional NewSite parameters.
+type SiteOption func(*Site)
+
+// WithHorizon sets the site's local horizon limit (e.g., 0 deg for ideal,
+// 20 deg for trees/hills). Defaults to angle.Zero() if omitted.
+func WithHorizon(h angle.Angle) SiteOption {
+	return func(s *Site) { s.horizon = h }
+}
+
 // NewSite creates a new observing site with validation.
 // name: A human-readable name for the site.
 // loc: The geodetic location (longitude, latitude, height).
-// horizon: The local horizon limit (e.g., 0 deg for ideal, 20 deg for trees/hills).
 // tz: The local time zone (optional, can be nil).
-func NewSite(name string, loc *coord.Geodetic, horizon angle.Angle, tz *time.Location) (*Site, error) {
+// opts: optional parameters — see WithHorizon.
+func NewSite(name string, loc *coord.Geodetic, tz *time.Location, opts ...SiteOption) (*Site, error) {
 	if loc == nil {
 		return nil, ErrNilLocation
 	}
 
-	if horizon.Degrees() < -90 || horizon.Degrees() > 90 {
+	s := &Site{
+		name:     name,
+		location: loc,
+		horizon:  angle.Zero(),
+		timeZone: tz,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	if s.horizon.Degrees() < -90 || s.horizon.Degrees() > 90 {
 		return nil, ErrInvalidHorizon
 	}
 
-	return &Site{
-		name:     name,
-		location: loc,
-		horizon:  horizon,
-		timeZone: tz,
-	}, nil
+	return s, nil
 }
 
 // Name returns the site's human-readable name.
@@ -170,7 +185,7 @@ func (s *Site) Equal(other *Site) bool {
 
 // WithHorizon returns a copy of s with the given horizon limit.
 func (s *Site) WithHorizon(h angle.Angle) (*Site, error) {
-	return NewSite(s.name, s.location, h, s.timeZone)
+	return NewSite(s.name, s.location, s.timeZone, WithHorizon(h))
 }
 
 // WithTimeZone returns a copy of s with the given time zone.

--- a/plan/observatory_test.go
+++ b/plan/observatory_test.go
@@ -16,7 +16,7 @@ func TestNewSite(t *testing.T) {
 	tz, _ := time.LoadLocation("Europe/Rome")
 	horizon := angle.Deg(20)
 
-	site, err := NewSite("My Observatory", loc, horizon, tz)
+	site, err := NewSite("My Observatory", loc, tz, WithHorizon(horizon))
 	testutil.AssertNoError(t, err)
 
 	testutil.AssertEqual(t, "Name", site.Name(), "My Observatory")
@@ -29,7 +29,7 @@ func TestNewSite(t *testing.T) {
 
 func TestDefaultTimeZone(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(0), 0)
-	site, _ := NewSite("UTC Site", loc, angle.Zero(), nil)
+	site, _ := NewSite("UTC Site", loc, nil)
 
 	testutil.AssertEqual(t, "Default TZ", site.TimeZone().String(), "UTC")
 }
@@ -37,19 +37,19 @@ func TestDefaultTimeZone(t *testing.T) {
 func TestInvalidHorizon(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(0), 0)
 
-	_, err := NewSite("Bad Horizon", loc, angle.Deg(100), nil)
+	_, err := NewSite("Bad Horizon", loc, nil, WithHorizon(angle.Deg(100)))
 	if !errors.Is(err, ErrInvalidHorizon) {
 		t.Errorf("Expected ErrInvalidHorizon, got %v", err)
 	}
 
-	_, err = NewSite("Bad Horizon Low", loc, angle.Deg(-95), nil)
+	_, err = NewSite("Bad Horizon Low", loc, nil, WithHorizon(angle.Deg(-95)))
 	if !errors.Is(err, ErrInvalidHorizon) {
 		t.Errorf("Expected ErrInvalidHorizon, got %v", err)
 	}
 }
 
 func TestNilLocation(t *testing.T) {
-	_, err := NewSite("No Location", nil, angle.Zero(), nil)
+	_, err := NewSite("No Location", nil, nil)
 	if !errors.Is(err, ErrNilLocation) {
 		t.Errorf("Expected ErrNilLocation, got %v", err)
 	}
@@ -57,7 +57,7 @@ func TestNilLocation(t *testing.T) {
 
 func TestString(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(10), angle.Deg(45), 500)
-	site, _ := NewSite("Test", loc, angle.Deg(20), nil)
+	site, _ := NewSite("Test", loc, nil, WithHorizon(angle.Deg(20)))
 
 	s := site.String()
 	if s == "" {
@@ -67,9 +67,9 @@ func TestString(t *testing.T) {
 
 func TestSiteEqual(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(10), angle.Deg(45), 500)
-	a, _ := NewSite("Test", loc, angle.Deg(20), nil)
-	b, _ := NewSite("Test", loc, angle.Deg(20), nil)
-	c, _ := NewSite("Other", loc, angle.Deg(20), nil)
+	a, _ := NewSite("Test", loc, nil, WithHorizon(angle.Deg(20)))
+	b, _ := NewSite("Test", loc, nil, WithHorizon(angle.Deg(20)))
+	c, _ := NewSite("Other", loc, nil, WithHorizon(angle.Deg(20)))
 
 	if !a.Equal(b) {
 		t.Error("identical sites should be equal")
@@ -82,7 +82,7 @@ func TestSiteEqual(t *testing.T) {
 
 func TestWithHorizon(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(0), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	s2, err := site.WithHorizon(angle.Deg(15))
 	testutil.AssertNoError(t, err)
@@ -97,7 +97,7 @@ func TestLocalSiderealTime(t *testing.T) {
 	// Greenwich (lon=0) at J2000.0 (2000-01-01 12:00:00 UTC = JD 2451545.0)
 	// GAST at J2000.0 is approximately 18.697 hours = 280.46 degrees
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(51.5), 0) // Greenwich
-	site, _ := NewSite("Greenwich", loc, angle.Zero(), nil)
+	site, _ := NewSite("Greenwich", loc, nil)
 
 	tm := time.FromJD(2451545.0, time.UTC)
 

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -17,7 +17,7 @@ import (
 func TestPlanner(t *testing.T) {
 	// North Pole makes Alt = Dec (independent of LST)
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(90), 0)
-	site, _ := NewSite("Test", loc, angle.Deg(0), nil)
+	site, _ := NewSite("Test", loc, nil)
 	constraints := []Constraint{
 		Altitude{Threshold: angle.Deg(30)},
 	}
@@ -42,7 +42,7 @@ func TestPlanner(t *testing.T) {
 
 func TestObservableWindows_Fixed(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	// Target at zenith at Greenwich J2000 (LST ~18.69h)
 	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
@@ -74,7 +74,7 @@ func TestObservableWindows_Fixed(t *testing.T) {
 
 func TestObservableWindows_Moving(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	sun := NewSun(eph.Default())
 
@@ -111,7 +111,7 @@ func (f *flipConstraint) Check(_ Observable, _ time.Time, _ *Site) (Result, erro
 
 func TestObservableWindows_Grouping(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()
@@ -140,7 +140,7 @@ func TestObservableWindows_Grouping(t *testing.T) {
 
 func TestIsObservable(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	// Equinox 2000 noon
 	tm := time.FromJD(2451545.0, time.UTC)
 
@@ -208,7 +208,7 @@ func TestIsObservable(t *testing.T) {
 
 func TestScoreObservable(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	tm := time.FromJD(2451545.0, time.UTC) // J2000 Noon (LST ~18.69h)
 
 	t.Run("AltitudeScoring", func(t *testing.T) {
@@ -279,7 +279,7 @@ func (p prioritizedTarget) Priority() float64 { return p.priority }
 
 func TestRankObservables(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	tm := time.FromJD(2451545.0, time.UTC)
 
 	t.Run("RankingStability", func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestRankObservables(t *testing.T) {
 
 func TestObservableWindows_StepTooLarge(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()
@@ -336,7 +336,7 @@ func TestObservableWindows_StepTooLarge(t *testing.T) {
 
 func TestObservableWindows_StepNotPositive(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()

--- a/plan/satellite_test.go
+++ b/plan/satellite_test.go
@@ -77,7 +77,7 @@ func TestPlanSatellite_PositionAndDetails(t *testing.T) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	site, err := NewSite("São Paulo", loc, angle.Zero(), nil)
+	site, err := NewSite("São Paulo", loc, nil)
 	if err != nil {
 		t.Fatalf("NewSite: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestPlanSatellite_ApparentMagnitudeRequiresContext(t *testing.T) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	site, err := NewSite("São Paulo", loc, angle.Zero(), nil)
+	site, err := NewSite("São Paulo", loc, nil)
 	if err != nil {
 		t.Fatalf("NewSite: %v", err)
 	}

--- a/plan/schedule_example_test.go
+++ b/plan/schedule_example_test.go
@@ -11,7 +11,7 @@ import (
 func ExampleScheduler_BuildSchedule() {
 	// Setup observatory and planner constraints
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Greenwich", loc, angle.Zero(), nil)
+	site, _ := NewSite("Greenwich", loc, nil)
 	planner, _ := NewPlanner(site, []Constraint{Altitude{Threshold: angle.Deg(30)}})
 
 	// Configure transition overheads (slew speeds, filter changes)

--- a/plan/scheduler_test.go
+++ b/plan/scheduler_test.go
@@ -20,7 +20,7 @@ func (m mockConstraint) Check(_ Observable, _ time.Time, _ *Site) (Result, error
 func TestSchedulerAndStrategies(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 
-	site, err := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, err := NewSite("TestSite", loc, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/plan/skybrightness_test.go
+++ b/plan/skybrightness_test.go
@@ -17,7 +17,7 @@ func skyTestFixture(t *testing.T) (*Site, time.Time, *coord.Context) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	if err != nil {
 		t.Fatalf("NewSite: %v", err)
 	}

--- a/plan/strategy_test.go
+++ b/plan/strategy_test.go
@@ -13,7 +13,7 @@ import (
 func TestSwapOptimizedStrategy(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 
-	site, err := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, err := NewSite("TestSite", loc, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestSwapOptimizedStrategy(t *testing.T) {
 func TestSwapOptimizedGapInsertion(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 
-	site, err := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, err := NewSite("TestSite", loc, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestEmptyScheduleGaps(t *testing.T) {
 // TestSwapOptimizedWithNilBase verifies the default base strategy fallback.
 func TestSwapOptimizedWithNilBase(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, _ := NewSite("TestSite", loc, nil)
 	planner, _ := NewPlanner(site, nil)
 
 	tm := &BasicTransitionModel{BaseSetup: 0}
@@ -215,7 +215,7 @@ func TestSwapOptimizedWithNilBase(t *testing.T) {
 // TestScoreBlockPlacement verifies that scoring uses altitude + priority.
 func TestScoreBlockPlacement(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	planner, _ := NewPlanner(site, nil)
 
 	b := &Block{

--- a/plan/transition_test.go
+++ b/plan/transition_test.go
@@ -11,7 +11,7 @@ import (
 func TestBasicTransitionModel(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 
-	site, err := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, err := NewSite("TestSite", loc, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBasicTransitionModel_SameEpoch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	site, err := NewSite("TestSite", loc, angle.Zero(), nil)
+	site, err := NewSite("TestSite", loc, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/plan/usno_test.go
+++ b/plan/usno_test.go
@@ -279,7 +279,7 @@ func TestUSNO_SunMoonOneDay(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to create geodetic: %v", err)
 				}
-				site, err := plan.NewSite(loc.Name, geodetic, angle.Zero(), tz)
+				site, err := plan.NewSite(loc.Name, geodetic, tz)
 				if err != nil {
 					t.Fatalf("Failed to create site: %v", err)
 				}
@@ -411,7 +411,7 @@ func TestUSNO_CelNav(t *testing.T) {
 	tm := time.Date(2026, time.April, 6, 21, 0, 0, 0, time.LocationUTC)
 	geodetic, _ := coord.NewGeodetic(angle.Deg(-46.6525), angle.Deg(-23.600833), 0)
 	tz, _ := time.LoadLocation("America/Sao_Paulo")
-	site, _ := plan.NewSite("São Paulo", geodetic, angle.Zero(), tz)
+	site, _ := plan.NewSite("São Paulo", geodetic, tz)
 	ctx := coord.NewContext(tm, site.Location(), site.Atmosphere())
 
 	// Validate Sun position
@@ -658,7 +658,7 @@ func TestUSNO_SiderealTime(t *testing.T) {
 
 	tz, _ := time.LoadLocation("America/Sao_Paulo")
 	geodetic, _ := coord.NewGeodetic(angle.Deg(-46.6525), angle.Deg(-23.600833), 786)
-	site, _ := plan.NewSite("São Paulo", geodetic, angle.Zero(), tz)
+	site, _ := plan.NewSite("São Paulo", geodetic, tz)
 
 	testTimes := []struct {
 		name string
@@ -914,7 +914,7 @@ func TestUSNO_PolarSun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create geodetic: %v", err)
 			}
-			site, err := plan.NewSite(loc.Name, geodetic, angle.Zero(), time.LocationUTC)
+			site, err := plan.NewSite(loc.Name, geodetic, time.LocationUTC)
 			if err != nil {
 				t.Fatalf("Failed to create site: %v", err)
 			}
@@ -1035,10 +1035,10 @@ func TestUSNO_HighAltitude(t *testing.T) {
 
 			// Build sites at sea level AND at summit
 			geodetic0, _ := coord.NewGeodetic(angle.Deg(loc.Lon), angle.Deg(loc.Lat), 0)
-			site0, _ := plan.NewSite(loc.Name+" (0m)", geodetic0, angle.Zero(), tz)
+			site0, _ := plan.NewSite(loc.Name+" (0m)", geodetic0, tz)
 
 			geodetic, _ := coord.NewGeodetic(angle.Deg(loc.Lon), angle.Deg(loc.Lat), loc.Height)
-			site, _ := plan.NewSite(loc.Name+" (8849m)", geodetic, angle.Zero(), tz)
+			site, _ := plan.NewSite(loc.Name+" (8849m)", geodetic, tz)
 
 			t.Logf("Horizon dip (8849m): %.4f°", site.HorizonDip().Degrees())
 			t.Logf("Sun threshold (0m):    %.4f°", site0.SunRiseSetThreshold().Degrees())
@@ -1218,7 +1218,7 @@ func TestUSNO_Equator(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create geodetic: %v", err)
 			}
-			site, err := plan.NewSite(loc.Name, geodetic, angle.Zero(), time.LocationUTC)
+			site, err := plan.NewSite(loc.Name, geodetic, time.LocationUTC)
 			if err != nil {
 				t.Fatalf("Failed to create site: %v", err)
 			}
@@ -1386,7 +1386,7 @@ func TestUSNO_PolarMoon(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create geodetic: %v", err)
 			}
-			site, err := plan.NewSite(loc.Name, geodetic, angle.Zero(), tz)
+			site, err := plan.NewSite(loc.Name, geodetic, tz)
 			if err != nil {
 				t.Fatalf("Failed to create site: %v", err)
 			}
@@ -1516,7 +1516,7 @@ func TestUSNO_CelNav_EdgeCases(t *testing.T) {
 
 			tm := time.Date(y, time.Month(mo), d, h, m, s, 0, time.LocationUTC)
 			geodetic, _ := coord.NewGeodetic(angle.Deg(tc.lon), angle.Deg(tc.lat), tc.height)
-			site, _ := plan.NewSite("test", geodetic, angle.Zero(), time.LocationUTC)
+			site, _ := plan.NewSite("test", geodetic, time.LocationUTC)
 			ctx := coord.NewContext(tm, site.Location(), site.Atmosphere())
 
 			prov := newEph(t)
@@ -1609,7 +1609,7 @@ func TestUSNO_AltitudeShift(t *testing.T) {
 				t.Fatalf("Failed to create geodetic: %v", err)
 			}
 			tz, _ := time.LoadLocation("Asia/Kathmandu")
-			site, err := plan.NewSite(ac.name, geodetic, angle.Zero(), tz)
+			site, err := plan.NewSite(ac.name, geodetic, tz)
 			if err != nil {
 				t.Fatalf("Failed to create site: %v", err)
 			}

--- a/plan/visibility_test.go
+++ b/plan/visibility_test.go
@@ -34,7 +34,7 @@ func TestIsVisible(t *testing.T) {
 		t.Fatalf("Failed to create geodetic site: %v", err)
 	}
 
-	site, err := NewSite("Test", loc, angle.Zero(), nil)
+	site, err := NewSite("Test", loc, nil)
 	if err != nil {
 		t.Fatalf("Failed to create observatory: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestVisibleIntervals(t *testing.T) {
 		t.Fatalf("Failed to create geodetic site: %v", err)
 	}
 
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	start := time.FromJD(2460000.5, time.UTC)
 	end := start.AddDays(1)
@@ -74,7 +74,7 @@ func TestVisibleIntervals(t *testing.T) {
 
 func TestVisibleIntervals_StepTooLarge(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	start := time.FromJD(2460000.5, time.UTC)
 	end := start.AddDays(1)
@@ -91,7 +91,7 @@ func TestVisibleIntervals_StepTooLarge(t *testing.T) {
 
 func TestNeverVisible(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	start := time.FromJD(2460000.5, time.UTC)
 	end := start.AddDays(1)
@@ -109,7 +109,7 @@ func TestNeverVisible(t *testing.T) {
 
 func TestTransitEstimate(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 
 	start := time.FromJD(2460000.0, time.UTC)
 	end := start.AddDays(0.5)
@@ -134,7 +134,7 @@ func TestTransitEstimate(t *testing.T) {
 
 func TestFind(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
-	site, _ := NewSite("Test", loc, angle.Zero(), nil)
+	site, _ := NewSite("Test", loc, nil)
 	start := time.FromJD(2460000.0, time.UTC)
 	end := start.AddDays(1)
 	obj := mockObject{pos: coord.NewICRS(angle.Deg(100), angle.Deg(20))}

--- a/remote/fetch.go
+++ b/remote/fetch.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
 
@@ -28,6 +29,7 @@ type readCfg struct {
 	cacheName string
 	validate  func([]byte) error
 	timeout   time.Duration
+	progress  func(downloaded, total int64)
 }
 
 // ReadOption customizes a single GetFile call.
@@ -51,6 +53,13 @@ func WithValidate(f func([]byte) error) ReadOption {
 // WithDownloadTimeout overrides Endpoint.DownloadTimeout for this one call.
 func WithDownloadTimeout(d time.Duration) ReadOption {
 	return func(c *readCfg) { c.timeout = d }
+}
+
+// WithProgress registers a callback invoked as a download progresses, with
+// the bytes transferred so far and the total (0 if unknown, e.g. no
+// Content-Length header). Never called for a cache hit.
+func WithProgress(f func(downloaded, total int64)) ReadOption {
+	return func(c *readCfg) { c.progress = f }
 }
 
 // GetFile ensures endpoint id's content at path is present and valid in
@@ -114,7 +123,13 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 		timeout = DefaultDownloadTimeout
 	}
 
-	if err := fetchInto(ctx, id, name, cacheFile, timeout, cfg.validate); err != nil {
+	if ep.ApproxSize == SizeVaries {
+		log.Printf("remote: downloading %s (endpoint %s, size varies)", cacheFile, id)
+	} else {
+		log.Printf("remote: downloading %s (endpoint %s, approx %d bytes)", cacheFile, id, ep.ApproxSize)
+	}
+
+	if err := fetchInto(ctx, id, name, cacheFile, timeout, cfg.validate, cfg.progress); err != nil {
 		return "", err
 	}
 
@@ -136,8 +151,9 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 // endpoint's ApproxSize, then again with the exact Content-Length once
 // response headers arrive. With validate non-nil, the full body is
 // buffered and validated before being written to dest; otherwise the
-// response streams straight through to Save.
-func fetchInto(ctx context.Context, id EndpointID, path string, dest gofs.File, timeout time.Duration, validate func([]byte) error) error {
+// response streams straight through to Save. With progress non-nil, it's
+// invoked as the body is read regardless of which of those two paths runs.
+func fetchInto(ctx context.Context, id EndpointID, path string, dest gofs.File, timeout time.Duration, validate func([]byte) error, progress func(downloaded, total int64)) error {
 	base, err := URL(id)
 	if err != nil {
 		return err
@@ -177,8 +193,18 @@ func fetchInto(ctx context.Context, id EndpointID, path string, dest gofs.File, 
 		return err
 	}
 
+	body := resp.Body
+
+	var bodyReader io.Reader = body
+
+	if progress != nil {
+		total := max(resp.ContentLength, 0)
+
+		bodyReader = &progressReader{r: body, total: total, onProgress: progress}
+	}
+
 	if validate != nil {
-		data, err := io.ReadAll(resp.Body)
+		data, err := io.ReadAll(bodyReader)
 		if err != nil {
 			return fmt.Errorf("%w: %s: %w", ErrDownloadFailed, name, err)
 		}
@@ -194,7 +220,7 @@ func fetchInto(ctx context.Context, id EndpointID, path string, dest gofs.File, 
 		return nil
 	}
 
-	if err := Save(resp.Body, dest); err != nil {
+	if err := Save(bodyReader, dest); err != nil {
 		return fmt.Errorf("%w: %w", ErrDownloadFailed, err)
 	}
 

--- a/remote/fetch_test.go
+++ b/remote/fetch_test.go
@@ -225,6 +225,90 @@ func TestGetFileWithCacheNameDiffersFromPath(t *testing.T) {
 	}
 }
 
+func TestGetFileWithProgressReportsBytesDirectSavePath(t *testing.T) {
+	cleanRemoteState(t)
+
+	const payload = "kernel-progress-payload"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	if err := SetURL(NAIFSPK, srv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	EnableDownloads(NAIFSPK, 0)
+
+	var mu sync.Mutex
+
+	var last int64
+
+	var calls int
+
+	_, err := GetFile(context.Background(), NAIFSPK, "planets/progress.bsp",
+		WithProgress(func(downloaded, _ int64) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			calls++
+			last = downloaded
+		}))
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+
+	if calls == 0 {
+		t.Fatal("WithProgress callback was never invoked")
+	}
+
+	if last != int64(len(payload)) {
+		t.Errorf("final downloaded = %d, want %d", last, len(payload))
+	}
+
+	calls = 0
+
+	if _, err := GetFile(context.Background(), NAIFSPK, "planets/progress.bsp",
+		WithProgress(func(int64, int64) { calls++ })); err != nil {
+		t.Fatalf("GetFile (cached): %v", err)
+	}
+
+	if calls != 0 {
+		t.Errorf("WithProgress must not fire on a cache hit; got %d calls", calls)
+	}
+}
+
+func TestGetFileWithProgressReportsBytesValidatedPath(t *testing.T) {
+	cleanRemoteState(t)
+
+	const payload = "leap-second-progress-payload"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	if err := SetURL(NAIFLSK, srv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	EnableDownloads(NAIFLSK, 0)
+
+	var last int64
+
+	_, err := GetFile(context.Background(), NAIFLSK, "naif0012.tls",
+		WithValidate(func([]byte) error { return nil }),
+		WithProgress(func(downloaded, _ int64) { last = downloaded }))
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+
+	if last != int64(len(payload)) {
+		t.Errorf("final downloaded = %d, want %d", last, len(payload))
+	}
+}
+
 func TestGetFileDownloadDeniedWithoutConsent(t *testing.T) {
 	cleanRemoteState(t)
 

--- a/remote/file.go
+++ b/remote/file.go
@@ -42,6 +42,27 @@ func Save(r io.Reader, dest gofs.File) error {
 	return nil
 }
 
+// progressReader wraps r, invoking onProgress after every Read that returns
+// data with the running byte count and total (0 if the total is unknown,
+// e.g. no Content-Length header).
+type progressReader struct {
+	r          io.Reader
+	total      int64
+	read       int64
+	onProgress func(downloaded, total int64)
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	if n > 0 {
+		p.read += int64(n)
+		p.onProgress(p.read, p.total)
+	}
+
+	//nolint:wrapcheck // must forward the underlying error (incl. io.EOF) unwrapped: io.Copy/io.ReadAll identity-check it via errors.Is
+	return n, err
+}
+
 // writeAtomicReader streams body into a temp file next to path and
 // atomically renames it into place — never leaving a partial file at
 // path. Used by Save for the local-filesystem destination path (go-fs's

--- a/skybrightness/atlas/doc.go
+++ b/skybrightness/atlas/doc.go
@@ -7,6 +7,10 @@
 // perform no runtime downloads: the caller supplies the data file as an
 // io.ReaderAt; this file lists the source URLs/DOIs.
 //
+// See also [github.com/TuSKan/astrogo/skybrightness/lpmap] for a live-API
+// alternative resolving the same World Atlas data with no downloaded file,
+// at the cost of requiring an API key and network access per query.
+//
 // # Quantity and conversion
 //
 // Atlases store the artificial-only zenith radiance in mcd/m². It is

--- a/skybrightness/importgraph_test.go
+++ b/skybrightness/importgraph_test.go
@@ -6,31 +6,36 @@ import (
 	"testing"
 )
 
-// TestCoreDoesNotImportAtlas enforces the layering rule that the core
-// skybrightness package (numeric, pure, no IO) must never depend on its atlas
-// sibling (file decoding, GeoTIFF). The atlas package depends on core, not the
-// other way around, so a violation would create a cycle in spirit and pull
-// decode/IO concerns into the hot numeric path.
-func TestCoreDoesNotImportAtlas(t *testing.T) {
+// TestCoreDoesNotImportSiblings enforces the layering rule that the core
+// skybrightness package (numeric, pure, no IO) must never depend on its
+// atlas or lpmap siblings (file decoding / live HTTP client respectively).
+// Both siblings depend on core, not the other way around, so a violation
+// would create a cycle in spirit and pull decode/IO/network concerns into
+// the hot numeric path.
+func TestCoreDoesNotImportSiblings(t *testing.T) {
 	t.Parallel()
 
-	const (
-		corePkg  = "github.com/TuSKan/astrogo/skybrightness"
-		atlasPkg = "github.com/TuSKan/astrogo/skybrightness/atlas"
-	)
+	const corePkg = "github.com/TuSKan/astrogo/skybrightness"
+
+	siblings := []string{
+		"github.com/TuSKan/astrogo/skybrightness/atlas",
+		"github.com/TuSKan/astrogo/skybrightness/lpmap",
+	}
 
 	pkg, err := build.Default.Import(corePkg, "", 0)
 	if err != nil {
 		t.Fatalf("import %s: %v", corePkg, err)
 	}
 
-	// Both production and in-package test imports must stay clear of atlas.
+	// Both production and in-package test imports must stay clear of the siblings.
 	all := append([]string{}, pkg.Imports...)
 	all = append(all, pkg.TestImports...)
 
 	for _, imp := range all {
-		if imp == atlasPkg || strings.HasPrefix(imp, atlasPkg+"/") {
-			t.Errorf("core skybrightness must not import %s (found %q)", atlasPkg, imp)
+		for _, sibling := range siblings {
+			if imp == sibling || strings.HasPrefix(imp, sibling+"/") {
+				t.Errorf("core skybrightness must not import %s (found %q)", sibling, imp)
+			}
 		}
 	}
 }

--- a/skybrightness/lpmap/doc.go
+++ b/skybrightness/lpmap/doc.go
@@ -1,6 +1,14 @@
-// Package lightpollution resolves a site's artificial night-sky brightness from
-// the lightpollutionmap.info QueryRaster service (the World Atlas 2015 layer,
+// Package lpmap resolves a site's artificial night-sky brightness from the
+// lightpollutionmap.info QueryRaster service (the World Atlas 2015 layer,
 // i.e. the Falchi et al. 2016 atlas) and converts it to a skybrightness floor.
+//
+// lpmap is a live-API sibling of [github.com/TuSKan/astrogo/skybrightness/atlas]:
+// both resolve the same World Atlas artificial-brightness data for the same
+// purpose (a [skybrightness.Floor] input), but atlas decodes a
+// caller-supplied offline file (no API key, no network) while lpmap queries
+// the service live (requires an API key, needs network access). Pick atlas
+// for offline/bundled-data use, lpmap when a live per-request query is
+// preferred over managing a data file.
 //
 // The QueryRaster API requires a free API key (https://www.lightpollutionmap.info,
 // 500 requests/day). Supply it via [WithAPIKey] or the LIGHTPOLLUTIONMAP_KEY
@@ -34,4 +42,4 @@
 //   - Falchi et al. 2016, "The new world atlas of artificial night sky
 //     brightness", Sci. Adv. 2, e1600377.
 //   - lightpollutionmap.info QueryRaster service (Jurij Stare).
-package lightpollution
+package lpmap

--- a/skybrightness/lpmap/lpmap.go
+++ b/skybrightness/lpmap/lpmap.go
@@ -1,4 +1,4 @@
-package lightpollution
+package lpmap
 
 import (
 	"context"
@@ -40,9 +40,9 @@ const (
 // Sentinel errors.
 var (
 	// ErrNoAPIKey is returned when no API key is configured.
-	ErrNoAPIKey = errors.New("lightpollution: no API key (use WithAPIKey or set LIGHTPOLLUTIONMAP_KEY)")
+	ErrNoAPIKey = errors.New("lpmap: no API key (use WithAPIKey or set LIGHTPOLLUTIONMAP_KEY)")
 	// ErrBadResponse is returned when the API response cannot be parsed.
-	ErrBadResponse = errors.New("lightpollution: unexpected API response")
+	ErrBadResponse = errors.New("lpmap: unexpected API response")
 )
 
 // Client queries the lightpollutionmap.info QueryRaster service.
@@ -140,13 +140,13 @@ func (c *Client) artificialBrightness(ctx context.Context, latDeg, lonDeg float6
 			return 0, fmt.Errorf("%w: status %d: %s", ErrBadResponse, httpErr.StatusCode, strings.TrimSpace(httpErr.Body))
 		}
 
-		return 0, fmt.Errorf("lightpollution: http: %w", err)
+		return 0, fmt.Errorf("lpmap: http: %w", err)
 	}
 	defer func() { _ = resp.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp, 1<<16))
 	if err != nil {
-		return 0, fmt.Errorf("lightpollution: read body: %w", err)
+		return 0, fmt.Errorf("lpmap: read body: %w", err)
 	}
 
 	return parseBrightness(string(body))

--- a/skybrightness/lpmap/lpmap_network_test.go
+++ b/skybrightness/lpmap/lpmap_network_test.go
@@ -1,12 +1,12 @@
 //go:build network
 
-//go test -tags network ./lightpollution
+//go test -tags network ./skybrightness/lpmap
 
 // These tests reach the live lightpollutionmap.info QueryRaster service and
 // require a free API key in the LIGHTPOLLUTIONMAP_KEY environment variable.
 // They skip automatically when the key is absent or the endpoint is unreachable
 // (DNS failure, firewall, transient outage) to avoid false-negative CI failures.
-package lightpollution
+package lpmap
 
 import (
 	"context"

--- a/skybrightness/lpmap/lpmap_test.go
+++ b/skybrightness/lpmap/lpmap_test.go
@@ -1,4 +1,4 @@
-package lightpollution
+package lpmap
 
 import (
 	"context"

--- a/skybrightness/lpmap/lpmap_test.go
+++ b/skybrightness/lpmap/lpmap_test.go
@@ -154,6 +154,35 @@ func TestFloorIsArtificialOnly(t *testing.T) {
 	testutil.AssertNear(t, "Floor SB (artificial-only)", gotSB, wantArtificialOnly, 1e-9)
 }
 
+func TestWithLayerOverridesDefault(t *testing.T) {
+	t.Cleanup(remote.Reset)
+
+	var gotLayer string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLayer = r.URL.Query().Get("ql")
+
+		if _, err := fmt.Fprint(w, "-46.6333,-23.5505,6.64"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer server.Close()
+
+	if err := remote.SetURL(remote.LightPollution, server.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	c := New(WithAPIKey("test-key"), WithHTTPClient(server.Client()), WithLayer("viirs_2023"))
+
+	_, err := c.Floor(context.Background(), -23.5505, -46.6333)
+	testutil.AssertNoError(t, err)
+
+	if gotLayer != "viirs_2023" {
+		t.Errorf("layer query param = %q, want %q", gotLayer, "viirs_2023")
+	}
+}
+
 // TestArtificialBrightnessRetriesOnTransientFailure verifies a transient 503
 // is retried (per R20: the client previously made one unconditional request
 // with no retry/backoff, unlike catalog/resolve.Client) and a request that


### PR DESCRIPTION
## Summary
- `ephemeris` package doc gains a "Choosing a Provider" table (`Default()` vs. de440s/de440/de442/de441 accuracy/size/offline tradeoffs).
- `plan.NewSite`'s `horizon` becomes the optional `WithHorizon` `SiteOption` (default `angle.Zero()`), matching the `WithX` pattern `Asteroid`/`Comet`/`DeepSkyObject`/`Satellite`/`Star` already use — signature changes from `NewSite(name, loc, horizon, tz)` to `NewSite(name, loc, tz, opts...)`.
- `lightpollution` moves to `skybrightness/lpmap`, a live-API sibling of `skybrightness/atlas` (disambiguates it from core `skybrightness`'s physics model).
- `plan` package doc gains a task-oriented "Finding what you need" symbol index.
- `remote.GetFile` gains `WithProgress` for download progress reporting, plus a one-line log at download start (never on a cache hit).

All breaking changes are documented in `CHANGELOG.md` under `[Unreleased]`. Pre-1.0, so breaking changes are acceptable per this project's convention.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] `go test -tags="integration,network,validation" ./...` — passes except two pre-existing live-API flakes (MAST HTML response, Horizons query rejection) in packages untouched by this PR
- [x] `go mod tidy` — no `go.mod`/`go.sum` churn
- [x] `go doc ./ephemeris` and `go doc ./plan` render the new sections correctly, all symbol links resolve
- [x] Manually ran `examples/06_tiny_plan` end-to-end after the `NewSite` signature change
- [ ] `-race` not runnable locally (no working cgo toolchain on this machine) — relies on CI