### PR TITLE
fix: gofmt examples/18_sky_brightness/main.go

### DIFF
--- a/examples/18_sky_brightness/main.go
+++ b/examples/18_sky_brightness/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Fatalf("load timezone: %v", err)
 	}
 
-	site, err := plan.NewSiteEarthLocation("Quinta Calixto", -22.5190,-46.4673, 835.05, plan.WithTimeZone(tz))
+	site, err := plan.NewSiteEarthLocation("Quinta Calixto", -22.5190, -46.4673, 835.05, plan.WithTimeZone(tz))
 	if err != nil {
 		log.Fatalf("build site: %v", err)
 	}


### PR DESCRIPTION
`examples/18_sky_brightness/main.go` was missing a space after a comma in the `plan.NewSiteEarthLocation(...)` call — `gofmt -l .` flags it on `main`. One-line whitespace fix, no behavior change.

Verification: `gofmt -l .` clean, `go build ./...` clean.