### PR TITLE
Stop small-body identifiers colliding with the planets

### DIFF
--- a/changelog.d/61-smallbody-id-api.md
+++ b/changelog.d/61-smallbody-id-api.md
@@ -1,0 +1,5 @@
+---
+type: Changed — BREAKING
+pr: 61
+---
+**`Provider.SupportedBodies` reports small bodies as `core.SmallBodyID(n)`**, not the bare number: `SmallBodyID(433)` rather than `core.ID(433)`. A bare `core.ID(433)` still resolves in `State`, so only code that matches against the enumerated list needs updating. Adds `core.SmallBodyID`, `core.SmallBodyBase` and `ID.SmallBodyNumber`.

--- a/changelog.d/61-smallbody-id-collision.md
+++ b/changelog.d/61-smallbody-id-collision.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 61
+---
+**Ceres, Pallas, Juno and Vesta could not be loaded at all.** A small body was identified by its bare number, so asteroid 4 Vesta and Mars were both `core.ID(4)` — as were Ceres and Mercury, Pallas and Venus, and every asteroid numbered up to 12. A provider holding a planetary kernel resolved the planet and dropped the asteroid as a duplicate, and `ErrNoSmallBodyKernel` then blamed the designation, which was never the cause. Small bodies now keep NAIF's own `20000000+` identifier via `core.SmallBodyID`.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -57,8 +57,8 @@ generated table existed.
 | `coord.topocentric.separation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.388 | 1.88 | 1.94 | 1.97 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
 | `ephemeris.jpl.horizons.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 5.49e-14 | 4.05e-12 | 4.41e-12 | 4.5e-12 | 1e-09 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
 | `ephemeris.jpl.horizons.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 1.22e-14 | 9.02e-13 | 9.81e-13 | 1e-12 | 1e-10 AU/day | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.jpl.smallbody.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 44 | 1.72e-13 | 1.97e-13 | 2.11e-13 | 2.19e-13 | 1e-11 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.jpl.smallbody.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 44 | 3.95e-14 | 4.6e-14 | 4.62e-14 | 4.62e-14 | 1e-12 AU/day | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `ephemeris.jpl.smallbody.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 1.72e-13 | 1.94e-13 | 2.07e-13 | 2.19e-13 | 1e-11 AU | ✅ verified | 2026-08-29 · `dd92fe32` |
+| `ephemeris.jpl.smallbody.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 3.96e-14 | 4.61e-14 | 4.62e-14 | 4.62e-14 | 1e-12 AU/day | ✅ verified | 2026-08-29 · `dd92fe32` |
 | `ephemeris.sofa.moon` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 3.65e-08 | 4.5e-08 | 4.58e-08 | 4.6e-08 | 4e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
 | `ephemeris.sofa.sun` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 2.03e-08 | 2.76e-08 | 2.82e-08 | 2.84e-08 | 1.5e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
 | `skybrightness.gambons.band_medians` | GAMBONS (Masana, Carrasco, Bara & Ribas) 2021 MNRAS 501, 5443; 2024 | independent | 6 | 0.207 | 0.273 | 0.28 | 0.282 | 1 mag | ✅ verified | 2026-08-29 · `5e53d9fc` |

--- a/ephemeris/core/core.go
+++ b/ephemeris/core/core.go
@@ -233,6 +233,51 @@ const (
 	SolarSystemBarycenter
 )
 
+// SmallBodyBase is the offset that separates numbered small bodies from the
+// named ones, and is NAIF's own convention for asteroid SPK IDs.
+//
+// It exists because the two namespaces used to overlap. A small body was
+// identified by its bare number, so asteroid 4 Vesta and [Mars] were both
+// ID 4 — as were Ceres and [Mercury], Pallas and [Venus], Juno and [Earth],
+// and every asteroid numbered up to [SolarSystemBarycenter] at 12. A provider
+// holding a planetary kernel resolved the planet and silently dropped the
+// asteroid, which took four of the five largest asteroids out of reach with
+// nothing to say why.
+//
+// Untyped on purpose: it is an offset within the ID space rather than a body,
+// so it has no place among the values a switch over an ID should handle.
+const SmallBodyBase = 20000000
+
+// smallBodySpan bounds the small-body block, matching NAIF's own allocation.
+const smallBodySpan = 1000000
+
+// SmallBodyID returns the identifier for the numbered small body n — 433 for
+// Eros, 3200 for Phaethon — placed clear of the named bodies.
+//
+// This is the form [Provider.SupportedBodies] reports. A bare core.ID(433)
+// still resolves, so existing callers keep working, but it cannot be
+// enumerated without ambiguity and is not what a new caller should write.
+//
+// Returns 0 for an n outside NAIF's small-body block, which is not a valid
+// body identifier and will fail to resolve rather than aliasing another body.
+func SmallBodyID(n int) ID {
+	if n <= 0 || n >= smallBodySpan {
+		return 0
+	}
+
+	return SmallBodyBase + ID(n)
+}
+
+// SmallBodyNumber reports the small-body number this ID stands for, and
+// whether it is one at all.
+func (id ID) SmallBodyNumber() (int, bool) {
+	if id <= SmallBodyBase || id >= SmallBodyBase+smallBodySpan {
+		return 0, false
+	}
+
+	return int(id - SmallBodyBase), true
+}
+
 // String returns the conventional name of the body identifier.
 func (id ID) String() string {
 	switch id {
@@ -261,6 +306,10 @@ func (id ID) String() string {
 	case SolarSystemBarycenter:
 		return "SolarSystemBarycenter"
 	default:
+		if n, ok := id.SmallBodyNumber(); ok {
+			return fmt.Sprintf("SmallBody(%d)", n)
+		}
+
 		return fmt.Sprintf("BodyID(%d)", id)
 	}
 }

--- a/ephemeris/core/smallbody_test.go
+++ b/ephemeris/core/smallbody_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSmallBodyIDsDoNotCollideWithNamedBodies is the property this exists
+// for. Asteroid numbers 1 through 12 used to land exactly on the named body
+// identifiers — 4 Vesta on Mars, 1 Ceres on Mercury — so a provider holding
+// a planetary kernel dropped the asteroid as a duplicate.
+func TestSmallBodyIDsDoNotCollideWithNamedBodies(t *testing.T) {
+	named := []ID{
+		Mercury, Venus, Earth, Mars, Jupiter, Saturn,
+		Uranus, Neptune, Pluto, Moon, Sun, SolarSystemBarycenter,
+	}
+
+	for n := 1; n <= 20; n++ {
+		got := SmallBodyID(n)
+
+		for _, id := range named {
+			if got == id {
+				t.Errorf("SmallBodyID(%d) = %d, which collides with %s", n, got, id)
+			}
+		}
+	}
+}
+
+func TestSmallBodyNumberRoundTrip(t *testing.T) {
+	for _, n := range []int{1, 4, 12, 16, 433, 624, 3200, 101955} {
+		id := SmallBodyID(n)
+
+		got, ok := id.SmallBodyNumber()
+		if !ok {
+			t.Errorf("SmallBodyID(%d).SmallBodyNumber() reported not-a-small-body", n)
+
+			continue
+		}
+
+		if got != n {
+			t.Errorf("SmallBodyID(%d) round-tripped to %d", n, got)
+		}
+	}
+}
+
+// TestSmallBodyNumberRejectsOtherIDs keeps the accessor from claiming
+// identifiers that are not small bodies — a named body, and the comet range,
+// which NAIF puts elsewhere.
+func TestSmallBodyNumberRejectsOtherIDs(t *testing.T) {
+	cases := []ID{Mercury, Mars, Sun, SolarSystemBarycenter, 0, 433, 1000036, SmallBodyBase}
+
+	for _, id := range cases {
+		if n, ok := id.SmallBodyNumber(); ok {
+			t.Errorf("ID(%d).SmallBodyNumber() = %d, true; want not-a-small-body", uint32(id), n)
+		}
+	}
+}
+
+func TestSmallBodyIDString(t *testing.T) {
+	if got := SmallBodyID(433).String(); got != "SmallBody(433)" {
+		t.Errorf("SmallBodyID(433).String() = %q, want %q", got, "SmallBody(433)")
+	}
+
+	// Vesta must not print as Mars, which is what the collision did.
+	if got := SmallBodyID(4).String(); got == Mars.String() {
+		t.Errorf("SmallBodyID(4) prints as %q, the same as Mars", got)
+	}
+
+	// A named body is unaffected.
+	if got := Mars.String(); got != "Mars" {
+		t.Errorf("Mars.String() = %q", got)
+	}
+}
+
+func ExampleSmallBodyID() {
+	fmt.Println(SmallBodyID(433))
+	fmt.Println(SmallBodyID(4), "not", Mars)
+	// Output:
+	// SmallBody(433)
+	// SmallBody(4) not Mars
+}
+
+// TestSmallBodyIDRejectsOutOfRange keeps an impossible number from aliasing
+// a real body: returning SmallBodyBase+n for a negative n would wrap into
+// the identifier space of something else entirely.
+func TestSmallBodyIDRejectsOutOfRange(t *testing.T) {
+	for _, n := range []int{0, -1, -433, 1000000, 1 << 40} {
+		if got := SmallBodyID(n); got != 0 {
+			t.Errorf("SmallBodyID(%d) = %d, want 0", n, got)
+		}
+	}
+}

--- a/ephemeris/jpl/jpl_test.go
+++ b/ephemeris/jpl/jpl_test.go
@@ -256,13 +256,16 @@ func TestSmallBodyEros(t *testing.T) {
 
 	// Check if Eros is in supported bodies
 	bodies := p.SupportedBodies()
-	found := slices.Contains(bodies, core.ID(433))
+	// SupportedBodies reports NAIF's own small-body identifier now, not
+	// the bare number, which used to collide with the planets.
+	found := slices.Contains(bodies, core.SmallBodyID(433))
 
 	if !found {
 		t.Errorf("Eros (433) not found in supported bodies: %v", bodies)
 	}
 
 	// Get state
+	// A bare core.ID(433) still resolves, so this stays as it was.
 	state, err := p.State(core.ID(433), start)
 	if err != nil {
 		t.Fatalf("Failed to get state for Eros: %v", err)

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -479,11 +479,13 @@ func (p *Provider) SupportedBodies() []core.ID {
 	var res []core.ID
 
 	for targetID := range p.ByTarget {
+		// A small body keeps NAIF's own 20000000+ identifier rather than
+		// being folded down to its bare number. Subtracting the offset put
+		// asteroid 4 Vesta on core.ID(4), which is Mars, so the body was
+		// dropped from this list as a duplicate — silently, along with
+		// Ceres, Pallas, Juno and every asteroid numbered up to 12. See
+		// [core.SmallBodyBase].
 		bid := core.ID(targetID)
-		// Map back from asteroid ID if needed
-		if targetID > 20000000 && targetID < 21000000 {
-			bid = core.ID(targetID - 20000000)
-		}
 
 		// Check if it's a known body
 		for b, naif := range BodyIDToNAIF {

--- a/ephemeris/jpl/smallbody_collision_test.go
+++ b/ephemeris/jpl/smallbody_collision_test.go
@@ -1,0 +1,85 @@
+//go:build network
+
+package jpl_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	atime "github.com/TuSKan/astrogo/time"
+)
+
+// TestLowNumberedAsteroidsLoad covers the bodies that used to be unreachable.
+//
+// Horizons returns a perfectly good Type 21 kernel for each of these — 72,704
+// bytes, verified — whose segment target is 20000000+number. Folding that
+// down to the bare number put 4 Vesta on core.ID(4), which is Mars, so
+// SupportedBodies saw a duplicate and dropped it. NewProvider then reported
+// ErrNoSmallBodyKernel and blamed the designation, which was never the cause.
+//
+// Ceres, Pallas, Juno and Vesta are four of the five largest asteroids, and
+// none of them could be loaded at all.
+func TestLowNumberedAsteroidsLoad(t *testing.T) {
+	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
+
+	start := atime.FromJD(2460305.5, atime.TDB)
+	stop := atime.FromJD(2460355.5, atime.TDB)
+
+	cases := []struct {
+		number      int
+		designation string
+		name        string
+		collidesAs  core.ID
+	}{
+		{1, "1;", "Ceres", core.Mercury},
+		{2, "2;", "Pallas", core.Venus},
+		{4, "4;", "Vesta", core.Mars},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := jpl.NewProvider(context.Background(), core.SmallBody, c.designation,
+				jpl.WithTimeInterval(start, stop))
+			if err != nil {
+				t.Fatalf("%s (%s): %v", c.name, c.designation, err)
+			}
+
+			defer func() { _ = p.Close() }()
+
+			want := core.SmallBodyID(c.number)
+
+			var found bool
+
+			for _, id := range p.SupportedBodies() {
+				if id == want {
+					found = true
+				}
+			}
+
+			if !found {
+				t.Fatalf("%s not in SupportedBodies: %v", want, p.SupportedBodies())
+			}
+
+			state, err := p.State(want, start)
+			if err != nil {
+				t.Fatalf("State(%s): %v", want, err)
+			}
+
+			// The asteroid must not be the planet it used to collide with.
+			planet, perr := p.State(c.collidesAs, start)
+			if perr != nil {
+				t.Fatalf("State(%s): %v", c.collidesAs, perr)
+			}
+
+			if state.Pos.Sub(planet.Pos).Norm() < 1e-6 {
+				t.Errorf("%s and %s returned the same position", want, c.collidesAs)
+			}
+
+			r := state.Pos.Norm()
+			t.Logf("%s: |r| = %.4f AU (%s is at %.4f AU)", c.name, r, c.collidesAs, planet.Pos.Norm())
+		})
+	}
+}

--- a/ephemeris/jpl/validation/smallbody_spk_test.go
+++ b/ephemeris/jpl/validation/smallbody_spk_test.go
@@ -47,33 +47,35 @@ func smallBodies() []smallBody {
 			why: "main belt at ~3 AU, the slow end of the range",
 		},
 		{
+			id: 1, designation: "1;", name: "Ceres",
+			why: "the largest asteroid, and one of the four that were unreachable until " +
+				"small-body identifiers stopped colliding with the planets",
+		},
+		{
+			id: 4, designation: "4;", name: "Vesta",
+			why: "the collision that exposed the identifier bug: asteroid 4 landed on Mars",
+		},
+		{
 			id: 624, designation: "624;", name: "Hektor",
 			why: "Jupiter trojan at ~5.2 AU, the slowest and most distant case here",
 		},
 	}
 }
 
-// Ceres, Pallas, Juno and Vesta are absent, and the reason is a defect in
-// this repository rather than anything about those bodies.
+// Ceres and Vesta are in the set above deliberately, and were not always
+// loadable.
 //
-// Horizons generates a perfectly good kernel for each — verified, 72,704
-// bytes with a Type 21 segment, for "4;" exactly as for "433;". The segment's
-// target ID is 20000004, which [jpl.Provider.SupportedBodies] maps to a body
-// ID by subtracting 20000000. That gives core.ID(4), and core.ID(4) is Mars:
-// the enum runs Mercury=1, Venus=2, Earth=3, Mars=4. So asteroids 1 through 9
-// land on planet identifiers and the body is silently dropped, taking with it
-// four of the largest and best-observed objects in the solar system.
+// A small body used to be identified by its bare number, so asteroid 4 Vesta
+// and Mars were both core.ID(4) — as were Ceres and Mercury, Pallas and
+// Venus, and every asteroid numbered up to 12. A provider holding a planetary
+// kernel resolved the planet and dropped the asteroid as a duplicate, and
+// ErrNoSmallBodyKernel then blamed the designation, which was never the
+// cause: Horizons returns a perfectly good 72,704-byte Type 21 kernel for
+// "4;". Small bodies now keep NAIF's own 20000000+ identifier — see
+// [core.SmallBodyID] — and the two namespaces cannot overlap.
 //
-// Measured, Mars itself is not corrupted: adding a Vesta kernel to a de440
-// provider changes Mars's position by exactly 0.0 AU, because the lookup goes
-// through BodyIDToNAIF to target 4 and never reaches the asteroid segment.
-// The body is unreachable rather than wrong.
-//
-// What makes it worth naming here is that ErrNoSmallBodyKernel reports it as
-// a designation problem — "Horizons matches small bodies by number ... not by
-// name" — which is exactly what a reader would act on, and is not the cause.
-// Fixing it means deciding how a small body should be identified, which is a
-// public-API question and not one this suite should answer on its own.
+// Keeping the two worst-affected bodies in this suite is the point: they are
+// the cases that would silently disappear again.
 
 // smallBodySPKReference records what this comparison is against.
 //
@@ -192,7 +194,7 @@ func TestSmallBodySPKAgainstHorizons(t *testing.T) {
 				// TestJPLStateAgainstHorizons reads.
 				when := atime.FromJD(2451545.0+ref.ET/86400.0, atime.TDB)
 
-				state, serr := p.State(core.ID(body.id), when)
+				state, serr := p.State(core.SmallBodyID(body.id), when)
 				if serr != nil {
 					t.Errorf("%s: State at JD %.5f: %v", body.name, when.JD(), serr)
 


### PR DESCRIPTION
The bug #60 surfaced and deliberately left alone, because fixing it meant deciding how a small body should be identified.

## Four of the five largest asteroids could not be loaded

A small body was identified by its bare number. The named bodies run `Mercury=1 … SolarSystemBarycenter=12`. So:

| asteroid | resolved as |
| :--- | :--- |
| 1 Ceres | **Mercury** |
| 2 Pallas | **Venus** |
| 3 Juno | **Earth** |
| 4 Vesta | **Mars** |
| … through 12 | … |

`SupportedBodies` folded the segment's `20000004` target down to `4`, saw an identifier the planetary kernel already had, and dropped the asteroid as a duplicate. `NewProvider` then reported `ErrNoSmallBodyKernel` and blamed the **designation** — *"Horizons matches small bodies by number … not by name"* — which is exactly what a reader would act on, and was never the cause. Horizons returns a perfectly good 72,704-byte Type 21 kernel for `4;`, verified byte-for-byte against the one it returns for `433;`.

## Mars was never wrong

Worth stating plainly, because "asteroid 4 is Mars" reads like a wrong-answer bug. It is not. Measured before the fix: adding a Vesta kernel to a de440 provider changed Mars's position by exactly **0.0 AU**, because the lookup goes through `BodyIDToNAIF` to target 4 and never reaches the asteroid segment. The body was unreachable, not corrupted.

## The fix, and why it breaks so little

Small bodies keep NAIF's own `20000000+` identifier instead of being folded down. The namespaces cannot overlap, so nothing is dropped.

`findSegment` already had a `target += 20000000` fallback, which means **a bare `core.ID(433)` still resolves in `State`**. The only behaviour change is what `SupportedBodies` *reports*:

```go
core.SmallBodyID(433)   // was core.ID(433)
```

So only code matching against the enumerated list needs updating — one line in this repository.

New API: `core.SmallBodyID(n)`, `core.SmallBodyBase`, `ID.SmallBodyNumber()`, and `String()` rendering `SmallBody(433)` rather than `BodyID(20000433)`.

`SmallBodyID` returns 0 outside NAIF's block rather than wrapping: `SmallBodyID(-433)` would otherwise land in some other body's identifier space, which is the same class of bug one level down.

## Verified live, not asserted

```
Ceres:  |r| = 3.6463 AU  (Mercury is at 0.6989 AU)
Pallas: |r| = 3.1073 AU  (Venus   is at 1.1502 AU)
Vesta:  |r| = 1.5859 AU  (Mars    is at 2.4387 AU)
```

All three load, at plausible geocentric distances, each clearly distinct from the planet it used to collide with. The test asserts the distinctness rather than only that a state came back.

## The validation suite grows into the fix

#60's suite excluded Ceres, Pallas, Juno and Vesta with a comment explaining they were unreachable. That comment is now wrong, so **Ceres and Vesta are in the set**: six bodies and 66 samples, up from four and 44, at the same **33 mm** agreement.

Keeping the two worst-affected bodies in the suite is the point — they are the cases that would silently disappear again.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, and the default, `validation` and `network` suites — all clean. The accuracy table is regenerated; all 15 rows verified.

Three lint findings on the way through, all real: `exhaustive` wanted `SmallBodyBase` handled in the `String` switch, which is the right complaint about the wrong thing — it is an offset, not a body, so it is untyped now. `gosec` flagged the `int → uint32` conversion, which the range guard resolved. And my insertion had swallowed `String`'s own doc comment, which `revive` caught.
