### PR TITLE
Route KindPlanetaryMoon through NewPlanetaryMoon in FromCatalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `plan.FromCatalog` now routes a `resolve.KindPlanetaryMoon` candidate through `plan.NewPlanetaryMoon`, instead of silently degrading it to a `*plan.GenericBody` with no photometric model — the gap affected any caller round-tripping a moon target through the catalog layer rather than calling `NewPlanetaryMoon` directly.
 
 ## [0.11.0] — 2026-07-29
 ### Added

--- a/plan/factory.go
+++ b/plan/factory.go
@@ -15,6 +15,7 @@ import (
 // Routing logic:
 //   - Satellite TLE → *Satellite
 //   - Planet/Moon/Star with provider → *Planet
+//   - PlanetaryMoon (a name plan.NewPlanetaryMoon recognizes) with provider → *PlanetaryMoon
 //   - HasM1 (comet photometry) → *Comet
 //   - HasH (asteroid photometry) → *Asteroid
 //   - Star kind → *Star
@@ -29,6 +30,19 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 
 	// ── Moving body with provider ──
 	if p != nil {
+		// PlanetaryMoon — resolve.KindPlanetaryMoon-tagged candidates (e.g.
+		// from plan/moons.go's gatherPlanetaryMoons) round-tripped through
+		// FromCatalog used to silently degrade to *GenericBody here, losing
+		// the H-G photometry NewPlanetaryMoon already knows how to build.
+		// An unrecognized name (not in plan's fixed moon table) falls
+		// through to the generic path below rather than failing, since
+		// FromCatalog has no error return.
+		if c.Kind == resolve.KindPlanetaryMoon {
+			if m, err := NewPlanetaryMoon(c.Name, p); err == nil {
+				return m
+			}
+		}
+
 		switch c.Kind { //nolint:exhaustive // only planet/moon/star routed here
 		case resolve.KindPlanet, resolve.KindMoon, resolve.KindStar:
 			// Sun/Moon/planets — the resolver uses KindStar for Sun

--- a/plan/factory_test.go
+++ b/plan/factory_test.go
@@ -1,0 +1,72 @@
+package plan_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog"
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// errStubMoonProviderState is returned by stubMoonProvider's State — this
+// test never exercises State (construction alone is enough to check the
+// routing), so the value only needs to exist, not be reachable.
+var errStubMoonProviderState = errors.New("stubMoonProvider: not implemented")
+
+// stubMoonProvider is a minimal eph.Provider whose State always errors —
+// FromCatalog's PlanetaryMoon routing only needs construction to succeed
+// (plan.NewPlanetaryMoon/NewAsteroid never call the provider eagerly), so
+// no real ephemeris data is needed to exercise the routing itself.
+type stubMoonProvider struct{}
+
+func (stubMoonProvider) State(eph.ID, time.Time) (eph.State, error) {
+	return eph.State{}, errStubMoonProviderState
+}
+
+func (stubMoonProvider) Close() error { return nil }
+
+// TestFromCatalog_PlanetaryMoon is a regression test for FromCatalog
+// silently degrading a resolve.KindPlanetaryMoon candidate to a
+// *plan.GenericBody with no photometric model — plan/moons.go's
+// gatherPlanetaryMoons already tags candidates this way, but FromCatalog
+// had no case for it, so any caller round-tripping a moon target through
+// the catalog layer (rather than calling plan.NewPlanetaryMoon directly)
+// lost the H-G reflectance model. A known name must now resolve to a real
+// *plan.PlanetaryMoon with the right parent planet.
+func TestFromCatalog_PlanetaryMoon(t *testing.T) {
+	c := catalog.Target{
+		Name: "Io",
+		Kind: resolve.KindPlanetaryMoon,
+	}
+
+	obj := plan.FromCatalog(c, stubMoonProvider{})
+
+	moon, ok := obj.(*plan.PlanetaryMoon)
+	if !ok {
+		t.Fatalf("FromCatalog: got %T, want *plan.PlanetaryMoon", obj)
+	}
+
+	if moon.Parent() != eph.Jupiter {
+		t.Errorf("Parent() = %v, want eph.Jupiter", moon.Parent())
+	}
+}
+
+// TestFromCatalog_UnknownPlanetaryMoonFallsThrough confirms an unrecognized
+// name (not in plan's fixed moon table) still falls through to the generic
+// path rather than being dropped entirely — FromCatalog has no error
+// return, so a lookup failure must degrade gracefully, not panic or nil-out.
+func TestFromCatalog_UnknownPlanetaryMoonFallsThrough(t *testing.T) {
+	c := catalog.Target{
+		Name: "NotARealMoon",
+		Kind: resolve.KindPlanetaryMoon,
+	}
+
+	obj := plan.FromCatalog(c, stubMoonProvider{})
+
+	if _, ok := obj.(*plan.GenericBody); !ok {
+		t.Fatalf("FromCatalog: got %T, want *plan.GenericBody", obj)
+	}
+}


### PR DESCRIPTION
## Summary
- `plan/moons.go`'s `gatherPlanetaryMoons` already tags candidates `resolve.KindPlanetaryMoon`, but `FromCatalog` had no case for it, so any caller round-tripping a moon target through the catalog layer (rather than calling `plan.NewPlanetaryMoon` directly) silently got a `*plan.GenericBody` with no H-G photometric model instead.
- `FromCatalog` now routes `resolve.KindPlanetaryMoon` through `NewPlanetaryMoon(c.Name, p)` before the main switch. An unrecognized name still falls through to the generic path, since `FromCatalog` has no error return.

## Test plan
- [x] New `plan/factory_test.go`: a known name ("Io") resolves to `*plan.PlanetaryMoon` with `Parent() == eph.Jupiter`; an unknown name falls through to `*plan.GenericBody`
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `golangci-lint run` — clean (fixed an `err113` dynamic-error finding)
- [x] `go test ./...` (whole repo) — clean
- [x] `go mod tidy` — no diff