### PR TITLE
docs: document concurrency and degradation in package docs

### DIFF
--- a/coord/doc.go
+++ b/coord/doc.go
@@ -34,4 +34,14 @@
 // Both [Context] and [Reducer] query the global IERS EOP model for DUT1 and
 // polar motion (XP/YP). If IERS data is unavailable, a one-time log warning
 // is emitted and zero corrections are applied (UT1 ≈ UTC, ~0.9 s worst case).
+//
+// # Concurrency
+//
+// A [Context] is read-only once built: no method assigns to its fields, and
+// [Context.Clone] and [Context.AtTime] return new values rather than mutating
+// the receiver. One Context may therefore be shared across goroutines, which
+// is what makes the "build one per epoch and reuse it" rule practical — the
+// expensive SOFA matrix is computed once and read concurrently.
+//
+// Everything else here is a value type.
 package coord

--- a/ephemeris/doc.go
+++ b/ephemeris/doc.go
@@ -63,4 +63,19 @@
 //
 // Use the [ToICRS] helper to convert Cartesian geocentric positions into
 // spherical [coord.ICRS] coordinates.
+//
+// # Concurrency
+//
+// A [Provider] is expected to be safe for concurrent use, and the ones here
+// are: the JPL provider guards its kernel set with a sync.RWMutex, and the
+// analytical provider is an empty struct. A third-party Provider is under the
+// same expectation, since a planner may call one from several goroutines.
+//
+// # Failure and degradation
+//
+// A missing kernel is an error rather than a silent gap: constructing a JPL
+// provider fails with remote.ErrDownloadDenied unless the caller has granted
+// download consent, and asking for a body or an epoch that a loaded kernel
+// does not cover fails with jpl.ErrNoSegment. Nothing here substitutes an
+// approximation for data it does not have.
 package ephemeris

--- a/skybrightness/doc.go
+++ b/skybrightness/doc.go
@@ -90,4 +90,13 @@
 //
 // A [Model] with no components is still legal and returns zero radiance,
 // saying so through [Quality] rather than pretending to be a dark sky.
+//
+// # Concurrency and I/O
+//
+// Evaluation performs no I/O and no network access: every dataset is resolved
+// by the provider layer under skybrightness/dataset and handed in through the
+// scene, which is enforced behaviourally by a test that evaluates identically
+// under remote.SetOffline and structurally by an import check. A model is
+// read-only once built and may be evaluated from several goroutines; the
+// spectral buffers a caller passes in are the caller's to keep separate.
 package skybrightness

--- a/time/doc.go
+++ b/time/doc.go
@@ -49,4 +49,22 @@
 //   - Full bidirectional scale conversion graph (UTC, TAI, TT, TDB, UT1).
 //   - Scale-safe cross-scale comparison and arithmetic.
 //   - Dynamic UT1/UTC derivations via the IERS EOP data model.
+//
+// # Concurrency
+//
+// The scale conversions are pure functions on a value type and are safe to
+// call from any goroutine. Earth-orientation data is process-wide state
+// behind a sync.RWMutex: [RegisterModel] and the lazy load that [Time.EOP],
+// [Time.UTC] and [Time.UT1] trigger are safe to race, and a caller that wants
+// determinism registers a model up front rather than relying on whatever the
+// first lookup happens to load.
+//
+// # Failure and degradation
+//
+// The EOP path degrades rather than failing: a pre-seeded cache object, then
+// a network fetch if consent was granted, then zero EOP with a one-time
+// warning. Zero EOP is a real answer with real error — up to about 0.9 s of
+// UT1 — so a caller who needs to know which of the three it got asks
+// [EOPSource]. [Time.UT1] is the exception and reports the failure instead of
+// degrading.
 package time


### PR DESCRIPTION
> Independent of #50–#54 — all branch from `main`.

§16 of the v0.15.1 review asks whether each package doc answers eight questions. I measured all 15 rather than sampling:

| question | packages answering |
| :--- | ---: |
| what problem it solves | **15 / 15** |
| external data / network | 9 / 15 |
| units | 5 / 15 |
| accuracy | 5 / 15 |
| frame / origin | 5 / 15 |
| worked example | 6 / 15 |
| **failure and degradation** | **1 / 15** |
| **concurrency** | **0 / 15** |

The first row is why the other rows matter: every package explains itself well enough that a reader trusts it, and then leaves unanswered the two questions where a wrong assumption is silent and expensive — sharing a value that turns out to be mutable, or reading a degraded answer as an authoritative one.

## What was added

The two missing sections, in the four packages where there is a **verified** property to state — not in all fifteen, because a doc paragraph asserting a property nobody checked is worse than its absence.

| package | concurrency | degradation |
| :--- | :--- | :--- |
| `coord` | `Context` is read-only after construction | — |
| `ephemeris` | `Provider` is expected to be safe; both here are | missing kernel is an error, never a gap |
| `time` | conversions pure; EOP behind an `RWMutex` | three levels, and how to ask which you got |
| `skybrightness` | evaluation performs no I/O | — |

The `coord` entry is the one with practical consequence. "Build one Context per epoch and reuse it" is advice the package already gives; whether that reuse may cross goroutines was never stated, so the cautious reader builds one per goroutine and pays for the SOFA matrix again.

## Every claim was verified, not asserted

That is the whole point of the change, so the method matters:

- **Mutexes** — read, not assumed. `jpl.Provider` guards its kernel set with a `sync.RWMutex`; `catalog/resolve`, `remote/api` and `remote/file` are likewise guarded.
- **`Context` immutability** — checked that no method assigns to a field, and that `Clone` and `AtTime` return new values. `AtTime` calls `Clone` on its first line.
- **The analytical provider** — I first wrote "holds no mutable state at all", which I had not checked. It is `type sofaProvider struct{}`, so the claim was true; it now says *empty struct*, which a reader can confirm in one jump.
- **`skybrightness`** — the no-I/O property is already asserted by `offline_test.go` and `importgraph_test.go`. The doc now points at a guarantee that is enforced, rather than making a new promise.
- **The 0.9 s figure** for zero-EOP UT1 error is the DUT1 bound that leap-second insertion maintains, not an estimate.

One symbol needed qualifying: `ErrNoSegment` lives in `ephemeris/jpl`, not `ephemeris`, so it is written `jpl.ErrNoSegment` and unbracketed — a doc link cannot resolve across a package the doc's own package does not import.

## Verification

`gofmt`, `go vet`, `golangci-lint` with and without build tags, and the test suites for all four packages — clean.

revive caught the insertion leaving a blank line between the comment and the `package` statement, which detaches a package comment and would have silently emptied `go doc` output for three packages. Fixed before pushing.
