### PR TITLE
Harden SPK/DAF reader against corrupted kernels, add fuzz tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ephemeris/jpl/spk`'s DAF/SPK binary reader no longer trusts file-derived integers (record counts, summary sizes, MAXDIM/KQ table indices, Chebyshev record layout) before validating them, closing several slice-bounds/makeslice panics and an unbounded-FWD-chain hang reachable from a corrupted or truncated kernel. New `FuzzNewReaderReadSummaries`/`FuzzEvaluateSegment`/`FuzzReadDoubles` fuzz the parser on every `go test ./...` run via their seed corpus.
 
 ## [0.11.0] — 2026-07-29
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,18 @@ Tests are partitioned by build tag — the default `go test ./...` runs only fas
 - `validation` — numerical comparisons against JPL Horizons and SOFA fixtures, mostly under [ephemeris/jpl/validation/](ephemeris/jpl/validation/) and `plan/{usno,nasa_eclipse,astropixels}_test.go`.
 - `integration` — cross-provider tests with offline caches.
 
+## Fuzzing
+
+`ephemeris/jpl/spk/fuzz_test.go` fuzzes the hand-rolled DAF/SPK binary parser against corrupted, truncated, and adversarial kernel bytes — the property under test is "never panics or hangs on attacker-influenceable input," not correctness (that's covered elsewhere by `TestSPKReader`/`TestEvaluateType21`). Its seed corpus (`f.Add(...)` literals only — no checked-in binary fixtures) runs as an ordinary test under `go test ./...`, so it's part of every CI run for free. Extended fuzzing beyond the seed corpus is a manual, periodic step, not a CI gate — run it locally when touching `ephemeris/jpl/spk/reader.go`:
+
+```bash
+go test -run=^$ -fuzz=FuzzNewReaderReadSummaries -fuzztime=60s ./ephemeris/jpl/spk/
+go test -run=^$ -fuzz=FuzzEvaluateSegment -fuzztime=60s ./ephemeris/jpl/spk/
+go test -run=^$ -fuzz=FuzzReadDoubles -fuzztime=60s ./ephemeris/jpl/spk/
+```
+
+Any crasher Go writes to `testdata/fuzz/` should be committed — that's the one place a small binary fixture is legitimate here, since it's a regression test for a bug the fuzzer found, not a data source.
+
 ## Embedded data
 
 There is no `go:generate` step in this codebase — it was removed deliberately. No package uses `go:embed` either — every data source is obtained at runtime through `remote.GetFile`, either explicitly (`catalog/openngc`, see [catalog/openngc/openngc.go](catalog/openngc/openngc.go)) or via a lazy, on-first-query load (`time`'s Earth Orientation Parameters, see [time/eop.go](time/eop.go) and the unexported `time/internal/iers`).

--- a/ephemeris/jpl/spk/fuzz_test.go
+++ b/ephemeris/jpl/spk/fuzz_test.go
@@ -1,0 +1,192 @@
+package spk_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
+)
+
+// This file fuzzes the SPK/DAF binary parser against corrupted, truncated,
+// and adversarial input — none of it goes through remote's consent gate or
+// touches the network; every seed here is a hand-built byte literal (no
+// checked-in binary fixture) or the reserialized word array from
+// TestEvaluateType21 in reader_test.go. Any crasher Go writes to
+// testdata/fuzz/ on a failing run should be committed as a regression test
+// for the bug it found — see CLAUDE.md's "Fuzzing" note for the manual,
+// longer-running invocation (`-fuzz=... -fuzztime=60s`); the seed corpus
+// below runs as a plain test under `go test ./...` with no flags needed.
+//
+// Property under test throughout: parsing/evaluating attacker-influenceable
+// bytes (a downloaded, truncated, or corrupted kernel) must never panic or
+// hang — it must return an error. Correctness of well-formed data is
+// already covered by TestSPKReader/TestEvaluateType21 elsewhere in this
+// package.
+
+// wordsToBytes packs vals as consecutive little-endian float64 DAF words
+// (1-based addressing, matching Reader.ReadDoubles), the same layout
+// newWordBuffer (reader_test.go) uses for a *spk.Reader — this returns the
+// raw bytes instead, for use as a fuzz corpus seed.
+func wordsToBytes(vals []float64) []byte {
+	buf := make([]byte, len(vals)*8)
+	for i, v := range vals {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(v))
+	}
+
+	return buf
+}
+
+// buildDAFHeader constructs a syntactically valid 1024-byte DAF file
+// record: the format identifier at [88:96] plus the ND/NI/FWD fields
+// NewReader decodes. BWD/FREE (unused by any parsing in this package) and
+// the ID word text are left zeroed — NewReader doesn't validate any of them.
+func buildDAFHeader(nd, ni, fwd int32, bigEndian bool) []byte {
+	buf := make([]byte, spk.RecordSize)
+
+	order, format := binary.ByteOrder(binary.LittleEndian), "LTL-IEEE"
+	if bigEndian {
+		order, format = binary.BigEndian, "BIG-IEEE"
+	}
+
+	copy(buf[88:96], format)
+	order.PutUint32(buf[8:12], uint32(nd))
+	order.PutUint32(buf[12:16], uint32(ni))
+	order.PutUint32(buf[76:80], uint32(fwd))
+
+	return buf
+}
+
+// buildSummaryRecordSPK constructs a 1024-byte DAF summary/directory record
+// holding exactly one ND=2/NI=6 (the standard SPK shape) summary — the
+// layout ReadSummaries decodes: the next-record pointer and summary count
+// as float64 words at [0:8]/[16:24], then each summary's doubles followed
+// by its integers starting at byte offset 24.
+func buildSummaryRecordSPK(order binary.ByteOrder, next int32, startET, endET float64, target, center, frame, segType, startAddr, endAddr int32) []byte {
+	buf := make([]byte, spk.RecordSize)
+
+	order.PutUint64(buf[0:8], math.Float64bits(float64(next)))
+	order.PutUint64(buf[16:24], math.Float64bits(1)) // nSum = 1
+
+	order.PutUint64(buf[24:32], math.Float64bits(startET))
+	order.PutUint64(buf[32:40], math.Float64bits(endET))
+
+	order.PutUint32(buf[40:44], uint32(target))
+	order.PutUint32(buf[44:48], uint32(center))
+	order.PutUint32(buf[48:52], uint32(frame))
+	order.PutUint32(buf[52:56], uint32(segType))
+	order.PutUint32(buf[56:60], uint32(startAddr))
+	order.PutUint32(buf[60:64], uint32(endAddr))
+
+	return buf
+}
+
+func FuzzNewReaderReadSummaries(f *testing.F) {
+	f.Add(buildDAFHeader(2, 6, 0, false)) // valid header, no summary records
+
+	validWithOneSummary := append(
+		buildDAFHeader(2, 6, 2, false),
+		buildSummaryRecordSPK(binary.LittleEndian, 0, -1e8, 1e8, 3, 10, 1, 2, 100, 200)...)
+	f.Add(validWithOneSummary)
+
+	f.Add(buildDAFHeader(2, 6, 0, true)) // big-endian variant
+
+	f.Add(make([]byte, spk.RecordSize)) // all-zero header: ND=NI=0, FWD=0
+	f.Add(make([]byte, 100))            // truncated: shorter than one record
+
+	f.Add(buildDAFHeader(1<<20, 1<<20, 0, false)) // extreme ND/NI
+	f.Add(buildDAFHeader(2, 6, -5, false))        // negative FWD
+
+	cyclic := append(
+		buildDAFHeader(2, 6, 2, false),
+		buildSummaryRecordSPK(binary.LittleEndian, 2, 0, 0, 0, 0, 0, 0, 0, 0)...) // record 2's FWD points back to itself
+	f.Add(cyclic)
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		r, err := spk.NewReader(fakeReaderAt{bytes.NewReader(data)})
+		if err != nil {
+			return // a rejected malformed header is a correct, expected outcome
+		}
+
+		_, _ = r.ReadSummaries() // property: never panics or hangs, error is fine
+	})
+}
+
+func FuzzEvaluateSegment(f *testing.F) {
+	// Type 21: TestEvaluateType21's synthetic single-record segment,
+	// reserialized to raw bytes (see reader_test.go for the field layout
+	// this encodes).
+	const (
+		t0        = 100.0
+		maxDim21  = 1.0
+		kqmax1    = 2.0
+		startAddr = 1
+	)
+
+	refPos := [3]float64{10, 20, 30}
+	refVel := [3]float64{1, 2, 3}
+	type21Rec := []float64{
+		t0, 1.0,
+		refPos[0], refVel[0], refPos[1], refVel[1], refPos[2], refVel[2],
+		99, 99, 99,
+		kqmax1,
+		0, 0, 0,
+	}
+	type21Words := append(append([]float64{}, type21Rec...), 999999.0, maxDim21, 1.0)
+
+	f.Add(uint8(2), int32(startAddr), int32(len(type21Words)), t0, wordsToBytes(type21Words))
+
+	// Type 2: a single Chebyshev record, one coefficient per axis
+	// (rSize=5), evaluated exactly at its own tInit so idx=0 with no
+	// boundary edge cases.
+	type2Words := []float64{
+		0.0, 1.0, 7.0, 8.0, 9.0, // rec: mid, radius, cx, cy, cz
+		0.0, 1.0, 5.0, 0.0, // meta at EndAddr-3..EndAddr: tInit, tLen, rSize, (unused)
+	}
+	f.Add(uint8(0), int32(1), int32(len(type2Words)), 0.0, wordsToBytes(type2Words))
+
+	// A few structurally-plausible-but-wrong mutations: truncated data,
+	// all-zero data, and an unsupported segment type (exercises the
+	// EvaluateSegment switch's default branch).
+	f.Add(uint8(1), int32(1), int32(9), 0.0, wordsToBytes(type2Words)[:10])
+	f.Add(uint8(2), int32(1), int32(20), 50.0, make([]byte, 200))
+	f.Add(uint8(0), int32(0), int32(0), math.NaN(), []byte{})
+
+	f.Fuzz(func(_ *testing.T, typeSel uint8, startAddr, endAddr int32, et float64, data []byte) {
+		segType := [3]int32{2, 3, 21}[int(typeSel)%3]
+
+		r := &spk.Reader{
+			F:       fakeReaderAt{bytes.NewReader(data)},
+			FileRec: spk.FileRecord{Order: binary.LittleEndian},
+		}
+		seg := &spk.Segment{
+			Type:      segType,
+			StartAddr: startAddr,
+			EndAddr:   endAddr,
+			StartET:   -1e12,
+			EndET:     1e12,
+		}
+
+		_, _, _ = spk.EvaluateSegment(seg, r, et) // property: never panics or hangs
+	})
+}
+
+func FuzzReadDoubles(f *testing.F) {
+	seed := wordsToBytes([]float64{1, 2, 3, 4, 5})
+	f.Add(int32(1), int32(5), seed)
+	f.Add(int32(1), int32(1), seed)
+	f.Add(int32(5), int32(1), seed) // endWord < startWord: count <= 0
+	f.Add(int32(-1), int32(3), seed)
+	f.Add(int32(1), int32(1<<30), seed) // extreme count
+	f.Add(int32(0), int32(0), []byte{})
+
+	f.Fuzz(func(_ *testing.T, startWord, endWord int32, data []byte) {
+		r := &spk.Reader{
+			F:       fakeReaderAt{bytes.NewReader(data)},
+			FileRec: spk.FileRecord{Order: binary.LittleEndian},
+		}
+
+		_, _ = r.ReadDoubles(startWord, endWord) // property: never panics or hangs
+	})
+}

--- a/ephemeris/jpl/spk/reader.go
+++ b/ephemeris/jpl/spk/reader.go
@@ -246,40 +246,91 @@ func (r *Reader) Close() error {
 	return nil
 }
 
-// ReadSummaries reads all segments summaries.
+// maxSummaryRecords bounds how many summary records ReadSummaries will
+// follow through the FWD linked list before giving up. Every legitimate
+// SPK kernel this library encounters has at most a few hundred summary
+// records; this cap is orders of magnitude more generous than that while
+// still turning a self-referential or corrupted FWD chain into a bounded
+// error instead of an unbounded append or an infinite loop. A cycle is
+// also detected directly (via visited), independent of this cap.
+const maxSummaryRecords = 1_000_000
+
+// ReadSummaries reads all segment summaries.
 func (r *Reader) ReadSummaries() ([]Summary, error) {
 	var summaries []Summary
 
+	nd, ni := int(r.FileRec.ND), int(r.FileRec.NI)
+	if nd < 0 || ni < 0 || nd+ni == 0 {
+		return nil, fmt.Errorf("%w: invalid summary shape ND=%d, NI=%d", ErrCorruptSPK, nd, ni)
+	}
+
+	// sumLen is derived from file-controlled ND/NI, then used below to slice
+	// a fixed 1024-byte record buffer — bound it against the record size
+	// itself (a summary that couldn't fit even one entry in its own
+	// directory record is structurally invalid, regardless of file type)
+	// rather than trusting it directly, which is what let a corrupted or
+	// adversarial ND/NI drive a slice-bounds panic here before this check.
+	sumLen := (nd + (ni+1)/2) * 8
+	if sumLen <= 0 || sumLen > RecordSize-24 {
+		return nil, fmt.Errorf("%w: invalid summary size %d bytes (from ND=%d, NI=%d)", ErrCorruptSPK, sumLen, nd, ni)
+	}
+
 	next := r.FileRec.FWD
+	visited := make(map[int32]bool)
 
 	for next != 0 {
+		if next < 0 {
+			return nil, fmt.Errorf("%w: negative FWD record pointer %d", ErrCorruptSPK, next)
+		}
+
+		if visited[next] {
+			return nil, fmt.Errorf("%w: cyclic FWD chain revisits record %d", ErrCorruptSPK, next)
+		}
+
+		visited[next] = true
+		if len(visited) > maxSummaryRecords {
+			return nil, fmt.Errorf("%w: exceeded %d summary records following the FWD chain", ErrCorruptSPK, maxSummaryRecords)
+		}
+
 		buf := make([]byte, RecordSize)
 		if _, err := r.F.ReadAt(buf, int64(next-1)*RecordSize); err != nil {
 			return nil, fmt.Errorf("spk: read summary record: %w", err)
 		}
 
 		fwdFloat := math.Float64frombits(r.FileRec.Order.Uint64(buf[0:8]))
+		if !finite(fwdFloat) {
+			return nil, fmt.Errorf("%w: non-finite FWD pointer in summary record", ErrCorruptSPK)
+		}
+
 		fwd := int32(fwdFloat)
-		nSum := int32(math.Float64frombits(r.FileRec.Order.Uint64(buf[16:24])))
-		sumLen := int(r.FileRec.ND+(r.FileRec.NI+1)/2) * 8
+
+		nSumFloat := math.Float64frombits(r.FileRec.Order.Uint64(buf[16:24]))
+		if !finite(nSumFloat) || nSumFloat < 0 {
+			return nil, fmt.Errorf("%w: invalid summary count in summary record", ErrCorruptSPK)
+		}
+
+		nSum := int32(nSumFloat)
+		if int64(24)+int64(nSum)*int64(sumLen) > RecordSize {
+			return nil, fmt.Errorf("%w: %d summaries of %d bytes overflow the %d-byte record", ErrCorruptSPK, nSum, sumLen, RecordSize)
+		}
 
 		for i := range nSum {
 			offset := 24 + int(i)*sumLen
 			sumBuf := buf[offset : offset+sumLen]
 
 			s := Summary{
-				Doubles:  make([]float64, r.FileRec.ND),
-				Integers: make([]int32, r.FileRec.NI),
+				Doubles:  make([]float64, nd),
+				Integers: make([]int32, ni),
 			}
 
-			for d := range r.FileRec.ND {
+			for d := range nd {
 				bits := r.FileRec.Order.Uint64(sumBuf[d*8 : (d+1)*8])
 				s.Doubles[d] = math.Float64frombits(bits)
 			}
 
-			intStart := int(r.FileRec.ND) * 8
-			for j := range r.FileRec.NI {
-				s.Integers[j] = int32(r.FileRec.Order.Uint32(sumBuf[intStart+int(j)*4 : intStart+int(j+1)*4]))
+			intStart := nd * 8
+			for j := range ni {
+				s.Integers[j] = int32(r.FileRec.Order.Uint32(sumBuf[intStart+j*4 : intStart+(j+1)*4]))
 			}
 
 			summaries = append(summaries, s)
@@ -291,21 +342,31 @@ func (r *Reader) ReadSummaries() ([]Summary, error) {
 	return summaries, nil
 }
 
+// maxDoublesPerRead bounds a single ReadDoubles call to 16Mi doubles
+// (128 MiB) — far more than any legitimate DAF record request needs (SPK
+// segments read at most a few thousand doubles at a time), while turning a
+// corrupted or adversarial word range into a bounded error instead of an
+// attempted multi-gigabyte allocation. Computing count in int64 (rather
+// than the file-controlled int32 startWord/endWord) also avoids the int32
+// overflow that could otherwise make a huge count wrap negative and slip
+// past a naive count<=0 check.
+const maxDoublesPerRead = 16 << 20
+
 // ReadDoubles reads a range of float64 from the data area.
 func (r *Reader) ReadDoubles(startWord, endWord int32) ([]float64, error) {
-	count := endWord - startWord + 1
-	if count <= 0 {
-		return nil, fmt.Errorf("%w: %d to %d", ErrInvalidWordBounds, startWord, endWord)
+	count := int64(endWord) - int64(startWord) + 1
+	if count <= 0 || count > maxDoublesPerRead {
+		return nil, fmt.Errorf("%w: %d to %d (count=%d)", ErrInvalidWordBounds, startWord, endWord, count)
 	}
 
 	buf := make([]byte, count*8)
 
-	n, err := r.F.ReadAt(buf, int64(startWord-1)*8)
+	n, err := r.F.ReadAt(buf, (int64(startWord)-1)*8)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("spk: read doubles: %w", err)
 	}
 
-	if n < len(buf) && (errors.Is(err, io.EOF) || err == nil) {
+	if int64(n) < int64(len(buf)) && (errors.Is(err, io.EOF) || err == nil) {
 		return nil, fmt.Errorf("%w: unexpected EOF reading word %d", ErrCorruptSPK, startWord)
 	}
 
@@ -316,6 +377,14 @@ func (r *Reader) ReadDoubles(startWord, endWord int32) ([]float64, error) {
 	}
 
 	return res, nil
+}
+
+// finite reports whether v is neither NaN nor ±Inf — used throughout this
+// file to reject a corrupted or adversarial kernel's non-finite metadata
+// (record counts, step sizes, epochs) before it can propagate into a
+// slice index or division.
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
 }
 
 // Segment represents an SPK segment descriptor.
@@ -393,10 +462,18 @@ func evaluateType21(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, er
 		return vector.Vec3{}, vector.Vec3{}, err
 	}
 
+	if !finite(meta[0]) || !finite(meta[1]) {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: non-finite MAXDIM/nRecs metadata", ErrCorruptSPK)
+	}
+
 	maxDim := int32(meta[0])
 	nRecs := int32(meta[1])
 
-	if nRecs <= 0 {
+	// maxType21Records is a generous upper bound guarding nRecs*dlSize
+	// (below) against int32 overflow — no real Horizons-generated small-body
+	// kernel this library targets has anywhere near this many records.
+	const maxType21Records = 10_000_000
+	if nRecs <= 0 || nRecs > maxType21Records {
 		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: %d", ErrInvalidRecordCount, nRecs)
 	}
 
@@ -441,11 +518,32 @@ func evaluateType21(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, er
 	refPos := [3]float64{rec[maxDim+1], rec[maxDim+3], rec[maxDim+5]}
 	refVel := [3]float64{rec[maxDim+2], rec[maxDim+4], rec[maxDim+6]}
 	dt := rec[maxDim+7 : maxDim+7+3*maxDim] // column-major: axis i occupies dt[i*maxDim : (i+1)*maxDim]
+
+	if !finite(rec[4*maxDim+7]) || !finite(rec[4*maxDim+8]) || !finite(rec[4*maxDim+9]) || !finite(rec[4*maxDim+10]) {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: non-finite KQMAX1/KQ metadata", ErrCorruptSPK)
+	}
+
 	kqmax1 := int32(rec[4*maxDim+7])
 	kq := [3]int32{int32(rec[4*maxDim+8]), int32(rec[4*maxDim+9]), int32(rec[4*maxDim+10])}
 
 	if kqmax1 < 2 || kqmax1 > maxAllowedDim+1 {
 		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: KQMAX1=%d, allowed [2,%d]", ErrInvalidOrder, kqmax1, maxAllowedDim+1)
+	}
+
+	// KQMAX1/KQ are read straight from the record with no guarantee they
+	// stay within this segment's own MAXDIM — unlike the maxAllowedDim+1
+	// check above (a fixed library-wide ceiling), this is the check that a
+	// small, valid-looking MAXDIM (e.g. 1) can't be paired with a
+	// KQMAX1/KQ large enough to index g/dt/w out of their MAXDIM-sized
+	// bounds below.
+	if kqmax1 > maxDim+1 {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: KQMAX1=%d exceeds this segment's own MAXDIM=%d", ErrInvalidOrder, kqmax1, maxDim)
+	}
+
+	for axis, k := range kq {
+		if k < 0 || k > maxDim {
+			return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: KQ[%d]=%d exceeds MAXDIM=%d", ErrInvalidOrder, axis, k, maxDim)
+		}
 	}
 
 	delta := et - t0
@@ -516,8 +614,38 @@ func evaluateType21(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, er
 		velArr[i] = refVel[i] + delta*axisSum(i)
 	}
 
-	return vector.Vec3{X: posArr[0], Y: posArr[1], Z: posArr[2]},
-		vector.Vec3{X: velArr[0], Y: velArr[1], Z: velArr[2]}, nil
+	pos = vector.Vec3{X: posArr[0], Y: posArr[1], Z: posArr[2]}
+	vel = vector.Vec3{X: velArr[0], Y: velArr[1], Z: velArr[2]}
+
+	if !finite(pos.X) || !finite(pos.Y) || !finite(pos.Z) || !finite(vel.X) || !finite(vel.Y) || !finite(vel.Z) {
+		// A non-finite step size (g) not already caught by the zero check
+		// above, or other corrupted difference-table data, can still
+		// propagate a NaN/Inf through the FC/WC/W recursion — fail loudly
+		// here rather than hand a silently-bad state/velocity to a caller.
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: non-finite evaluated position/velocity", ErrCorruptSPK)
+	}
+
+	return pos, vel, nil
+}
+
+// validateChebyshevMeta checks the (tInit, tLen, rSize) triple
+// evaluateType2/evaluateType3 derive their record layout from, before that
+// layout is used to size any read, slice, or division. A corrupt kernel
+// could otherwise supply a non-finite or non-positive tLen (dividing to
+// ±Inf/NaN in the idx computation below), or an rSize too small to hold
+// even the leading mid/radius pair — evaluateType2/3 used to read rec[0]
+// and rec[1] unconditionally, so a too-short record panicked instead of
+// erroring.
+func validateChebyshevMeta(tInit, tLen float64, rSize int32) error {
+	if !finite(tInit) || !finite(tLen) || tLen <= 0 {
+		return fmt.Errorf("%w: non-finite or non-positive record length %g", ErrCorruptSPK, tLen)
+	}
+
+	if rSize < 2 {
+		return fmt.Errorf("%w: record size %d too small (need >= 2)", ErrRecordTooShort, rSize)
+	}
+
+	return nil
 }
 
 func evaluateType2(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err error) {
@@ -527,7 +655,14 @@ func evaluateType2(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err
 	}
 
 	tInit, tLen, rSize := meta[0], meta[1], int32(meta[2])
+	if err := validateChebyshevMeta(tInit, tLen, rSize); err != nil {
+		return vector.Vec3{}, vector.Vec3{}, err
+	}
+
 	nCoeffs := (rSize - 2) / 3
+	if nCoeffs <= 0 {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: %d coefficients derived from record size %d", ErrRecordTooShort, nCoeffs, rSize)
+	}
 
 	idx := max(int32((et-tInit)/tLen), 0)
 
@@ -538,11 +673,23 @@ func evaluateType2(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err
 		return vector.Vec3{}, vector.Vec3{}, err
 	}
 
+	if int32(len(rec)) < 2+3*nCoeffs {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: %d doubles (need >= %d)", ErrRecordTooShort, len(rec), 2+3*nCoeffs)
+	}
+
 	mid, radius := rec[0], rec[1]
+	if !finite(mid) || !finite(radius) || radius == 0 {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: invalid mid=%g/radius=%g", ErrCorruptSPK, mid, radius)
+	}
+
 	tau := (et - mid) / radius
 	pos.X, vel.X = EvalChebyshev(rec[2:2+nCoeffs], tau, radius, true)
 	pos.Y, vel.Y = EvalChebyshev(rec[2+nCoeffs:2+2*nCoeffs], tau, radius, true)
 	pos.Z, vel.Z = EvalChebyshev(rec[2+2*nCoeffs:2+3*nCoeffs], tau, radius, true)
+
+	if !finite(pos.X) || !finite(pos.Y) || !finite(pos.Z) || !finite(vel.X) || !finite(vel.Y) || !finite(vel.Z) {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: non-finite evaluated position/velocity", ErrCorruptSPK)
+	}
 
 	return pos, vel, nil
 }
@@ -554,7 +701,14 @@ func evaluateType3(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err
 	}
 
 	tInit, tLen, rSize := meta[0], meta[1], int32(meta[2])
+	if err := validateChebyshevMeta(tInit, tLen, rSize); err != nil {
+		return vector.Vec3{}, vector.Vec3{}, err
+	}
+
 	nCoeffs := (rSize - 2) / 6
+	if nCoeffs <= 0 {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: %d coefficients derived from record size %d", ErrRecordTooShort, nCoeffs, rSize)
+	}
 
 	idx := max(int32((et-tInit)/tLen), 0)
 
@@ -565,7 +719,15 @@ func evaluateType3(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err
 		return vector.Vec3{}, vector.Vec3{}, err
 	}
 
+	if int32(len(rec)) < 2+6*nCoeffs {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: %d doubles (need >= %d)", ErrRecordTooShort, len(rec), 2+6*nCoeffs)
+	}
+
 	mid, radius := rec[0], rec[1]
+	if !finite(mid) || !finite(radius) || radius == 0 {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: invalid mid=%g/radius=%g", ErrCorruptSPK, mid, radius)
+	}
+
 	tau := (et - mid) / radius
 	pos.X, _ = EvalChebyshev(rec[2:2+nCoeffs], tau, radius, false)
 	pos.Y, _ = EvalChebyshev(rec[2+nCoeffs:2+2*nCoeffs], tau, radius, false)
@@ -574,6 +736,10 @@ func evaluateType3(s *Segment, r *Reader, et float64) (pos, vel vector.Vec3, err
 	vel.X, _ = EvalChebyshev(rec[vStart:vStart+nCoeffs], tau, radius, false)
 	vel.Y, _ = EvalChebyshev(rec[vStart+nCoeffs:vStart+2*nCoeffs], tau, radius, false)
 	vel.Z, _ = EvalChebyshev(rec[vStart+2*nCoeffs:vStart+3*nCoeffs], tau, radius, false)
+
+	if !finite(pos.X) || !finite(pos.Y) || !finite(pos.Z) || !finite(vel.X) || !finite(vel.Y) || !finite(vel.Z) {
+		return vector.Vec3{}, vector.Vec3{}, fmt.Errorf("%w: non-finite evaluated position/velocity", ErrCorruptSPK)
+	}
 
 	return pos, vel, nil
 }

--- a/ephemeris/jpl/spk/reader_hardening_test.go
+++ b/ephemeris/jpl/spk/reader_hardening_test.go
@@ -1,0 +1,508 @@
+package spk_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
+)
+
+// This file deterministically exercises every validation branch added to
+// harden the SPK/DAF reader against corrupted/adversarial kernels (see
+// fuzz_test.go for the property-based counterpart — "never panics" — this
+// file instead pins down "rejects this specific malformed input with this
+// specific sentinel error").
+
+func pokeFloat64(buf []byte, offset int, v float64, order binary.ByteOrder) {
+	order.PutUint64(buf[offset:offset+8], math.Float64bits(v))
+}
+
+func newReaderWithSummaryData(data []byte, nd, ni, fwd int32) *spk.Reader {
+	return &spk.Reader{
+		F:       fakeReaderAt{bytes.NewReader(data)},
+		FileRec: spk.FileRecord{ND: nd, NI: ni, FWD: fwd, Order: binary.LittleEndian},
+	}
+}
+
+func TestReadSummaries_RejectsInvalidShape(t *testing.T) {
+	cases := []struct {
+		name   string
+		nd, ni int32
+	}{
+		{"negative ND", -1, 6},
+		{"negative NI", 2, -1},
+		{"both zero", 0, 0},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newReaderWithSummaryData(nil, tt.nd, tt.ni, 0)
+
+			_, err := r.ReadSummaries()
+			if !errors.Is(err, spk.ErrCorruptSPK) {
+				t.Errorf("err = %v, want ErrCorruptSPK", err)
+			}
+		})
+	}
+}
+
+func TestReadSummaries_RejectsOversizedSummary(t *testing.T) {
+	// ND/NI large enough that a single summary entry couldn't fit in one
+	// 1024-byte directory record.
+	r := newReaderWithSummaryData(nil, 1000, 1000, 0)
+
+	_, err := r.ReadSummaries()
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestReadSummaries_RejectsNegativeFWD(t *testing.T) {
+	r := newReaderWithSummaryData(nil, 2, 6, -5)
+
+	_, err := r.ReadSummaries()
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestReadSummaries_RejectsCyclicFWD(t *testing.T) {
+	order := binary.LittleEndian
+	data := make([]byte, spk.RecordSize)
+	pokeFloat64(data, 0, 1.0, order) // FWD points back to record 1 (itself)
+	pokeFloat64(data, 16, 0.0, order)
+
+	r := newReaderWithSummaryData(data, 2, 6, 1)
+
+	_, err := r.ReadSummaries()
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestReadSummaries_RejectsNonFiniteFWD(t *testing.T) {
+	order := binary.LittleEndian
+	data := make([]byte, spk.RecordSize)
+	pokeFloat64(data, 0, math.NaN(), order)
+	pokeFloat64(data, 16, 0.0, order)
+
+	r := newReaderWithSummaryData(data, 2, 6, 1)
+
+	_, err := r.ReadSummaries()
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestReadSummaries_RejectsInvalidSummaryCount(t *testing.T) {
+	cases := []struct {
+		name string
+		nSum float64
+	}{
+		{"negative", -1.0},
+		{"non-finite", math.NaN()},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			order := binary.LittleEndian
+			data := make([]byte, spk.RecordSize)
+			pokeFloat64(data, 0, 0.0, order)
+			pokeFloat64(data, 16, tt.nSum, order)
+
+			r := newReaderWithSummaryData(data, 2, 6, 1)
+
+			_, err := r.ReadSummaries()
+			if !errors.Is(err, spk.ErrCorruptSPK) {
+				t.Errorf("err = %v, want ErrCorruptSPK", err)
+			}
+		})
+	}
+}
+
+func TestReadSummaries_RejectsSummaryCountOverflowingRecord(t *testing.T) {
+	order := binary.LittleEndian
+	data := make([]byte, spk.RecordSize)
+	pokeFloat64(data, 0, 0.0, order)
+	pokeFloat64(data, 16, 1000.0, order) // 1000 summaries of 40 bytes each: way over 1024
+
+	r := newReaderWithSummaryData(data, 2, 6, 1)
+
+	_, err := r.ReadSummaries()
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestReadSummaries_ValidSingleRecord(t *testing.T) {
+	order := binary.LittleEndian
+	data := buildSummaryRecordSPK(order, 0, -1e8, 1e8, 3, 10, 1, 2, 100, 200)
+
+	r := newReaderWithSummaryData(data, 2, 6, 1)
+
+	sums, err := r.ReadSummaries()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sums) != 1 {
+		t.Fatalf("len(sums) = %d, want 1", len(sums))
+	}
+
+	if sums[0].Integers[0] != 3 {
+		t.Errorf("target = %d, want 3", sums[0].Integers[0])
+	}
+}
+
+func TestReadDoubles_RejectsNonPositiveCount(t *testing.T) {
+	r := &spk.Reader{F: fakeReaderAt{bytes.NewReader(nil)}, FileRec: spk.FileRecord{Order: binary.LittleEndian}}
+
+	_, err := r.ReadDoubles(5, 1) // endWord < startWord
+
+	if !errors.Is(err, spk.ErrInvalidWordBounds) {
+		t.Errorf("err = %v, want ErrInvalidWordBounds", err)
+	}
+}
+
+func TestReadDoubles_RejectsExcessiveCount(t *testing.T) {
+	r := &spk.Reader{F: fakeReaderAt{bytes.NewReader(nil)}, FileRec: spk.FileRecord{Order: binary.LittleEndian}}
+
+	_, err := r.ReadDoubles(1, 1<<28) // far beyond maxDoublesPerRead
+
+	if !errors.Is(err, spk.ErrInvalidWordBounds) {
+		t.Errorf("err = %v, want ErrInvalidWordBounds", err)
+	}
+}
+
+func TestReadDoubles_RejectsUnexpectedEOF(t *testing.T) {
+	r := &spk.Reader{F: fakeReaderAt{bytes.NewReader(make([]byte, 8))}, FileRec: spk.FileRecord{Order: binary.LittleEndian}}
+
+	_, err := r.ReadDoubles(1, 5) // requests 5 words, only 1 word of data backing it
+
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+// buildType21Words assembles a single-record type-21 segment word array
+// with the given maxDim/kqmax1/kq/g, for exercising evaluateType21's
+// validation branches deterministically. et is chosen so the record's own
+// epoch entry is selected.
+func buildType21Words(maxDim, kqmax1 int32, kq [3]float64, g []float64) []float64 {
+	words := make([]float64, 0, 1+int(maxDim)+6+3*int(maxDim)+1+3+3)
+	words = append(words, 0.0) // t0
+	words = append(words, g...)
+	words = append(words, 10, 1, 20, 2, 30, 3) // refPos/refVel interleaved
+	words = append(words, make([]float64, 3*maxDim)...)
+	words = append(words, float64(kqmax1))
+	words = append(words, kq[:]...)
+	words = append(words, 999999.0, float64(maxDim), 1.0) // epoch table, MAXDIM, nRecs
+
+	return words
+}
+
+// evaluateType21Segment evaluates words at et=5.0 (t0 is always 0 in
+// buildType21Words, so delta=5 exercises the FC/WC/W recursion every case
+// here needs) and wraps EvaluateSegment's error for wrapcheck.
+func evaluateType21Segment(words []float64) error {
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 21, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	if _, _, err := spk.EvaluateSegment(seg, r, 5.0); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}
+
+func TestEvaluateType21_RejectsInvalidMetadata(t *testing.T) {
+	g1 := []float64{1.0}
+
+	cases := []struct {
+		name      string
+		maxDim    int32
+		kqmax1    int32
+		kq        [3]float64
+		g         []float64
+		wantErrIs error
+	}{
+		{"zero MAXDIM", 0, 2, [3]float64{0, 0, 0}, nil, spk.ErrInvalidOrder},
+		{"MAXDIM too large", 26, 2, [3]float64{0, 0, 0}, make([]float64, 26), spk.ErrInvalidOrder},
+		{"KQMAX1 below range", 1, 1, [3]float64{0, 0, 0}, g1, spk.ErrInvalidOrder},
+		{"KQMAX1 above range", 1, 27, [3]float64{0, 0, 0}, g1, spk.ErrInvalidOrder},
+		{"KQMAX1 exceeds this segment's MAXDIM", 1, 3, [3]float64{0, 0, 0}, g1, spk.ErrInvalidOrder},
+		{"KQ exceeds MAXDIM", 1, 2, [3]float64{2, 0, 0}, g1, spk.ErrInvalidOrder},
+		{"negative KQ", 1, 2, [3]float64{-1, 0, 0}, g1, spk.ErrInvalidOrder},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			words := buildType21Words(tt.maxDim, tt.kqmax1, tt.kq, tt.g)
+
+			err := evaluateType21Segment(words)
+			if !errors.Is(err, tt.wantErrIs) {
+				t.Errorf("err = %v, want %v", err, tt.wantErrIs)
+			}
+		})
+	}
+}
+
+func TestEvaluateType21_RejectsNonFiniteRecordCount(t *testing.T) {
+	words := buildType21Words(1, 2, [3]float64{0, 0, 0}, []float64{1.0})
+	// Corrupt nRecs (last word) to NaN.
+	words[len(words)-1] = math.NaN()
+
+	err := evaluateType21Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType21_RejectsInvalidRecordCount(t *testing.T) {
+	cases := []struct {
+		name  string
+		nRecs float64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"too large", 20_000_000},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			words := buildType21Words(1, 2, [3]float64{0, 0, 0}, []float64{1.0})
+			words[len(words)-1] = tt.nRecs
+
+			err := evaluateType21Segment(words)
+			if !errors.Is(err, spk.ErrInvalidRecordCount) {
+				t.Errorf("err = %v, want ErrInvalidRecordCount", err)
+			}
+		})
+	}
+}
+
+func TestEvaluateType21_RejectsNonFiniteKQMetadata(t *testing.T) {
+	words := buildType21Words(1, 2, [3]float64{0, 0, 0}, []float64{1.0})
+	// KQMAX1 word is right after the MDA table: t0(1) + g(maxDim=1) + refPosVel(6) + dt(3*maxDim=3) = index 11.
+	words[11] = math.NaN()
+
+	err := evaluateType21Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType21_RejectsNonFiniteResult(t *testing.T) {
+	// maxDim=2, kqmax1=3 puts the g-division loop (mq2=1) in play; g[0]=NaN
+	// isn't caught by the "zero step size" check (NaN != 0) and propagates
+	// through the FC/W recursion, landing in w[2] specifically — so KQ[0]
+	// must be large enough (2) that axis 0's sum actually reads w[2], or
+	// the contamination never reaches the returned position/velocity.
+	words := buildType21Words(2, 3, [3]float64{2, 0, 0}, []float64{math.NaN(), 1.0})
+
+	dtOffset := 1 + 2 + 6 // t0(1) + g(maxDim=2) + refPosVel(6)
+	for i := range 6 {
+		words[dtOffset+i] = 1.0 // dt table, all axes: non-zero so axisSum actually uses w
+	}
+
+	err := evaluateType21Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType21_ValidRecord(t *testing.T) {
+	// Regression guard: the hardening above must not reject a legitimate
+	// record (mirrors TestEvaluateType21 in reader_test.go, at delta=0).
+	words := buildType21Words(1, 2, [3]float64{0, 0, 0}, []float64{1.0})
+
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 21, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	pos, _, err := spk.EvaluateSegment(seg, r, 0.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pos.X != 10 || pos.Y != 20 || pos.Z != 30 {
+		t.Errorf("pos = %+v, want refPos (10,20,30) at delta=0", pos)
+	}
+}
+
+// buildType2Words assembles a single-record type-2 segment word array. The
+// meta block evaluateType2 reads is ReadDoubles(EndAddr-3, EndAddr) — 4
+// words, not 3 — even though only meta[0..2] (tInit, tLen, rSize) are
+// used; the trailing 0.0 is the unused 4th word (nRecs, in a real kernel).
+func buildType2Words(mid, radius float64, coeffs []float64) []float64 {
+	words := []float64{mid, radius}
+	words = append(words, coeffs...)
+	words = append(words, coeffs...)
+	words = append(words, coeffs...)
+
+	rSize := float64(2 + 3*len(coeffs))
+
+	return append(words, 0.0, 1.0, rSize, 0.0) // tInit, tLen, rSize, (unused)
+}
+
+func evaluateType2Segment(words []float64) error {
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 2, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	if _, _, err := spk.EvaluateSegment(seg, r, 5.0); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}
+
+func TestEvaluateType2_RejectsInvalidMeta(t *testing.T) {
+	cases := []struct {
+		name          string
+		tInit, tLen   float64
+		rSize         float64
+		wantErrSubstr error
+	}{
+		{"non-finite tLen", 0, math.NaN(), 5, spk.ErrCorruptSPK},
+		{"zero tLen", 0, 0, 5, spk.ErrCorruptSPK},
+		{"negative tLen", 0, -1, 5, spk.ErrCorruptSPK},
+		{"rSize too small", 0, 1, 1, spk.ErrRecordTooShort},
+		{"rSize yields zero coefficients", 0, 1, 2, spk.ErrRecordTooShort},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// The rec block itself is well-formed (matches buildType2Words'
+			// own rSize=5 for a single coefficient) — only the trailing meta
+			// triple is overridden, since every case here is expected to
+			// fail validateChebyshevMeta/the nCoeffs<=0 check, both of which
+			// run before rec is ever read.
+			words := buildType2Words(0, 1, []float64{1.0})
+			n := len(words)
+			words[n-4] = tt.tInit
+			words[n-3] = tt.tLen
+			words[n-2] = tt.rSize
+
+			err := evaluateType2Segment(words)
+			if !errors.Is(err, tt.wantErrSubstr) {
+				t.Errorf("err = %v, want %v", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestEvaluateType2_RejectsInvalidMidRadius(t *testing.T) {
+	cases := []struct {
+		name        string
+		mid, radius float64
+	}{
+		{"non-finite mid", math.NaN(), 1.0},
+		{"non-finite radius", 0.0, math.NaN()},
+		{"zero radius", 0.0, 0.0},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			words := buildType2Words(tt.mid, tt.radius, []float64{1.0})
+
+			err := evaluateType2Segment(words)
+			if !errors.Is(err, spk.ErrCorruptSPK) {
+				t.Errorf("err = %v, want ErrCorruptSPK", err)
+			}
+		})
+	}
+}
+
+func TestEvaluateType2_RejectsNonFiniteResult(t *testing.T) {
+	words := buildType2Words(0.0, 1.0, []float64{math.NaN()})
+
+	err := evaluateType2Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType2_ValidRecord(t *testing.T) {
+	words := buildType2Words(0.0, 1.0, []float64{7.0})
+
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 2, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	pos, _, err := spk.EvaluateSegment(seg, r, 0.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pos.X != 7 || pos.Y != 7 || pos.Z != 7 {
+		t.Errorf("pos = %+v, want (7,7,7) (single-coefficient Chebyshev is constant)", pos)
+	}
+}
+
+// buildType3Words assembles a single-record type-3 segment word array — see
+// buildType2Words' doc comment for why the meta block needs 4 trailing words.
+func buildType3Words(mid, radius float64, coeff float64) []float64 {
+	words := []float64{mid, radius}
+	for range 6 { // pos x3, vel x3 axes, one coefficient each
+		words = append(words, coeff)
+	}
+
+	return append(words, 0.0, 1.0, 8.0, 0.0) // tInit, tLen, rSize (2+6*1=8), (unused)
+}
+
+func evaluateType3Segment(words []float64) error {
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 3, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	if _, _, err := spk.EvaluateSegment(seg, r, 5.0); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}
+
+func TestEvaluateType3_RejectsInvalidMidRadius(t *testing.T) {
+	words := buildType3Words(math.NaN(), 1.0, 1.0)
+
+	err := evaluateType3Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType3_RejectsNonFiniteResult(t *testing.T) {
+	words := buildType3Words(0.0, 1.0, math.NaN())
+
+	err := evaluateType3Segment(words)
+	if !errors.Is(err, spk.ErrCorruptSPK) {
+		t.Errorf("err = %v, want ErrCorruptSPK", err)
+	}
+}
+
+func TestEvaluateType3_ValidRecord(t *testing.T) {
+	words := buildType3Words(0.0, 1.0, 9.0)
+
+	r := newWordBuffer(words)
+	seg := &spk.Segment{Type: 3, StartAddr: 1, EndAddr: int32(len(words)), StartET: -1e9, EndET: 1e9}
+
+	pos, vel, err := spk.EvaluateSegment(seg, r, 0.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pos.X != 9 || vel.X != 9 {
+		t.Errorf("pos.X/vel.X = %v/%v, want 9/9 (single-coefficient Chebyshev is constant)", pos.X, vel.X)
+	}
+}
+
+func TestEvaluateSegment_UnsupportedType(t *testing.T) {
+	r := newWordBuffer([]float64{0})
+	seg := &spk.Segment{Type: 99, StartAddr: 1, EndAddr: 1}
+
+	_, _, err := spk.EvaluateSegment(seg, r, 0.0)
+	if !errors.Is(err, spk.ErrUnsupportedSegment) {
+		t.Errorf("err = %v, want ErrUnsupportedSegment", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `ReadSummaries`/`ReadDoubles`/`evaluateType21`/`evaluateType2`/`evaluateType3` all trusted file-derived integers (ND/NI, summary counts, MAXDIM/KQ table indices, Chebyshev record sizes) as safe to use directly for slicing, indexing, and allocation sizing. A corrupted or truncated kernel could trigger slice-bounds/makeslice panics, and a self-referential FWD chain in the summary directory could hang the reader in an unbounded loop.
- Validates every file-derived integer against structural bounds before use, returning the existing `ErrCorruptSPK`/`ErrInvalidOrder`/`ErrInvalidRecordCount` sentinels instead of panicking.
- Adds `FuzzNewReaderReadSummaries`/`FuzzEvaluateSegment`/`FuzzReadDoubles` with a hand-built seed corpus (no checked-in binaries) that runs under plain `go test ./...`.
- Documents the manual extended-fuzzing invocation in `CLAUDE.md` as a periodic step, not a CI gate.

## Test plan
- [x] Seed corpus runs clean as a normal test (`go test ./ephemeris/jpl/spk/...`)
- [x] Ran each fuzz target for 30s+ locally — 8k, 4M, and 3.9M executions respectively, zero crashers
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run` — clean (fixed 6 lint findings: `intrange`, unused fuzz-callback params, `unparam`)
- [x] `go test ./...` (whole repo, untagged) — clean
- [x] `go mod tidy` — no diff