### PR TITLE
catalog: reconcile multi-provider results with cross-match and field precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `catalog.Resolver` now cross-matches and merges every registered provider's hit for a query into one `Target`, instead of `Resolve` returning whichever provider answered first and `Search` deduplicating only on the useless `Catalog+":"+ID` key (which can never catch a cross-provider duplicate). Cross-matching is by shared alias/ID first (union-find over `Target.ID`/`Target.Aliases`), falling back to angular separation — after epoch-normalizing each candidate to J2000 via the new `coord.PropagateEpoch` — for candidates with no alias/ID overlap. `catalog.Gaia`/`catalog.VizieR`, whose `Resolve`/`Search` are permanently stubbed (neither does name-based lookup), are now bridged in via their `resolve.ConeSearcher` capability around each group's anchor position, so their astrometry can participate in a merge instead of being reachable only through a separate `ConeSearch` call. Each merged field is chosen by a per-field provider-precedence table (Coord/Parallax/PmRA/PmDec are treated as one coupled cluster, taken from a single provider, never mixed field-by-field); `Target.Provenance map[string]string` records which provider (`Provider.Name()`) contributed each field, nil for a `Target` sourced from a single provider.
+- `(*catalog.Resolver).PositionMatchThreshold(threshold angle.Angle) *Resolver` — sets the maximum angular separation, after epoch normalization, at which two `Target`s are considered the same object (default 2 arcsec); returns the receiver for chaining, e.g. `catalog.NewResolver(catalog.SIMBAD).PositionMatchThreshold(angle.Arcsec(2)).Resolve(ctx, "...")`.
+- `(*catalog.Resolver).Limit(n int) *Resolver` — sets `Search`'s maximum result count (default 10, previously hardcoded); also chainable.
+- `coord.PropagateEpoch(c ICRS, fromEpoch, toEpoch time.Time) (ICRS, error)` — rigorous SOFA (`Pmsafe`) space-motion propagation of an ICRS position's proper motion/parallax/radial velocity from one epoch to another; a zero epoch is treated as `time.J2000`. `internal/gofaext.Pmsafe` wraps the underlying SOFA call.
+- `time.J2000` — the standard epoch J2000.0 (JD 2451545.0 TT).
+- `resolve.Kind` constants `KindAsteroid`, `KindComet`, `KindSatellite`, canonicalizing string values `catalog/sbdb` and `catalog/norad` already used informally as bare `resolve.Kind("Asteroid")`/`"Comet"`/`"Satellite"` literals.
+
+### Changed — BREAKING
+- **`resolve.Provider`'s `Resolve`/`Search` methods now take `ctx context.Context` as their first parameter.** This ripples into every catalog provider package (`simbad`, `mast`, `jpl`, `sbdb`, `norad`, `gaia`, `vizier`, `openngc`) and every caller — a provider or `Resolver` that built its own internal `context.Background()`/`context.TODO()` now forwards the caller's `ctx` instead, so cancellation propagates end-to-end, including into the `ConeSearch` bridge calls above. `catalog.Resolver.Resolve`/`Search` already took a `ctx`; this closes the gap at the interface's own layer rather than only at the top-level orchestrator.
+
+### Fixed
+- `catalog/gaia`'s CSV row parser discarded RA/Dec `ParseFloat` errors and still reported `HasCoord: true`, so a malformed or empty position silently became a fake `(0, 0)` reported as real. Rows with an unparseable RA or Dec are now skipped entirely.
+- `catalog/mast`'s XML/JSON decode set `HasCoord: true` unconditionally, independent of whether a `<ra>`/`<dec>` (or `ra`/`decl`) field was actually present in the response, for the same reason as above. RA/Dec now decode into presence-aware (`*float64`) fields, and `HasCoord` is only set when both are genuinely present.
+- `catalog/mast`'s `Target.Catalog` held the relayed sub-resolver name (`"NED"`, `"SIMBAD"`, `"VizieR"` — whichever service MAST's `Mast.Name.Lookup` internally answered from) instead of `"mast"`, inconsistent with every other provider setting `Catalog` to its own name. `Catalog` is now always `"mast"`; the relayed resolver name is preserved as an `Aliases` entry instead of being discarded.
+- `catalog/mast` never set `Target.Epoch`; it now defaults to `time.J2000` (SIMBAD/NED name-lookup responses are conventionally J2000 — a documented best-effort assumption, since the API doesn't report which sub-resolver actually answered).
+- `catalog/vizier`'s `ConeSearch` never populated `Target.ID`, even though the same designation value was already used for `Name`/`Designation`. `ID` is now set from the same value.
+- `catalog/vizier`'s `ConeSearch` never set `Target.Epoch`, despite its three registered tables having genuinely different native reference epochs (2MASS ~J2000, Hipparcos J1991.25, Gaia DR3 J2016.0). Each table's schema (`tables.go`) now carries its own `Epoch`, stamped onto every row it produces.
+- `catalog/openngc` never set `Target.Epoch`, despite its RA/Dec being J2000 by the catalog's own convention. Rows now carry `Epoch: time.J2000` explicitly.
+
 ## [0.7.0] — 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Resolve real catalog targets, check tonight's twilight and Moon, score observabi
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -145,14 +146,15 @@ func main() {
 	// ── Targets ──
 	// Resolve by name — coordinates come from SIMBAD/OpenNGC automatically.
 	resolver := catalog.NewResolver(catalog.SIMBAD, catalog.OpenNGC)
+	ctx := context.Background()
 
-	omegaCenCat, err := resolver.Resolve("NGC 5139") // Omega Centauri
+	omegaCenCat, err := resolver.Resolve(ctx, "NGC 5139") // Omega Centauri
 	if err != nil {
 		log.Fatal(err)
 	}
 	omegaCen := plan.FromCatalog(omegaCenCat, nil)
 
-	sgrACat, err := resolver.Resolve("Sgr A*")
+	sgrACat, err := resolver.Resolve(ctx, "Sgr A*")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -341,7 +343,7 @@ Appulse: 2026-11-16 01:38 UTC (min sep: 1.19°)
 ```go
 // Resolve ISS from the live NORAD/CelestTrak catalog.
 resolver := catalog.NewResolver(catalog.NORAD)
-target, _ := resolver.Resolve("ISS (Zarya)")
+target, _ := resolver.Resolve(context.Background(), "ISS (Zarya)")
 
 // SGP4 provider — implements the same Provider interface as JPL planets.
 prov, _ := ephemeris.NewProvider(ephemeris.Satellites, target.Name,

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -1,9 +1,12 @@
 package catalog
 
 import (
+	"context"
 	"errors"
 	"sort"
+	"sync"
 
+	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/gaia"
 	"github.com/TuSKan/astrogo/catalog/jpl"
 	"github.com/TuSKan/astrogo/catalog/mast"
@@ -13,6 +16,8 @@ import (
 	"github.com/TuSKan/astrogo/catalog/sbdb"
 	"github.com/TuSKan/astrogo/catalog/simbad"
 	"github.com/TuSKan/astrogo/catalog/vizier"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Source represents an astronomical data provider type.
@@ -58,13 +63,62 @@ type (
 	SeqIterator[T any] = resolve.SeqIterator[T]
 )
 
-// Resolver orchestrates multiple providers to find astronomical targets.
-type Resolver struct {
-	providers []Provider
+// defaultPositionMatchThreshold is the maximum angular separation (after
+// epoch normalization) at which two Targets from different providers,
+// sharing no alias or ID, are still considered the same physical object.
+// 2 arcsec is generous against typical SIMBAD/OpenNGC/MAST-relayed position
+// precision, and tight against typical inter-object separation in dense
+// fields — see Resolver.PositionMatchThreshold to override it.
+var defaultPositionMatchThreshold = angle.Arcsec(2)
+
+// defaultCap is Search's default result-count ceiling — see Resolver.Limit.
+const defaultCap = 10
+
+// coneSearchRadiusFactor widens a ConeSearch bridge query beyond the
+// acceptance threshold (bounding candidate retrieval, not match
+// acceptance — retrieved candidates are still filtered against the exact
+// threshold before being accepted into a group).
+const coneSearchRadiusFactor = 2.5
+
+type resolverConfig struct {
+	positionMatchThreshold angle.Angle
+	cap                    int
 }
 
-// NewResolver instantiates remote and local catalog implementations securely.
+// coneProvider pairs a resolve.ConeSearcher with the provider name
+// (Provider.Name()) that produced it — ConeSearcher itself has no Name()
+// method, so this is captured once at construction from the same
+// concrete provider value that also satisfies Provider.
+type coneProvider struct {
+	name string
+	cs   resolve.ConeSearcher
+}
+
+// Resolver orchestrates multiple providers to find astronomical targets.
+//
+// Resolve and Search cross-match every provider's results for the same
+// query — by shared alias/ID first, falling back to angular separation
+// (after epoch-normalizing via proper motion) when alias sets don't
+// overlap — and merge each group of matching Targets field-by-field from a
+// provider-precedence table, rather than returning one provider's whole,
+// possibly-incomplete record. Registered ConeSearcher providers (Gaia,
+// VizieR) are bridged in around each group's anchor position, so their
+// astrometry can participate even though neither does name-based lookup.
+type Resolver struct {
+	providers     []Provider
+	coneSearchers []coneProvider
+	cfg           resolverConfig
+}
+
+// NewResolver instantiates remote and local catalog implementations
+// securely for the given sources. Use Limit/PositionMatchThreshold on the
+// returned Resolver to override their defaults (10 results, 2 arcsec).
 func NewResolver(sources ...Source) *Resolver {
+	cfg := resolverConfig{
+		positionMatchThreshold: defaultPositionMatchThreshold,
+		cap:                    defaultCap,
+	}
+
 	var providers []Provider
 
 	for _, src := range sources {
@@ -88,64 +142,103 @@ func NewResolver(sources ...Source) *Resolver {
 		}
 	}
 
-	return &Resolver{providers: providers}
+	var coneSearchers []coneProvider
+
+	for _, p := range providers {
+		if cs, ok := p.(resolve.ConeSearcher); ok {
+			coneSearchers = append(coneSearchers, coneProvider{name: p.Name(), cs: cs})
+		}
+	}
+
+	return &Resolver{providers: providers, coneSearchers: coneSearchers, cfg: cfg}
 }
 
-// Resolve finds a single target matching the query across all providers.
-func (r *Resolver) Resolve(query string) (Target, error) {
+// Limit sets the maximum number of results Search returns (default 10) and
+// returns r for chaining.
+func (r *Resolver) Limit(n int) *Resolver {
+	r.cfg.cap = n
+	return r
+}
+
+// PositionMatchThreshold sets the maximum angular separation (after epoch
+// normalization) at which two Targets are considered the same object
+// (default 2 arcsec) and returns r for chaining.
+func (r *Resolver) PositionMatchThreshold(threshold angle.Angle) *Resolver {
+	r.cfg.positionMatchThreshold = threshold
+	return r
+}
+
+// candidate pairs a Target with the name of the provider (Provider.Name(),
+// never Target.Catalog) that produced it.
+type candidate struct {
+	target   Target
+	provider string
+}
+
+// Resolve finds a single target matching the query, merged across every
+// provider that resolves it directly.
+func (r *Resolver) Resolve(ctx context.Context, query string) (Target, error) {
 	q := resolve.Normalize(query)
 	if q == "" {
 		return Target{}, ErrNotFound
 	}
 
-	// First-match-wins: providers are tried in priority order.
-	// If a provider resolves the query, return immediately.
+	var candidates []candidate
+
 	for _, p := range r.providers {
-		if t, ok := p.Resolve(query); ok {
-			return t, nil
+		if t, ok := p.Resolve(ctx, query); ok {
+			candidates = append(candidates, candidate{t, p.Name()})
 		}
 	}
 
-	// Fall back to fuzzy search across all providers.
-	results := r.Search(query)
-	if len(results) > 0 {
-		return results[0], nil
+	if len(candidates) == 0 {
+		results := r.Search(ctx, query)
+		if len(results) > 0 {
+			return results[0], nil
+		}
+
+		return Target{}, ErrNotFound
 	}
 
-	return Target{}, ErrNotFound
+	groups := r.reconcile(ctx, candidates)
+
+	// candidates (and therefore groups) preserve provider-registration
+	// order, so the first group corresponds to the highest-priority
+	// provider's hit unless it was merged with a later one.
+	return groups[0], nil
 }
 
-// Search returns all matching targets from all providers.
-func (r *Resolver) Search(query string) []Target {
+// Search returns all matching, cross-matched-and-merged targets from every
+// provider, ranked by name/alias/ID match quality and capped at Limit's
+// configured limit (default 10).
+func (r *Resolver) Search(ctx context.Context, query string) []Target {
 	q := resolve.Normalize(query)
 	if q == "" {
 		return nil
 	}
 
-	var all []Target
+	var candidates []candidate
+
 	for _, p := range r.providers {
-		all = append(all, p.Search(query)...)
-	}
-
-	unique := make([]Target, 0, len(all))
-	seen := make(map[string]bool)
-
-	for _, t := range all {
-		key := t.Catalog + ":" + t.ID
-		if !seen[key] {
-			seen[key] = true
-
-			unique = append(unique, t)
+		for _, t := range p.Search(ctx, query) {
+			candidates = append(candidates, candidate{t, p.Name()})
 		}
 	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	groups := r.reconcile(ctx, candidates)
 
 	type scoredTarget struct {
 		t     Target
 		score float64
 	}
 
-	scored := make([]scoredTarget, len(unique))
-	for i, t := range unique {
+	scored := make([]scoredTarget, len(groups))
+
+	for i, t := range groups {
 		bestScore := resolve.Score(q, t.Name)
 		for _, alias := range t.Aliases {
 			if s := resolve.Score(q, alias); s > bestScore {
@@ -164,7 +257,7 @@ func (r *Resolver) Search(query string) []Target {
 		return scored[i].score > scored[j].score
 	})
 
-	limit := min(len(scored), 10)
+	limit := min(len(scored), r.cfg.cap)
 
 	final := make([]Target, limit)
 	for i := range limit {
@@ -172,4 +265,565 @@ func (r *Resolver) Search(query string) []Target {
 	}
 
 	return final
+}
+
+// ── Cross-match + merge pipeline ─────────────────────────────────────────
+
+// reconcile cross-matches candidates describing the same physical object
+// (by shared alias/ID, falling back to position after epoch-normalizing),
+// bridges any registered ConeSearcher's astrometry in around each group's
+// trustworthy anchor position, and merges each resulting group into one
+// Target via field-level provider precedence.
+func (r *Resolver) reconcile(ctx context.Context, candidates []candidate) []Target {
+	uf := newUnionFind(len(candidates))
+	unionByAlias(candidates, uf)
+	unionByPosition(candidates, uf, r.cfg.positionMatchThreshold)
+
+	groups := groupCandidates(candidates, uf)
+
+	if len(r.coneSearchers) > 0 {
+		groups = r.bridgeConeSearch(ctx, groups)
+	}
+
+	merged := make([]Target, len(groups))
+	for i, g := range groups {
+		merged[i] = mergeGroup(g)
+	}
+
+	return merged
+}
+
+// group holds every candidate believed to describe the same physical
+// object, in provider-registration order.
+type group struct {
+	candidates []candidate
+}
+
+// ── Union-find ────────────────────────────────────────────────────────────
+
+type unionFind struct {
+	parent []int
+	rank   []int
+}
+
+func newUnionFind(n int) *unionFind {
+	uf := &unionFind{parent: make([]int, n), rank: make([]int, n)}
+	for i := range uf.parent {
+		uf.parent[i] = i
+	}
+
+	return uf
+}
+
+func (uf *unionFind) find(x int) int {
+	for uf.parent[x] != x {
+		uf.parent[x] = uf.parent[uf.parent[x]] // path halving
+		x = uf.parent[x]
+	}
+
+	return x
+}
+
+func (uf *unionFind) union(a, b int) {
+	ra, rb := uf.find(a), uf.find(b)
+	if ra == rb {
+		return
+	}
+
+	if uf.rank[ra] < uf.rank[rb] {
+		ra, rb = rb, ra
+	}
+
+	uf.parent[rb] = ra
+	if uf.rank[ra] == uf.rank[rb] {
+		uf.rank[ra]++
+	}
+}
+
+// ── Alias-graph cross-match (primary signal) ─────────────────────────────
+
+type matchKey struct {
+	kind  byte // 'i' for ID, 'a' for alias — both funnel into the same union pass
+	value string
+}
+
+// unionByAlias generalizes bigsky's "join on shared Tycho/Hipparcos ID" to
+// Go's Aliases []string: every candidate's own ID and every alias it
+// carries are indexed together, and any two candidates sharing a bucket
+// are unioned. SIMBAD's own cross-identifier table is the one place
+// another provider's native ID format already shows up inside a
+// different provider's Aliases, which is what makes this work in
+// practice for e.g. a SIMBAD hit and a Gaia ConeSearch hit of the same
+// star.
+func unionByAlias(candidates []candidate, uf *unionFind) {
+	idx := make(map[matchKey][]int)
+
+	add := func(k matchKey, i int) { idx[k] = append(idx[k], i) }
+
+	for i, c := range candidates {
+		if c.target.ID != "" {
+			add(matchKey{'i', resolve.Normalize(c.target.ID)}, i)
+		}
+
+		for _, a := range c.target.Aliases {
+			if a != "" {
+				add(matchKey{'a', resolve.Normalize(a)}, i)
+			}
+		}
+	}
+
+	for _, indices := range idx {
+		for i := 1; i < len(indices); i++ {
+			uf.union(indices[0], indices[i])
+		}
+	}
+}
+
+// ── Positional fallback cross-match (secondary signal) ───────────────────
+
+// trustworthyCoord reports whether c's Coord should be trusted for
+// positional cross-matching. Gaia and MAST have both been observed to set
+// HasCoord unconditionally even when the underlying parse/decode failed;
+// this is defense in depth on top of the upstream fixes to those
+// providers, cheap and correct regardless of whether a future regression
+// reintroduces that class of bug.
+func trustworthyCoord(t Target, provider string) bool {
+	if !t.HasCoord {
+		return false
+	}
+
+	switch provider {
+	case "gaia", "mast":
+		return !t.Coord.IsZero()
+	default:
+		return true
+	}
+}
+
+// singletonIndices returns the indices whose union-find group currently
+// has size 1 — the only candidates eligible for positional matching,
+// since anything the alias pass already grouped needs no further check.
+func singletonIndices(candidates []candidate, uf *unionFind) []int {
+	counts := make(map[int]int, len(candidates))
+	for i := range candidates {
+		counts[uf.find(i)]++
+	}
+
+	out := make([]int, 0, len(candidates))
+
+	for i := range candidates {
+		if counts[uf.find(i)] == 1 {
+			out = append(out, i)
+		}
+	}
+
+	return out
+}
+
+// unionByPosition epoch-normalizes every still-singleton, trustworthy-coord
+// candidate to J2000 and unions any pair within threshold. O(M²) over the
+// remaining singletons M, which is bounded by provider count (not catalog
+// size) at this point in the pipeline — appropriate at this scale; see
+// catalog/doc.go for the fuller justification against a spatial index.
+func unionByPosition(candidates []candidate, uf *unionFind, threshold angle.Angle) {
+	singletons := singletonIndices(candidates, uf)
+
+	type normalized struct {
+		idx int
+		c   coord.ICRS
+	}
+
+	norm := make([]normalized, 0, len(singletons))
+
+	for _, i := range singletons {
+		cand := candidates[i]
+		if !trustworthyCoord(cand.target, cand.provider) {
+			continue
+		}
+
+		propagated, err := coord.PropagateEpoch(cand.target.Coord, cand.target.Epoch, time.J2000)
+		if err != nil {
+			continue
+		}
+
+		norm = append(norm, normalized{i, propagated})
+	}
+
+	for a := range norm {
+		for b := a + 1; b < len(norm); b++ {
+			if uf.find(norm[a].idx) == uf.find(norm[b].idx) {
+				continue
+			}
+
+			if coord.Separation(norm[a].c, norm[b].c) <= threshold {
+				uf.union(norm[a].idx, norm[b].idx)
+			}
+		}
+	}
+}
+
+// groupCandidates assembles union-find groups, preserving first-seen-root
+// order so group 0 corresponds to the highest-priority (first-registered)
+// provider's candidate unless it was merged with a later one.
+func groupCandidates(candidates []candidate, uf *unionFind) []group {
+	byRoot := make(map[int]*group, len(candidates))
+
+	var order []int
+
+	for i, c := range candidates {
+		root := uf.find(i)
+
+		g, ok := byRoot[root]
+		if !ok {
+			g = &group{}
+			byRoot[root] = g
+
+			order = append(order, root)
+		}
+
+		g.candidates = append(g.candidates, c)
+	}
+
+	groups := make([]group, len(order))
+	for i, root := range order {
+		groups[i] = *byRoot[root]
+	}
+
+	return groups
+}
+
+// ── ConeSearch bridge (Gaia/VizieR) ──────────────────────────────────────
+
+// anchorCoord returns the first trustworthy, epoch-normalized position in
+// g, if any — the center a ConeSearch bridge query is built around.
+func anchorCoord(g group) (coord.ICRS, bool) {
+	for _, c := range g.candidates {
+		if !trustworthyCoord(c.target, c.provider) {
+			continue
+		}
+
+		propagated, err := coord.PropagateEpoch(c.target.Coord, c.target.Epoch, time.J2000)
+		if err != nil {
+			continue
+		}
+
+		return propagated, true
+	}
+
+	return coord.ICRS{}, false
+}
+
+// bridgeConeSearch fires a ConeSearch against every registered
+// ConeSearcher around each group's anchor position (concurrently, ctx
+// cancellable), then folds any result within threshold of that anchor
+// into the group. Groups with no anchor position (e.g. JPL/SBDB-only
+// matches, which never set Coord) never trigger a ConeSearch call.
+func (r *Resolver) bridgeConeSearch(ctx context.Context, groups []group) []group {
+	type job struct {
+		groupIdx int
+		anchor   coord.ICRS
+	}
+
+	var jobs []job
+
+	for i, g := range groups {
+		if anchor, ok := anchorCoord(g); ok {
+			jobs = append(jobs, job{i, anchor})
+		}
+	}
+
+	if len(jobs) == 0 {
+		return groups
+	}
+
+	extra := make([][]candidate, len(groups))
+	radius := r.cfg.positionMatchThreshold.MulScalar(coneSearchRadiusFactor)
+
+	var wg sync.WaitGroup
+
+	var mu sync.Mutex
+
+	for _, j := range jobs {
+		for _, cp := range r.coneSearchers {
+			wg.Add(1)
+
+			go func(groupIdx int, anchor coord.ICRS, cp coneProvider) {
+				defer wg.Done()
+
+				req := resolve.ConeRequest{Center: anchor, Radius: radius, Limit: 20}
+
+				var found []candidate
+
+				iter := cp.cs.ConeSearch(ctx, req)
+				iter(func(t resolve.Target, err error) bool {
+					if err == nil {
+						found = append(found, candidate{t, cp.name})
+					}
+
+					return true
+				})
+
+				if len(found) == 0 {
+					return
+				}
+
+				mu.Lock()
+
+				extra[groupIdx] = append(extra[groupIdx], found...)
+
+				mu.Unlock()
+			}(j.groupIdx, j.anchor, cp)
+		}
+	}
+
+	wg.Wait()
+
+	for i := range groups {
+		if len(extra[i]) == 0 {
+			continue
+		}
+
+		groups[i] = foldConeSearchResults(groups[i], extra[i], r.cfg.positionMatchThreshold)
+	}
+
+	return groups
+}
+
+// foldConeSearchResults filters newCandidates (a bridge query's raw
+// results, retrieved within the wider coneSearchRadiusFactor radius) down
+// to those genuinely within threshold of g's own anchor, and appends them
+// to g.
+func foldConeSearchResults(g group, newCandidates []candidate, threshold angle.Angle) group {
+	anchor, ok := anchorCoord(g)
+	if !ok {
+		return g
+	}
+
+	for _, nc := range newCandidates {
+		if !trustworthyCoord(nc.target, nc.provider) {
+			continue
+		}
+
+		propagated, err := coord.PropagateEpoch(nc.target.Coord, nc.target.Epoch, time.J2000)
+		if err != nil {
+			continue
+		}
+
+		if coord.Separation(anchor, propagated) <= threshold {
+			g.candidates = append(g.candidates, nc)
+		}
+	}
+
+	return g
+}
+
+// ── Field-level precedence merge ─────────────────────────────────────────
+
+// fieldRule coalesces one field (or a tightly-coupled cluster of fields)
+// from whichever provider in a group ranks highest in precedence and
+// actually has it populated.
+type fieldRule struct {
+	precedence []string
+	hasField   func(Target) bool
+	take       func(dst *Target, src Target, provider string)
+}
+
+func setProvenance(dst *Target, field, provider string) {
+	if dst.Provenance == nil {
+		dst.Provenance = make(map[string]string)
+	}
+
+	dst.Provenance[field] = provider
+}
+
+// scalarFieldRules covers fields whose precedence is independent of
+// Coord/Parallax/PmRA/PmDec (handled separately in mergeGroup, since
+// those four are astrometrically coupled and must come from the same
+// source or not at all).
+var scalarFieldRules = []fieldRule{
+	{
+		// Gaia's VMag is a derived G->V estimate, not real photometry —
+		// ranks last despite leading astrometry precedence below.
+		precedence: []string{"simbad", "openngc", "gaia"},
+		hasField:   func(t Target) bool { return t.HasVMag },
+		take: func(dst *Target, src Target, provider string) {
+			dst.VMag, dst.HasVMag = src.VMag, true
+			setProvenance(dst, "VMag", provider)
+		},
+	},
+	{
+		precedence: []string{"gaia", "simbad", "vizier", "openngc", "mast"},
+		hasField:   func(t Target) bool { return !t.Epoch.IsZero() },
+		take: func(dst *Target, src Target, provider string) {
+			dst.Epoch = src.Epoch
+			setProvenance(dst, "Epoch", provider)
+		},
+	},
+	{
+		precedence: []string{"simbad"},
+		hasField:   func(t Target) bool { return t.RadialVelocity != 0 },
+		take: func(dst *Target, src Target, provider string) {
+			dst.RadialVelocity = src.RadialVelocity
+			setProvenance(dst, "RadialVelocity", provider)
+		},
+	},
+	{
+		// SBDB-only physical-parameter cluster (H/G/M1/K1/M2/K2/G1/G2) —
+		// no other provider populates any of these today.
+		precedence: []string{"sbdb"},
+		hasField:   func(t Target) bool { return t.HasH || t.HasM1 || t.HasG1G2 },
+		take: func(dst *Target, src Target, provider string) {
+			dst.H, dst.HasH = src.H, src.HasH
+			dst.G = src.G
+			dst.M1, dst.HasM1 = src.M1, src.HasM1
+			dst.K1 = src.K1
+			dst.M2 = src.M2
+			dst.K2 = src.K2
+			dst.G1, dst.G2, dst.HasG1G2 = src.G1, src.G2, src.HasG1G2
+			setProvenance(dst, "PhysicalParams", provider)
+		},
+	},
+}
+
+// astrometricPrecedence orders providers for Coord/Parallax/PmRA/PmDec,
+// treated as one coupled cluster: mixing Coord from one source with
+// proper motion from another would describe an internally-inconsistent
+// astrometric solution, so whichever provider wins Coord also supplies
+// whatever of Parallax/PmRA/PmDec it has (possibly none).
+var astrometricPrecedence = []string{"gaia", "simbad", "openngc", "mast", "vizier"}
+
+// mergeGroup coalesces g's candidates into one Target: identity/metadata
+// fields take the first group member (registration order) with a value;
+// Aliases is always a union; Coord/Parallax/PmRA/PmDec come from the
+// highest-precedence trustworthy-coord member; every other field follows
+// scalarFieldRules.
+func mergeGroup(g group) Target {
+	var merged Target
+
+	for _, c := range g.candidates {
+		t := c.target
+
+		if merged.ID == "" && t.ID != "" {
+			merged.ID = t.ID
+			setProvenance(&merged, "ID", c.provider)
+		}
+
+		if merged.Name == "" && t.Name != "" {
+			merged.Name = t.Name
+			setProvenance(&merged, "Name", c.provider)
+		}
+
+		if merged.Designation == "" && t.Designation != "" {
+			merged.Designation = t.Designation
+			setProvenance(&merged, "Designation", c.provider)
+		}
+
+		if merged.SPKID == "" && t.SPKID != "" {
+			merged.SPKID = t.SPKID
+			setProvenance(&merged, "SPKID", c.provider)
+		}
+
+		if merged.Catalog == "" && t.Catalog != "" {
+			merged.Catalog = t.Catalog
+			setProvenance(&merged, "Catalog", c.provider)
+		}
+
+		if merged.Kind == "" && t.Kind != "" {
+			merged.Kind = t.Kind
+			setProvenance(&merged, "Kind", c.provider)
+		}
+
+		if merged.TLELine1 == "" && t.TLELine1 != "" {
+			merged.TLELine1 = t.TLELine1
+			setProvenance(&merged, "TLELine1", c.provider)
+		}
+
+		if merged.TLELine2 == "" && t.TLELine2 != "" {
+			merged.TLELine2 = t.TLELine2
+			setProvenance(&merged, "TLELine2", c.provider)
+		}
+	}
+
+	merged.Aliases = collectAliases(g)
+
+astrometry:
+	for _, provider := range astrometricPrecedence {
+		for _, c := range g.candidates {
+			if c.provider != provider || !trustworthyCoord(c.target, c.provider) {
+				continue
+			}
+
+			merged.Coord, merged.HasCoord = c.target.Coord, true
+			setProvenance(&merged, "Coord", provider)
+
+			if c.target.Parallax != 0 {
+				merged.Parallax = c.target.Parallax
+				setProvenance(&merged, "Parallax", provider)
+			}
+
+			if c.target.PmRA != 0 {
+				merged.PmRA = c.target.PmRA
+				setProvenance(&merged, "PmRA", provider)
+			}
+
+			if c.target.PmDec != 0 {
+				merged.PmDec = c.target.PmDec
+				setProvenance(&merged, "PmDec", provider)
+			}
+
+			break astrometry
+		}
+	}
+
+	for _, rule := range scalarFieldRules {
+		for _, provider := range rule.precedence {
+			for _, c := range g.candidates {
+				if c.provider != provider || !rule.hasField(c.target) {
+					continue
+				}
+
+				rule.take(&merged, c.target, provider)
+
+				goto nextRule
+			}
+		}
+
+	nextRule:
+	}
+
+	return merged
+}
+
+// collectAliases unions every group member's own ID and Aliases list —
+// never precedence-picked, since more cross-IDs only helps a future
+// alias-graph pass, and this is exactly what feeds it.
+func collectAliases(g group) []string {
+	seen := make(map[string]bool)
+
+	var out []string
+
+	add := func(v string) {
+		if v == "" {
+			return
+		}
+
+		key := resolve.Normalize(v)
+		if seen[key] {
+			return
+		}
+
+		seen[key] = true
+
+		out = append(out, v)
+	}
+
+	for _, c := range g.candidates {
+		add(c.target.ID)
+
+		for _, a := range c.target.Aliases {
+			add(a)
+		}
+	}
+
+	return out
 }

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -1,10 +1,15 @@
 package catalog
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
 )
 
 type mockProvider struct {
@@ -13,12 +18,13 @@ type mockProvider struct {
 }
 
 func (p *mockProvider) Name() string { return p.name }
-func (p *mockProvider) Resolve(query string) (Target, bool) {
+
+func (p *mockProvider) Resolve(_ context.Context, query string) (Target, bool) {
 	t, ok := p.targets[resolve.Normalize(query)]
 	return t, ok
 }
 
-func (p *mockProvider) Search(query string) []Target {
+func (p *mockProvider) Search(_ context.Context, query string) []Target {
 	var res []Target
 
 	q := resolve.Normalize(query)
@@ -29,6 +35,36 @@ func (p *mockProvider) Search(query string) []Target {
 	}
 
 	return res
+}
+
+// mockConeSearcher is a resolve.ConeSearcher stub that ignores its request
+// and always yields a fixed set of targets — matching production
+// ConeSearchers (Gaia/VizieR), the request-driven filtering happens
+// downstream in Resolver.foldConeSearchResults, not inside the searcher.
+type mockConeSearcher struct {
+	targets []Target
+}
+
+func (m *mockConeSearcher) Capabilities() []resolve.Capability {
+	return []resolve.Capability{resolve.CapConeSearch}
+}
+
+func (m *mockConeSearcher) ConeSearch(_ context.Context, _ resolve.ConeRequest) resolve.SeqIterator[Target] {
+	return resolve.SliceSeq(m.targets)
+}
+
+// containsNormalized reports whether id appears in aliases, comparing under
+// resolve.Normalize (matching how the alias-graph cross-match itself keys
+// its buckets).
+func containsNormalized(aliases []string, id string) bool {
+	want := resolve.Normalize(id)
+	for _, a := range aliases {
+		if resolve.Normalize(a) == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TestResolver_Resolve(t *testing.T) {
@@ -61,7 +97,7 @@ func TestResolver_Resolve(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			got, err := r.Resolve(tt.query)
+			got, err := r.Resolve(context.Background(), tt.query)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -74,35 +110,68 @@ func TestResolver_Resolve(t *testing.T) {
 	}
 }
 
+// TestResolver_ProviderPriority confirms that when multiple providers
+// resolve the same physical object (linked here by a shared alias), Resolve
+// merges their disjoint fields into one Target rather than any single
+// provider's whole record winning outright — and that Provenance records
+// which provider contributed each field.
 func TestResolver_ProviderPriority(t *testing.T) {
-	// When multiple providers resolve the same query,
-	// the first provider in priority order wins.
-	p1 := &mockProvider{
-		name: "p1",
-		targets: map[string]Target{
-			"target": {ID: "target", Name: "Target 1", Catalog: "p1"},
+	p1 := &mockProvider{name: "gaia", targets: map[string]Target{
+		"target": {
+			ID: "gaia-1", Aliases: []string{"shared"},
+			Coord: coord.NewICRS(angle.Deg(101.287155), angle.Deg(-16.716116)), HasCoord: true,
+			Epoch: time.J2000,
+			PmRA:  angle.Arcsec(-0.379), PmDec: angle.Arcsec(-1.303), Parallax: angle.Arcsec(0.379),
 		},
-	}
-	p2 := &mockProvider{
-		name: "p2",
-		targets: map[string]Target{
-			"target": {ID: "target", Name: "Target 2", Catalog: "p2"},
+	}}
+	p2 := &mockProvider{name: "simbad", targets: map[string]Target{
+		"target": {
+			ID: "* alf CMa", Name: "Sirius", Aliases: []string{"shared", "HD 48915"},
+			VMag: -1.46, HasVMag: true,
 		},
+	}}
+	p3 := &mockProvider{name: "mast", targets: map[string]Target{
+		"target": {
+			ID: "MAST-1", Name: "Sirius A", Aliases: []string{"shared"},
+		},
+	}}
+
+	r := &Resolver{
+		providers: []resolve.Provider{p1, p2, p3},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
 	}
 
-	r := &Resolver{providers: []resolve.Provider{p1, p2}}
-
-	got, err := r.Resolve("target")
+	got, err := r.Resolve(context.Background(), "target")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got.Catalog != "p1" {
-		t.Errorf("expected p1 (first provider), got catalog=%s", got.Catalog)
+	if got.ID != "gaia-1" || got.Provenance["ID"] != "gaia" {
+		t.Errorf("expected gaia's ID (first-registered with a value), got ID=%q provenance=%q", got.ID, got.Provenance["ID"])
 	}
 
-	if got.Name != "Target 1" {
-		t.Errorf("expected 'Target 1', got %q", got.Name)
+	if got.Name != "Sirius" || got.Provenance["Name"] != "simbad" {
+		t.Errorf("expected simbad's Name (first non-empty after gaia), got Name=%q provenance=%q", got.Name, got.Provenance["Name"])
+	}
+
+	if !got.HasCoord || got.Provenance["Coord"] != "gaia" {
+		t.Errorf("expected gaia's Coord (astrometric precedence), got HasCoord=%v provenance=%q", got.HasCoord, got.Provenance["Coord"])
+	}
+
+	testutil.AssertNear(t, "merged PmRA", got.PmRA.Arcseconds(), -0.379, 1e-9)
+
+	if got.Provenance["PmRA"] != "gaia" {
+		t.Errorf("expected gaia's PmRA as part of the coupled astrometric cluster, provenance=%q", got.Provenance["PmRA"])
+	}
+
+	if got.VMag != -1.46 || got.Provenance["VMag"] != "simbad" {
+		t.Errorf("expected simbad's VMag, got %v/%q", got.VMag, got.Provenance["VMag"])
+	}
+
+	for _, id := range []string{"gaia-1", "* alf CMa", "HD 48915", "MAST-1"} {
+		if !containsNormalized(got.Aliases, id) {
+			t.Errorf("expected merged Aliases to include %q, got %v", id, got.Aliases)
+		}
 	}
 }
 
@@ -134,6 +203,377 @@ func BenchmarkResolve(b *testing.B) {
 
 	r := &Resolver{providers: []resolve.Provider{p}}
 	for range b.N {
-		_, _ = r.Resolve("M42")
+		_, _ = r.Resolve(context.Background(), "M42")
+	}
+}
+
+// ── mergeGroup: field-precedence merge unit tests ───────────────────────────
+
+func TestMergeGroup_IdentityFieldsFirstNonEmptyWins(t *testing.T) {
+	g := group{candidates: []candidate{
+		{provider: "p1", target: Target{}},
+		{provider: "p2", target: Target{ID: "id2", Name: "Name2", Catalog: "cat2"}},
+		{provider: "p3", target: Target{ID: "id3", Name: "Name3", Catalog: "cat3"}},
+	}}
+
+	got := mergeGroup(g)
+
+	if got.ID != "id2" || got.Name != "Name2" || got.Catalog != "cat2" {
+		t.Fatalf("expected first-non-empty (p2) to win identity fields, got %+v", got)
+	}
+
+	if got.Provenance["ID"] != "p2" || got.Provenance["Name"] != "p2" || got.Provenance["Catalog"] != "p2" {
+		t.Errorf("expected identity field provenance = p2, got %+v", got.Provenance)
+	}
+}
+
+func TestMergeGroup_AliasesAlwaysUnioned(t *testing.T) {
+	g := group{candidates: []candidate{
+		{provider: "p1", target: Target{ID: "id1", Aliases: []string{"alpha"}}},
+		{provider: "p2", target: Target{ID: "id2", Aliases: []string{"alpha", "beta"}}},
+	}}
+
+	got := mergeGroup(g)
+
+	want := []string{"id1", "alpha", "id2", "beta"}
+	if len(got.Aliases) != len(want) {
+		t.Fatalf("Aliases = %v, want %v", got.Aliases, want)
+	}
+
+	for i, w := range want {
+		if resolve.Normalize(got.Aliases[i]) != resolve.Normalize(w) {
+			t.Errorf("Aliases[%d] = %q, want %q", i, got.Aliases[i], w)
+		}
+	}
+}
+
+// TestMergeGroup_AstrometricClusterComesFromOneProvider confirms
+// Coord/PmRA/PmDec/Parallax are treated as one coupled cluster taken
+// entirely from the highest-precedence trustworthy provider, never mixed
+// field-by-field across providers (which would describe an internally
+// inconsistent astrometric solution).
+func TestMergeGroup_AstrometricClusterComesFromOneProvider(t *testing.T) {
+	gaiaCoord := coord.NewICRS(angle.Deg(10), angle.Deg(20))
+	simbadCoord := coord.NewICRS(angle.Deg(11), angle.Deg(21)) // deliberately different, to prove it's not used
+
+	g := group{candidates: []candidate{
+		{provider: "simbad", target: Target{
+			Coord: simbadCoord, HasCoord: true,
+			PmRA: angle.Arcsec(99), PmDec: angle.Arcsec(99), Parallax: angle.Arcsec(99),
+		}},
+		{provider: "gaia", target: Target{
+			Coord: gaiaCoord, HasCoord: true,
+			PmRA: angle.Arcsec(1.2), PmDec: angle.Arcsec(-3.4), Parallax: angle.Arcsec(5.6),
+		}},
+	}}
+
+	got := mergeGroup(g)
+
+	if !got.Coord.Equal(gaiaCoord) {
+		t.Errorf("Coord = %v, want gaia's %v (gaia outranks simbad)", got.Coord, gaiaCoord)
+	}
+
+	testutil.AssertNear(t, "PmRA", got.PmRA.Arcseconds(), 1.2, 1e-9)
+	testutil.AssertNear(t, "PmDec", got.PmDec.Arcseconds(), -3.4, 1e-9)
+	testutil.AssertNear(t, "Parallax", got.Parallax.Arcseconds(), 5.6, 1e-9)
+
+	for _, field := range []string{"Coord", "PmRA", "PmDec", "Parallax"} {
+		if got.Provenance[field] != "gaia" {
+			t.Errorf("Provenance[%q] = %q, want gaia", field, got.Provenance[field])
+		}
+	}
+}
+
+// TestMergeGroup_UntrustworthyCoordFallsBackToNextProvider exercises
+// trustworthyCoord's guard against the bug class where Gaia/MAST set
+// HasCoord unconditionally even when the underlying position is actually
+// (0,0) — the merge must skip straight past that candidate to the next
+// provider in astrometric precedence.
+func TestMergeGroup_UntrustworthyCoordFallsBackToNextProvider(t *testing.T) {
+	simbadCoord := coord.NewICRS(angle.Deg(15), angle.Deg(25))
+
+	g := group{candidates: []candidate{
+		{provider: "gaia", target: Target{Coord: coord.ICRS{}, HasCoord: true}},
+		{provider: "simbad", target: Target{Coord: simbadCoord, HasCoord: true}},
+	}}
+
+	got := mergeGroup(g)
+
+	if !got.Coord.Equal(simbadCoord) {
+		t.Errorf("expected fallback to simbad's coord since gaia's is untrustworthy, got %v", got.Coord)
+	}
+
+	if got.Provenance["Coord"] != "simbad" {
+		t.Errorf("Provenance[Coord] = %q, want simbad", got.Provenance["Coord"])
+	}
+}
+
+// TestMergeGroup_VMagPrecedence confirms real photometry (SIMBAD) outranks
+// Gaia's derived G->V estimate.
+func TestMergeGroup_VMagPrecedence(t *testing.T) {
+	g := group{candidates: []candidate{
+		{provider: "gaia", target: Target{VMag: 5.0, HasVMag: true}},
+		{provider: "simbad", target: Target{VMag: 4.5, HasVMag: true}},
+	}}
+
+	got := mergeGroup(g)
+
+	if got.VMag != 4.5 || got.Provenance["VMag"] != "simbad" {
+		t.Errorf("expected simbad's VMag (real photometry outranks Gaia's derived estimate), got VMag=%v provenance=%v",
+			got.VMag, got.Provenance["VMag"])
+	}
+}
+
+// ── Cross-match integration tests (via Resolver.Resolve/Search) ────────────
+
+// TestResolver_CrossMatchByAlias confirms two providers sharing the same ID
+// string (the direct generalization of bigsky's "join on shared Tycho ID")
+// merge into one Target combining their disjoint fields.
+func TestResolver_CrossMatchByAlias(t *testing.T) {
+	p1 := &mockProvider{name: "gaia", targets: map[string]Target{
+		"sirius": {
+			ID: "gaia-1", Coord: coord.NewICRS(angle.Deg(101.28), angle.Deg(-16.71)),
+			HasCoord: true, Epoch: time.J2000,
+		},
+	}}
+	p2 := &mockProvider{name: "simbad", targets: map[string]Target{
+		"sirius": {ID: "gaia-1", Aliases: []string{"HD 48915"}, VMag: -1.46, HasVMag: true},
+	}}
+
+	r := &Resolver{
+		providers: []resolve.Provider{p1, p2},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got, err := r.Resolve(context.Background(), "sirius")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.HasCoord {
+		t.Error("expected merged target to carry gaia's Coord")
+	}
+
+	if got.VMag != -1.46 {
+		t.Errorf("expected merged target to carry simbad's VMag, got %v", got.VMag)
+	}
+
+	if !containsNormalized(got.Aliases, "HD 48915") {
+		t.Errorf("expected merged Aliases to include HD 48915, got %v", got.Aliases)
+	}
+}
+
+// TestResolver_CrossMatchByPosition_SameEpochMerges confirms two providers
+// with no shared alias/ID, but positions within the default 2" threshold at
+// the same epoch, merge via the positional fallback.
+func TestResolver_CrossMatchByPosition_SameEpochMerges(t *testing.T) {
+	p1 := &mockProvider{name: "p1", targets: map[string]Target{
+		"a": {ID: "A1", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.822), angle.Deg(-5.391)), HasCoord: true, Epoch: time.J2000},
+	}}
+	p2 := &mockProvider{name: "p2", targets: map[string]Target{
+		"b": {ID: "B2", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911)), HasCoord: true, Epoch: time.J2000},
+	}}
+
+	r := &Resolver{
+		providers: []resolve.Provider{p1, p2},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got := r.Search(context.Background(), "TestObj")
+	if len(got) != 1 {
+		t.Fatalf("expected positional fallback to merge into 1 target, got %d: %+v", len(got), got)
+	}
+
+	if !containsNormalized(got[0].Aliases, "A1") || !containsNormalized(got[0].Aliases, "B2") {
+		t.Errorf("expected merged Aliases to include both source IDs, got %v", got[0].Aliases)
+	}
+}
+
+// TestResolver_CrossMatchByPosition_TooFarDoesNotMerge is the negative case:
+// two candidates well outside the match threshold must remain separate
+// Targets, not be forced together.
+func TestResolver_CrossMatchByPosition_TooFarDoesNotMerge(t *testing.T) {
+	p1 := &mockProvider{name: "p1", targets: map[string]Target{
+		"a": {ID: "A1", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.80), angle.Deg(-5.39)), HasCoord: true, Epoch: time.J2000},
+	}}
+	p2 := &mockProvider{name: "p2", targets: map[string]Target{
+		"b": {ID: "B2", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.82), angle.Deg(-5.39)), HasCoord: true, Epoch: time.J2000},
+	}}
+
+	r := &Resolver{
+		providers: []resolve.Provider{p1, p2},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got := r.Search(context.Background(), "TestObj")
+	if len(got) != 2 {
+		t.Fatalf("expected two distinct targets beyond the match threshold, got %d: %+v", len(got), got)
+	}
+}
+
+// TestResolver_CrossMatchByPosition_EpochMismatchAppliesPropagation builds a
+// second candidate 50 (simulated) years after the first, carrying the exact
+// proper motion needed to have arrived at its stored position from the
+// first candidate's — proving the positional fallback genuinely propagates
+// through coord.PropagateEpoch before comparing, not just comparing raw
+// stored coordinates. The sanity check confirms the raw (unpropagated)
+// separation is far outside the threshold, so a regression that skipped
+// propagation would fail this test honestly instead of passing by
+// coincidence.
+func TestResolver_CrossMatchByPosition_EpochMismatchAppliesPropagation(t *testing.T) {
+	baseRA, baseDec := angle.Deg(10), angle.Deg(0)
+	pmRA, pmDec := angle.Arcsec(1.0), angle.Arcsec(0)
+	parallax := angle.Arcsec(0.01)
+
+	laterEpoch := time.J2000.Add((50 * 365.25 * 24) * time.Hour)
+
+	base := coord.NewICRSWithKinematics(baseRA, baseDec, pmRA, pmDec, parallax, 0)
+
+	laterCoord, err := coord.PropagateEpoch(base, time.J2000, laterEpoch)
+	if err != nil {
+		t.Fatalf("test setup: PropagateEpoch: %v", err)
+	}
+
+	if sep := coord.Separation(base, laterCoord); sep.Arcseconds() < defaultPositionMatchThreshold.Arcseconds() {
+		t.Fatalf("test setup invalid: raw separation %.3f\" already within threshold", sep.Arcseconds())
+	}
+
+	p1 := &mockProvider{name: "p1", targets: map[string]Target{
+		"a": {ID: "P1", Name: "TestStar", Coord: base, HasCoord: true, Epoch: time.J2000},
+	}}
+	p2 := &mockProvider{name: "p2", targets: map[string]Target{
+		"b": {
+			ID: "P2", Name: "TestStar", Coord: laterCoord, HasCoord: true, Epoch: laterEpoch,
+			PmRA: pmRA, PmDec: pmDec, Parallax: parallax,
+		},
+	}}
+
+	r := &Resolver{
+		providers: []resolve.Provider{p1, p2},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got := r.Search(context.Background(), "TestStar")
+	if len(got) != 1 {
+		t.Fatalf("expected epoch-normalized positional match to merge into 1 target, got %d: %+v", len(got), got)
+	}
+}
+
+// TestResolver_ConeSearchBridge_FoldsInAstrometry confirms a registered
+// ConeSearcher (Gaia/VizieR's real role) contributes its astrometry into a
+// group anchored by a name-resolvable provider's position, and that its
+// higher astrometric precedence then wins the merge.
+func TestResolver_ConeSearchBridge_FoldsInAstrometry(t *testing.T) {
+	anchor := coord.NewICRS(angle.Deg(50), angle.Deg(10))
+	coneCoord := coord.NewICRS(angle.Deg(50.0001), angle.Deg(10.0001)) // ~0.5" from anchor
+
+	p1 := &mockProvider{name: "simbad", targets: map[string]Target{
+		"star": {ID: "S1", Name: "Star", Coord: anchor, HasCoord: true, Epoch: time.J2000},
+	}}
+
+	cs := &mockConeSearcher{targets: []Target{
+		{ID: "GAIA123", Coord: coneCoord, HasCoord: true, Epoch: time.J2000, Parallax: angle.Arcsec(5)},
+	}}
+
+	r := &Resolver{
+		providers:     []resolve.Provider{p1},
+		coneSearchers: []coneProvider{{name: "gaia", cs: cs}},
+		cfg:           resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got, err := r.Resolve(context.Background(), "star")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Provenance["Coord"] != "gaia" {
+		t.Errorf("expected the bridged gaia candidate to win Coord precedence, provenance=%q", got.Provenance["Coord"])
+	}
+
+	testutil.AssertNear(t, "Parallax", got.Parallax.Arcseconds(), 5, 1e-9)
+
+	if got.Provenance["Parallax"] != "gaia" {
+		t.Errorf("expected Parallax provenance = gaia, got %q", got.Provenance["Parallax"])
+	}
+
+	if !containsNormalized(got.Aliases, "GAIA123") {
+		t.Errorf("expected merged Aliases to include the bridged candidate's ID, got %v", got.Aliases)
+	}
+}
+
+// ── Configurable chained setters ─────────────────────────────────────────────
+
+func TestResolver_Limit(t *testing.T) {
+	r := &Resolver{cfg: resolverConfig{cap: defaultCap}}
+
+	if got := r.Limit(5); got != r {
+		t.Error("Limit should return r for chaining")
+	}
+
+	if r.cfg.cap != 5 {
+		t.Errorf("Limit(5) set cap = %d, want 5", r.cfg.cap)
+	}
+}
+
+func TestResolver_PositionMatchThreshold(t *testing.T) {
+	r := &Resolver{cfg: resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold}}
+
+	if got := r.PositionMatchThreshold(angle.Arcsec(10)); got != r {
+		t.Error("PositionMatchThreshold should return r for chaining")
+	}
+
+	testutil.AssertNear(t, "positionMatchThreshold", r.cfg.positionMatchThreshold.Arcseconds(), 10, 1e-9)
+}
+
+// TestResolver_Search_RespectsCap confirms Search actually caps its result
+// count at cfg.cap rather than the old hardcoded 10.
+func TestResolver_Search_RespectsCap(t *testing.T) {
+	p := &mockProvider{name: "p", targets: map[string]Target{
+		"1": {ID: "T1", Name: "TestObj"},
+		"2": {ID: "T2", Name: "TestObj"},
+		"3": {ID: "T3", Name: "TestObj"},
+	}}
+
+	// All three targets share no aliases/IDs/positions, so each remains its
+	// own group; Search's rank-then-cap step is what limits the count.
+	r := &Resolver{
+		providers: []resolve.Provider{p},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: 2},
+	}
+
+	got := r.Search(context.Background(), "TestObj")
+	if len(got) != 2 {
+		t.Fatalf("expected Limit(2)'s configured cap to limit results to 2, got %d", len(got))
+	}
+}
+
+// TestResolver_PositionMatchThreshold_Configurable demonstrates that
+// widening PositionMatchThreshold changes cross-match behavior: the same
+// two candidates fail to merge under a tight threshold but do merge under
+// a looser one.
+func TestResolver_PositionMatchThreshold_Configurable(t *testing.T) {
+	newResolver := func(threshold angle.Angle) *Resolver {
+		p1 := &mockProvider{name: "p1", targets: map[string]Target{
+			"a": {ID: "A1", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.80), angle.Deg(-5.39)), HasCoord: true, Epoch: time.J2000},
+		}}
+		p2 := &mockProvider{name: "p2", targets: map[string]Target{
+			"b": {ID: "B2", Name: "TestObj", Coord: coord.NewICRS(angle.Deg(83.8003), angle.Deg(-5.39)), HasCoord: true, Epoch: time.J2000},
+		}}
+
+		return &Resolver{
+			providers: []resolve.Provider{p1, p2},
+			cfg:       resolverConfig{positionMatchThreshold: threshold, cap: defaultCap},
+		}
+	}
+
+	// ~1.08" apart (0.0003 deg * 3600 * cos(-5.39deg)).
+	tight := newResolver(angle.Arcsec(0.5))
+	if got := tight.Search(context.Background(), "TestObj"); len(got) != 2 {
+		t.Fatalf("expected a tight 0.5\" threshold to keep candidates separate, got %d results", len(got))
+	}
+
+	loose := newResolver(angle.Arcsec(2))
+	if got := loose.Search(context.Background(), "TestObj"); len(got) != 1 {
+		t.Fatalf("expected a loose 2\" threshold to merge the same candidates, got %d results", len(got))
 	}
 }

--- a/catalog/example_test.go
+++ b/catalog/example_test.go
@@ -1,6 +1,7 @@
 package catalog_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ func TestIntegration(t *testing.T) {
 	// We'll search for the Andromeda Galaxy (M31)
 	resolver := catalog.NewResolver(catalog.SIMBAD)
 
-	andromeda, err := resolver.Resolve("M31")
+	andromeda, err := resolver.Resolve(context.Background(), "M31")
 	if err != nil {
 		t.Skipf("Skipping integration test — cannot reach SIMBAD: %v", err)
 	}

--- a/catalog/gaia/gaia.go
+++ b/catalog/gaia/gaia.go
@@ -44,12 +44,12 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve always returns false for Gaia (no name resolution).
-func (p *Provider) Resolve(_ string) (resolve.Target, bool) {
+func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, bool) {
 	return resolve.Target{}, false
 }
 
 // Search always returns nil for Gaia (no name search).
-func (p *Provider) Search(_ string) []resolve.Target {
+func (p *Provider) Search(_ context.Context, _ string) []resolve.Target {
 	return nil
 }
 
@@ -136,8 +136,16 @@ func parseCSV(body io.Reader) ([]resolve.Target, error) {
 		}
 
 		id := row[col["source_id"]]
-		raDeg, _ := strconv.ParseFloat(row[col["ra"]], 64)
-		decDeg, _ := strconv.ParseFloat(row[col["dec"]], 64)
+
+		raDeg, raErr := strconv.ParseFloat(row[col["ra"]], 64)
+		decDeg, decErr := strconv.ParseFloat(row[col["dec"]], 64)
+
+		if raErr != nil || decErr != nil {
+			// A row with an unparseable/missing position is useless for
+			// astrometric cross-matching and worse than absent — skip it
+			// rather than reporting a fake (0,0) as if it were real.
+			continue
+		}
 
 		t := resolve.Target{
 			ID:       id,

--- a/catalog/gaia/gaia_test.go
+++ b/catalog/gaia/gaia_test.go
@@ -56,6 +56,57 @@ func TestGaiaOfflineConeSearch(t *testing.T) {
 	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "Gaia DR3")
 }
 
+// TestGaiaOfflineConeSearch_SkipsUnparseableRow is a regression test: a row
+// with a malformed RA/Dec must be skipped entirely, never silently become a
+// fake (0,0) position reported as HasCoord=true (the bug class this
+// provider used to have — see catalog/catalog.go's trustworthyCoord, which
+// exists as defense in depth against exactly this).
+func TestGaiaOfflineConeSearch_SkipsUnparseableRow(t *testing.T) {
+	csvData := `source_id,ra,dec,pmra,pmdec,parallax
+111111111,not-a-number,41.269,1.1,-2.2,5.5
+222222222,10.684,41.269,1.1,-2.2,5.5
+`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+
+		if _, err := fmt.Fprint(w, csvData); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	prov := New()
+	prov.client.HTTPClient.Transport = &mockTransport{Handler: server.Config.Handler}
+
+	req := resolve.ConeRequest{
+		Center: coord.NewICRS(angle.Deg(10), angle.Deg(40)),
+		Radius: angle.Deg(5),
+	}
+
+	iter := prov.ConeSearch(context.Background(), req)
+
+	var targets []resolve.Target
+
+	iter(func(tar resolve.Target, err error) bool {
+		testutil.AssertNoError(t, err)
+
+		targets = append(targets, tar)
+
+		return true
+	})
+
+	if len(targets) != 1 {
+		t.Fatalf("expected the unparseable row to be skipped, leaving 1 target, got %d", len(targets))
+	}
+
+	testutil.AssertEqual(t, "ID", targets[0].ID, "222222222")
+
+	if !targets[0].HasCoord || targets[0].Coord.IsZero() {
+		t.Errorf("expected a real, non-zero coordinate, got HasCoord=%v Coord=%v", targets[0].HasCoord, targets[0].Coord)
+	}
+}
+
 type mockTransport struct {
 	Handler http.Handler
 }
@@ -78,12 +129,12 @@ func TestProviderInterface(t *testing.T) {
 		t.Errorf("expected CapConeSearch, got %v", caps)
 	}
 
-	_, ok := p.Resolve("foo")
+	_, ok := p.Resolve(context.Background(), "foo")
 	if ok {
 		t.Error("expected Resolve to return false")
 	}
 
-	if p.Search("foo") != nil {
+	if p.Search(context.Background(), "foo") != nil {
 		t.Error("expected Search to return nil")
 	}
 }

--- a/catalog/jpl/jpl.go
+++ b/catalog/jpl/jpl.go
@@ -52,8 +52,8 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve performs exact-match resolution for a query.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
-	targets := p.Search(query)
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+	targets := p.Search(ctx, query)
 	if len(targets) > 0 {
 		return targets[0], true
 	}
@@ -62,8 +62,7 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 }
 
 // Search performs a fuzzy search for the query.
-func (p *Provider) Search(query string) []resolve.Target {
-	ctx := context.TODO()
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 
 	iter := p.ResolveObject(ctx, req)

--- a/catalog/jpl/jpl_test.go
+++ b/catalog/jpl/jpl_test.go
@@ -228,7 +228,7 @@ func TestJPLResolve_ReturnsRealMatch(t *testing.T) {
 	result := "Target body name: Mars (499)                      {source: mar099}\n"
 	prov := newMockProvider(jsonResultPayload(t, result))
 
-	target, ok := prov.Resolve("Mars")
+	target, ok := prov.Resolve(context.Background(), "Mars")
 	testutil.AssertEqual(t, "Resolve Ok", ok, true)
 	testutil.AssertEqual(t, "Resolve Name", target.Name, "Mars")
 }
@@ -307,7 +307,7 @@ func TestProviderInterface(t *testing.T) {
 
 	// Fast fail search / resolve without any real network call.
 	// This hits the missing coverage lines.
-	_, ok := p.Resolve("non_existent_body_to_trigger_miss")
+	_, ok := p.Resolve(context.Background(), "non_existent_body_to_trigger_miss")
 	if ok {
 		t.Error("expected Resolve to fail with no transport")
 	}

--- a/catalog/mast/mast.go
+++ b/catalog/mast/mast.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // ErrAPIError indicates a MAST API error response.
@@ -51,8 +52,8 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve resolves a query to a target.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
-	targets := p.Search(query)
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+	targets := p.Search(ctx, query)
 	if len(targets) > 0 {
 		return targets[0], true
 	}
@@ -61,8 +62,7 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 }
 
 // Search searches for targets matching the query.
-func (p *Provider) Search(query string) []resolve.Target {
-	ctx := context.TODO()
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 
 	iter := p.ResolveObject(ctx, req)
@@ -125,10 +125,10 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 		if trimmed := bytes.TrimSpace(data); len(trimmed) > 0 && trimmed[0] == '<' {
 			var xmlPayload struct {
 				ResolvedCoordinate []struct {
-					CanonicalName string  `xml:"canonicalName"`
-					Resolver      string  `xml:"resolver"`
-					RA            float64 `xml:"ra"`
-					Dec           float64 `xml:"dec"`
+					CanonicalName string   `xml:"canonicalName"`
+					Resolver      string   `xml:"resolver"`
+					RA            *float64 `xml:"ra"`
+					Dec           *float64 `xml:"dec"`
 				} `xml:"resolvedCoordinate"`
 			}
 
@@ -139,23 +139,17 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 
 			targets = make([]resolve.Target, 0, len(xmlPayload.ResolvedCoordinate))
 			for _, match := range xmlPayload.ResolvedCoordinate {
-				targets = append(targets, resolve.Target{
-					ID:       match.CanonicalName,
-					Name:     match.CanonicalName,
-					Coord:    coord.NewICRS(angle.Deg(match.RA), angle.Deg(match.Dec)),
-					HasCoord: true,
-					Catalog:  match.Resolver,
-				})
+				targets = append(targets, newMASTTarget(match.CanonicalName, match.Resolver, match.RA, match.Dec))
 			}
 		} else {
 			var jsonPayload struct {
 				Status             string `json:"status"`
 				Msg                string `json:"msg"`
 				ResolvedCoordinate []struct {
-					CanonicalName string  `json:"canonicalName"`
-					Resolver      string  `json:"resolver"`
-					RA            float64 `json:"ra"`
-					Decl          float64 `json:"decl"`
+					CanonicalName string   `json:"canonicalName"`
+					Resolver      string   `json:"resolver"`
+					RA            *float64 `json:"ra"`
+					Decl          *float64 `json:"decl"`
 				} `json:"resolvedCoordinate"`
 			}
 
@@ -171,13 +165,7 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 
 			targets = make([]resolve.Target, 0, len(jsonPayload.ResolvedCoordinate))
 			for _, match := range jsonPayload.ResolvedCoordinate {
-				targets = append(targets, resolve.Target{
-					ID:       match.CanonicalName,
-					Name:     match.CanonicalName,
-					Coord:    coord.NewICRS(angle.Deg(match.RA), angle.Deg(match.Decl)),
-					HasCoord: true,
-					Catalog:  match.Resolver,
-				})
+				targets = append(targets, newMASTTarget(match.CanonicalName, match.Resolver, match.RA, match.Decl))
 			}
 		}
 
@@ -192,6 +180,45 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 			}
 		}
 	}
+}
+
+// newMASTTarget builds a resolve.Target from one decoded resolvedCoordinate
+// match, in either the XML or JSON response shape.
+//
+// ra/dec are pointers rather than bare float64 so a genuinely-absent field
+// (no <ra> element, no "ra" JSON key) decodes to nil instead of a
+// masquerading 0.0 — HasCoord is only set true when both are actually
+// present, matching how every other astrogo catalog provider treats a
+// missing position as absent rather than real.
+//
+// Catalog is always "mast" (consistent with every other provider setting
+// Catalog to its own name), never the relayed sub-resolver name (NED,
+// Simbad, VizieR) MAST's Name.Lookup service internally used to answer —
+// that information isn't discarded, it's preserved as an alias instead, so
+// Catalog keeps one consistent meaning ("which provider produced this row")
+// across the whole package.
+//
+// Epoch defaults to time.J2000 as a best-effort assumption: the API doesn't
+// report which sub-resolver's native epoch actually answered, but
+// SIMBAD/NED name-lookup responses are conventionally J2000.
+func newMASTTarget(canonicalName, resolver string, ra, dec *float64) resolve.Target {
+	t := resolve.Target{
+		ID:      canonicalName,
+		Name:    canonicalName,
+		Catalog: "mast",
+		Epoch:   time.J2000,
+	}
+
+	if resolver != "" {
+		t.Aliases = []string{resolver}
+	}
+
+	if ra != nil && dec != nil {
+		t.Coord = coord.NewICRS(angle.Deg(*ra), angle.Deg(*dec))
+		t.HasCoord = true
+	}
+
+	return t
 }
 
 // ConeSearch is not yet implemented for CAOM spatial search: STScI's

--- a/catalog/mast/mast_test.go
+++ b/catalog/mast/mast_test.go
@@ -53,8 +53,20 @@ func TestMastOfflineResolve(t *testing.T) {
 	}
 
 	testutil.AssertEqual(t, "Name", targets[0].Name, "M31")
-	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "NED")
+	// Catalog is always "mast" (consistent with every other provider setting
+	// Catalog to its own name), never the relayed sub-resolver name — see
+	// newMASTTarget's doc comment. That name is preserved as an alias instead.
+	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "mast")
+
+	if len(targets[0].Aliases) != 1 || targets[0].Aliases[0] != "NED" {
+		t.Errorf("expected relayed resolver name preserved as an alias, got %v", targets[0].Aliases)
+	}
+
 	testutil.AssertEqual(t, "RA", targets[0].Coord.RA().Degrees(), 10.684)
+
+	if targets[0].Epoch.IsZero() {
+		t.Error("expected a default J2000 Epoch, got zero value")
+	}
 }
 
 // TestMastOfflineResolveXML covers a live-observed MAST quirk: the invoke
@@ -94,7 +106,12 @@ func TestMastOfflineResolveXML(t *testing.T) {
 	}
 
 	testutil.AssertEqual(t, "Name", targets[0].Name, "M  31")
-	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "SIMBAD")
+	testutil.AssertEqual(t, "Catalog", targets[0].Catalog, "mast")
+
+	if len(targets[0].Aliases) != 1 || targets[0].Aliases[0] != "SIMBAD" {
+		t.Errorf("expected relayed resolver name preserved as an alias, got %v", targets[0].Aliases)
+	}
+
 	testutil.AssertEqual(t, "RA", targets[0].Coord.RA().Degrees(), 10.684708)
 	testutil.AssertEqual(t, "Dec", targets[0].Coord.Dec().Degrees(), 41.26875)
 }
@@ -135,6 +152,30 @@ func TestMastOfflineResolveXMLNoMatch(t *testing.T) {
 	}
 }
 
+// TestNewMASTTarget_MissingCoordIsNotFake is a regression test: a match with
+// no ra/dec (nil pointers, e.g. an XML response with no <ra>/<dec> element)
+// must yield HasCoord=false, never a fake (0,0) reported as real — the same
+// bug class fixed in Gaia's row parsing.
+func TestNewMASTTarget_MissingCoordIsNotFake(t *testing.T) {
+	got := newMASTTarget("M31", "NED", nil, nil)
+
+	if got.HasCoord {
+		t.Errorf("expected HasCoord=false for a match with no coordinate, got HasCoord=true Coord=%v", got.Coord)
+	}
+
+	if got.Catalog != "mast" {
+		t.Errorf("Catalog = %q, want mast", got.Catalog)
+	}
+
+	if len(got.Aliases) != 1 || got.Aliases[0] != "NED" {
+		t.Errorf("expected relayed resolver name preserved as an alias, got %v", got.Aliases)
+	}
+
+	if got.Epoch.IsZero() {
+		t.Error("expected a default J2000 Epoch even without a coordinate")
+	}
+}
+
 type mockTransport struct {
 	Handler http.Handler
 }
@@ -163,8 +204,8 @@ func TestProviderInterface(t *testing.T) {
 	// offline — see CLAUDE.md's build-tag convention.
 	p.client.HTTPClient.Transport = errTransport{}
 
-	_, _ = p.Resolve("non_existent_body")
-	_ = p.Search("non_existent_body")
+	_, _ = p.Resolve(context.Background(), "non_existent_body")
+	_ = p.Search(context.Background(), "non_existent_body")
 }
 
 var errNoTransport = errors.New("errTransport: no network access in this test")

--- a/catalog/norad/norad.go
+++ b/catalog/norad/norad.go
@@ -274,8 +274,8 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve attempts to find a single satellite by name or catalog number.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
-	targets := p.Search(query)
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+	targets := p.Search(ctx, query)
 	if len(targets) > 0 {
 		return targets[0], true
 	}
@@ -284,10 +284,10 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 }
 
 // Search returns satellites matching the query string.
-func (p *Provider) Search(query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	// No local timeout wrapper needed: NewClientFor(remote.CelesTrak) already
 	// bounds the whole request at the endpoint's registered Timeout.
-	gps, err := p.Fetch(context.Background(), QueryName, query)
+	gps, err := p.Fetch(ctx, QueryName, query)
 	if err != nil || len(gps) == 0 {
 		return nil
 	}
@@ -351,7 +351,7 @@ func gpToTarget(gp GP) resolve.Target {
 		ID:          strconv.Itoa(gp.NoradCatID),
 		Name:        gp.ObjectName,
 		Designation: gp.ObjectID,
-		Kind:        resolve.Kind("Satellite"),
+		Kind:        resolve.KindSatellite,
 		Catalog:     "norad",
 		Epoch:       epoch,
 		TLELine1:    l1,

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -104,7 +104,7 @@ func TestResolve_Live(t *testing.T) {
 	requireCelestrak(t)
 
 	p := New()
-	target, ok := p.Resolve("ISS")
+	target, ok := p.Resolve(context.Background(), "ISS")
 	if !ok {
 		t.Fatal("Failed to resolve ISS")
 	}

--- a/catalog/norad/norad_offline_test.go
+++ b/catalog/norad/norad_offline_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/remote"
 )
 
@@ -45,14 +46,20 @@ func TestNewFetchSearchResolve(t *testing.T) {
 		t.Errorf("Capabilities() = %v, want exactly one capability", caps)
 	}
 
-	targets := p.Search("ISS")
+	targets := p.Search(context.Background(), "ISS")
 	if len(targets) != 1 || targets[0].Name != "ISS (ZARYA)" {
 		t.Fatalf("Search(%q) = %+v, want a single ISS (ZARYA) target", "ISS", targets)
 	}
 
-	target, ok := p.Resolve("ISS")
+	target, ok := p.Resolve(context.Background(), "ISS")
 	if !ok || target.Name != "ISS (ZARYA)" {
 		t.Fatalf("Resolve(%q) = %+v, %v, want ISS (ZARYA), true", "ISS", target, ok)
+	}
+
+	// Regression: Kind must be the canonical resolve.KindSatellite constant,
+	// not an ad hoc resolve.Kind("Satellite") string built outside the enum.
+	if target.Kind != resolve.KindSatellite {
+		t.Errorf("Kind = %q, want %q", target.Kind, resolve.KindSatellite)
 	}
 
 	gp, err := p.FetchByID(context.Background(), 25544)

--- a/catalog/openngc/fetch.go
+++ b/catalog/openngc/fetch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Sentinel errors for the raw OpenNGC CSV format.
@@ -106,6 +107,7 @@ func toTargets(records []targetRecord) []resolve.Target {
 			HasCoord: true,
 			Catalog:  "openngc",
 			Aliases:  rec.Aliases,
+			Epoch:    time.J2000, // OpenNGC's RA/Dec are J2000 by catalog convention
 		}
 
 		if v, err := strconv.ParseFloat(rec.VMag, 64); err == nil {

--- a/catalog/openngc/fetch_test.go
+++ b/catalog/openngc/fetch_test.go
@@ -1,6 +1,7 @@
 package openngc
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/TuSKan/astrogo/remote"
+	astrotime "github.com/TuSKan/astrogo/time"
 )
 
 const (
@@ -72,11 +74,18 @@ func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 
 	p := New()
 
-	if got, ok := p.Resolve("M42"); !ok || got.ID != "NGC1976" {
+	got, ok := p.Resolve(context.Background(), "M42")
+	if !ok || got.ID != "NGC1976" {
 		t.Errorf("Resolve(M42) = %+v, %v, want NGC1976, true", got, ok)
 	}
 
-	if got, ok := p.Resolve("M31"); !ok || got.ID != "NGC224" {
+	// Regression: Epoch used to never be set despite OpenNGC's RA/Dec being
+	// implicitly J2000 by the catalog's own convention.
+	if !got.Epoch.Equal(astrotime.J2000) {
+		t.Errorf("Epoch = %v, want time.J2000", got.Epoch)
+	}
+
+	if got, ok := p.Resolve(context.Background(), "M31"); !ok || got.ID != "NGC224" {
 		t.Errorf("Resolve(M31) = %+v, %v, want NGC224, true", got, ok)
 	}
 }
@@ -140,7 +149,7 @@ func TestNewDefaultDenyIssuesNoRequest(t *testing.T) {
 		t.Errorf("New() must not touch the network when downloads aren't enabled; server saw %d hits", got)
 	}
 
-	if _, ok := p.Resolve("M42"); ok {
+	if _, ok := p.Resolve(context.Background(), "M42"); ok {
 		t.Error("expected an empty provider when downloads are disabled")
 	}
 }

--- a/catalog/openngc/openngc.go
+++ b/catalog/openngc/openngc.go
@@ -61,8 +61,10 @@ func New() *Provider {
 // Name returns the provider identifier.
 func (p *Provider) Name() string { return "openngc" }
 
-// Resolve performs exact-match resolution for a query.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
+// Resolve performs exact-match resolution for a query. ctx is accepted for
+// resolve.Provider conformance only — resolution runs over the in-memory
+// index built once at New(), with no I/O to cancel.
+func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, bool) {
 	q := resolve.Normalize(query)
 	if idx, ok := p.byKey[q]; ok {
 		return p.targets[idx], true
@@ -71,8 +73,9 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 	return resolve.Target{}, false
 }
 
-// Search performs fuzzy search across all NGC/IC objects.
-func (p *Provider) Search(query string) []resolve.Target {
+// Search performs fuzzy search across all NGC/IC objects. ctx is accepted
+// for resolve.Provider conformance only — see Resolve.
+func (p *Provider) Search(_ context.Context, query string) []resolve.Target {
 	q := resolve.Normalize(query)
 	if q == "" {
 		return nil

--- a/catalog/openngc/openngc_test.go
+++ b/catalog/openngc/openngc_test.go
@@ -1,6 +1,7 @@
 package openngc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
@@ -49,7 +50,7 @@ func TestProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			got, ok := p.Resolve(tt.query)
+			got, ok := p.Resolve(context.Background(), tt.query)
 			if ok != tt.found {
 				t.Errorf("Resolve(%q) ok = %v, want %v", tt.query, ok, tt.found)
 				return
@@ -65,7 +66,7 @@ func TestProvider(t *testing.T) {
 func TestSearch(t *testing.T) {
 	p := newTestProvider()
 
-	results := p.Search("orion")
+	results := p.Search(context.Background(), "orion")
 	if len(results) == 0 {
 		t.Fatalf("Search(%q) returned no results", "orion")
 	}
@@ -88,7 +89,7 @@ func BenchmarkSearch(b *testing.B) {
 	p := newTestProvider()
 
 	for range b.N {
-		p.Search("nebula")
+		p.Search(context.Background(), "nebula")
 	}
 }
 

--- a/catalog/resolve/target.go
+++ b/catalog/resolve/target.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -35,6 +36,12 @@ const (
 	KindAsterism Kind = "Asterism"
 	// KindDoubleStar represents a double star.
 	KindDoubleStar Kind = "DoubleStar"
+	// KindAsteroid represents a minor planet (asteroid).
+	KindAsteroid Kind = "Asteroid"
+	// KindComet represents a comet.
+	KindComet Kind = "Comet"
+	// KindSatellite represents an artificial Earth satellite.
+	KindSatellite Kind = "Satellite"
 	// KindOther represents other celestial objects.
 	KindOther Kind = "Other"
 )
@@ -109,6 +116,10 @@ type Target struct {
 	HasCoord bool
 	// HasOblateness is true if the target has oblateness information.
 	HasOblateness bool
+	// Provenance maps each populated field name to the provider name
+	// (Provider.Name(), never Target.Catalog) that contributed its value
+	// in a merged Target. Nil for a Target sourced from a single provider.
+	Provenance map[string]string
 }
 
 // ICRS implements coord.Object for a static catalog Target.
@@ -119,8 +130,8 @@ func (t Target) ICRS(_ time.Time) (coord.ICRS, error) {
 // Provider defines the interface for astronomical catalogs.
 type Provider interface {
 	Name() string
-	Resolve(query string) (Target, bool)
-	Search(query string) []Target
+	Resolve(ctx context.Context, query string) (Target, bool)
+	Search(ctx context.Context, query string) []Target
 }
 
 var (

--- a/catalog/sbdb/sbdb.go
+++ b/catalog/sbdb/sbdb.go
@@ -45,8 +45,8 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve performs exact-match resolution for a query.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
-	targets := p.Search(query)
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+	targets := p.Search(ctx, query)
 	if len(targets) > 0 {
 		return targets[0], true
 	}
@@ -55,8 +55,7 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 }
 
 // Search performs fuzzy search across all MPC-registered small bodies.
-func (p *Provider) Search(query string) []resolve.Target {
-	ctx := context.TODO()
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	req := resolve.ObjectRequest{Query: query, Limit: 1}
 
 	iter := p.ResolveObject(ctx, req)
@@ -122,9 +121,9 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 			return
 		}
 
-		kindStr := "Asteroid"
+		kind := resolve.KindAsteroid
 		if payload.Object.Kind == "c" {
-			kindStr = "Comet"
+			kind = resolve.KindComet
 		}
 
 		t := resolve.Target{
@@ -132,7 +131,7 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 			Name:        payload.Object.FullName,
 			Designation: payload.Object.Des,
 			SPKID:       payload.Object.SpkID,
-			Kind:        resolve.Kind(kindStr),
+			Kind:        kind,
 			Catalog:     "sbdb",
 		}
 

--- a/catalog/sbdb/sbdb_test.go
+++ b/catalog/sbdb/sbdb_test.go
@@ -40,13 +40,19 @@ func TestSBDBResolver(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve("aten")
+	tar, ok := prov.Resolve(context.Background(), "aten")
 	if !ok {
 		t.Fatalf("Failed to resolve Aten")
 	}
 
 	testutil.AssertEqual(t, "Resolve ID name", tar.Name, "2062 Aten (1976 AA)")
 	testutil.AssertEqual(t, "Resolve SPKID", tar.SPKID, "20002062")
+
+	// Regression: Kind must be the canonical resolve.KindAsteroid constant,
+	// not an ad hoc resolve.Kind("Asteroid") string built outside the enum.
+	if tar.Kind != resolve.KindAsteroid {
+		t.Errorf("Kind = %q, want %q", tar.Kind, resolve.KindAsteroid)
+	}
 
 	// Test cache bypassing HTTP mock and testing async SeqIterator
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -70,6 +76,43 @@ func TestSBDBResolver(t *testing.T) {
 	}
 }
 
+func TestSBDBResolver_CometKind(t *testing.T) {
+	jsonData := `{
+		"object": {
+			"spkid": "1000036",
+			"fullname": "1P/Halley",
+			"des": "1P",
+			"kind": "c"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if _, err := fmt.Fprint(w, jsonData); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	t.Cleanup(remote.Reset)
+
+	if err := remote.SetURL(remote.JPLSBDB, server.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := New()
+
+	tar, ok := prov.Resolve(context.Background(), "halley")
+	if !ok {
+		t.Fatalf("Failed to resolve Halley")
+	}
+
+	if tar.Kind != resolve.KindComet {
+		t.Errorf("Kind = %q, want %q", tar.Kind, resolve.KindComet)
+	}
+}
+
 func TestProviderInterface(t *testing.T) {
 	p := New()
 	if p.Name() != "sbdb" {
@@ -81,6 +124,6 @@ func TestProviderInterface(t *testing.T) {
 		t.Errorf("expected CapObjectResolution, got %v", caps)
 	}
 
-	_, _ = p.Resolve("non_existent_body")
-	_ = p.Search("non_existent_body")
+	_, _ = p.Resolve(context.Background(), "non_existent_body")
+	_ = p.Search(context.Background(), "non_existent_body")
 }

--- a/catalog/simbad/simbad.go
+++ b/catalog/simbad/simbad.go
@@ -43,8 +43,8 @@ func (p *Provider) Capabilities() []resolve.Capability {
 
 // Resolve matches a single object by returning the most relevant hit.
 // Adheres strictly to resolve.Provider and utilizes AstroGo scoring for precision.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
-	targets := p.Search(query)
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+	targets := p.Search(ctx, query)
 	if len(targets) == 0 {
 		return resolve.Target{}, false
 	}
@@ -74,8 +74,7 @@ func (p *Provider) Resolve(query string) (resolve.Target, bool) {
 }
 
 // Search matches all objects closely matching a freeform query.
-func (p *Provider) Search(query string) []resolve.Target {
-	ctx := context.TODO()
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 
 	iter := p.ResolveObject(ctx, req)

--- a/catalog/simbad/simbad_test.go
+++ b/catalog/simbad/simbad_test.go
@@ -88,7 +88,7 @@ func TestResolveMock(t *testing.T) {
 		Handler: server.Config.Handler,
 	}
 
-	tgt, ok := p.Resolve("m31")
+	tgt, ok := p.Resolve(context.Background(), "m31")
 	if !ok {
 		t.Fatalf("failed to resolve target")
 	}
@@ -203,6 +203,6 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	// Triggers internal error paths since we didn't mock
-	_, _ = p.Resolve("non_existent_body")
-	_ = p.Search("non_existent_body")
+	_, _ = p.Resolve(context.Background(), "non_existent_body")
+	_ = p.Search(context.Background(), "non_existent_body")
 }

--- a/catalog/vizier/tables.go
+++ b/catalog/vizier/tables.go
@@ -1,6 +1,9 @@
 package vizier
 
-import "github.com/TuSKan/astrogo/catalog/resolve"
+import (
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
+)
 
 // tableSchema describes a VizieR table's ADQL column names for the fields
 // ConeSearch needs, keyed by VizieR table identifier (e.g. "II/246/out").
@@ -16,11 +19,24 @@ type tableSchema struct {
 	DesigCol string
 	// Kind is the resolve.Kind assigned to every row from this table.
 	Kind resolve.Kind
+	// Epoch is this table's native reference epoch for RA/Dec — the three
+	// tables registered below genuinely differ (2MASS ~J2000, Hipparcos
+	// J1991.25, Gaia DR3 J2016.0), so this cannot be a single package-wide
+	// constant; every row from a table is stamped with its own.
+	Epoch time.Time
 }
 
 // defaultTable is used when a ConeRequest doesn't specify Table, preserving
 // this package's original single-table behavior exactly.
 const defaultTable = "II/246/out"
+
+// Standard reference epochs for the tables below, expressed as two-part
+// Julian dates matching each survey's own documented catalog epoch.
+var (
+	epoch2MASS     = time.J2000                         // "raj2000"/"dej2000" column names state this explicitly
+	epochHipparcos = time.FromJD(2448349.0625, time.TT) // J1991.25, the Hipparcos catalog's own reference epoch
+	epochGaiaDR3   = time.FromJD(2457388.5, time.TT)    // J2016.0, Gaia DR3's reference epoch
+)
 
 // tableSchemas is the registry of VizieR tables ConeSearch knows how to
 // query. Column names below are verified against VizieR's live TAP service
@@ -32,9 +48,9 @@ const defaultTable = "II/246/out"
 //nolint:gochecknoglobals // read-only registry, populated once at init
 var tableSchemas = map[string]tableSchema{
 	// 2MASS Point Source Catalog — the package's original hardcoded table.
-	defaultTable: {RACol: "raj2000", DecCol: "dej2000", DesigCol: `"2MASS"`, Kind: resolve.KindStar},
+	defaultTable: {RACol: "raj2000", DecCol: "dej2000", DesigCol: `"2MASS"`, Kind: resolve.KindStar, Epoch: epoch2MASS},
 	// Hipparcos main catalog.
-	"I/239/hip_main": {RACol: "RAICRS", DecCol: "DEICRS", DesigCol: "HIP", Kind: resolve.KindStar},
+	"I/239/hip_main": {RACol: "RAICRS", DecCol: "DEICRS", DesigCol: "HIP", Kind: resolve.KindStar, Epoch: epochHipparcos},
 	// Gaia DR3 (VizieR mirror of the Gaia archive).
-	"I/355/gaiadr3": {RACol: "RA_ICRS", DecCol: "DE_ICRS", DesigCol: "DR3Name", Kind: resolve.KindStar},
+	"I/355/gaiadr3": {RACol: "RA_ICRS", DecCol: "DE_ICRS", DesigCol: "DR3Name", Kind: resolve.KindStar, Epoch: epochGaiaDR3},
 }

--- a/catalog/vizier/vizier.go
+++ b/catalog/vizier/vizier.go
@@ -56,12 +56,12 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve always returns false for VizieR (use ConeSearch instead).
-func (p *Provider) Resolve(_ string) (resolve.Target, bool) {
+func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, bool) {
 	return resolve.Target{}, false // Not supported directly, use ConeSearch
 }
 
 // Search always returns nil for VizieR (use ConeSearch instead).
-func (p *Provider) Search(_ string) []resolve.Target {
+func (p *Provider) Search(_ context.Context, _ string) []resolve.Target {
 	return nil
 }
 
@@ -122,7 +122,7 @@ func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) reso
 		}
 		defer func() { _ = body.Close() }()
 
-		targets, err := parseCSV(body, schema.Kind)
+		targets, err := parseCSV(body, schema)
 		if err != nil {
 			yield(resolve.Target{}, err)
 			return
@@ -142,10 +142,10 @@ func (p *Provider) ConeSearch(ctx context.Context, req resolve.ConeRequest) reso
 }
 
 // parseCSV extracts designation/ra/dec rows from the ADQL query's CSV
-// response, tagging every row with kind. Columns are located by header name
-// rather than assumed position, so the parser stays correct if the SELECT
-// clause in ConeSearch is reordered.
-func parseCSV(body io.Reader, kind resolve.Kind) ([]resolve.Target, error) {
+// response, tagging every row with schema's kind and native epoch. Columns
+// are located by header name rather than assumed position, so the parser
+// stays correct if the SELECT clause in ConeSearch is reordered.
+func parseCSV(body io.Reader, schema tableSchema) ([]resolve.Target, error) {
 	reader := csv.NewReader(body)
 
 	header, err := reader.Read()
@@ -197,11 +197,13 @@ func parseCSV(body io.Reader, kind resolve.Kind) ([]resolve.Target, error) {
 
 		targets = append(targets, resolve.Target{
 			Catalog:     "vizier",
+			ID:          designation,
 			Name:        designation,
 			Designation: designation,
-			Kind:        kind,
+			Kind:        schema.Kind,
 			Coord:       coord.NewICRS(angle.Deg(raDeg), angle.Deg(decDeg)),
 			HasCoord:    true,
+			Epoch:       schema.Epoch,
 		})
 	}
 

--- a/catalog/vizier/vizier_test.go
+++ b/catalog/vizier/vizier_test.go
@@ -74,8 +74,39 @@ func TestVizierOfflineConeSearch(t *testing.T) {
 }
 
 func TestParseCSVMissingColumn(t *testing.T) {
-	if _, err := parseCSV(strings.NewReader("ra,dec\n1,2\n"), resolve.KindStar); !errors.Is(err, ErrUnexpectedSchema) {
+	if _, err := parseCSV(strings.NewReader("ra,dec\n1,2\n"), tableSchemas[defaultTable]); !errors.Is(err, ErrUnexpectedSchema) {
 		t.Errorf("expected ErrUnexpectedSchema, got %v", err)
+	}
+}
+
+// TestParseCSV_PopulatesIDAndEpoch is a regression test: ID used to be left
+// empty (only Name/Designation were set from the same designation value),
+// and Epoch used to never be set despite each table having a genuinely
+// different native reference epoch.
+func TestParseCSV_PopulatesIDAndEpoch(t *testing.T) {
+	schema := tableSchemas["I/239/hip_main"]
+
+	targets, err := parseCSV(strings.NewReader("designation,ra,dec\n32349,101.28,-16.71\n"), schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+
+	got := targets[0]
+
+	if got.ID != "32349" {
+		t.Errorf("ID = %q, want %q", got.ID, "32349")
+	}
+
+	if got.ID != got.Designation {
+		t.Errorf("expected ID to match Designation (%q), got %q", got.Designation, got.ID)
+	}
+
+	if !got.Epoch.Equal(epochHipparcos) {
+		t.Errorf("Epoch = %v, want the table's own Hipparcos epoch %v", got.Epoch, epochHipparcos)
 	}
 }
 
@@ -240,12 +271,12 @@ func TestProviderInterface(t *testing.T) {
 		t.Errorf("expected CapConeSearch, got %v", caps)
 	}
 
-	_, ok := p.Resolve("foo")
+	_, ok := p.Resolve(context.Background(), "foo")
 	if ok {
 		t.Error("expected Resolve to return false")
 	}
 
-	if p.Search("foo") != nil {
+	if p.Search(context.Background(), "foo") != nil {
 		t.Error("expected Search to return nil")
 	}
 

--- a/coord/coord.go
+++ b/coord/coord.go
@@ -6,14 +6,16 @@ import (
 	"math"
 
 	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/internal/gofaext"
 	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
 
 // Sentinel errors for coordinate validation.
 var (
-	ErrNotFinite     = errors.New("coordinate component must be finite")
-	ErrLatitudeRange = errors.New("latitude/altitude out of range")
+	ErrNotFinite         = errors.New("coordinate component must be finite")
+	ErrLatitudeRange     = errors.New("latitude/altitude out of range")
+	ErrPropagationFailed = errors.New("coord: space-motion propagation failed")
 )
 
 // Object represents any celestial entity that has a predictable position
@@ -547,4 +549,50 @@ func PositionAngle(from, to ICRS) angle.Angle {
 	x := math.Cos(d1)*math.Tan(d2) - math.Sin(d1)*math.Cos(dra)
 
 	return angle.Atan2(y, x).Wrap360()
+}
+
+// PropagateEpoch applies rigorous SOFA space-motion propagation (proper
+// motion, parallax, light-time/relativistic correction via Pmsafe) to move
+// an ICRS position with kinematics from fromEpoch to toEpoch. If c has no
+// proper motion, parallax, or radial velocity, the position is returned
+// unchanged — propagation over any interval is a no-op for a motionless
+// point. A zero fromEpoch or toEpoch (time.Time{}) is treated as
+// time.J2000, matching the epoch convention most catalogs cross-matched
+// against assume when they don't report one explicitly.
+//
+// This is rigorous relativistic space-motion propagation (good to
+// sub-milliarcsecond over the years-to-decades spans catalog cross-matching
+// needs) — a different problem from Context.AtTime's O(1) approximate
+// short-span Earth-rotation update, which re-derives observer-frame state,
+// not a star's own kinematics.
+func PropagateEpoch(c ICRS, fromEpoch, toEpoch time.Time) (ICRS, error) {
+	if fromEpoch.IsZero() {
+		fromEpoch = time.J2000
+	}
+
+	if toEpoch.IsZero() {
+		toEpoch = time.J2000
+	}
+
+	if fromEpoch.Equal(toEpoch) {
+		return c, nil
+	}
+
+	ep1a, ep1b := fromEpoch.TT().JDParts()
+	ep2a, ep2b := toEpoch.TT().JDParts()
+
+	ra2, dec2, pmr2, pmd2, px2, rv2, status := gofaext.Pmsafe(
+		c.RA().Radians(), c.Dec().Radians(),
+		c.PmRA().Radians(), c.PmDec().Radians(),
+		c.Parallax().Arcseconds(), c.RV(),
+		ep1a, ep1b, ep2a, ep2b,
+	)
+	if status < 0 {
+		return ICRS{}, fmt.Errorf("%w: status %d", ErrPropagationFailed, status)
+	}
+
+	out := NewICRSWithKinematics(angle.Rad(ra2), angle.Rad(dec2), angle.Rad(pmr2), angle.Rad(pmd2), angle.Arcsec(px2), rv2)
+	out.SetDist(c.Dist())
+
+	return out, nil
 }

--- a/coord/coord_test.go
+++ b/coord/coord_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
 )
 
 func TestValidation(t *testing.T) {
@@ -325,6 +326,54 @@ func TestSeparationAndPositionAngle(t *testing.T) {
 
 	pa := coord.PositionAngle(ic1, ic2)
 	testutil.AssertNear(t, "PositionAngle", pa.Degrees(), 90.0, 1e-10)
+}
+
+func TestPropagateEpoch_NoKinematicsIsNoOp(t *testing.T) {
+	c := coord.NewICRS(angle.Deg(10), angle.Deg(20))
+
+	later := time.J2000.Add((50 * 365.25 * 24) * time.Hour)
+
+	out, err := coord.PropagateEpoch(c, time.J2000, later)
+	testutil.AssertNoError(t, err)
+	testutil.AssertNear(t, "RA unchanged with no kinematics", out.RA().Degrees(), c.RA().Degrees(), 1e-12)
+	testutil.AssertNear(t, "Dec unchanged with no kinematics", out.Dec().Degrees(), c.Dec().Degrees(), 1e-12)
+}
+
+func TestPropagateEpoch_SameEpochIsNoOp(t *testing.T) {
+	c := coord.NewICRSWithKinematics(angle.Deg(10), angle.Deg(0), angle.Arcsec(1), angle.Arcsec(0), angle.Arcsec(0.1), 0)
+
+	out, err := coord.PropagateEpoch(c, time.J2000, time.J2000)
+	testutil.AssertNoError(t, err)
+	testutil.AssertNear(t, "RA unchanged at same epoch", out.RA().Degrees(), c.RA().Degrees(), 1e-15)
+}
+
+func TestPropagateEpoch_AppliesProperMotion(t *testing.T) {
+	// dec=0 so cos(dec)=1: coordinate-angle pmRA of 1 arcsec/yr over 10
+	// years should shift RA by ~10 arcsec, to within a small tolerance for
+	// the relativistic/parallax correction Pmsafe also applies.
+	c := coord.NewICRSWithKinematics(angle.Deg(10), angle.Deg(0), angle.Arcsec(1), angle.Arcsec(0), angle.Arcsec(0.1), 0)
+
+	later := time.J2000.Add((10 * 365.25 * 24) * time.Hour)
+
+	out, err := coord.PropagateEpoch(c, time.J2000, later)
+	testutil.AssertNoError(t, err)
+
+	shiftArcsec := (out.RA().Degrees() - c.RA().Degrees()) * 3600
+	testutil.AssertNear(t, "RA shift over 10yr at 1 arcsec/yr PM", shiftArcsec, 10.0, 0.1)
+}
+
+func TestPropagateEpoch_ZeroEpochDefaultsToJ2000(t *testing.T) {
+	c := coord.NewICRSWithKinematics(angle.Deg(10), angle.Deg(0), angle.Arcsec(1), angle.Arcsec(0), angle.Arcsec(0.1), 0)
+
+	later := time.J2000.Add((10 * 365.25 * 24) * time.Hour)
+
+	explicit, err := coord.PropagateEpoch(c, time.J2000, later)
+	testutil.AssertNoError(t, err)
+
+	implicit, err := coord.PropagateEpoch(c, time.Time{}, later)
+	testutil.AssertNoError(t, err)
+
+	testutil.AssertNear(t, "zero fromEpoch matches explicit J2000", implicit.RA().Degrees(), explicit.RA().Degrees(), 1e-15)
 }
 
 func TestMoreRoundTrips(t *testing.T) {

--- a/examples/02_target_visibility/main.go
+++ b/examples/02_target_visibility/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -26,7 +27,7 @@ func main() {
 	planner, _ := plan.NewPlanner(site, constraints)
 
 	// 3. Set Target using SIMBAD
-	targetData, err := catalog.NewResolver(catalog.SIMBAD).Resolve("Orion Nebula")
+	targetData, err := catalog.NewResolver(catalog.SIMBAD).Resolve(context.Background(), "Orion Nebula")
 	if err != nil {
 		log.Fatalf("Failed to resolve target: %v", err)
 	}

--- a/examples/03_rise_transit_set/main.go
+++ b/examples/03_rise_transit_set/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -17,7 +18,7 @@ func main() {
 	site, _ := plan.NewSite("São Paulo", loc)
 
 	// 2. Set a Deep Space Target
-	sirius, err := catalog.NewResolver(catalog.SIMBAD).Resolve("Sirius")
+	sirius, err := catalog.NewResolver(catalog.SIMBAD).Resolve(context.Background(), "Sirius")
 	if err != nil {
 		log.Fatalf("Failed to resolve target: %s", "Sirius")
 	}

--- a/examples/05_resolve_name/main.go
+++ b/examples/05_resolve_name/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/TuSKan/astrogo/catalog"
@@ -17,13 +18,15 @@ func main() {
 	// No need to import catalog/openngc directly.
 	remote.EnableDownloads(remote.OpenNGC, 5<<20) // ~2 MB combined source CSVs
 
+	ctx := context.Background()
+
 	resolver := catalog.NewResolver(catalog.OpenNGC, catalog.SIMBAD, catalog.MAST)
 
 	query := "Andromeda"
 	fmt.Printf("Executing advanced Search for ambiguous query: %q...\n", query)
 
 	// 3. Perform a fuzzy Search combining all endpoints
-	results := resolver.Search(query)
+	results := resolver.Search(ctx, query)
 
 	if len(results) == 0 {
 		fmt.Println("No matches found.")
@@ -50,11 +53,13 @@ func main() {
 		fmt.Println("    -------------------------------------------------------------------")
 	}
 
-	// 5. Demonstrate the strict Resolve() guarantee
-	fmt.Printf("\nExecuting strict Resolve() on %q...\n", "M31")
+	// 5. Demonstrate Resolve(), which now cross-matches and merges every
+	// provider's hit for the query into a single, richer Target instead of
+	// returning the first provider that happens to answer.
+	fmt.Printf("\nExecuting Resolve() on %q...\n", "M31")
 
-	exact, err := resolver.Resolve("M31")
+	exact, err := resolver.Resolve(ctx, "M31")
 	if err == nil {
-		fmt.Printf("Strictly matched: %s (%s) perfectly.\n", exact.Name, exact.ID)
+		fmt.Printf("Matched: %s (%s), merged from %d field(s) with attributed provenance.\n", exact.Name, exact.ID, len(exact.Provenance))
 	}
 }

--- a/examples/12_satellite_tracking/main.go
+++ b/examples/12_satellite_tracking/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	resolver := catalog.NewResolver(catalog.NORAD)
 
-	target, err := resolver.Resolve("ISS (Zarya)")
+	target, err := resolver.Resolve(context.Background(), "ISS (Zarya)")
 	if err != nil {
 		log.Fatalf("Failed to resolve ISS (Zarya): %v", err)
 	}

--- a/examples/14_target_scoring/main.go
+++ b/examples/14_target_scoring/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -55,7 +56,7 @@ func main() {
 
 	targets := make([]plan.Observable, 0, len(lookups))
 	for _, l := range lookups {
-		t, err := l.resolver.Resolve(l.name)
+		t, err := l.resolver.Resolve(context.Background(), l.name)
 		if err != nil {
 			fmt.Printf("  ⚠ Could not resolve %q: %v\n", l.name, err)
 			continue

--- a/examples/15_target_details/deep-sky/main.go
+++ b/examples/15_target_details/deep-sky/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -31,7 +32,7 @@ func main() {
 
 	resolver := catalog.NewResolver(catalog.OpenNGC, catalog.SIMBAD)
 
-	catTarget, err := resolver.Resolve("M31")
+	catTarget, err := resolver.Resolve(context.Background(), "M31")
 	if err != nil {
 		log.Fatalf("failed to resolve M31: %v", err)
 	}

--- a/examples/15_target_details/satellites/main.go
+++ b/examples/15_target_details/satellites/main.go
@@ -22,7 +22,7 @@ func main() {
 	// We'll use the satellite epoch for context later or current time
 	resolver := catalog.NewResolver(catalog.NORAD)
 
-	catTarget, err := resolver.Resolve("ISS (Zarya)")
+	catTarget, err := resolver.Resolve(context.Background(), "ISS (Zarya)")
 	if err != nil {
 		log.Fatalf("failed to resolve ISS: %v", err)
 	}

--- a/examples/15_target_details/stars/main.go
+++ b/examples/15_target_details/stars/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -31,7 +32,7 @@ func main() {
 
 	resolver := catalog.NewResolver(catalog.OpenNGC, catalog.SIMBAD)
 
-	catTarget, err := resolver.Resolve("Sirius")
+	catTarget, err := resolver.Resolve(context.Background(), "Sirius")
 	if err != nil {
 		log.Fatalf("failed to resolve Sirius: %v", err)
 	}

--- a/internal/gofaext/gofaext.go
+++ b/internal/gofaext/gofaext.go
@@ -323,3 +323,24 @@ func Pnm06a(date1, date2 float64) [3][3]float64 {
 func Ee06a(date1, date2 float64) float64 {
 	return gofa.Ee06a(date1, date2)
 }
+
+// Pmsafe applies stellar space motion (proper motion, parallax, radial
+// velocity) to propagate a catalog position from one epoch to another,
+// guarding against the near-zero-parallax case that would otherwise make
+// the underlying relativistic iteration fail outright.
+//
+// ra1, dec1 are in radians; pmr1, pmd1 are coordinate proper motions in
+// radians/Julian-year (already ×cos(dec)); px1 is parallax in arcseconds;
+// rv1 is radial velocity in km/s (positive receding). ep1a/ep1b and
+// ep2a/ep2b are the "from" and "to" epochs as two-part TDB Julian dates.
+//
+// status: 0 = OK; 1 = parallax overridden (was zero/negative/too small);
+// 2 = proper motion implied >1% c, treated as zero; 4 = did not converge;
+// -1 = system error (bad parallax data, e.g. NaN). Bits combine (3 = both
+// 1 and 2); treat any status >= 0 as "propagated, inputs adjusted", only
+// -1 as a hard failure.
+func Pmsafe(ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b float64) (ra2, dec2, pmr2, pmd2, px2, rv2 float64, status int) {
+	status = gofa.Pmsafe(ra1, dec1, pmr1, pmd1, px1, rv1, ep1a, ep1b, ep2a, ep2b, &ra2, &dec2, &pmr2, &pmd2, &px2, &rv2)
+
+	return ra2, dec2, pmr2, pmd2, px2, rv2, status
+}

--- a/time/time.go
+++ b/time/time.go
@@ -103,6 +103,11 @@ var LoadLocation = time.LoadLocation
 // LocationUTC is the UTC location.
 var LocationUTC = time.UTC
 
+// J2000 is the standard epoch J2000.0 (JD 2451545.0 TT) — the reference
+// epoch most star catalogs (Gaia excepted, at J2016.0) and orbital-element
+// sources assume when they don't report their own epoch explicitly.
+var J2000 = FromJD(2451545.0, TT)
+
 var (
 	// RFC1123 is a time format that conforms to RFC 1123.
 	RFC1123 = time.RFC1123


### PR DESCRIPTION
## Summary
- `catalog.Resolver` now cross-matches every registered provider's hit for a query into one merged `Target` (shared alias/ID first, falling back to epoch-normalized angular separation via a new `coord.PropagateEpoch`), instead of `Resolve` returning whichever provider answered first and `Search` deduplicating on a key that can't catch cross-provider duplicates.
- Gaia/VizieR's `ConeSearch` capability is bridged in around each cross-matched group's anchor position, so their astrometry can participate even though neither does name-based lookup. Each field is chosen by a provider-precedence table (Coord/Parallax/PmRA/PmDec are one coupled cluster, never mixed field-by-field); `Target.Provenance` records which provider contributed each field.
- `Resolver` gains chainable `Limit(n)` / `PositionMatchThreshold(angle.Angle)` setters replacing the previous hardcoded `Search` cap (10) and match threshold (2″):
  ```go
  resolver := catalog.NewResolver(catalog.OpenNGC, catalog.SIMBAD, catalog.MAST).
      Limit(10).
      PositionMatchThreshold(angle.Arcsec(2))
  target, err := resolver.Resolve(ctx, "M31")
  ```
- Fixes real per-provider bugs found while building this: Gaia/MAST reporting `HasCoord=true` on a parse/decode failure (fake `(0,0)`), MAST's `Catalog` field holding a relayed sub-resolver name instead of `"mast"`, VizieR never setting `Target.ID`, inconsistent `Epoch` population across providers, and SBDB/NORAD's `Kind` strings canonicalized into named constants (`KindAsteroid`/`KindComet`/`KindSatellite`).

## Breaking changes
- `resolve.Provider.Resolve`/`Search` now take `ctx context.Context` as their first parameter, so cancellation propagates end-to-end into the underlying HTTP calls (verified: every request-building call in `remote.Client` uses `http.NewRequestWithContext`, and retries respect `context.Canceled`/`DeadlineExceeded`).
- See `CHANGELOG.md` `[Unreleased]` for the full list.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run ./...` all clean
- [x] `go test ./...` (default suite)
- [x] `go test -tags=network ./catalog/...` (live reachability)
- [x] `go test -tags="integration,network,validation" ./...` (full gate)
- [x] `go mod tidy` — no changes
- [x] New tests: alias-graph cross-match, positional fallback (same-epoch and epoch-mismatch-with-proper-motion), ConeSearch bridge, `trustworthyCoord` guard, field-precedence merge with `Provenance` assertions, `Limit`/`PositionMatchThreshold` behavior, plus regression tests for each per-provider bug fix
- [x] Manually resolved "Sirius" against live SIMBAD/Gaia/OpenNGC and inspected `Provenance`
- [ ] `-race` not run — no cgo/gcc available in this environment; CI should cover it