### PR TITLE
fix(openngc): isolate cache dir in TestNewDefaultDenyIssuesNoRequest

### DIFF
--- a/catalog/openngc/fetch_test.go
+++ b/catalog/openngc/fetch_test.go
@@ -128,6 +128,7 @@ func TestNewSkipsBodyWhenUnchanged(t *testing.T) {
 
 func TestNewDefaultDenyIssuesNoRequest(t *testing.T) {
 	t.Cleanup(remote.Reset)
+	remote.SetDataDirPath(t.TempDir())
 
 	var hits atomic.Int32
 


### PR DESCRIPTION
## Summary
- `TestNewDefaultDenyIssuesNoRequest` (catalog/openngc/fetch_test.go) was the only test in its file that didn't isolate its cache directory via `remote.SetDataDirPath(t.TempDir())`, unlike its siblings (`TestNewFetchesFromNetworkWhenDownloadsEnabled`, `TestNewSkipsBodyWhenUnchanged`, `TestNewDoesNotAccumulateCacheFiles`).
- Because of that, it silently depended on the real default OS cache directory having no pre-existing `NGC.csv`. If any prior run of the library (an example, another test) had legitimately cached OpenNGC's CSVs there, `remote.GetFile` finds the file and — since `OpenNGC` is `Mutable` — does a live `unchanged()` HEAD-probe against the endpoint (redirected to this test's `httptest.Server`), incrementing the hit counter the test asserts must stay at zero. Reproduced this exact failure locally after running a real example.

## Test plan
- [x] Reproduced the failure by pre-seeding the real cache dir with a fake `NGC.csv`, confirmed it fails before the fix
- [x] Confirmed it now passes with the same pre-seeded file present, after the fix
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run` — clean
- [x] `go test ./...` — all packages pass