### PR TITLE
fix(mast): sniff response format instead of trusting requested format

### DIFF
--- a/catalog/mast/mast.go
+++ b/catalog/mast/mast.go
@@ -1,10 +1,13 @@
 package mast
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -108,39 +111,74 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 		}
 		defer func() { _ = body.Close() }()
 
-		// The request above always sets "format": "json" (MAST defaults to
-		// XML otherwise), so a 2xx response body is always JSON — no
-		// format sniffing needed.
-		var jsonPayload struct {
-			Status             string `json:"status"`
-			Msg                string `json:"msg"`
-			ResolvedCoordinate []struct {
-				CanonicalName string  `json:"canonicalName"`
-				Resolver      string  `json:"resolver"`
-				RA            float64 `json:"ra"`
-				Decl          float64 `json:"decl"`
-			} `json:"resolvedCoordinate"`
-		}
-
-		if err := json.NewDecoder(body).Decode(&jsonPayload); err != nil {
-			yield(resolve.Target{}, fmt.Errorf("mast: decode response: %w", err))
+		data, err := io.ReadAll(body)
+		if err != nil {
+			yield(resolve.Target{}, fmt.Errorf("mast: read response: %w", err))
 			return
 		}
 
-		if jsonPayload.Status == "ERROR" {
-			yield(resolve.Target{}, fmt.Errorf("%w: %s", ErrAPIError, jsonPayload.Msg))
-			return
-		}
+		// The request above always sets "format": "json", but MAST has been
+		// observed to ignore it and return its default XML body anyway —
+		// sniff the actual content instead of trusting the requested format.
+		var targets []resolve.Target
 
-		targets := make([]resolve.Target, 0, len(jsonPayload.ResolvedCoordinate))
-		for _, match := range jsonPayload.ResolvedCoordinate {
-			targets = append(targets, resolve.Target{
-				ID:       match.CanonicalName,
-				Name:     match.CanonicalName,
-				Coord:    coord.NewICRS(angle.Deg(match.RA), angle.Deg(match.Decl)),
-				HasCoord: true,
-				Catalog:  match.Resolver,
-			})
+		if trimmed := bytes.TrimSpace(data); len(trimmed) > 0 && trimmed[0] == '<' {
+			var xmlPayload struct {
+				ResolvedCoordinate []struct {
+					CanonicalName string  `xml:"canonicalName"`
+					Resolver      string  `xml:"resolver"`
+					RA            float64 `xml:"ra"`
+					Dec           float64 `xml:"dec"`
+				} `xml:"resolvedCoordinate"`
+			}
+
+			if err := xml.Unmarshal(data, &xmlPayload); err != nil {
+				yield(resolve.Target{}, fmt.Errorf("mast: decode XML response: %w", err))
+				return
+			}
+
+			targets = make([]resolve.Target, 0, len(xmlPayload.ResolvedCoordinate))
+			for _, match := range xmlPayload.ResolvedCoordinate {
+				targets = append(targets, resolve.Target{
+					ID:       match.CanonicalName,
+					Name:     match.CanonicalName,
+					Coord:    coord.NewICRS(angle.Deg(match.RA), angle.Deg(match.Dec)),
+					HasCoord: true,
+					Catalog:  match.Resolver,
+				})
+			}
+		} else {
+			var jsonPayload struct {
+				Status             string `json:"status"`
+				Msg                string `json:"msg"`
+				ResolvedCoordinate []struct {
+					CanonicalName string  `json:"canonicalName"`
+					Resolver      string  `json:"resolver"`
+					RA            float64 `json:"ra"`
+					Decl          float64 `json:"decl"`
+				} `json:"resolvedCoordinate"`
+			}
+
+			if err := json.Unmarshal(data, &jsonPayload); err != nil {
+				yield(resolve.Target{}, fmt.Errorf("mast: decode response: %w", err))
+				return
+			}
+
+			if jsonPayload.Status == "ERROR" {
+				yield(resolve.Target{}, fmt.Errorf("%w: %s", ErrAPIError, jsonPayload.Msg))
+				return
+			}
+
+			targets = make([]resolve.Target, 0, len(jsonPayload.ResolvedCoordinate))
+			for _, match := range jsonPayload.ResolvedCoordinate {
+				targets = append(targets, resolve.Target{
+					ID:       match.CanonicalName,
+					Name:     match.CanonicalName,
+					Coord:    coord.NewICRS(angle.Deg(match.RA), angle.Deg(match.Decl)),
+					HasCoord: true,
+					Catalog:  match.Resolver,
+				})
+			}
 		}
 
 		if err := p.cache.Set(cacheKey, targets); err != nil {

--- a/catalog/mast/mast_test.go
+++ b/catalog/mast/mast_test.go
@@ -57,6 +57,84 @@ func TestMastOfflineResolve(t *testing.T) {
 	testutil.AssertEqual(t, "RA", targets[0].Coord.RA().Degrees(), 10.684)
 }
 
+// TestMastOfflineResolveXML covers a live-observed MAST quirk: the invoke
+// API sometimes ignores the request's "format": "json" field and returns
+// its default XML body anyway. ResolveObject must sniff and decode this
+// correctly rather than failing to parse it as JSON.
+func TestMastOfflineResolveXML(t *testing.T) {
+	xmlPayload := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><ns2:resolvedItems xmlns:ns2="santa.stsci.edu"><resolvedCoordinate><canonicalName>M  31</canonicalName><dec>41.26875</dec><objectType>AGN</objectType><ra>10.684708</ra><resolver>SIMBAD</resolver><resolverTime>513</resolverTime><searchString>m31</searchString></resolvedCoordinate><status></status></ns2:resolvedItems>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml;charset=UTF-8")
+
+		if _, err := fmt.Fprint(w, xmlPayload); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	prov := New()
+	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
+
+	req := resolve.ObjectRequest{Query: "M31"}
+	iter := prov.ResolveObject(context.Background(), req)
+
+	var targets []resolve.Target
+
+	iter(func(tar resolve.Target, err error) bool {
+		testutil.AssertNoError(t, err)
+
+		targets = append(targets, tar)
+
+		return true
+	})
+
+	if len(targets) != 1 {
+		t.Fatalf("Expected 1 target, got %d", len(targets))
+	}
+
+	testutil.AssertEqual(t, "Name", targets[0].Name, "M  31")
+	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "SIMBAD")
+	testutil.AssertEqual(t, "RA", targets[0].Coord.RA().Degrees(), 10.684708)
+	testutil.AssertEqual(t, "Dec", targets[0].Coord.Dec().Degrees(), 41.26875)
+}
+
+// TestMastOfflineResolveXMLNoMatch covers the XML "not found" shape: no
+// resolvedCoordinate element and an empty status, as observed live for an
+// unresolvable name — this must yield zero targets, not an error.
+func TestMastOfflineResolveXMLNoMatch(t *testing.T) {
+	xmlPayload := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><ns2:resolvedItems xmlns:ns2="santa.stsci.edu"><status></status></ns2:resolvedItems>`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml;charset=UTF-8")
+
+		if _, err := fmt.Fprint(w, xmlPayload); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	prov := New()
+	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
+
+	req := resolve.ObjectRequest{Query: "ThisIsNotARealObjectXYZ123"}
+	iter := prov.ResolveObject(context.Background(), req)
+
+	var targets []resolve.Target
+
+	iter(func(tar resolve.Target, err error) bool {
+		testutil.AssertNoError(t, err)
+
+		targets = append(targets, tar)
+
+		return true
+	})
+
+	if len(targets) != 0 {
+		t.Fatalf("Expected 0 targets, got %d", len(targets))
+	}
+}
+
 type mockTransport struct {
 	Handler http.Handler
 }


### PR DESCRIPTION
## Summary
Discovered while re-verifying the full `-tags=network` test gate for an unrelated fix: `TestMastNetworkResolve` failed against the live MAST API with `invalid character '<' looking for beginning of value` — not a reachability flake (the TCP pre-check passed), but the endpoint returning an XML body despite the request's `"format": "json"` field.

Confirmed by hand against the live API (`mast.stsci.edu/api/v0/invoke`, `Mast.Name.Lookup`): every variant tried (JSON-body `format:json`, `Accept: application/json` header, GET with query param) still returns `200 OK` with an XML body. MAST is currently ignoring the requested format entirely, contradicting the doc comment this code relied on ("the request above always sets format:json ... so a 2xx response is always JSON").

- `ResolveObject` now reads the raw body and sniffs its first non-whitespace byte (`<` → XML, else JSON) instead of trusting the requested format, mirroring the same sniff-raw-bytes approach `catalog/fink` already uses for its JSON-vs-parquet split.
- Added an XML struct matching the live-observed `<ns2:resolvedItems>` shape and decode path.
- Kept the JSON decode path as a fallback in case MAST ever honors the format param again.

## Test plan
- [x] New offline tests: `TestMastOfflineResolveXML` (XML success shape) and `TestMastOfflineResolveXMLNoMatch` (XML "not found" shape — no `resolvedCoordinate`, empty `status`).
- [x] Existing `TestMastOfflineResolve` (JSON path) still passes unchanged.
- [x] `TestMastNetworkResolve` (`-tags=network`) now passes live against the real API.
- [x] `go vet`, `gofmt -l .`, `golangci-lint run` all clean on the package.

