### PR TITLE
Guard plan.Solver against silent non-finite results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `plan.Solver.FindRoot`/`FindExtremum` no longer silently return a non-finite (NaN/±Inf) result as a success — both now guard every evaluator output and internal step computation, returning the new `plan.ErrNonFiniteEvaluation` instead. Also fixes a latent divide-by-zero in `FindRoot`'s inverse-quadratic-interpolation step-clamp when the bracket has already converged to zero width.
 
 ## [0.11.0] — 2026-07-29
 ### Added

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -33,6 +33,11 @@ var (
 
 	// ErrBracketingViolated indicates f(a) and f(b) have the same sign in root finding.
 	ErrBracketingViolated = errors.New("solver: bracketing condition violated: f(a) and f(b) have the same sign")
+	// ErrNonFiniteEvaluation indicates an Evaluator returned NaN or ±Inf, or
+	// a solver's internal step computation produced a non-finite trial
+	// point — both FindRoot and FindExtremum guard against silently
+	// converging on (and returning as success) a non-finite result.
+	ErrNonFiniteEvaluation = errors.New("solver: evaluator returned a non-finite value")
 	// ErrEventNotFound indicates no event was found in the search window.
 	ErrEventNotFound = errors.New("no event found in search window")
 

--- a/plan/solver.go
+++ b/plan/solver.go
@@ -50,6 +50,17 @@ func DefaultSolver() Solver {
 // It returns the metric value and an error if the computation fails.
 type Evaluator func(t time.Time) (float64, error)
 
+// finite reports whether v is neither NaN nor ±Inf. FindRoot and
+// FindExtremum both guard every evaluator result (and every internal step
+// computation derived from one) with this — without it, a NaN/Inf value
+// can silently satisfy every convergence/comparison test in these
+// algorithms (NaN comparisons are always false; Inf-Inf arithmetic yields
+// NaN) and be returned as a "successful" result with a nil error instead
+// of failing loudly.
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
 // FindRoot finds the time t in [t1, t2] where eval(t) ≈ 0 using Chandrupatla's method.
 //
 // Precondition: eval(t1) and eval(t2) must have opposite signs (bracketing condition).
@@ -81,9 +92,17 @@ func (s Solver) FindRoot(eval Evaluator, t1, t2 time.Time) (time.Time, float64, 
 		return time.Time{}, 0, fmt.Errorf("solver: eval at a: %w", err)
 	}
 
+	if !finite(fa) {
+		return time.Time{}, 0, fmt.Errorf("solver: eval at a: %w", ErrNonFiniteEvaluation)
+	}
+
 	fb, err := eval(timeAt(xb))
 	if err != nil {
 		return time.Time{}, 0, fmt.Errorf("solver: eval at b: %w", err)
+	}
+
+	if !finite(fb) {
+		return time.Time{}, 0, fmt.Errorf("solver: eval at b: %w", ErrNonFiniteEvaluation)
 	}
 
 	// Verify bracketing condition
@@ -134,22 +153,40 @@ func (s Solver) FindRoot(eval Evaluator, t1, t2 time.Time) (time.Time, float64, 
 				t = fa*fc/((fb-fa)*(fb-fc)) +
 					(xc-xa)/(xb-xa)*fa*fb/((fc-fa)*(fc-fb))
 
-				// Clamp to prevent stepping too close to bracket boundaries
-				tlim := 0.5 * tolSec / math.Abs(xb-xa)
-				if tlim < 1e-12 {
-					tlim = 1e-12
-				}
+				// Clamp to prevent stepping too close to bracket boundaries.
+				// xb == xa (bracket already converged to zero width) would
+				// otherwise divide by zero here, producing an Inf/NaN tlim
+				// that propagates into xt below — bail to plain bisection
+				// (t stays 0.5) instead. In practice the outer loop's own
+				// convergence check (math.Abs(xb-xa) <= tolSec) already
+				// breaks before this is reached for any tolSec > 0, but
+				// guard it directly rather than relying on that.
+				if width := math.Abs(xb - xa); width > 0 {
+					tlim := 0.5 * tolSec / width
+					if tlim < 1e-12 {
+						tlim = 1e-12
+					}
 
-				t = math.Max(tlim, math.Min(1-tlim, t))
+					t = math.Max(tlim, math.Min(1-tlim, t))
+				} else {
+					t = 0.5
+				}
 			}
 		}
 
 		// ── Evaluate at new trial point ────────────────────────────────
 		xt := xa + t*(xb-xa)
+		if !finite(xt) {
+			return time.Time{}, 0, fmt.Errorf("solver: non-finite trial point at iter %d: %w", i, ErrNonFiniteEvaluation)
+		}
 
 		ft, err := eval(timeAt(xt))
 		if err != nil {
 			return time.Time{}, 0, fmt.Errorf("solver: eval at iter %d: %w", i, err)
+		}
+
+		if !finite(ft) {
+			return time.Time{}, 0, fmt.Errorf("solver: eval at iter %d: %w", i, ErrNonFiniteEvaluation)
 		}
 
 		// ── Update bracket and third point ─────────────────────────────
@@ -194,6 +231,10 @@ func (s Solver) FindExtremum(eval Evaluator, t1, t3 time.Time, isMax bool) (time
 		return time.Time{}, 0, fmt.Errorf("solver: extremum eval at x: %w", err)
 	}
 
+	if !finite(fx) {
+		return time.Time{}, 0, fmt.Errorf("solver: extremum eval at x: %w", ErrNonFiniteEvaluation)
+	}
+
 	if isMax {
 		fx = -fx
 	}
@@ -230,12 +271,17 @@ func (s Solver) FindExtremum(eval Evaluator, t1, t3 time.Time, isMax bool) (time
 				q = -q
 			}
 
-			// Accept parabolic step if within bracket and reducing distance
-			if math.Abs(p) < math.Abs(0.5*q*float64(e)) &&
+			// Accept parabolic step if within bracket and reducing distance.
+			// step is checked finite before use — a degenerate fit (q≈0)
+			// can otherwise produce an Inf/NaN p/q that would convert to
+			// time.Duration with implementation-defined behavior.
+			step := p / q
+			if finite(step) &&
+				math.Abs(p) < math.Abs(0.5*q*float64(e)) &&
 				p > q*float64(a.Sub(x)) &&
 				p < q*float64(b.Sub(x)) {
 				e = d
-				d = time.Duration(p / q)
+				d = time.Duration(step)
 				useParabolic = true
 			}
 		}
@@ -249,6 +295,9 @@ func (s Solver) FindExtremum(eval Evaluator, t1, t3 time.Time, isMax bool) (time
 			}
 
 			d = time.Duration(float64(e) * goldenRatio)
+			if !finite(float64(d)) {
+				return time.Time{}, 0, fmt.Errorf("solver: extremum non-finite step at iter %d: %w", i, ErrNonFiniteEvaluation)
+			}
 		}
 
 		// Evaluate at the new trial point
@@ -266,6 +315,10 @@ func (s Solver) FindExtremum(eval Evaluator, t1, t3 time.Time, isMax bool) (time
 		fu, err := eval(u)
 		if err != nil {
 			return time.Time{}, 0, fmt.Errorf("solver: extremum eval at iter %d: %w", i, err)
+		}
+
+		if !finite(fu) {
+			return time.Time{}, 0, fmt.Errorf("solver: extremum eval at iter %d: %w", i, ErrNonFiniteEvaluation)
 		}
 
 		if isMax {
@@ -305,7 +358,11 @@ func (s Solver) FindExtremum(eval Evaluator, t1, t3 time.Time, isMax bool) (time
 		return time.Time{}, 0, fmt.Errorf("solver: final eval: %w", err)
 	}
 
-	return x, finalVal, err
+	if !finite(finalVal) {
+		return time.Time{}, 0, fmt.Errorf("solver: final eval: %w", ErrNonFiniteEvaluation)
+	}
+
+	return x, finalVal, nil
 }
 
 // CrossesTarget checks whether a cyclic quantity moved through a target angle

--- a/plan/solver_nan_test.go
+++ b/plan/solver_nan_test.go
@@ -1,0 +1,149 @@
+package plan_test
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// nonFiniteAt returns an Evaluator that returns badVal on the callN'th
+// invocation (1-indexed) and f(seconds-from-epoch) on every other call —
+// used to inject a NaN/Inf evaluation at a specific point in FindRoot's or
+// FindExtremum's iteration sequence without needing to predict the exact
+// trial-point value the algorithm will pick internally. callN=1 lands on
+// the very first evaluation (t1 for FindRoot, the midpoint for
+// FindExtremum); callN=2 lands on FindRoot's t2; any higher callN lands on
+// an interior trial point chosen by the algorithm during iteration.
+func nonFiniteAt(f func(float64) float64, badVal float64, callN int) plan.Evaluator {
+	calls := 0
+
+	return func(t time.Time) (float64, error) {
+		calls++
+		if calls == callN {
+			return badVal, nil
+		}
+
+		return f(t.Sub(epoch).Seconds()), nil
+	}
+}
+
+// nonFiniteValues covers every IEEE 754 non-finite case: NaN comparisons
+// are always false (so NaN silently survives every "!=" convergence/IQI
+// gate in solver.go), and ±Inf pass the fa*fb>0 bracketing check as well
+// as arithmetic like Inf-Inf, both of which historically let a
+// non-finite value reach the end of FindRoot/FindExtremum with a nil
+// error before this guard existed.
+var nonFiniteValues = []struct {
+	name string
+	val  float64
+}{
+	{"NaN", math.NaN()},
+	{"+Inf", math.Inf(1)},
+	{"-Inf", math.Inf(-1)},
+}
+
+func TestFindRoot_NonFiniteEvaluation(t *testing.T) {
+	s := tightSolver()
+
+	positions := []struct {
+		name  string
+		callN int
+	}{
+		{"at_t1", 1},
+		{"at_t2", 2},
+		{"interior", 3},
+	}
+
+	for _, nf := range nonFiniteValues {
+		for _, pos := range positions {
+			t.Run(nf.name+"_"+pos.name, func(t *testing.T) {
+				eval := nonFiniteAt(func(x float64) float64 { return x - 5 }, nf.val, pos.callN)
+
+				_, _, err := s.FindRoot(eval, after(0), after(10))
+				if err == nil {
+					t.Fatalf("FindRoot: want error for non-finite %s at %s, got nil (non-finite value silently accepted)", nf.name, pos.name)
+				}
+
+				if !errors.Is(err, plan.ErrNonFiniteEvaluation) {
+					t.Errorf("FindRoot: err = %v, want it to wrap plan.ErrNonFiniteEvaluation", err)
+				}
+			})
+		}
+	}
+}
+
+func TestFindExtremum_NonFiniteEvaluation(t *testing.T) {
+	s := tightSolver()
+
+	positions := []struct {
+		name  string
+		callN int
+	}{
+		{"at_x", 1},
+		{"interior", 2},
+	}
+
+	for _, nf := range nonFiniteValues {
+		for _, pos := range positions {
+			t.Run(nf.name+"_"+pos.name, func(t *testing.T) {
+				// f(x) = -(x-5)^2 — a maximum at x=5 over [0,10].
+				eval := nonFiniteAt(func(x float64) float64 { return -(x - 5) * (x - 5) }, nf.val, pos.callN)
+
+				_, _, err := s.FindExtremum(eval, after(0), after(10), true)
+				if err == nil {
+					t.Fatalf("FindExtremum: want error for non-finite %s at %s, got nil (non-finite value silently accepted)", nf.name, pos.name)
+				}
+
+				if !errors.Is(err, plan.ErrNonFiniteEvaluation) {
+					t.Errorf("FindExtremum: err = %v, want it to wrap plan.ErrNonFiniteEvaluation", err)
+				}
+			})
+		}
+	}
+}
+
+// TestFindRoot_WellBehavedStillConverges is the positive control required
+// alongside the non-finite guards above: a legitimate evaluator that never
+// produces a non-finite value must still converge exactly as it did before
+// the guards were added, confirming they reject only genuinely non-finite
+// results, not merely large or extreme-but-finite ones.
+func TestFindRoot_WellBehavedStillConverges(t *testing.T) {
+	s := tightSolver()
+
+	root, _, err := s.FindRoot(timeFunc(func(x float64) float64 {
+		return x - 5
+	}), after(0), after(10))
+	if err != nil {
+		t.Fatalf("FindRoot: unexpected error for a well-behaved evaluator: %v", err)
+	}
+
+	rootSec := root.Sub(epoch).Seconds()
+	if math.Abs(rootSec-5) > 1e-6 {
+		t.Errorf("root = %.9f, want 5.0", rootSec)
+	}
+}
+
+// TestFindExtremum_WellBehavedStillConverges is FindExtremum's counterpart
+// positive control.
+func TestFindExtremum_WellBehavedStillConverges(t *testing.T) {
+	s := tightSolver()
+
+	tExt, val, err := s.FindExtremum(timeFunc(func(x float64) float64 {
+		return -(x - 5) * (x - 5)
+	}), after(0), after(10), true)
+	if err != nil {
+		t.Fatalf("FindExtremum: unexpected error for a well-behaved evaluator: %v", err)
+	}
+
+	extSec := tExt.Sub(epoch).Seconds()
+	if math.Abs(extSec-5) > 1e-4 {
+		t.Errorf("extremum time = %.6f, want ~5.0", extSec)
+	}
+
+	if math.Abs(val) > 1e-4 {
+		t.Errorf("value at extremum = %g, want ~0", val)
+	}
+}


### PR DESCRIPTION
## Summary
- `FindRoot`'s bracketing check and IQI gate both let NaN/Inf slip through undetected (NaN comparisons are always false; Inf arithmetic degrades to NaN), so a misbehaving `Evaluator` could converge to a garbage time/value with a `nil` error instead of failing loudly. `FindExtremum` had the same gap.
- Adds a `finite()` guard on every evaluator result and every internal step computation derived from one, returning a new `ErrNonFiniteEvaluation` sentinel on failure.
- Fixes a real divide-by-zero in `FindRoot`'s IQI step-clamp (`tlim`) when the bracket has already converged to zero width — now falls back to plain bisection instead of producing an Inf/NaN step.

## Test plan
- [x] New `plan/solver_nan_test.go`: 15 non-finite injection cases (NaN/+Inf/-Inf × at-boundary/interior, both `FindRoot`/`FindExtremum`) + 2 positive controls confirming well-behaved evaluators still converge exactly as before
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] `go test ./plan/...` (untagged) — clean, no regression
- [x] `go test -tags="integration,network,validation" ./plan/...` — clean (235s), confirms no real evaluator anywhere in `plan` was silently relying on the old non-finite-tolerant behavior
- [x] `go mod tidy` — no diff