### PR TITLE
perf: add coord.Context.AtTime fast-path, wire into EventSolver hot loop

### DIFF
--- a/coord/context.go
+++ b/coord/context.go
@@ -29,6 +29,12 @@ type Context struct {
 	mat    [3][3]float64 // ICRS → TIRS rotation matrix
 	obsVec vector.Vec3   // observer position in ICRS frame (AU)
 
+	// rc2i (precession-nutation) and rpom (polar motion) are the slow
+	// factors C2t06a composes internally (mat = C2tcio(rc2i, era, rpom)).
+	// Cached so AtTime can recompute mat from a fresh era alone.
+	rc2i [3][3]float64
+	rpom [3][3]float64
+
 	// Cached site trigonometry (computed once).
 	sinLat, cosLat float64
 	sinLon, cosLon float64
@@ -56,34 +62,24 @@ func NewContext(t time.Time, site *Geodetic, atm atmosphere.Atmosphere) *Context
 		p, atm.Temperature, atm.Humidity, atm.Wavelength,
 	)
 
-	// Precompute C2t06a matrix and observer ICRS vector once.
+	// Precompute the C2t06a matrix and observer ICRS vector once, via its
+	// decomposed factors (rc2i, rpom) rather than the monolithic call, so
+	// AtTime can later recompute mat from a fresh Earth Rotation Angle
+	// alone without rebuilding the slow precession-nutation/polar-motion
+	// factors. Bit-identical to a direct C2t06a call.
 	ut1, ut2 := jd1, jd2+eop.DUT1/86400.0
 	tt1, tt2 := t.TT().JDParts()
-	mat := gofaext.C2t06a(tt1, tt2, ut1, ut2, eop.XP, eop.YP)
+	rc2i := gofaext.C2i06a(tt1, tt2)
+	sp := gofaext.Sp00(tt1, tt2)
+	rpom := gofaext.Pom00(eop.XP, eop.YP, sp)
+	era0 := gofaext.Era00(ut1, ut2)
+	mat := gofaext.C2tcio(rc2i, era0, rpom)
 
 	sinLat, cosLat := math.Sincos(site.Lat().Radians())
 	sinLon, cosLon := math.Sincos(site.Lon().Radians())
 
-	const (
-		au  = 149597870.7
-		rEq = 6378.137
-		f   = 1.0 / 298.257223563
-	)
-
-	cEarth := 1.0 / math.Sqrt(cosLat*cosLat+(1.0-f)*(1.0-f)*sinLat*sinLat)
-	sEarth := (1.0 - f) * (1.0 - f) * cEarth
-	heightKm := site.Height() / 1000.0
-
-	xTIRS := (rEq*cEarth + heightKm) * cosLat * cosLon / au
-	yTIRS := (rEq*cEarth + heightKm) * cosLat * sinLon / au
-	zTIRS := (rEq*sEarth + heightKm) * sinLat / au
-
-	// Observer ICRS = transpose(mat) * TIRS
-	obsVec := vector.Vec3{
-		X: mat[0][0]*xTIRS + mat[1][0]*yTIRS + mat[2][0]*zTIRS,
-		Y: mat[0][1]*xTIRS + mat[1][1]*yTIRS + mat[2][1]*zTIRS,
-		Z: mat[0][2]*xTIRS + mat[1][2]*yTIRS + mat[2][2]*zTIRS,
-	}
+	tirs := tirsVec(sinLat, cosLat, sinLon, cosLon, site.Height())
+	obsVec := icrsFromTIRS(mat, tirs)
 
 	return &Context{
 		t:      t,
@@ -93,6 +89,8 @@ func NewContext(t time.Time, site *Geodetic, atm atmosphere.Atmosphere) *Context
 		eop:    eop,
 		mat:    mat,
 		obsVec: obsVec,
+		rc2i:   rc2i,
+		rpom:   rpom,
 		sinLat: sinLat, cosLat: cosLat,
 		sinLon: sinLon, cosLon: cosLon,
 	}
@@ -104,6 +102,67 @@ func NewContext(t time.Time, site *Geodetic, atm atmosphere.Atmosphere) *Context
 func (ctx *Context) Clone() *Context {
 	c := *ctx // shallow copy — all fields are value types or immutable pointers
 	return &c
+}
+
+// tirsVec returns the observer's geocentric position in the TIRS frame
+// (AU) from site trigonometry and height — pure site geometry, independent
+// of time, shared by NewContext and AtTime.
+func tirsVec(sinLat, cosLat, sinLon, cosLon, heightM float64) vector.Vec3 {
+	const (
+		au  = 149597870.7
+		rEq = 6378.137
+		f   = 1.0 / 298.257223563
+	)
+
+	cEarth := 1.0 / math.Sqrt(cosLat*cosLat+(1.0-f)*(1.0-f)*sinLat*sinLat)
+	sEarth := (1.0 - f) * (1.0 - f) * cEarth
+	heightKm := heightM / 1000.0
+
+	return vector.Vec3{
+		X: (rEq*cEarth + heightKm) * cosLat * cosLon / au,
+		Y: (rEq*cEarth + heightKm) * cosLat * sinLon / au,
+		Z: (rEq*sEarth + heightKm) * sinLat / au,
+	}
+}
+
+// icrsFromTIRS rotates a TIRS-frame vector into the ICRS frame:
+// v_ICRS = transpose(mat) * v_TIRS.
+func icrsFromTIRS(mat [3][3]float64, tirs vector.Vec3) vector.Vec3 {
+	return vector.Vec3{
+		X: mat[0][0]*tirs.X + mat[1][0]*tirs.Y + mat[2][0]*tirs.Z,
+		Y: mat[0][1]*tirs.X + mat[1][1]*tirs.Y + mat[2][1]*tirs.Z,
+		Z: mat[0][2]*tirs.X + mat[1][2]*tirs.Y + mat[2][2]*tirs.Z,
+	}
+}
+
+// AtTime derives a new Context at instant t from this one, cheaply updating
+// only Earth-rotation-dependent state (the ASTROM Earth Rotation Angle, the
+// celestial-to-terrestrial matrix, and the observer vector) while reusing
+// this Context's precession-nutation, Earth ephemeris, polar motion, cached
+// EOP, and site/atmosphere state. Cost is O(1) (a handful of trig calls and
+// matrix multiplies) versus NewContext's ~91 µs full SOFA rebuild.
+//
+// Accuracy: holding precession-nutation and aberration fixed costs ≲0.1″ per
+// hour of |t − ctx.Time()| — dominated by nutation's ~13.66-day term
+// (≈0.025″/h) and the annual-aberration direction's drift (≈0.015″/h);
+// precession (≈0.006″/h) and reusing this Context's DUT1/polar-motion
+// (<0.001″/h combined) are smaller still. At the horizon's steepest crossing
+// rate, 0.1″ of positional error is under 0.01 s of rise/set-time bias.
+// Callers sweeping longer spans should rebuild a fresh NewContext
+// periodically rather than calling AtTime indefinitely far from ctx.Time().
+func (ctx *Context) AtTime(t time.Time) *Context {
+	t = t.UTC()
+	jd1, jd2 := t.JDParts()
+	ut1, ut2 := jd1, jd2+ctx.eop.DUT1/86400.0
+	era := gofaext.Era00(ut1, ut2)
+
+	c := ctx.Clone()
+	c.t = t
+	gofaext.Aper(era, &c.astrom)
+	c.mat = gofaext.C2tcio(c.rc2i, era, c.rpom)
+	c.obsVec = icrsFromTIRS(c.mat, tirsVec(c.sinLat, c.cosLat, c.sinLon, c.cosLon, c.site.Height()))
+
+	return c
 }
 
 // Time returns the encapsulated observation time.

--- a/coord/context_attime_test.go
+++ b/coord/context_attime_test.go
@@ -1,0 +1,127 @@
+package coord_test
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// TestContextAtTime_ZeroDeltaMatchesNewContext proves AtTime(ctx.Time())
+// reproduces a fresh NewContext exactly — the decomposition (C2i06a/Era00/
+// Pom00 composed via C2tcio, astrom.Eral updated via Aper) must be
+// bit-identical to the monolithic build at the same instant.
+func TestContextAtTime_ZeroDeltaMatchesNewContext(t *testing.T) {
+	site, err := coord.NewGeodetic(angle.Deg(2.1686), angle.Deg(41.3874), 0)
+	testutil.AssertNoError(t, err)
+
+	atm := atmosphere.Atmosphere{Pressure: 0}
+	base := time.FromJD(2461000.0, time.UTC)
+
+	fresh := coord.NewContext(base, site, atm)
+	derived := coord.NewContext(base, site, atm).AtTime(base)
+
+	star := coord.NewICRS(angle.Hour(6.75), angle.Deg(-16.7))
+
+	wantAA, err := fresh.ICRSToAltAz(star)
+	testutil.AssertNoError(t, err)
+
+	gotAA, err := derived.ICRSToAltAz(star)
+	testutil.AssertNoError(t, err)
+
+	testutil.AssertNear(t, "ICRSToAltAz Alt at Δt=0", gotAA.Alt().Degrees(), wantAA.Alt().Degrees(), 1e-12)
+	testutil.AssertNear(t, "ICRSToAltAz Az at Δt=0", gotAA.Az().Degrees(), wantAA.Az().Degrees(), 1e-12)
+
+	wantHA, err := fresh.ICRSToHourAngle(star)
+	testutil.AssertNoError(t, err)
+
+	gotHA, err := derived.ICRSToHourAngle(star)
+	testutil.AssertNoError(t, err)
+
+	testutil.AssertNear(t, "ICRSToHourAngle at Δt=0", gotHA.Degrees(), wantHA.Degrees(), 1e-12)
+
+	// Moving-body path: an arbitrary geocentric ICRS vector at roughly
+	// lunar distance (AU).
+	vec := vector.V3(0.0016, 0.0019, 0.0008)
+
+	wantGeo := fresh.GeocentricToObserved(vec)
+	gotGeo := derived.GeocentricToObserved(vec)
+
+	testutil.AssertNear(t, "GeocentricToObserved Alt at Δt=0", gotGeo.Alt().Degrees(), wantGeo.Alt().Degrees(), 1e-12)
+	testutil.AssertNear(t, "GeocentricToObserved Az at Δt=0", gotGeo.Az().Degrees(), wantGeo.Az().Degrees(), 1e-12)
+}
+
+// TestContextAtTime_DriftStaysWithinDocumentedBound proves AtTime's error
+// versus a fresh NewContext at the same later instant (a) stays under the
+// ~0.1"/hour bound documented on AtTime, and (b) is non-zero/growing with
+// Δt — guarding against a broken cheap path that silently no-ops instead of
+// actually advancing the Earth Rotation Angle.
+func TestContextAtTime_DriftStaysWithinDocumentedBound(t *testing.T) {
+	site, err := coord.NewGeodetic(angle.Deg(2.1686), angle.Deg(41.3874), 0)
+	testutil.AssertNoError(t, err)
+
+	atm := atmosphere.Atmosphere{Pressure: 0}
+	base := time.FromJD(2461000.0, time.UTC)
+	ctx := coord.NewContext(base, site, atm)
+	star := coord.NewICRS(angle.Hour(6.75), angle.Deg(-16.7))
+
+	const boundArcsecPerHour = 0.1
+
+	// Altitude error versus a fresh NewContext at the same later instant
+	// must stay within the documented bound. This is NOT checked for
+	// monotonic growth across checkpoints: altitude is a diurnal
+	// projection of the underlying pointing error, and that projection
+	// isn't monotonic in Δt (e.g. near a slowly-changing altitude extremum
+	// the same pointing error yields a smaller Alt error) — only the
+	// bound matters here.
+	for _, hours := range []float64{1, 6, 24} {
+		later := base.Add(time.Duration(hours * float64(time.Hour)))
+
+		want, err := coord.NewContext(later, site, atm).ICRSToAltAz(star)
+		testutil.AssertNoError(t, err)
+
+		got, err := ctx.AtTime(later).ICRSToAltAz(star)
+		testutil.AssertNoError(t, err)
+
+		errArcsec := angle.Rad(want.Alt().Radians()-got.Alt().Radians()).Degrees() * 3600
+		if errArcsec < 0 {
+			errArcsec = -errArcsec
+		}
+
+		if bound := boundArcsecPerHour * hours; errArcsec > bound {
+			t.Errorf("Δt=%gh: AtTime altitude error = %g\", want <= %g\" (documented bound)", hours, errArcsec, bound)
+		}
+	}
+}
+
+// TestContextAtTime_AdvancesEarthRotation guards against a broken cheap
+// path that silently no-ops instead of updating the Earth Rotation Angle:
+// unlike the diurnally-projected altitude error above, Hour Angle tracks
+// ERA directly and must advance at very close to the sidereal rate
+// (~15.041"/s, i.e. ~15.041°/hour) between two AtTime derivations an hour
+// apart.
+func TestContextAtTime_AdvancesEarthRotation(t *testing.T) {
+	site, err := coord.NewGeodetic(angle.Deg(2.1686), angle.Deg(41.3874), 0)
+	testutil.AssertNoError(t, err)
+
+	atm := atmosphere.Atmosphere{Pressure: 0}
+	base := time.FromJD(2461000.0, time.UTC)
+	ctx := coord.NewContext(base, site, atm)
+	star := coord.NewICRS(angle.Hour(6.75), angle.Deg(-16.7))
+
+	ha0, err := ctx.AtTime(base).ICRSToHourAngle(star)
+	testutil.AssertNoError(t, err)
+
+	oneHourLater := base.Add(time.Hour)
+
+	ha1, err := ctx.AtTime(oneHourLater).ICRSToHourAngle(star)
+	testutil.AssertNoError(t, err)
+
+	const siderealDegPerHour = 15.041
+
+	testutil.AssertNear(t, "Hour Angle advance over 1h", ha1.Degrees()-ha0.Degrees(), siderealDegPerHour, 0.01)
+}

--- a/internal/gofaext/gofaext.go
+++ b/internal/gofaext/gofaext.go
@@ -194,6 +194,60 @@ func C2t06a(tta, ttb, uta, utb, xp, yp float64) [3][3]float64 {
 	return rc2t
 }
 
+// Era00 returns the Earth Rotation Angle (IAU 2000) in radians for the given
+// UT1 two-part Julian date — the one orientation quantity that changes
+// materially between nearby instants (as opposed to precession, nutation,
+// and polar motion, which drift sub-arcsecond per day).
+func Era00(uta, utb float64) float64 {
+	return gofa.Era00(uta, utb)
+}
+
+// Aper updates only astrom.Eral (= theta + astrom.Along) in place, leaving
+// every other ASTROM field untouched — an O(1) alternative to rebuilding the
+// whole ASTROM via Apco13 when only the Earth Rotation Angle has changed.
+func Aper(theta float64, astrom *ASTROM) {
+	gofa.Aper(theta, astrom)
+}
+
+// C2i06a returns the celestial-to-intermediate (precession-nutation, IAU
+// 2006/2000A) matrix for the given TT two-part Julian date — the slow factor
+// of C2t06a, safe to cache across a short time window and reuse with a
+// freshly computed Era00/Pom00 via C2tcio.
+func C2i06a(tta, ttb float64) [3][3]float64 {
+	var rc2i [3][3]float64
+	gofa.C2i06a(tta, ttb, &rc2i)
+
+	return rc2i
+}
+
+// Sp00 returns the TIO locator s' (radians) for the given TT two-part
+// Julian date.
+func Sp00(tta, ttb float64) float64 {
+	return gofa.Sp00(tta, ttb)
+}
+
+// Pom00 returns the polar-motion matrix for polar coordinates xp, yp
+// (radians) and TIO locator sp (radians) — the other slow factor of C2t06a.
+func Pom00(xp, yp, sp float64) [3][3]float64 {
+	var rpom [3][3]float64
+	gofa.Pom00(xp, yp, sp, &rpom)
+
+	return rpom
+}
+
+// C2tcio assembles the celestial-to-terrestrial matrix from a cached
+// celestial-to-intermediate matrix, a fresh Earth Rotation Angle, and a
+// cached polar-motion matrix. Composing C2i06a + Era00 + Pom00 this way is
+// bit-identical to C2t06a at the same instant, but lets a caller hold rc2i
+// and rpom fixed across a series of nearby instants and recompute only era —
+// the fast path C2t06a's own SOFA documentation describes for exactly this.
+func C2tcio(rc2i [3][3]float64, era float64, rpom [3][3]float64) [3][3]float64 {
+	var rc2t [3][3]float64
+	gofa.C2tcio(rc2i, era, rpom, &rc2t)
+
+	return rc2t
+}
+
 // Refco determining the constants A and B in the atmospheric refraction model
 // dz = A tan z + B tan^3 z.
 // phpa is pressure in hPa, tc is temp in C, rh is relative humidity, wl is wavelength in um.

--- a/internal/gofaext/gofaext_test.go
+++ b/internal/gofaext/gofaext_test.go
@@ -78,3 +78,55 @@ func TestGofaExtWrappers(t *testing.T) {
 		t.Errorf("Gst06a failed, got zero")
 	}
 }
+
+// TestC2tcioDecompositionMatchesC2t06a proves that composing the
+// decomposed factors (C2i06a, Era00, Pom00/Sp00) via C2tcio reproduces the
+// monolithic C2t06a call exactly — the property coord.Context.AtTime relies
+// on to cheaply recompute only the Earth-rotation-dependent factor.
+func TestC2tcioDecompositionMatchesC2t06a(t *testing.T) {
+	const (
+		tt1, tt2 = 2451545.0, 0.25 // an arbitrary TT epoch
+		ut1, ut2 = 2451545.0, 0.24 // a nearby UT1 epoch (DUT1 offset)
+		xp, yp   = 1.5e-7, 2.3e-7  // arbitrary polar motion, radians
+	)
+
+	want := gofaext.C2t06a(tt1, tt2, ut1, ut2, xp, yp)
+
+	rc2i := gofaext.C2i06a(tt1, tt2)
+	sp := gofaext.Sp00(tt1, tt2)
+	rpom := gofaext.Pom00(xp, yp, sp)
+	era := gofaext.Era00(ut1, ut2)
+	got := gofaext.C2tcio(rc2i, era, rpom)
+
+	for i := range 3 {
+		for j := range 3 {
+			testutil.AssertNear(t, "C2tcio decomposition", got[i][j], want[i][j], 1e-15)
+		}
+	}
+}
+
+// TestAperUpdatesOnlyEral proves Aper touches only ASTROM.Eral, leaving
+// every other field (populated by a real Apco13 call) untouched — the
+// property that makes it a safe O(1) substitute for a full Apco13 rebuild
+// when only the Earth Rotation Angle has changed.
+func TestAperUpdatesOnlyEral(t *testing.T) {
+	astrom, _ := gofaext.Apco13(
+		2451545.0, 0.5, 0.1,
+		0.3, 0.7, 500.0,
+		1.5e-7, 2.3e-7,
+		1013.25, 15.0, 0.5, 0.55,
+	)
+
+	before := astrom
+	gofaext.Aper(1.2345, &astrom)
+
+	if astrom.Eral != 1.2345+before.Along {
+		t.Errorf("Aper: Eral = %v, want %v", astrom.Eral, 1.2345+before.Along)
+	}
+
+	astrom.Eral = before.Eral // neutralize the one expected change
+
+	if astrom != before {
+		t.Errorf("Aper mutated a field other than Eral:\nbefore=%+v\nafter=%+v", before, astrom)
+	}
+}

--- a/plan/bench_test.go
+++ b/plan/bench_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
 
 	atime "github.com/TuSKan/astrogo/time"
 )
@@ -181,5 +182,63 @@ func BenchmarkTransitEstimate(b *testing.B) {
 
 	for range b.N {
 		_, _, _ = TransitEstimate(obj, site, start, end)
+	}
+}
+
+// ── Fortnight Event Sweep (issue #10 repro) ─────────────────────────────────
+
+// BenchmarkFortnightEvents mirrors an observing-planner workload (the shape
+// reported in https://github.com/TuSKan/astrogo/issues/10): for each of 14
+// days, compute sun rise/set/transit, the three twilight bands, and moon
+// rise/set — the standard "14-night forecast" that made coord.NewContext
+// ~65% of total CPU before Context.AtTime (see coord/context.go) let
+// solveVisibility amortize one full NewContext per ~hour of solve window
+// instead of rebuilding one per sample and per bisection iteration.
+func BenchmarkFortnightEvents(b *testing.B) {
+	g, err := coord.NewGeodetic(angle.Deg(2.1686), angle.Deg(41.3874), 0) // Barcelona
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tz, err := time.LoadLocation("Europe/Madrid")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	site, err := NewSite("bcn", g, WithTimeZone(tz))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	provider := eph.Default()
+	start := atime.Date(2026, 7, 20, 0, 0, 0, 0, tz)
+
+	b.ResetTimer()
+
+	for range b.N {
+		for d := range 14 {
+			day := start.AddDate(0, 0, d)
+			next := day.AddDate(0, 0, 1)
+
+			if _, err := SunEvents(day, next, site, provider); err != nil {
+				b.Fatal(err)
+			}
+
+			if _, _, err := CivilDawnDusk(day, next, site, provider); err != nil {
+				b.Fatal(err)
+			}
+
+			if _, _, err := NauticalDawnDusk(day, next, site, provider); err != nil {
+				b.Fatal(err)
+			}
+
+			if _, _, err := AstronomicalDawnDusk(day, next, site, provider); err != nil {
+				b.Fatal(err)
+			}
+
+			if _, err := MoonEvents(day, next, site, provider); err != nil {
+				b.Fatal(err)
+			}
+		}
 	}
 }

--- a/plan/events.go
+++ b/plan/events.go
@@ -290,8 +290,44 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 	// series would introduce in the root-finder.
 	geomAtm := atmosphere.Atmosphere{Pressure: 0} // zero pressure → no refraction
 
+	// eventCtxRefresh bounds how far a coord.Context.AtTime derivation may
+	// drift from its last full coord.NewContext rebuild. AtTime's documented
+	// accuracy is ≲0.1″/hour (holding precession-nutation and aberration
+	// fixed); at 1h that's <0.01s of rise/set-time bias — a >100x margin
+	// against the solver's ~1s Tolerance and this package's minute-level
+	// USNO/NASA reference tolerances, while still turning the large majority
+	// of per-sample and per-bisection-iteration NewContext calls (~91µs
+	// each) into O(1) AtTime derivations.
+	const eventCtxRefresh = 1 * time.Hour
+
+	// contextCache returns a closure that rebuilds a full coord.NewContext
+	// only when t has drifted more than eventCtxRefresh from the last
+	// rebuild, deriving every other call cheaply via AtTime. evalVal and
+	// evalHA use independent caches since they evaluate under different
+	// atmospheres (geomAtm vs. spec.Observer.Atmosphere()).
+	contextCache := func(atm atmosphere.Atmosphere) func(t time.Time) *coord.Context {
+		var base *coord.Context
+
+		return func(t time.Time) *coord.Context {
+			if base == nil || t.Sub(base.Time()).Abs() > eventCtxRefresh {
+				base = coord.NewContext(t, spec.Observer.Location(), atm)
+			}
+
+			return base.AtTime(t)
+		}
+	}
+
+	// evalCtx backs evalVal (rise/set/twilight, geometric no-refraction
+	// atmosphere); evalHACtx backs the transit search's evalHA closure
+	// (defined further below, inside the event loop, since it's only
+	// needed once a transit candidate is found) — both declared here so a
+	// single cache persists across every sample and bisection iteration,
+	// and across multiple transit candidates, within this solveVisibility call.
+	evalCtx := contextCache(geomAtm)
+	evalHACtx := contextCache(spec.Observer.Atmosphere())
+
 	evalVal := func(t time.Time) (float64, error) {
-		ctx := coord.NewContext(t, spec.Observer.Location(), geomAtm)
+		ctx := evalCtx(t)
 
 		// For solar system bodies, use the vector-based topocentric pipeline
 		// which properly corrects for diurnal parallax (critical for the Moon: ~1°).
@@ -412,7 +448,7 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 						return 0, fmt.Errorf("events: target position: %w", err)
 					}
 
-					ctx := coord.NewContext(t, spec.Observer.Location(), spec.Observer.Atmosphere())
+					ctx := evalHACtx(t)
 
 					ha, err := ctx.ICRSToHourAngle(pos)
 					if err != nil {


### PR DESCRIPTION
## Summary
Fixes #10. `coord.NewContext` (SOFA `Apco13` + IAU 2006/2000A precession-nutation) was rebuilt from scratch for every sampled instant *and* every bisection-refinement step in `plan.EventSolver`'s rise/set/twilight/transit sweeps — reported (and verified against current `main`) at ~65% of total CPU in a 14-night forecast benchmark.

- Decomposed the monolithic `gofaext.C2t06a` celestial-to-terrestrial matrix build into its cacheable precession-nutation (`C2i06a`)/polar-motion (`Pom00`) factors plus the fast-changing Earth Rotation Angle (`Era00`) term, composed via `C2tcio` — SOFA's own doc comment on `C2tcio` names this exact decomposition as the intended fast path for a time series where only ERA changes. Bit-identical to the old monolithic build (verified to 1e-15).
- Added public `coord.Context.AtTime(t) *Context`: derives a new `Context` at a nearby instant in O(1) by updating only ERA-dependent state (`astrom.Eral` via `gofaext.Aper`, the c2t matrix, the observer vector) and reusing everything else. Documented accuracy bound: ≲0.1″/hour (dominated by nutation ≈0.025″/h and aberration ≈0.015″/h; precession and DUT1/polar-motion reuse are smaller still).
- `plan/events.go`'s `solveVisibility` now rebuilds a full `Context` only once per hour of solve window (>100x margin against the ~1s solver tolerance and existing minute-level accuracy fixtures) and derives every coarse sample and bisection step from it via `AtTime`. The two post-refinement display rebuilds are left untouched so reported event values are unaffected.

**Result:** `BenchmarkFortnightEvents` (14-night sweep, the issue's repro shape): ~1.6s/op → ~0.6s/op (~2.6-2.8x on this machine; issue estimated 3-5x).

## Test plan
- [x] `internal/gofaext`: new test proves the `C2i06a`+`Era00`+`Pom00`+`C2tcio` decomposition is bit-identical (1e-15) to `C2t06a`, and `Aper` mutates only `astrom.Eral`.
- [x] `coord/context_attime_test.go` (new): `AtTime(ctx.Time())` matches a fresh `NewContext` exactly at Δt=0 (ICRS/AltAz, Hour Angle, and moving-body `GeocentricToObserved` paths); drift vs. a fresh `NewContext` stays within the documented bound at Δt=1h/6h/24h; Hour Angle advances at the correct sidereal rate (~15.041°/h), proving ERA is actually advancing.
- [x] Full existing regression suite unaffected: `go test ./...`, `-tags=validation ./plan/...` (USNO/NASA/astropixels fixtures) and `./ephemeris/jpl/validation/...` all pass with zero tolerance changes.
- [x] `go vet`, `gofmt -l .`, `golangci-lint run` all clean.
- [x] `go mod tidy` — no changes.
- [ ] Race detector (`-race`) not run — no C compiler available in this environment for cgo.

