### PR TITLE
Classify a connection dropped mid-transfer (missing commit from #56)

### DIFF
--- a/internal/testutil/upstream.go
+++ b/internal/testutil/upstream.go
@@ -3,8 +3,10 @@ package testutil
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
+	"syscall"
 	"testing"
 )
 
@@ -17,10 +19,11 @@ import (
 // outage at CelesTrak or JPL is reported as a defect in this repository — and
 // it blocks pull requests that never touched the package.
 //
-// The classification is deliberately narrow. A 5xx, a 429, a 408 or a request
-// that never completed is the upstream's problem. Every other 4xx is not: a
-// 400 or a 404 means astrogo built a request the service rejected, which is
-// exactly the defect these tests exist to catch, and it stays a failure.
+// The classification is deliberately narrow. A 5xx, a 429, a 408, a request
+// that never completed and a connection dropped mid-transfer are the
+// upstream's problem. Every other 4xx is not: a 400 or a 404 means astrogo
+// built a request the service rejected, which is exactly the defect these
+// tests exist to catch, and it stays a failure.
 func SkipOnUpstreamFailure(tb testing.TB, err error) {
 	tb.Helper()
 
@@ -61,6 +64,21 @@ func upstreamFailure(err error) (string, bool) {
 	var nerr net.Error
 	if errors.As(err, &nerr) && nerr.Timeout() {
 		return "network timeout", true
+	}
+
+	// A connection dropped or truncated mid-transfer. Not a timeout, so the
+	// check above misses it — AstroPixels reset one request out of sixteen
+	// while the other fifteen parsed cleanly, which failed CI on a branch
+	// that had not touched the network at all.
+	switch {
+	case errors.Is(err, syscall.ECONNRESET):
+		return "connection reset by peer", true
+	case errors.Is(err, syscall.ECONNABORTED):
+		return "connection aborted", true
+	case errors.Is(err, syscall.EPIPE):
+		return "broken pipe", true
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return "truncated response", true
 	}
 
 	return "", false

--- a/internal/testutil/upstream_test.go
+++ b/internal/testutil/upstream_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"syscall"
 	"testing"
 )
 
@@ -36,6 +38,15 @@ func TestUpstreamFailureClassification(t *testing.T) {
 		{"429 rate limited", &httpStatusError{429}, true},
 		{"408 request timeout", &httpStatusError{408}, true},
 		{"deadline exceeded", context.DeadlineExceeded, true},
+
+		// Dropped mid-transfer: not a timeout, so it needs its own arm.
+		// This is the case that failed CI on #51, which had not touched
+		// the network at all.
+		{"connection reset", &net.OpError{Err: syscall.ECONNRESET}, true},
+		{"wrapped connection reset", fmt.Errorf("read: %w", &net.OpError{Err: syscall.ECONNRESET}), true},
+		{"connection aborted", &net.OpError{Err: syscall.ECONNABORTED}, true},
+		{"broken pipe", &net.OpError{Err: syscall.EPIPE}, true},
+		{"truncated response", io.ErrUnexpectedEOF, true},
 		{"network timeout", timeout, true},
 		{"wrapped 500", fmt.Errorf("norad: fetch failed: %w", &httpStatusError{500}), true},
 

--- a/plan/astropixels_test.go
+++ b/plan/astropixels_test.go
@@ -27,6 +27,8 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/time"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
 )
 
 // ── AstroPixels Reference Types ──────────────────────────────────────────────
@@ -192,7 +194,12 @@ func fetchAstroPixelsPage(t *testing.T, startYear int) string {
 		t.Skipf("AstroPixels returned status %d for %s", resp.StatusCode, url)
 	}
 
+	// The request succeeded and the status was 200, so the two guards above
+	// have already passed; a failure here is the connection dropping
+	// mid-body, which is the server's doing and not a defect in this parser.
 	body, err := io.ReadAll(resp.Body)
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
 		t.Fatalf("Failed to read AstroPixels response: %v", err)
 	}


### PR DESCRIPTION
Follow-up to #56, which merged one commit short.

#56 was merged at `2d29730`; the commit above it was pushed after CI had already gone green and never made it in. So `main` carries the classifier without the case that prompted it.

## What is missing

CI on #51 failed on **AstroPixels resetting one request out of sixteen** while the other fifteen parsed cleanly — on a branch that had not touched the network at all. That is the failure #56 exists to prevent, and #56 as merged does not prevent it:

```
astropixels_test.go:236: Failed to read AstroPixels response:
  read tcp 10.1.1.59:36618->162.241.219.161:443: read: connection reset by peer
```

**A reset is not a timeout.** `net.Error.Timeout()` returns false for it, so the error falls past every arm now on `main` and lands on the failure path.

Adds `ECONNRESET`, `ECONNABORTED`, `EPIPE` and `io.ErrUnexpectedEOF`: a connection dropped or truncated part-way is unambiguously the server's doing, and none of them can be produced by astrogo sending a bad request.

The AstroPixels helper already skipped on a failed request and on a non-200, so both of its guards had passed before the body read; the failure was inside `io.ReadAll`, which is now classified too.

## Why the extra arms are justified

They come from a real CI failure rather than from imagining what else could break. The first version of this classifier was written against a CelesTrak 500 and would not have caught a reset — which is the argument for adding these four and not a speculative list beyond them.

`400`, `404`, `401`, `403` and decode failures still fail, unchanged.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, and the full default suite — all clean on top of current `main`. 19 classification subtests pass, 5 of them new.
