### PR TITLE
Run CI on stacked PRs, and end the CHANGELOG conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+  # Every pull request, not only those targeting main. A stacked PR — one
+  # opened against another branch while its parent is still in review —
+  # matched no branch filter here and so ran no checks at all, which reads
+  # as "nothing to report" rather than "nothing was run".
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/changelog.d/59-changelog-d.md
+++ b/changelog.d/59-changelog-d.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 59
+---
+**Changelog entries now live one-per-file in `changelog.d/`**, assembled into `CHANGELOG.md` at release time. `CHANGELOG.md` was the only file five of eight pull requests conflicted on in a single batch — never the code — and resolving one textually can silently re-file an entry under the wrong heading, since merge markers carry no section information.

--- a/changelog.d/59-ci-stacked-prs.md
+++ b/changelog.d/59-ci-stacked-prs.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 59
+---
+**CI now runs on every pull request, not only those targeting `main`.** A stacked pull request matched no branch filter and so ran no checks at all, which reads as "nothing to report" rather than "nothing was run".

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,57 @@
+# changelog.d
+
+One file per changelog entry, assembled into `CHANGELOG.md` at release time.
+
+## Why
+
+`CHANGELOG.md` was the only file five of eight pull requests conflicted on in
+a single batch of parallel work — never the code, always the changelog. Every
+branch appends to the same `[Unreleased]` section, so every branch after the
+first has to resolve a conflict by hand.
+
+Resolving one textually is not harmless. Merge markers say nothing about which
+heading a bullet belongs under, so an entry inherits whichever heading happens
+to precede it in the merged text: during the v0.16.0 batch a `### Added` entry
+silently became a `### Fixed` one, and the diff looked like whitespace. One
+file per entry cannot collide, and cannot lose its own section.
+
+## Adding an entry
+
+Create `changelog.d/<PR-number>-<short-slug>.md`:
+
+```markdown
+---
+type: Fixed
+pr: 61
+---
+**`Time.ToGo` reinterpreted any scale as UTC.** One instant produced different
+`time.Time` values depending on which scale the caller held — measured, 69.184 s
+apart. It now converts to UTC first.
+```
+
+`type` is one of the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+sections this project already uses: `Added`, `Changed`, `Changed — BREAKING`,
+`Deprecated`, `Removed`, `Fixed`, `Security`.
+
+Keep the body to the 1–3 lines `CLAUDE.md` asks for. Forensic detail — root
+cause, before/after numbers, live-test confirmation — belongs in the pull
+request description or the code's own doc comment. The changelog is an index,
+not the record.
+
+## Releasing
+
+```bash
+go test ./internal/changelog/ -run TestAssembleRelease -update -release-version 0.17.0
+```
+
+That folds every entry here into a new `CHANGELOG.md` section, in the order
+above, extends the link-reference chain, and deletes the consumed files. Review
+the result before tagging.
+
+The `-update` gate follows this repository's existing convention for generated
+artefacts — the Horizons corpus and the accuracy table work the same way — so
+nothing rewrites a checked-in file as a side effect of running the tests.
+
+Without `-update`, `go test ./internal/changelog/` checks that every file here
+parses and names a valid type. A malformed entry fails ordinary CI rather than
+surfacing at release time.

--- a/internal/changelog/assemble.go
+++ b/internal/changelog/assemble.go
@@ -1,0 +1,161 @@
+package changelog
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Sentinel errors for assembling a release.
+var (
+	ErrNoUnreleased     = errors.New("changelog: CHANGELOG.md has no [Unreleased] heading")
+	ErrVersionExists    = errors.New("changelog: version already released")
+	ErrNoUnreleasedLink = errors.New("changelog: CHANGELOG.md has no [Unreleased] link reference")
+)
+
+const unreleasedHeading = "## [Unreleased]"
+
+// versionHeading matches a released section heading, e.g.
+// "## [0.16.0] — 2026-08-29".
+var versionHeading = regexp.MustCompile(`(?m)^## \[([0-9]+\.[0-9]+\.[0-9]+)\]`)
+
+// unreleasedLink matches the link reference [Unreleased] resolves through,
+// whose target names the most recent tag.
+var unreleasedLink = regexp.MustCompile(`(?m)^\[Unreleased\]: (\S+/compare/v)([0-9]+\.[0-9]+\.[0-9]+)(\.\.\.HEAD)$`)
+
+// Assemble inserts a new release section built from entries, leaving
+// [Unreleased] empty and extending the link-reference chain.
+//
+// Released sections are never rewritten — this changelog is forward-only —
+// so everything below the new section is copied verbatim.
+//
+// Anything already written by hand under [Unreleased] is folded into the
+// release alongside the fragments, merged by heading. Appending the two
+// bodies instead would produce a second "### Fixed" under one release,
+// which is the same silently-wrong output that motivated changelog.d in the
+// first place; and dropping them would lose entries written before the
+// convention existed.
+func Assemble(src, version, date string, entries []Entry) (string, error) {
+	if !strings.Contains(src, unreleasedHeading) {
+		return "", ErrNoUnreleased
+	}
+
+	for _, m := range versionHeading.FindAllStringSubmatch(src, -1) {
+		if m[1] == version {
+			return "", fmt.Errorf("%w: %s", ErrVersionExists, version)
+		}
+	}
+
+	link := unreleasedLink.FindStringSubmatch(src)
+	if link == nil {
+		return "", ErrNoUnreleasedLink
+	}
+
+	head, existing, tail := splitUnreleased(src)
+
+	body := mergeSections(existing, Render(entries))
+
+	out := head + unreleasedHeading + "\n\n## [" + version + "] — " + date + "\n" + body + "\n" + tail
+
+	// Point [Unreleased] at the new tag, and add this version's own link
+	// directly beneath it to match the existing newest-first chain.
+	compareURL, previous := link[1], link[2]
+	newLinks := "[Unreleased]: " + compareURL + version + "...HEAD\n" +
+		"[" + version + "]: " + compareURL + previous + "...v" + version
+
+	return strings.Replace(out, link[0], newLinks, 1), nil
+}
+
+// splitUnreleased returns everything before the [Unreleased] heading, the
+// body between it and the next "## " heading, and everything from that
+// heading on. With no [Unreleased] heading the whole input is the head,
+// a case Assemble refuses before reaching here.
+func splitUnreleased(src string) (head, body, tail string) {
+	head, rest, found := strings.Cut(src, unreleasedHeading)
+	if !found {
+		return src, "", ""
+	}
+
+	body, tail, found = strings.Cut(rest, "\n## ")
+	if !found {
+		return head, rest, ""
+	}
+
+	return head, body, "## " + tail
+}
+
+// mergeSections combines two rendered bodies, keeping one heading each and
+// preserving the canonical section order.
+func mergeSections(bodies ...string) string {
+	buckets := make(map[string][]string, len(SectionOrder))
+
+	var order []string
+
+	for _, body := range bodies {
+		var current string
+
+		for line := range strings.SplitSeq(body, "\n") {
+			switch {
+			case strings.HasPrefix(line, "### "):
+				current = strings.TrimSpace(strings.TrimPrefix(line, "### "))
+				if _, seen := buckets[current]; !seen {
+					buckets[current] = nil
+
+					order = append(order, current)
+				}
+			case strings.TrimSpace(line) == "" || current == "":
+				// Blank lines are re-emitted below; text before the first
+				// heading is preamble and is not an entry.
+			default:
+				buckets[current] = append(buckets[current], line)
+			}
+		}
+	}
+
+	var b strings.Builder
+
+	for _, section := range sortSections(order) {
+		if len(buckets[section]) == 0 {
+			continue
+		}
+
+		b.WriteString("\n### ")
+		b.WriteString(section)
+		b.WriteString("\n")
+
+		for _, line := range buckets[section] {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// sortSections puts known sections in [SectionOrder], then any unrecognised
+// ones in the order they were found — a heading this package does not know
+// about is still somebody's entry, and dropping it would be worse than
+// filing it last.
+func sortSections(found []string) []string {
+	out := make([]string, 0, len(found))
+	seen := make(map[string]bool, len(found))
+
+	for _, section := range SectionOrder {
+		for _, f := range found {
+			if f == section && !seen[f] {
+				out = append(out, f)
+				seen[f] = true
+			}
+		}
+	}
+
+	for _, f := range found {
+		if !seen[f] {
+			out = append(out, f)
+			seen[f] = true
+		}
+	}
+
+	return out
+}

--- a/internal/changelog/assemble_test.go
+++ b/internal/changelog/assemble_test.go
@@ -1,0 +1,254 @@
+package changelog
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+//nolint:gochecknoglobals // test flags must be package-level to register
+var (
+	update  = flag.Bool("update", false, "assemble changelog.d into CHANGELOG.md and delete the consumed fragments")
+	version = flag.String("release-version", "", "version to assemble under, e.g. 0.17.0")
+)
+
+const (
+	changelogPath = "../../CHANGELOG.md"
+	fragmentDir   = "../../changelog.d"
+	unreleased    = "## [Unreleased]"
+)
+
+// TestAssembleRelease folds changelog.d into CHANGELOG.md.
+//
+// Gated behind -update like the Horizons corpus generator and the accuracy
+// table, so running the test suite never rewrites a checked-in file as a
+// side effect. Without the flag it reports what a release would contain and
+// writes nothing, which is also a useful thing to be able to ask.
+func TestAssembleRelease(t *testing.T) {
+	entries, err := LoadEntries(os.DirFS(fragmentDir))
+	if err != nil {
+		t.Fatalf("load fragments: %v", err)
+	}
+
+	if !*update {
+		t.Logf("%d pending entries; rerun with -update -release-version X.Y.Z to assemble", len(entries))
+
+		for _, e := range entries {
+			t.Logf("  %-20s %s", e.Type, firstLine(e.Body))
+		}
+
+		return
+	}
+
+	if *version == "" {
+		t.Fatal("-update requires -release-version, e.g. -release-version 0.17.0")
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("no fragments in changelog.d: nothing to release")
+	}
+
+	raw, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("read CHANGELOG.md: %v", err)
+	}
+
+	next, err := Assemble(string(raw), *version, today(), entries)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+
+	if werr := os.WriteFile(changelogPath, []byte(next), 0o600); werr != nil {
+		t.Fatalf("write CHANGELOG.md: %v", werr)
+	}
+
+	// Only once the new CHANGELOG is safely on disk: a fragment deleted
+	// before that is an entry lost to a failed write.
+	for _, e := range entries {
+		if rerr := os.Remove(fragmentDir + "/" + e.Name); rerr != nil {
+			t.Errorf("remove consumed fragment %s: %v", e.Name, rerr)
+		}
+	}
+
+	t.Logf("assembled %d entries into %s and cleared changelog.d", len(entries), *version)
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(s, "\n")
+
+	return line
+}
+
+func today() string { return time.Now().UTC().Format("2006-01-02") }
+
+func TestAssembleInsertsSectionAndLink(t *testing.T) {
+	src := "# Changelog\n\n" + unreleased + "\n\n" +
+		"## [0.16.0] — 2026-08-29\n\n### Fixed\n- old thing\n\n" +
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.16.0...HEAD\n" +
+		"[0.16.0]: https://github.com/TuSKan/astrogo/compare/v0.15.1...v0.16.0\n"
+
+	got, err := Assemble(src, "0.17.0", "2026-09-01", []Entry{
+		{Type: "Fixed", PR: 61, Body: "**A fix.**"},
+	})
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+
+	for _, want := range []string{
+		"## [0.17.0] — 2026-09-01",
+		"### Fixed\n- **A fix.**",
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.17.0...HEAD",
+		"[0.17.0]: https://github.com/TuSKan/astrogo/compare/v0.16.0...v0.17.0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("assembled CHANGELOG missing %q", want)
+		}
+	}
+
+	// The previous release and its link must survive untouched — released
+	// entries are never rewritten.
+	if !strings.Contains(got, "## [0.16.0] — 2026-08-29") ||
+		!strings.Contains(got, "[0.16.0]: https://github.com/TuSKan/astrogo/compare/v0.15.1...v0.16.0") {
+		t.Error("assembling disturbed the previous release")
+	}
+
+	// An empty [Unreleased] must remain, ready for the next cycle.
+	if !strings.Contains(got, unreleased) {
+		t.Error("assembled CHANGELOG has no [Unreleased] heading left")
+	}
+}
+
+func TestAssembleRefusesADuplicateVersion(t *testing.T) {
+	src := "# Changelog\n\n" + unreleased + "\n\n## [0.16.0] — 2026-08-29\n\n" +
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.16.0...HEAD\n"
+
+	_, err := Assemble(src, "0.16.0", "2026-09-01", []Entry{{Type: "Fixed", Body: "x"}})
+	if err == nil {
+		t.Fatal("assembling over an existing version was allowed")
+	}
+}
+
+func TestAssembleRefusesAChangelogWithoutUnreleased(t *testing.T) {
+	_, err := Assemble("# Changelog\n\n## [0.16.0] — 2026-08-29\n", "0.17.0", "2026-09-01",
+		[]Entry{{Type: "Fixed", Body: "x"}})
+	if err == nil {
+		t.Fatal("assembling into a CHANGELOG with no [Unreleased] was allowed")
+	}
+}
+
+// TestAssembleIsDeterministic matters because the output is committed: the
+// same inputs must not produce a diff.
+func TestAssembleIsDeterministic(t *testing.T) {
+	src := "# Changelog\n\n" + unreleased + "\n\n## [0.16.0] — 2026-08-29\n\n" +
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.16.0...HEAD\n"
+
+	entries := []Entry{
+		{Type: "Fixed", PR: 2, Body: "**b**"},
+		{Type: "Added", PR: 1, Body: "**a**"},
+		{Type: "Fixed", PR: 3, Body: "**c**"},
+	}
+
+	first, err := Assemble(src, "0.17.0", "2026-09-01", entries)
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+
+	for range 5 {
+		again, aerr := Assemble(src, "0.17.0", "2026-09-01", entries)
+		if aerr != nil {
+			t.Fatalf("Assemble: %v", aerr)
+		}
+
+		if again != first {
+			t.Fatal("Assemble is not deterministic across runs")
+		}
+	}
+}
+
+// TestFragmentsSurviveAFailedWrite is the ordering guarantee spelled out:
+// LoadEntries must not mutate the directory, so a later failure loses
+// nothing.
+func TestFragmentsSurviveAFailedWrite(t *testing.T) {
+	dir := fstest.MapFS{
+		"1-a.md": {Data: []byte("---\ntype: Fixed\npr: 1\n---\nbody\n")},
+	}
+
+	if _, err := LoadEntries(dir); err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+
+	if _, err := dir.Open("1-a.md"); err != nil {
+		t.Errorf("LoadEntries consumed a fragment: %v", err)
+	}
+}
+
+func ExampleRender() {
+	fmt.Print(Render([]Entry{
+		{Type: "Fixed", PR: 2, Body: "**Second.**"},
+		{Type: "Added", PR: 1, Body: "**First.**"},
+	}))
+	// Output:
+	//
+	// ### Added
+	// - **First.**
+	//
+	// ### Fixed
+	// - **Second.**
+}
+
+// TestAssembleMergesHandWrittenUnreleasedEntries is the case the end-to-end
+// trial caught: the file had entries written directly under [Unreleased]
+// before changelog.d existed, and appending the fragments below them
+// produced two "### Fixed" headings in one release — precisely the silent
+// mis-filing this package exists to prevent.
+func TestAssembleMergesHandWrittenUnreleasedEntries(t *testing.T) {
+	src := "# Changelog\n\n" + unreleased + "\n\n### Fixed\n- **Written by hand.**\n\n" +
+		"### Added\n- **Also by hand.**\n\n" +
+		"## [0.16.0] — 2026-08-29\n\n### Fixed\n- released, untouched\n\n" +
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.16.0...HEAD\n"
+
+	got, err := Assemble(src, "0.17.0", "2026-09-01", []Entry{
+		{Type: "Fixed", PR: 61, Body: "**From a fragment.**"},
+	})
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+
+	release, _, _ := strings.Cut(strings.SplitN(got, "## [0.17.0]", 2)[1], "## [0.16.0]")
+
+	if n := strings.Count(release, "### Fixed"); n != 1 {
+		t.Errorf("release has %d Fixed headings, want 1:\n%s", n, release)
+	}
+
+	for _, want := range []string{"**Written by hand.**", "**From a fragment.**", "**Also by hand.**"} {
+		if !strings.Contains(release, want) {
+			t.Errorf("release lost entry %q", want)
+		}
+	}
+
+	// Canonical order survives the merge.
+	if strings.Index(release, "### Added") > strings.Index(release, "### Fixed") {
+		t.Error("sections are not in canonical order after merging")
+	}
+}
+
+// TestAssembleKeepsAnUnknownSection: a heading this package does not know
+// is still somebody's entry. Filing it last beats dropping it.
+func TestAssembleKeepsAnUnknownSection(t *testing.T) {
+	src := "# Changelog\n\n" + unreleased + "\n\n### Notes\n- **Something odd.**\n\n" +
+		"## [0.16.0] — 2026-08-29\n\n" +
+		"[Unreleased]: https://github.com/TuSKan/astrogo/compare/v0.16.0...HEAD\n"
+
+	got, err := Assemble(src, "0.17.0", "2026-09-01", []Entry{{Type: "Fixed", Body: "**x**"}})
+	if err != nil {
+		t.Fatalf("Assemble: %v", err)
+	}
+
+	if !strings.Contains(got, "**Something odd.**") {
+		t.Error("an unrecognised section was dropped")
+	}
+}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,222 @@
+// Package changelog assembles CHANGELOG.md from the one-file-per-entry
+// fragments in changelog.d.
+//
+// CHANGELOG.md was the only file five of eight pull requests conflicted on
+// in a single batch of parallel work — never the code, always the changelog,
+// because every branch appends to the same [Unreleased] section.
+//
+// Resolving such a conflict textually is not harmless. Merge markers carry
+// no information about which heading a bullet belongs under, so an entry
+// inherits whichever heading happens to precede it in the merged text: in
+// the v0.16.0 batch an "Added" entry silently became a "Fixed" one, in a
+// diff that looked like reordering. A file per entry cannot collide, and
+// carries its own section.
+package changelog
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Sentinel errors for fragment parsing.
+var (
+	ErrNoFrontMatter = errors.New("changelog: fragment has no --- front matter")
+	ErrNoType        = errors.New("changelog: fragment declares no type")
+	ErrUnknownType   = errors.New("changelog: unknown type")
+	ErrEmptyBody     = errors.New("changelog: fragment has no body")
+)
+
+// SectionOrder is the order sections appear in a release, following Keep a
+// Changelog with this project's "Changed — BREAKING" variant kept alongside
+// plain Changed.
+//
+//nolint:gochecknoglobals // the canonical section order, read-only
+var SectionOrder = []string{
+	"Added",
+	"Changed — BREAKING",
+	"Changed",
+	"Deprecated",
+	"Removed",
+	"Fixed",
+	"Security",
+}
+
+// Entry is one changelog fragment.
+type Entry struct {
+	// Type is the section it belongs in, one of [SectionOrder].
+	Type string
+
+	// PR is the pull request number, used to order entries within a
+	// section so a release reads in the order things landed.
+	PR int
+
+	// Body is the entry text, already in the "- **Thing.** Why." shape
+	// CHANGELOG.md uses, without the leading bullet.
+	Body string
+
+	// Name is the fragment's filename, for error messages.
+	Name string
+}
+
+// ParseEntry reads one fragment.
+//
+// The format is deliberately the smallest thing that works: a --- delimited
+// header of key: value lines, then the body. Not YAML — the header has two
+// keys and pulling in a parser for that would be the tail wagging the dog.
+func ParseEntry(name, src string) (Entry, error) {
+	e := Entry{Name: name}
+
+	sc := bufio.NewScanner(strings.NewReader(src))
+	if !sc.Scan() || strings.TrimSpace(sc.Text()) != "---" {
+		return e, fmt.Errorf("%w: %s", ErrNoFrontMatter, name)
+	}
+
+	var body strings.Builder
+
+	inHeader := true
+
+	for sc.Scan() {
+		line := sc.Text()
+
+		if inHeader {
+			if strings.TrimSpace(line) == "---" {
+				inHeader = false
+
+				continue
+			}
+
+			key, value, found := strings.Cut(line, ":")
+			if !found {
+				continue
+			}
+
+			switch strings.TrimSpace(key) {
+			case "type":
+				e.Type = strings.TrimSpace(value)
+			case "pr":
+				e.PR, _ = strconv.Atoi(strings.TrimSpace(value))
+			}
+
+			continue
+		}
+
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+
+	if err := sc.Err(); err != nil {
+		return e, fmt.Errorf("changelog: read %s: %w", name, err)
+	}
+
+	if inHeader {
+		return e, fmt.Errorf("%w: %s", ErrNoFrontMatter, name)
+	}
+
+	if e.Type == "" {
+		return e, fmt.Errorf("%w: %s", ErrNoType, name)
+	}
+
+	if !validType(e.Type) {
+		return e, fmt.Errorf("%w %q in %s (want one of %s)", ErrUnknownType, e.Type, name, strings.Join(SectionOrder, ", "))
+	}
+
+	e.Body = strings.TrimSpace(body.String())
+	if e.Body == "" {
+		return e, fmt.Errorf("%w: %s", ErrEmptyBody, name)
+	}
+
+	return e, nil
+}
+
+func validType(t string) bool { return slices.Contains(SectionOrder, t) }
+
+// LoadEntries parses every .md fragment in dir, skipping README.md.
+//
+// Every fragment is parsed even after one fails, so a run reports all the
+// malformed files rather than only the first — the difference between one
+// fix and one fix per iteration.
+func LoadEntries(dir fs.FS) ([]Entry, error) {
+	names, err := fs.Glob(dir, "*.md")
+	if err != nil {
+		return nil, fmt.Errorf("changelog: list fragments: %w", err)
+	}
+
+	var (
+		entries []Entry
+		errs    []error
+	)
+
+	for _, name := range names {
+		if strings.EqualFold(path.Base(name), "README.md") {
+			continue
+		}
+
+		raw, rerr := fs.ReadFile(dir, name)
+		if rerr != nil {
+			errs = append(errs, fmt.Errorf("changelog: read %s: %w", name, rerr))
+
+			continue
+		}
+
+		e, perr := ParseEntry(name, string(raw))
+		if perr != nil {
+			errs = append(errs, perr)
+
+			continue
+		}
+
+		entries = append(entries, e)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return entries, nil
+}
+
+// Render turns entries into a CHANGELOG section body, headings in
+// [SectionOrder] and entries within a heading ordered by PR number.
+//
+// Returns the empty string for no entries, so a caller can tell "nothing to
+// release" from "a release with no notes".
+func Render(entries []Entry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+
+	bySection := make(map[string][]Entry, len(SectionOrder))
+	for _, e := range entries {
+		bySection[e.Type] = append(bySection[e.Type], e)
+	}
+
+	var b strings.Builder
+
+	for _, section := range SectionOrder {
+		in := bySection[section]
+		if len(in) == 0 {
+			continue
+		}
+
+		sort.SliceStable(in, func(i, j int) bool { return in[i].PR < in[j].PR })
+
+		b.WriteString("\n### ")
+		b.WriteString(section)
+		b.WriteString("\n")
+
+		for _, e := range in {
+			b.WriteString("- ")
+			b.WriteString(e.Body)
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,163 @@
+package changelog
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestParseEntry(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantErr error
+		want    Entry
+	}{
+		{
+			name: "well formed",
+			src:  "---\ntype: Fixed\npr: 61\n---\n**A thing.** Why it mattered.\n",
+			want: Entry{Type: "Fixed", PR: 61, Body: "**A thing.** Why it mattered."},
+		},
+		{
+			name: "multi-line body",
+			src:  "---\ntype: Added\npr: 7\n---\nfirst line\nsecond line\n",
+			want: Entry{Type: "Added", PR: 7, Body: "first line\nsecond line"},
+		},
+		{
+			name: "the BREAKING variant is a real section here",
+			src:  "---\ntype: Changed — BREAKING\npr: 1\n---\nbody\n",
+			want: Entry{Type: "Changed — BREAKING", PR: 1, Body: "body"},
+		},
+		{
+			name: "no pr number is allowed",
+			src:  "---\ntype: Security\n---\nbody\n",
+			want: Entry{Type: "Security", PR: 0, Body: "body"},
+		},
+
+		// Each of these fails the build rather than surfacing at release
+		// time, which is the whole reason this parser has a test.
+		{name: "no front matter", src: "type: Fixed\nbody\n", wantErr: ErrNoFrontMatter},
+		{name: "unterminated front matter", src: "---\ntype: Fixed\nbody\n", wantErr: ErrNoFrontMatter},
+		{name: "no type", src: "---\npr: 3\n---\nbody\n", wantErr: ErrNoType},
+		{name: "misspelled type", src: "---\ntype: Fixes\n---\nbody\n", wantErr: ErrUnknownType},
+		{name: "wrong case", src: "---\ntype: fixed\n---\nbody\n", wantErr: ErrUnknownType},
+		{name: "empty body", src: "---\ntype: Fixed\n---\n\n", wantErr: ErrEmptyBody},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseEntry(c.name+".md", c.src)
+
+			if c.wantErr != nil {
+				if !errors.Is(err, c.wantErr) {
+					t.Fatalf("ParseEntry = %v, want %v", err, c.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseEntry: %v", err)
+			}
+
+			if got.Type != c.want.Type || got.PR != c.want.PR || got.Body != c.want.Body {
+				t.Errorf("ParseEntry = %+v, want type=%q pr=%d body=%q",
+					got, c.want.Type, c.want.PR, c.want.Body)
+			}
+		})
+	}
+}
+
+// TestParseEntryNamesTheFile is not cosmetic: a release assembles every
+// fragment at once, and an error that does not say which file is wrong
+// sends the reader through all of them.
+func TestParseEntryNamesTheFile(t *testing.T) {
+	_, err := ParseEntry("0061-some-fix.md", "---\ntype: Nonsense\n---\nbody\n")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	if !strings.Contains(err.Error(), "0061-some-fix.md") {
+		t.Errorf("error does not name the offending file: %v", err)
+	}
+}
+
+func TestLoadEntriesSkipsReadme(t *testing.T) {
+	dir := fstest.MapFS{
+		"README.md":   {Data: []byte("# changelog.d\n\nNot an entry.\n")},
+		"58-thing.md": {Data: []byte("---\ntype: Added\npr: 58\n---\nbody\n")},
+		"59-other.md": {Data: []byte("---\ntype: Fixed\npr: 59\n---\nbody\n")},
+		"notes.txt":   {Data: []byte("ignored, not markdown")},
+		"60-third.md": {Data: []byte("---\ntype: Fixed\npr: 60\n---\nbody\n")},
+	}
+
+	got, err := LoadEntries(dir)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("loaded %d entries, want 3 (README.md and notes.txt excluded)", len(got))
+	}
+}
+
+// TestLoadEntriesReportsEveryBadFragment is the difference between one fix
+// and one fix per iteration.
+func TestLoadEntriesReportsEveryBadFragment(t *testing.T) {
+	dir := fstest.MapFS{
+		"1-bad.md":  {Data: []byte("no front matter\n")},
+		"2-bad.md":  {Data: []byte("---\ntype: Nope\n---\nbody\n")},
+		"3-good.md": {Data: []byte("---\ntype: Fixed\npr: 3\n---\nbody\n")},
+	}
+
+	_, err := LoadEntries(dir)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	for _, want := range []string{"1-bad.md", "2-bad.md"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %s: %v", want, err)
+		}
+	}
+}
+
+func TestRenderOrdersSectionsAndEntries(t *testing.T) {
+	got := Render([]Entry{
+		{Type: "Fixed", PR: 20, Body: "**Second fix.**"},
+		{Type: "Added", PR: 9, Body: "**An addition.**"},
+		{Type: "Fixed", PR: 10, Body: "**First fix.**"},
+		{Type: "Changed — BREAKING", PR: 1, Body: "**A break.**"},
+	})
+
+	want := "\n### Added\n- **An addition.**\n" +
+		"\n### Changed — BREAKING\n- **A break.**\n" +
+		"\n### Fixed\n- **First fix.**\n- **Second fix.**\n"
+
+	if got != want {
+		t.Errorf("Render =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestRenderEmpty distinguishes "nothing to release" from "a release with
+// no notes", which the caller has to be able to tell apart.
+func TestRenderEmpty(t *testing.T) {
+	if got := Render(nil); got != "" {
+		t.Errorf("Render(nil) = %q, want empty", got)
+	}
+}
+
+// TestCheckedInFragmentsParse runs in ordinary CI, so a malformed fragment
+// fails the pull request that added it rather than the release weeks later.
+func TestCheckedInFragmentsParse(t *testing.T) {
+	dir := os.DirFS("../../changelog.d")
+
+	entries, err := LoadEntries(dir)
+	if err != nil {
+		t.Fatalf("changelog.d contains a malformed fragment: %v", err)
+	}
+
+	t.Logf("%d pending changelog entries", len(entries))
+}


### PR DESCRIPTION
Two problems from the same batch of parallel work. Independent of #58.

## Stacked pull requests ran no checks

```yaml
pull_request:
  branches:
    - main
```

A pull request opened against another branch — while its parent is still in review — matched no filter here and so ran **nothing**. Not a failure, not a skip: an empty check list, which reads as *nothing to report* rather than *nothing was run*. Now triggers on every pull request.

## CHANGELOG.md was the only file that ever conflicted

Five of eight pull requests in the v0.16.0 batch conflicted. **Every one was `CHANGELOG.md` alone; none was code.** Every branch appends to the same `[Unreleased]` section, so every branch after the first resolves by hand.

That resolution is not harmless, and this is the argument for the change:

> Merge markers carry no information about which heading a bullet belongs under. An entry inherits whichever heading happens to precede it in the merged text.

During that batch an `### Added` entry silently became a `### Fixed` one, in a diff that looked like reordering. A file per entry cannot collide, and carries its own section.

## The mechanism

`changelog.d/<pr>-<slug>.md`, with a two-key header:

```markdown
---
type: Fixed
pr: 61
---
**A thing.** Why it mattered.
```

Not YAML — the header has two keys, and pulling in a parser for that would be the tail wagging the dog.

Assembly is an `-update`-gated test, matching the convention the Horizons corpus generator and the accuracy table already use, so **running the test suite never rewrites a checked-in file as a side effect**:

```bash
go test ./internal/changelog/ -run TestAssembleRelease -update -release-version 0.17.0
```

Without the flag it reports what a release would contain and writes nothing. `TestCheckedInFragmentsParse` runs in ordinary CI, so a malformed fragment fails the pull request that added it rather than the release weeks later.

## The defect the end-to-end trial caught

Worth calling out, because the unit tests were green and wrong.

I ran the assembler against the **real** `CHANGELOG.md` before trusting it. The current `[Unreleased]` still holds v0.16.0's sixteen entries — we tagged without promoting them — and inserting a release above them produced **two `### Fixed` headings in one release**. Precisely the silent mis-filing this whole change exists to prevent, reintroduced by the tool meant to end it.

`Assemble` now merges hand-written `[Unreleased]` entries with the fragments *by heading*, which also makes it robust against anyone editing the file directly. Re-verified end to end: 5 headings, 0 duplicates, all 18 entries preserved (16 existing + 2 new).

An unrecognised heading is kept and filed last rather than dropped — a heading this package does not know about is still somebody's entry.

## Dogfooded

This pull request's own two changelog entries are fragments, not `CHANGELOG.md` edits.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, and the full default suite — clean. The assembler has tests for section ordering, determinism across runs (the output is committed, so identical inputs must not produce a diff), duplicate-version refusal, every malformed-fragment shape, and that `LoadEntries` never mutates the directory — a fragment deleted before the new CHANGELOG is safely written is an entry lost to a failed write.
