### PR TITLE
fix(remote): log downloading only after consent is granted

### DIFF
--- a/remote/fetch.go
+++ b/remote/fetch.go
@@ -123,12 +123,6 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 		timeout = DefaultDownloadTimeout
 	}
 
-	if ep.ApproxSize == SizeVaries {
-		log.Printf("remote: downloading %s (endpoint %s, size varies)", cacheFile, id)
-	} else {
-		log.Printf("remote: downloading %s (endpoint %s, approx %d bytes)", cacheFile, id, ep.ApproxSize)
-	}
-
 	if err := fetchInto(ctx, id, name, cacheFile, timeout, cfg.validate, cfg.progress); err != nil {
 		return "", err
 	}
@@ -167,6 +161,12 @@ func fetchInto(ctx context.Context, id EndpointID, path string, dest gofs.File, 
 	ep, _ := Lookup(id)
 	if err := CheckDownload(id, name, ep.ApproxSize); err != nil {
 		return err
+	}
+
+	if ep.ApproxSize == SizeVaries {
+		log.Printf("remote: downloading %s (endpoint %s, size varies)", dest, id)
+	} else {
+		log.Printf("remote: downloading %s (endpoint %s, approx %d bytes)", dest, id, ep.ApproxSize)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/remote/fetch_test.go
+++ b/remote/fetch_test.go
@@ -1,12 +1,15 @@
 package remote
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -306,6 +309,41 @@ func TestGetFileWithProgressReportsBytesValidatedPath(t *testing.T) {
 
 	if last != int64(len(payload)) {
 		t.Errorf("final downloaded = %d, want %d", last, len(payload))
+	}
+}
+
+func TestGetFileDoesNotLogDownloadingWhenConsentDenied(t *testing.T) {
+	cleanRemoteState(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("kernel-bytes"))
+	}))
+	defer srv.Close()
+
+	if err := SetURL(NAIFSPK, srv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuf bytes.Buffer
+
+	prevOutput := log.Writer()
+	prevFlags := log.Flags()
+
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+
+	t.Cleanup(func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	})
+
+	_, err := GetFile(context.Background(), NAIFSPK, "planets/de442.bsp")
+	if !errors.Is(err, ErrDownloadDenied) {
+		t.Fatalf("expected ErrDownloadDenied, got %v", err)
+	}
+
+	if strings.Contains(logBuf.String(), "remote: downloading") {
+		t.Errorf("logged a \"downloading\" message despite consent being denied:\n%s", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
Fixes #40.

`GetFile` logged `remote: downloading ...` unconditionally once it decided the cache was missing or stale, before `fetchInto` ran `CheckDownload`, the actual consent gate. So the log fired even when the download was about to be denied with `ErrDownloadDenied`, and no HTTP request was ever built. Any caller that never grants consent (the safe default) saw a misleading "downloading" line on every attempt, with no signal that it was actually refused.

**Fix:** move the log line into `fetchInto`, right after `CheckDownload` succeeds, so it only fires once a request is actually about to go out.

**Test:** `TestGetFileDoesNotLogDownloadingWhenConsentDenied` captures log output via a consent-denied `GetFile` call and asserts no "downloading" line appears. Confirmed it fails against the current code and passes after the fix.

**Verified:**
- `go test ./remote/...` — all pass, including existing tests that still see the log line logged once consent *is* granted (unchanged behavior for the success path).
- `go test ./time/...` — all pass (the `iers` lazy-load consumer of this path).
- `go build ./...`, `go vet ./remote/... ./time/...`, `gofmt -l` — clean.
