### PR TITLE
Validate small-body SPK evaluation against Horizons (33 mm)

### DIFF
--- a/changelog.d/60-horizons-command-string.md
+++ b/changelog.d/60-horizons-command-string.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 60
+---
+**The Horizons query helpers take the COMMAND payload as a string** rather than a NAIF ID as an int, because a small body needs Horizons' designation syntax (`433;`) and an int cannot express it. `StateVector.NaifID`, which was written and never read, becomes `StateVector.Command` and records what was actually queried.

--- a/changelog.d/60-smallbody-spk-validation.md
+++ b/changelog.d/60-smallbody-spk-validation.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 60
+---
+**Small-body SPK evaluation is now validated against Horizons.** The only assertion on a small-body position was `0.1 AU < |r| < 5.0 AU` — a bound spanning two orders of magnitude, guarding the hand-rolled SPK **Type 21** decoder where a defect once corrupted positions. Astrogo agrees with Horizons to **33 mm** across four bodies from 1 to 5 AU and eccentricity 0.08 to 0.89.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -49,19 +49,21 @@ generated table existed.
 
 | Suite | Reference | Independence | N | p50 | p95 | p99 | Max | Contract | Status | Last verified |
 |---|---|---|---:|---:|---:|---:|---:|---:|---|---|
-| `coord.rv.barycentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 1.16e-09 | 4.31e-07 | 6.98e-07 | 6.98e-07 | 0.001 km/s | ✅ verified | 2026-08-29 · `eb433f99` |
-| `coord.rv.heliocentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 1.16e-09 | 4.31e-07 | 6.98e-07 | 6.98e-07 | 0.001 km/s | ✅ verified | 2026-08-29 · `eb433f99` |
-| `coord.topocentric.corpus` | JPL Horizons OBSERVER + VECTORS, AIRLESS | independent | 103 | 0.433 | 1.9 | 1.99 | 2.07 | 3 arcsec | ✅ verified | 2026-08-29 · `eb433f99` |
-| `coord.topocentric.crosstrack` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.379 | 1.88 | 1.93 | 1.96 | 3 arcsec | ✅ verified | 2026-08-29 · `eb433f99` |
-| `coord.topocentric.elevation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.0665 | 0.272 | 0.352 | 0.372 | 3 arcsec | ✅ verified | 2026-08-29 · `eb433f99` |
-| `coord.topocentric.separation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.388 | 1.88 | 1.94 | 1.97 | 3 arcsec | ✅ verified | 2026-08-29 · `eb433f99` |
-| `ephemeris.jpl.horizons.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 5.49e-14 | 4.05e-12 | 4.41e-12 | 4.5e-12 | 1e-09 AU | ✅ verified | 2026-08-29 · `eb433f99` |
-| `ephemeris.jpl.horizons.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 1.22e-14 | 9.02e-13 | 9.81e-13 | 1e-12 | 1e-10 AU/day | ✅ verified | 2026-08-29 · `eb433f99` |
-| `ephemeris.sofa.moon` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 3.65e-08 | 4.5e-08 | 4.58e-08 | 4.6e-08 | 4e-07 AU | ✅ verified | 2026-08-29 · `eb433f99` |
-| `ephemeris.sofa.sun` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 2.03e-08 | 2.76e-08 | 2.82e-08 | 2.84e-08 | 1.5e-07 AU | ✅ verified | 2026-08-29 · `eb433f99` |
-| `skybrightness.gambons.band_medians` | GAMBONS (Masana, Carrasco, Bara & Ribas) 2021 MNRAS 501, 5443; 2024 | independent | 6 | 0.207 | 0.273 | 0.28 | 0.282 | 1 mag | ✅ verified | 2026-08-29 · `eb433f99` |
-| `time.scale.roundtrip.arithmetic` | scale round trip, A to B and back | independent | 120 | 0 | 9.41e-12 | 9.59e-12 | 9.59e-12 | 1e-06 s | ✅ verified | 2026-08-29 · `eb433f99` |
-| `time.scale.roundtrip.modelled` | scale round trip, A to B and back | independent | 180 | 0 | 6.83e-06 | 0.943 | 0.943 | 5 s | ✅ verified | 2026-08-29 · `eb433f99` |
+| `coord.rv.barycentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.rv.heliocentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.topocentric.corpus` | JPL Horizons OBSERVER + VECTORS, AIRLESS | independent | 103 | 0.433 | 1.9 | 1.99 | 2.07 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.topocentric.crosstrack` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.379 | 1.88 | 1.93 | 1.96 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.topocentric.elevation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.0665 | 0.272 | 0.352 | 0.372 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.topocentric.separation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.388 | 1.88 | 1.94 | 1.97 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.jpl.horizons.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 5.49e-14 | 4.05e-12 | 4.41e-12 | 4.5e-12 | 1e-09 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.jpl.horizons.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 1.22e-14 | 9.02e-13 | 9.81e-13 | 1e-12 | 1e-10 AU/day | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.jpl.smallbody.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 44 | 1.72e-13 | 1.97e-13 | 2.11e-13 | 2.19e-13 | 1e-11 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.jpl.smallbody.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 44 | 3.95e-14 | 4.6e-14 | 4.62e-14 | 4.62e-14 | 1e-12 AU/day | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.sofa.moon` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 3.65e-08 | 4.5e-08 | 4.58e-08 | 4.6e-08 | 4e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.sofa.sun` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 2.03e-08 | 2.76e-08 | 2.82e-08 | 2.84e-08 | 1.5e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `skybrightness.gambons.band_medians` | GAMBONS (Masana, Carrasco, Bara & Ribas) 2021 MNRAS 501, 5443; 2024 | independent | 6 | 0.207 | 0.273 | 0.28 | 0.282 | 1 mag | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `time.scale.roundtrip.arithmetic` | scale round trip, A to B and back | independent | 120 | 0 | 9.41e-12 | 9.59e-12 | 9.59e-12 | 1e-06 s | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `time.scale.roundtrip.modelled` | scale round trip, A to B and back | independent | 180 | 0 | 6.83e-06 | 0.943 | 0.943 | 5 s | ✅ verified | 2026-08-29 · `5e53d9fc` |
 
 Every figure above is a **measured** value over the corpus named in its suite, not a bound. The contract column is the bound, and it is a separate claim: it says what the software must achieve and why, and it does not move when a measurement does. See `internal/metrology` for the reasoning, and each suite's own doc comment for the rationale behind its contract.
 

--- a/ephemeris/jpl/validation/gen_corpus_test.go
+++ b/ephemeris/jpl/validation/gen_corpus_test.go
@@ -140,7 +140,7 @@ func TestGenerateCorpus(t *testing.T) {
 			// One vector series per (body, span) — the geocentric state
 			// does not depend on the site, so this is fetched once and
 			// reused across every site below.
-			vectors, err := fetchVectorSeries(target.naifID, target.name, span.start, span.stop, span.step)
+			vectors, err := fetchVectorSeries(target.command(), target.name, span.start, span.stop, span.step)
 			if err != nil {
 				t.Logf("vectors for %s over %s: %v — this span is omitted for this body",
 					target.name, span.class, err)
@@ -149,7 +149,7 @@ func TestGenerateCorpus(t *testing.T) {
 			}
 
 			for _, site := range sites {
-				points, err := fetchObserverSeries(target.naifID, target.name,
+				points, err := fetchObserverSeries(target.command(), target.name,
 					site.Lon, site.Lat, site.Height, span.start, span.stop, span.step)
 				if err != nil {
 					t.Logf("observer table for %s @ %s over %s: %v — omitted",

--- a/ephemeris/jpl/validation/horizons_api_test.go
+++ b/ephemeris/jpl/validation/horizons_api_test.go
@@ -29,8 +29,11 @@ var (
 
 // StateVector matches your desired JSON output
 type StateVector struct {
-	Body    string    `json:"body"`
-	NaifID  int       `json:"naif_id"`
+	Body string `json:"body"`
+	// Command is the Horizons COMMAND payload this row was fetched
+	// with — "499" for a planet, "433;" for a small body — so a row
+	// carries enough to reproduce the request that produced it.
+	Command string    `json:"command"`
 	Epoch   string    `json:"epoch"`
 	ET      float64   `json:"et"`
 	Pos     []float64 `json:"pos"`
@@ -70,14 +73,14 @@ func horizonsUnavailable(body string) bool {
 // path agrees with DE440 to 5e-14 AU, and the corpus generator hit exactly
 // that 69 seconds — about 1040 arcseconds of hour angle — when it used
 // unsuffixed epochs and stored the column as TDB.
-func fetchVector(naifID int, bodyName string, startStr, stopStr string) (*StateVector, error) {
+func fetchVector(command, bodyName string, startStr, stopStr string) (*StateVector, error) {
 	// 1. Define the base URL
 	baseURL := "https://ssd.jpl.nasa.gov/api/horizons.api"
 
 	// 2. Build the query parameters safely
 	params := url.Values{}
 	params.Add("format", "text")
-	params.Add("COMMAND", fmt.Sprintf("'%d'", naifID))
+	params.Add("COMMAND", "'"+command+"'")
 	params.Add("CENTER", "'@399'")
 	params.Add("MAKE_EPHEM", "'YES'")
 	params.Add("EPHEM_TYPE", "'VECTORS'")
@@ -169,7 +172,7 @@ func fetchVector(naifID int, bodyName string, startStr, stopStr string) (*StateV
 	// 4. Build the final struct
 	sv := &StateVector{
 		Body:    bodyName,
-		NaifID:  naifID,
+		Command: command,
 		Epoch:   "2000-01-01T12:00:00Z",
 		ET:      etSeconds,
 		Pos:     pos,
@@ -188,12 +191,12 @@ func fetchVector(naifID int, bodyName string, startStr, stopStr string) (*StateV
 // The geocentric state does not depend on the observing site, so one series
 // per body covers every site in a corpus at once. That is the difference
 // between a few dozen requests to somebody else's server and a few hundred.
-func fetchVectorSeries(naifID int, bodyName, startStr, stopStr, stepStr string) ([]StateVector, error) {
+func fetchVectorSeries(command, bodyName, startStr, stopStr, stepStr string) ([]StateVector, error) {
 	baseURL := "https://ssd.jpl.nasa.gov/api/horizons.api"
 
 	params := url.Values{}
 	params.Add("format", "text")
-	params.Add("COMMAND", fmt.Sprintf("'%d'", naifID))
+	params.Add("COMMAND", "'"+command+"'")
 	params.Add("CENTER", "'@399'")
 	params.Add("MAKE_EPHEM", "'YES'")
 	params.Add("EPHEM_TYPE", "'VECTORS'")
@@ -257,7 +260,7 @@ func fetchVectorSeries(naifID int, bodyName, startStr, stopStr, stepStr string) 
 
 		sv := StateVector{
 			Body:    bodyName,
-			NaifID:  naifID,
+			Command: command,
 			ET:      (val(0) - 2451545.0) * 86400.0,
 			Pos:     []float64{val(2), val(3), val(4)},
 			Vel:     []float64{val(5), val(6), val(7)},
@@ -303,12 +306,12 @@ type ObserverPoint struct {
 // fetchObserverTable queries the Horizons API for a ground-based observer with
 // QUANTITIES='1,2,4,20': astrometric RA/Dec, apparent RA/Dec, airless Az/El and
 // observer range.
-func fetchObserverTable(naifID int, bodyName string, lon, lat, height float64, startStr, stopStr string) (*ObserverPoint, error) {
+func fetchObserverTable(command, bodyName string, lon, lat, height float64, startStr, stopStr string) (*ObserverPoint, error) {
 	baseURL := "https://ssd.jpl.nasa.gov/api/horizons.api"
 
 	params := url.Values{}
 	params.Add("format", "text")
-	params.Add("COMMAND", fmt.Sprintf("'%d'", naifID))
+	params.Add("COMMAND", "'"+command+"'")
 	params.Add("CENTER", "'coord@399'")                                          // Earth Observer
 	params.Add("SITE_COORD", fmt.Sprintf("'%f,%f,%f'", lon, lat, height/1000.0)) // Longitude, Latitude, Elevation in km
 	params.Add("MAKE_EPHEM", "'YES'")
@@ -482,12 +485,12 @@ func parseObserverRow(cols []string, bodyName string) ObserverPoint {
 // of the OBSERVER table — unlike fetchObserverTable, which only parses
 // lines[0]. This lets the precision-floor matrix cover many epochs per
 // (body, site) pair in a single request instead of one request per epoch.
-func fetchObserverSeries(naifID int, bodyName string, lon, lat, height float64, startStr, stopStr, stepStr string) ([]ObserverPoint, error) {
+func fetchObserverSeries(command, bodyName string, lon, lat, height float64, startStr, stopStr, stepStr string) ([]ObserverPoint, error) {
 	baseURL := "https://ssd.jpl.nasa.gov/api/horizons.api"
 
 	params := url.Values{}
 	params.Add("format", "text")
-	params.Add("COMMAND", fmt.Sprintf("'%d'", naifID))
+	params.Add("COMMAND", "'"+command+"'")
 	params.Add("CENTER", "'coord@399'") // Earth Observer
 	params.Add("SITE_COORD", fmt.Sprintf("'%f,%f,%f'", lon, lat, height/1000.0))
 	params.Add("MAKE_EPHEM", "'YES'")

--- a/ephemeris/jpl/validation/horizons_compare_test.go
+++ b/ephemeris/jpl/validation/horizons_compare_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
 	eph "github.com/TuSKan/astrogo/ephemeris"
@@ -55,7 +56,7 @@ func loadCases(t *testing.T) []*StateVector {
 	out := make([]*StateVector, 0, len(horizonsCases()))
 
 	for _, c := range horizonsCases() {
-		sv, err := fetchVector(c.naifID, c.name, start, stop)
+		sv, err := fetchVector(strconv.Itoa(c.naifID), c.name, start, stop)
 		if errors.Is(err, errHorizonsUnavailable) {
 			return nil
 		}

--- a/ephemeris/jpl/validation/observer_pipeline_test.go
+++ b/ephemeris/jpl/validation/observer_pipeline_test.go
@@ -41,7 +41,7 @@ func TestPhase1ObserverPipelineAgainstHorizons(t *testing.T) {
 	obsTime := atime.Date(2024, 11, 1, 12, 0, 0, 0, time.UTC)
 
 	// Fetch Topocentric Observer Table for Mars (NAIF ID: 499)
-	marsHorizons, err := fetchObserverTable(499, "Mars", site.Lon().Degrees(), site.Lat().Degrees(), site.Height(), tStrStart, tStrStop)
+	marsHorizons, err := fetchObserverTable("499", "Mars", site.Lon().Degrees(), site.Lat().Degrees(), site.Height(), tStrStart, tStrStop)
 	if errors.Is(err, errHorizonsUnavailable) {
 		t.Skipf("JPL Horizons is not answering with API data, skipping live comparison: %v", err)
 	}

--- a/ephemeris/jpl/validation/observer_precision_test.go
+++ b/ephemeris/jpl/validation/observer_precision_test.go
@@ -5,6 +5,7 @@ package jpl_test
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -30,6 +31,14 @@ type observerPrecisionBody struct {
 	naifID int
 	name   string
 }
+
+// command is the Horizons COMMAND payload for this body.
+//
+// A planet or satellite is addressed by its NAIF ID. A small body needs
+// Horizons' own designation syntax — "433;" rather than "433" — which is why
+// the query builders take a string: an int cannot express the difference,
+// and getting it wrong resolves to a different object rather than failing.
+func (b observerPrecisionBody) command() string { return strconv.Itoa(b.naifID) }
 
 // TestObserverPrecisionMatrix characterizes the real achieved precision of
 // the full astrometric -> apparent -> observed pipeline against JPL
@@ -262,7 +271,7 @@ func TestObserverPrecisionMatrix(t *testing.T) {
 		for _, ns := range sites {
 			loc := ns.site.Location()
 
-			points, err := fetchObserverSeries(body.naifID, body.name,
+			points, err := fetchObserverSeries(body.command(), body.name,
 				loc.Lon().Degrees(), loc.Lat().Degrees(), loc.Height(),
 				startTime, stopTime, stepSize)
 			if err != nil {

--- a/ephemeris/jpl/validation/smallbody_spk_test.go
+++ b/ephemeris/jpl/validation/smallbody_spk_test.go
@@ -1,0 +1,221 @@
+//go:build network
+
+package jpl_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
+	"github.com/TuSKan/astrogo/internal/metrology"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// smallBody is one asteroid to validate, with the reason it is in the set.
+//
+// Horizons matches small bodies by number or by its own designation syntax,
+// not by name: "433" and "433;" resolve to Eros while "Eros" does not, and
+// "DES=433;" resolves to a different object entirely (248370). The semicolon
+// form is used throughout because it is the one that means "small body" to
+// Horizons rather than "look this up in the planetary table first".
+type smallBody struct {
+	id          int
+	designation string
+	name        string
+	why         string
+}
+
+func smallBodies() []smallBody {
+	return []smallBody{
+		{
+			id: 433, designation: "433;", name: "Eros",
+			why: "near-Earth, and the only small body this repository had any position test for",
+		},
+		{
+			id: 3200, designation: "3200;", name: "Phaethon",
+			why: "e=0.89 with perihelion inside Mercury's orbit, so its difference arrays " +
+				"span a far wider range of speeds than a main-belt body's",
+		},
+		{
+			id: 16, designation: "16;", name: "Psyche",
+			why: "main belt at ~3 AU, the slow end of the range",
+		},
+		{
+			id: 624, designation: "624;", name: "Hektor",
+			why: "Jupiter trojan at ~5.2 AU, the slowest and most distant case here",
+		},
+	}
+}
+
+// Ceres, Pallas, Juno and Vesta are absent, and the reason is a defect in
+// this repository rather than anything about those bodies.
+//
+// Horizons generates a perfectly good kernel for each — verified, 72,704
+// bytes with a Type 21 segment, for "4;" exactly as for "433;". The segment's
+// target ID is 20000004, which [jpl.Provider.SupportedBodies] maps to a body
+// ID by subtracting 20000000. That gives core.ID(4), and core.ID(4) is Mars:
+// the enum runs Mercury=1, Venus=2, Earth=3, Mars=4. So asteroids 1 through 9
+// land on planet identifiers and the body is silently dropped, taking with it
+// four of the largest and best-observed objects in the solar system.
+//
+// Measured, Mars itself is not corrupted: adding a Vesta kernel to a de440
+// provider changes Mars's position by exactly 0.0 AU, because the lookup goes
+// through BodyIDToNAIF to target 4 and never reaches the asteroid segment.
+// The body is unreachable rather than wrong.
+//
+// What makes it worth naming here is that ErrNoSmallBodyKernel reports it as
+// a designation problem — "Horizons matches small bodies by number ... not by
+// name" — which is exactly what a reader would act on, and is not the cause.
+// Fixing it means deciding how a small body should be identified, which is a
+// public-API question and not one this suite should answer on its own.
+
+// smallBodySPKReference records what this comparison is against.
+//
+// Horizons generates the SPK and Horizons produces the reference vectors, so
+// both sides descend from the same JPL small-body solution. That makes this a
+// check on astrogo's Type 21 decoding and evaluation rather than independent
+// validation of the orbit, and the shared ancestry is recorded so the
+// generated table says so rather than leaving a reader to assume otherwise.
+func smallBodySPKReference() metrology.Reference {
+	return metrology.Reference{
+		Kind:           metrology.KindHorizons,
+		Name:           "JPL Horizons",
+		Version:        "VECTORS, geocentric, ICRF",
+		Source:         "https://ssd.jpl.nasa.gov/api/horizons.api",
+		Dataset:        "Horizons-generated SPK (Type 21) against Horizons' own vectors",
+		SharedAncestor: "JPL small-body solution",
+	}
+}
+
+// TestSmallBodySPKAgainstHorizons compares astrogo's evaluation of a
+// Horizons-generated small-body kernel against Horizons' own state vectors.
+//
+// # Why this suite exists
+//
+// Until now the only assertion anywhere on a small-body position was
+// 0.1 AU < |r| < 5.0 AU, in ephemeris/jpl's TestSmallBodyEros. That bound
+// spans two orders of magnitude and is satisfied by most of the inner solar
+// system, so it cannot distinguish a correct position from one that is wrong
+// by an astronomical unit.
+//
+// What it guards is worth more than that. Small-body kernels are SPK
+// **Type 21** — Extended Modified Difference Arrays — which is a different
+// decoder from the Type 2/3 Chebyshev polynomials the planetary kernels use,
+// hand-rolled in this repository, and one where a decoding defect has
+// previously corrupted small-body positions. TestJPLStateAgainstHorizons
+// covers the Chebyshev path at 1e-9 AU; nothing covered this one.
+//
+// # What it can and cannot show
+//
+// Horizons generates the kernel and Horizons produces the reference, so a
+// disagreement is not an orbit difference: it is astrogo mis-decoding or
+// mis-evaluating a file whose contents both sides agree on. That is exactly
+// the fault class Type 21 is exposed to, and it is not independent validation
+// of the orbit itself — see [smallBodySPKReference].
+func TestSmallBodySPKAgainstHorizons(t *testing.T) {
+	position := metrology.NewSuite("ephemeris.jpl.smallbody.position", smallBodySPKReference(),
+		metrology.MustContract(1e-11, "AU",
+			"1.5 m. Both sides read the same difference arrays, so the residual is floating-point "+
+				"scatter between two evaluation orders, measured at 2.2e-13 AU (33 mm) across four "+
+				"bodies spanning 1 to 5 AU and eccentricity 0.08 to 0.89. This sits ~45x above that "+
+				"scatter, leaving room for other epochs and platforms without tracking the noise, "+
+				"and two orders of magnitude below the 1e-9 AU the Chebyshev path allows, so a "+
+				"regression in this decoder is caught long before it reaches the planetary bound",
+			"measured 2024-01-01 to 2024-02-10 against Horizons' own vectors; cf. "+
+				"TestJPLStateAgainstHorizons for the Chebyshev path"))
+
+	velocity := metrology.NewSuite("ephemeris.jpl.smallbody.velocity", smallBodySPKReference(),
+		metrology.MustContract(1e-12, "AU/day",
+			"1.7 mm/s. The velocity is read from the same difference arrays as the position and "+
+				"fails to the same causes, so it is bounded the same way: ~22x the 4.6e-14 AU/day "+
+				"scatter measured, and two orders below the Chebyshev path's 1e-10 AU/day",
+			"same measurement as the position bound on this comparison"))
+
+	if !testutil.Reachable(horizonsHost) {
+		metrology.NotVerified(t, "JPL Horizons is unreachable", position, velocity)
+	}
+
+	// A span short enough that one Horizons SPK covers it comfortably, and
+	// long enough that a decoding fault at a difference-array boundary has
+	// somewhere to show up.
+	const (
+		startJD = 2460310.5 // 2024-01-01
+		days    = 40
+		stepJD  = 4
+
+		// The kernel is asked for more than the reference series covers.
+		// Requesting exactly the same span leaves the final epoch on the
+		// segment's own boundary, where the first run of this suite got
+		// "no coverage for target at requested epoch" for every body.
+		marginDays = 5
+	)
+
+	start := atime.FromJD(startJD-marginDays, atime.TDB)
+	stop := atime.FromJD(startJD+days+marginDays, atime.TDB)
+
+	for _, body := range smallBodies() {
+		t.Run(body.name, func(t *testing.T) {
+			p, err := jpl.NewProvider(context.Background(), core.SmallBody, body.designation,
+				jpl.WithTimeInterval(start, stop))
+			if err != nil {
+				// Horizons can return a syntactically valid but empty SPK
+				// for a request it otherwise accepts — an external anomaly
+				// this repository already detects and names rather than
+				// caching a broken kernel.
+				if errors.Is(err, spk.ErrHorizonsEmptyKernel) {
+					t.Skipf("Horizons returned an unusable SPK for %s: %v", body.name, err)
+				}
+
+				t.Fatalf("provider for %s (%s): %v", body.name, body.designation, err)
+			}
+
+			defer func() { _ = p.Close() }()
+
+			refs, err := fetchVectorSeries(body.designation, body.name,
+				"2024-01-01 00:00 TDB", "2024-02-10 00:00", fmt.Sprintf("%dd", stepJD))
+			if err != nil {
+				t.Skipf("Horizons vectors for %s: %v", body.name, err)
+			}
+
+			if len(refs) == 0 {
+				t.Skipf("Horizons returned no vectors for %s", body.name)
+			}
+
+			for _, ref := range refs {
+				// ET is seconds past J2000.0 TDB, the same convention
+				// TestJPLStateAgainstHorizons reads.
+				when := atime.FromJD(2451545.0+ref.ET/86400.0, atime.TDB)
+
+				state, serr := p.State(core.ID(body.id), when)
+				if serr != nil {
+					t.Errorf("%s: State at JD %.5f: %v", body.name, when.JD(), serr)
+
+					continue
+				}
+
+				dPos := state.Pos.Sub(vector.Vec3{X: ref.Pos[0], Y: ref.Pos[1], Z: ref.Pos[2]}).Norm()
+				dVel := state.Vel.Sub(vector.Vec3{X: ref.Vel[0], Y: ref.Vel[1], Z: ref.Vel[2]}).Norm()
+
+				ctx := fmt.Sprintf("JD %.5f TDB, |dPos| = %.3f m", when.JD(), dPos*kmPerAU*1e3)
+
+				position.Add(metrology.Sample{Error: dPos, Label: body.name, Context: ctx})
+				velocity.Add(metrology.Sample{Error: dVel, Label: body.name, Context: ctx})
+			}
+
+			t.Logf("%s (%s): %s", body.name, body.designation, body.why)
+		})
+	}
+
+	if position.Len() == 0 {
+		metrology.NotVerified(t, "no small body produced a comparable state", position, velocity)
+	}
+
+	position.Report(t)
+	velocity.Report(t)
+}


### PR DESCRIPTION
§20 of the v0.15.1 review — the largest remaining hole in the validation record.

## What was guarding small-body positions

```go
if dist < 0.1 || dist > 5.0 {
```

That is the whole of it. A bound spanning two orders of magnitude, satisfied by most of the inner solar system, which cannot distinguish a correct position from one wrong by an astronomical unit.

What it was guarding is worth more. Small-body kernels are SPK **Type 21** — Extended Modified Difference Arrays — a *different* decoder from the Type 2/3 Chebyshev polynomials the planetary kernels use, hand-rolled in this repository, and one where a decoding defect has previously corrupted small-body positions. `TestJPLStateAgainstHorizons` covers the Chebyshev path at 1e-9 AU. Nothing covered this one.

## The result

**33 millimetres.** 44 samples, four bodies from 1 to 5 AU, eccentricity 0.08 to 0.89.

| | measured max | contract |
| :--- | ---: | ---: |
| position | 2.192e-13 AU (33 mm) | 1e-11 AU |
| velocity | 4.62e-14 AU/day | 1e-12 AU/day |

Bodies chosen to stress the difference arrays rather than to be famous: **433 Eros** (near-Earth, the one body that had any test), **3200 Phaethon** (e=0.89, perihelion inside Mercury's orbit — the widest speed range available), **16 Psyche** (main belt, ~3 AU), **624 Hektor** (Jupiter trojan, ~5.2 AU, the slow end).

Both sides read the same JPL solution, so this checks astrogo's decoding and evaluation, **not** the orbit. The reference records that shared ancestry so the generated table says so rather than letting a reader assume otherwise.

## The contract, and the one I threw away

I wrote 1e-9 AU first, matching the Chebyshev path. Measured, that had **4,560× headroom** — a bound that cannot fail for the reason it exists, which is the exact criticism `TestJPLStateAgainstHorizons`' own doc comment makes of the tolerances it replaced. It is now 1e-11 AU: ~45× the float scatter actually observed, and two orders of magnitude below what the planetary path allows, so a regression in this decoder is caught long before it reaches the planetary bound.

## Two defects the first run found

**Coverage off-by-one.** Asking Horizons for a kernel spanning exactly the reference series put the final epoch on the segment's own boundary — `no coverage for target at requested epoch`, for every body. The kernel is now requested five days wider each way.

**`"1"` silently resolves to a comet.** While looking for a working Ceres designation, `COMMAND='1'` returned a provider supporting `BodyID(1000036)` — a comet, not Ceres. Same trap as `DES=433;` resolving to 248370 in #51: a designation that succeeds and gives you a different object.

## A real bug this surfaced, not fixed here

**Ceres, Pallas, Juno and Vesta cannot be loaded at all**, and the cause is in this repository.

Horizons returns a perfectly good kernel for `4;` — verified, 72,704 bytes, Type 21 segment, identical in shape to Eros's. Its segment target ID is **20000004**. `SupportedBodies` maps that to a body ID by subtracting 20000000, giving `core.ID(4)` — and the enum runs `Mercury=1, Venus=2, Earth=3, Mars=4`. **Asteroids 1 through 9 land on planet identifiers and are silently dropped**, taking four of the largest and best-observed objects in the solar system with them.

Measured, Mars itself is *not* corrupted: adding a Vesta kernel to a de440 provider changes Mars's position by exactly **0.0 AU**, because the lookup goes through `BodyIDToNAIF` to target 4 and never reaches the asteroid segment. The body is unreachable rather than wrong.

What makes it worth flagging loudly: `ErrNoSmallBodyKernel` reports this as a *designation* problem — "Horizons matches small bodies by number … not by name" — which is what a reader would act on, and is not the cause.

Not fixed here because fixing it means deciding how a small body should be identified, which is a public-API question and shouldn't be settled inside a validation suite. Happy to take it next.

## Also in this change

The Horizons query helpers take the `COMMAND` payload as a **string** rather than a NAIF ID as an `int`, because `433;` cannot be expressed as an int. `StateVector.NaifID` — written and never read — becomes `Command`, recording what was actually queried so a row carries enough to reproduce its own request.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, and the default, `validation` and `network` suites — clean.

The generated accuracy table goes from **13 rows to 15, all verified**. Re-rendered twice: the first pass recorded three rows as NOT VERIFIED, including "JPL Horizons is unreachable" in the same run where this new suite reached Horizons successfully. Retried individually, all three verify — the long batch had been rate-limited. Publishing that first table would have put a false claim in the document this whole exercise exists to make trustworthy.
