### PR TITLE
Classify an upstream outage as not-verified, not as a test failure

### DIFF
--- a/catalog/gaia/gaia_network_test.go
+++ b/catalog/gaia/gaia_network_test.go
@@ -4,7 +4,6 @@ package gaia
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/url"
 	"testing"
@@ -45,22 +44,6 @@ func requireGaia(t *testing.T) {
 	testutil.RequireReachable(t, net.JoinHostPort(u.Hostname(), port))
 }
 
-// skipIfUnresponsive turns a timed-out query into a skip. The TCP pre-check
-// above is not sufficient on its own: a TAP front end can accept the
-// connection and then never answer, which is downtime rather than wrong data,
-// and the policy is that only wrong data from a responsive endpoint fails.
-//
-// ESA's did this routinely, which is a large part of why it is no longer the
-// default archive.
-func skipIfUnresponsive(t *testing.T, err error) {
-	t.Helper()
-
-	var netErr net.Error
-	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
-		t.Skipf("the archive accepted the connection but did not answer, skipping live test: %v", err)
-	}
-}
-
 func TestGaiaNetworkConeSearch(t *testing.T) {
 	requireGaia(t)
 
@@ -85,7 +68,7 @@ func TestGaiaNetworkConeSearch(t *testing.T) {
 
 	iter(func(tar resolve.Target, err error) bool {
 		if err != nil {
-			skipIfUnresponsive(t, err)
+			testutil.SkipOnUpstreamFailure(t, err)
 			t.Fatalf("Live network failed: %v", err)
 		}
 

--- a/catalog/mast/mast_network_test.go
+++ b/catalog/mast/mast_network_test.go
@@ -37,6 +37,8 @@ func TestMastNetworkResolve(t *testing.T) {
 	var targets []resolve.Target
 
 	iter(func(tar resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("Live network failed: %v", err)
 		}

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -13,6 +13,7 @@ package norad
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,10 +23,33 @@ import (
 // requireCelestrak skips the test when the CelestTrak API endpoint is
 // unreachable (DNS failure, firewall, etc.).  This avoids false-negative
 // CI failures for transient network issues.
+// celestrakHealth is probed once per run and shared by every live test here,
+// so a CelesTrak outage costs one request rather than one per test.
+var celestrakHealth struct {
+	once sync.Once
+	err  error
+}
+
+// requireCelestrak skips unless CelesTrak is both reachable and working.
+//
+// Reachability alone is not enough: CelesTrak answering "500 Internal Server
+// Error" opens a socket perfectly well, so the probe passed and the assertions
+// below failed, reporting a CelesTrak outage as an astrogo defect on pull
+// requests that never touched this package. A 4xx still fails, because that
+// would mean astrogo built a request CelesTrak rejected.
 func requireCelestrak(t *testing.T) {
 	t.Helper()
 
 	testutil.RequireReachable(t, "celestrak.org:443")
+
+	celestrakHealth.once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		_, celestrakHealth.err = New().Fetch(ctx, QueryCatNr, "25544")
+	})
+
+	testutil.SkipOnUpstreamFailure(t, celestrakHealth.err)
 }
 
 func TestFetchISS_Live(t *testing.T) {
@@ -37,6 +61,8 @@ func TestFetchISS_Live(t *testing.T) {
 	p := New()
 
 	gps, err := p.Fetch(ctx, QueryCatNr, "25544")
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("Failed to fetch ISS data: %v", err)
 	}
@@ -85,6 +111,8 @@ func TestFetchGroup_Live(t *testing.T) {
 	p := New()
 
 	gps, err := p.Fetch(ctx, QueryGroup, GroupStations)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("Failed to fetch Stations group: %v", err)
 	}

--- a/catalog/sbdb/sbdb_network_test.go
+++ b/catalog/sbdb/sbdb_network_test.go
@@ -36,6 +36,8 @@ func TestSBDBNetworkResolve(t *testing.T) {
 	var targets []resolve.Target
 
 	iter(func(tar resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("Live network failed: %v", err)
 		}
@@ -117,6 +119,8 @@ func TestSBDBNetworkSearchBright(t *testing.T) {
 	// Wachmann 2) alongside real bright asteroids (H<5 includes Pluto).
 	iter := prov.SearchBright(ctx, resolve.BrightRequest{MaxVMag: 1, Limit: 20})
 	iter(func(tgt resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("live SearchBright failed: %v", err)
 		}
@@ -225,6 +229,8 @@ func TestSBDBNetworkResolveInterstellar(t *testing.T) {
 	var targets []resolve.Target
 
 	iter(func(tar resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("Live network failed: %v", err)
 		}

--- a/catalog/simbad/simbad_network_test.go
+++ b/catalog/simbad/simbad_network_test.go
@@ -36,6 +36,8 @@ func TestSimbadNetworkResolve(t *testing.T) {
 	var targets []resolve.Target
 
 	iter(func(tar resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("Live network failed: %v", err)
 		}
@@ -78,6 +80,8 @@ func TestSimbadNetworkSearchBright(t *testing.T) {
 	var targets []resolve.Target
 
 	iter(func(tgt resolve.Target, err error) bool {
+		testutil.SkipOnUpstreamFailure(t, err)
+
 		if err != nil {
 			t.Fatalf("live SearchBright failed: %v", err)
 		}

--- a/internal/testutil/upstream.go
+++ b/internal/testutil/upstream.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+)
+
+// SkipOnUpstreamFailure skips tb when err is the remote service failing rather
+// than astrogo misbehaving.
+//
+// [RequireReachable] answers whether a socket opens, which is not the same
+// question as whether the service works. A host answering "500 Internal Server
+// Error" passes the reachability probe and then fails the assertion, so an
+// outage at CelesTrak or JPL is reported as a defect in this repository — and
+// it blocks pull requests that never touched the package.
+//
+// The classification is deliberately narrow. A 5xx, a 429, a 408 or a request
+// that never completed is the upstream's problem. Every other 4xx is not: a
+// 400 or a 404 means astrogo built a request the service rejected, which is
+// exactly the defect these tests exist to catch, and it stays a failure.
+func SkipOnUpstreamFailure(tb testing.TB, err error) {
+	tb.Helper()
+
+	if err == nil {
+		return
+	}
+
+	if reason, ok := upstreamFailure(err); ok {
+		tb.Skipf("upstream service failure, not verified: %s (%v)", reason, err)
+	}
+}
+
+// upstreamFailure reports whether err is the remote end failing, and why.
+func upstreamFailure(err error) (string, bool) {
+	// Matched through an interface, not remote/api's concrete type: testutil is
+	// imported by nearly every test in the repository, and importing remote
+	// here would both create a cycle with remote's own tests and pull the
+	// cloud-storage dependency tree into every test binary.
+	var status interface{ HTTPStatus() int }
+	if errors.As(err, &status) {
+		switch code := status.HTTPStatus(); {
+		case code >= 500:
+			return "server error", true
+		case code == http.StatusTooManyRequests:
+			return "rate limited", true
+		case code == http.StatusRequestTimeout:
+			return "request timeout", true
+		default:
+			// 4xx other than the two above means we sent a bad request.
+			return "", false
+		}
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "deadline exceeded", true
+	}
+
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		return "network timeout", true
+	}
+
+	return "", false
+}

--- a/internal/testutil/upstream_test.go
+++ b/internal/testutil/upstream_test.go
@@ -1,0 +1,93 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+// httpStatusError is any error carrying an HTTP status, matched structurally. Using a
+// local type here rather than remote/api's keeps this package free of the
+// cloud dependency tree, and proves the classifier works for any error that
+// reports a status — not only remote/api's.
+type httpStatusError struct{ code int }
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("http %d", e.code) }
+
+func (e *httpStatusError) HTTPStatus() int { return e.code }
+
+// errStaticParse stands in for a decode failure, which is astrogo's problem.
+var errStaticParse = errors.New("invalid character 'x'")
+
+func TestUpstreamFailureClassification(t *testing.T) {
+	timeout := &net.DNSError{IsTimeout: true}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// The upstream is broken or throttling: not our defect.
+		{"500 server error", &httpStatusError{500}, true},
+		{"502 bad gateway", &httpStatusError{502}, true},
+		{"503 unavailable", &httpStatusError{503}, true},
+		{"429 rate limited", &httpStatusError{429}, true},
+		{"408 request timeout", &httpStatusError{408}, true},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"network timeout", timeout, true},
+		{"wrapped 500", fmt.Errorf("norad: fetch failed: %w", &httpStatusError{500}), true},
+
+		// We sent a bad request: exactly what these tests exist to catch.
+		{"400 bad request", &httpStatusError{400}, false},
+		{"404 not found", &httpStatusError{404}, false},
+		{"401 unauthorized", &httpStatusError{401}, false},
+		{"403 forbidden", &httpStatusError{403}, false},
+		{"parse failure", errStaticParse, false},
+		{"connection refused", &net.DNSError{}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, got := upstreamFailure(c.err); got != c.want {
+				t.Fatalf("upstreamFailure(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSkipOnUpstreamFailureIgnoresNil(t *testing.T) {
+	// A nil error must not skip: the call succeeded and the assertions
+	// that follow are the point of the test.
+	SkipOnUpstreamFailure(t, nil)
+}
+
+func TestSkipOnUpstreamFailureSkipsA500(t *testing.T) {
+	fake := &fakeTB{TB: t}
+	SkipOnUpstreamFailure(fake, &httpStatusError{503})
+
+	if !fake.skipped {
+		t.Fatal("a 503 must skip, not fail: the service is down, astrogo is not")
+	}
+}
+
+func TestSkipOnUpstreamFailureKeepsA404(t *testing.T) {
+	fake := &fakeTB{TB: t}
+	SkipOnUpstreamFailure(fake, &httpStatusError{404})
+
+	if fake.skipped {
+		t.Fatal("a 404 must not skip: astrogo built a request the service rejected")
+	}
+}
+
+// fakeTB records whether Skipf was called instead of skipping the real test.
+type fakeTB struct {
+	testing.TB
+
+	skipped bool
+}
+
+func (f *fakeTB) Helper() {}
+
+func (f *fakeTB) Skipf(string, ...any) { f.skipped = true }

--- a/plan/observatory_network_test.go
+++ b/plan/observatory_network_test.go
@@ -4,8 +4,6 @@ package plan
 
 import (
 	"context"
-	"errors"
-	"net"
 	"testing"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
@@ -23,29 +21,12 @@ func requireGeocoding(t *testing.T) {
 	}
 }
 
-// skipIfUnresponsive turns a timed-out request into a skip. A TCP
-// pre-check is not sufficient on its own: these public endpoints routinely
-// accept a connection and then fail to answer, which is downtime rather
-// than wrong data.
-func skipIfUnresponsive(t *testing.T, err error) {
-	t.Helper()
-
-	var netErr net.Error
-	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
-		t.Skipf("geocoding service accepted the connection but did not answer, skipping: %v", err)
-	}
-}
-
-// TestNewSiteEarthAddress_Live confirms a real geocoding + elevation round
-// trip against the live Nominatim and Open-Elevation APIs — Greenwich
-// Observatory should resolve to approximately its well-known coordinates
-// (51.48°N, 0°) and elevation (~45m).
 func TestNewSiteEarthAddress_Live(t *testing.T) {
 	requireGeocoding(t)
 
 	site, err := NewSiteEarthAddress(context.Background(), "Greenwich", "Royal Observatory, Greenwich, London, UK")
 	if err != nil {
-		skipIfUnresponsive(t, err)
+		testutil.SkipOnUpstreamFailure(t, err)
 		t.Fatalf("NewSiteEarthAddress: %v", err)
 	}
 

--- a/remote/api/client.go
+++ b/remote/api/client.go
@@ -354,3 +354,10 @@ type HTTPError struct {
 func (e *HTTPError) Error() string {
 	return fmt.Sprintf("remote/api: http %d - %s", e.StatusCode, e.Body)
 }
+
+// HTTPStatus returns the status code of the response that produced this error.
+//
+// It exists so a caller can branch on the status — backing off on a 429,
+// treating a 5xx as the service's fault rather than its own — through a small
+// interface rather than a dependency on this package's concrete type.
+func (e *HTTPError) HTTPStatus() int { return e.StatusCode }

--- a/skybrightness/dataset/dust/network_test.go
+++ b/skybrightness/dataset/dust/network_test.go
@@ -32,6 +32,8 @@ func TestFetchAgainstTheRealService(t *testing.T) {
 		dust.Direction{L: angle.Deg(0), B: angle.Deg(0)},  // Galactic centre
 		dust.Direction{L: angle.Deg(0), B: angle.Deg(90)}, // north Galactic pole
 	)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}

--- a/skybrightness/dataset/passband/passband_network_test.go
+++ b/skybrightness/dataset/passband/passband_network_test.go
@@ -119,11 +119,15 @@ func TestFetchIsCached(t *testing.T) {
 	const id = "Generic/Bessell.V"
 
 	first, err := passband.Fetch(t.Context(), id)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("first fetch: %v", err)
 	}
 
 	second, err := passband.Fetch(t.Context(), id)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("second fetch: %v", err)
 	}

--- a/skybrightness/dataset/starlight/gaia_network_test.go
+++ b/skybrightness/dataset/starlight/gaia_network_test.go
@@ -52,6 +52,8 @@ func TestGaiaQueryIsAcceptedByTheArchive(t *testing.T) {
 	t.Logf("query: %s", adql)
 
 	m, counts, err := starlight.RunChunk(ctx, build, 100000, 100003)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("the archive rejected the generated query: %v", err)
 	}
@@ -393,6 +395,8 @@ func TestFourBandQueryIsOnePass(t *testing.T) {
 	t.Logf("query (%d characters): %s", len(adql), adql)
 
 	m, counts, err := starlight.RunChunk(ctx, build, 100000, 100003)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("the archive rejected the four-band query: %v", err)
 	}


### PR DESCRIPTION
The integration job failed on #52 and #53. Neither touches `catalog/norad`, which is where it failed.

The cause was **CelesTrak returning HTTP 500**. Three live tests gate on `RequireReachable`, which asks whether a socket opens — not whether the service works:

```go
testutil.RequireReachable(t, "celestrak.org:443")   // passes: the socket opens fine
...
t.Fatalf("Failed to fetch ISS data: %v", err)       // fails: the service returned 500
```

So someone else's outage was reported as a defect in this repository, and blocked two pull requests that had nothing to do with it.

This is the inverse of the skip-that-reads-as-a-pass fixed in #50. There, a service that was up looked unreachable. Here, **a service that is up and broken is indistinguishable from code that is wrong** — and the second failure mode is the one that costs other people's merges.

## The classification, and why it is narrow

`testutil.SkipOnUpstreamFailure` classifies the *error* rather than the socket.

| classified as the upstream's fault | still a failure |
| :--- | :--- |
| 5xx | **400, 404, 401, 403** |
| 429 rate limited | decode/parse errors |
| 408 request timeout | anything with no status |
| deadline exceeded, network timeout | |

The right-hand column is the point. A 400 or a 404 means **astrogo built a request the service rejected**, which is exactly the defect these tests exist to catch. Widening the skip to all non-2xx would have made the suite unable to fail for the reason it was written. Every row is covered by a table test.

## An extraction, not an invention

`catalog/gaia` and `plan` each carried a private `skipIfUnresponsive`. Two copies of the same idea — and **both handled only timeouts**, so neither would have caught the 500 that actually broke CI. Both are deleted and call the shared one.

## The import that could not be

The obvious implementation matches `*api.HTTPError` directly. It cannot:

- `internal/testutil` → `remote/api` → `remote`, and `remote`'s own tests import `testutil`. A real cycle, which `go vet` on individual packages does not show and the repo-wide lint does.
- Worse than the cycle: `testutil` is imported by nearly every test in the repository, so that edge would pull **gocloud and its transitive tree into every test binary**.

Matched through `interface{ HTTPStatus() int }` instead. `remote/api.HTTPError` gains the accessor, which earns its place independently — a caller backing off on a 429 should not need a type assertion — and the classifier now works for any error that reports a status, which the test proves by using a local type rather than `remote/api`'s.

## Coverage

Applied to the 11 live-fetch sites across 7 packages with the same exposure. `norad`'s gate now probes health **once per run**, shared by its three tests, rather than once per test — an outage costs one request, not three.

## Verification

`gofmt`, `go vet` and `golangci-lint` under every tag combination, the default suite, and the integration suite that was failing — all clean. The three CelesTrak tests pass live now that the service has recovered; the skip path is proven by unit test rather than by waiting for the next outage.
