### PR TITLE
Report Horizons' refusal, and refuse a body it did not send

### DIFF
--- a/changelog.d/62-horizons-refusal.md
+++ b/changelog.d/62-horizons-refusal.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 62
+---
+**A Horizons refusal arrived as success.** Asked to generate an SPK for 101955 Bennu, Horizons answers "SPK creation is not available for pre-computed objects in the major body index" — a complete explanation, which `spk.CacheAPI` never parsed. The caller got an empty kernel list and a nil error, then a misleading complaint about designation syntax that was never wrong. The service's own sentence now reaches the caller as `spk.ErrHorizonsRefused`.

--- a/changelog.d/62-wrong-small-body.md
+++ b/changelog.d/62-wrong-small-body.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 62
+---
+**A bare number could load a different object entirely.** `NewProvider(ctx, core.SmallBody, "1")` returned comet 1000036, not 1 Ceres, because a bare number resolves against Horizons' major-body and comet indices before the numbered-asteroid record — and every mechanical check passed, so nothing said so. A numbered asteroid must now arrive as `core.SmallBodyID(n)` or the load fails with `jpl.ErrWrongSmallBody`.

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/TuSKan/astrogo/ephemeris/core"
@@ -41,6 +43,17 @@ var (
 	// resolves to a different object entirely. Getting that wrong is easy;
 	// getting it wrong silently is what this refuses.
 	ErrNoSmallBodyKernel = errors.New("jpl: no small-body kernel for designation")
+
+	// ErrWrongSmallBody is returned when Horizons answers with a body that
+	// is not the one asked for.
+	//
+	// The load succeeds in every mechanical sense — a kernel arrives, a
+	// segment parses, a new body appears — and the object is simply somebody
+	// else. Asking for "1" returns comet 1000036 rather than 1 Ceres,
+	// because a bare number resolves against the major-body and comet
+	// indices first; "DES=433;" returns 248370 rather than Eros. Both are
+	// quieter than a failure and worse.
+	ErrWrongSmallBody = errors.New("jpl: horizons returned a different small body")
 )
 
 // KMPerAU is the number of kilometers per astronomical unit.
@@ -522,15 +535,60 @@ func (p *Provider) loadSmallBodyKernels(readers []*spk.Reader) error {
 		}
 	}
 
-	if len(p.SupportedBodies()) == before {
+	after := p.SupportedBodies()
+
+	if len(after) == before {
 		return fmt.Errorf("%w: %q added no body to the %d already in the planetary "+
 			"base kernel; Horizons matches small bodies by number (\"433\") or by its own "+
-			"designation syntax (\"433;\"), not by name, and some numbers it accepts return "+
-			"a kernel with no small-body segment",
+			"designation syntax (\"433;\"), not by name",
 			ErrNoSmallBodyKernel, p.kernel, before)
 	}
 
-	return nil
+	return p.verifyRequestedBodyLoaded(after)
+}
+
+// numberedAsteroid reports the asteroid number a designation names, and
+// whether it names one at all. "433" and "433;" both name 433; a provisional
+// designation or a comet fragment names nothing predictable.
+func numberedAsteroid(designation string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSuffix(designation, ";"))
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+
+	return n, true
+}
+
+// verifyRequestedBodyLoaded checks that the body loaded is the body asked
+// for, when the designation says which one that is.
+//
+// A bare number is ambiguous to Horizons: it resolves against the major-body
+// and comet indices before the numbered-asteroid record, so asking for "1"
+// returns comet 1000036 rather than 1 Ceres — and the load succeeds, because
+// a body genuinely was added. The caller then works with a different object
+// entirely, which is the same failure as "DES=433;" resolving to 248370
+// rather than Eros.
+//
+// A numbered asteroid has a knowable identifier, so this is checkable rather
+// than a matter of trusting the syntax: asteroid n must arrive as
+// [core.SmallBodyID](n). A designation that is not a bare number — a comet
+// fragment, a provisional designation — names nothing this can predict and
+// is left alone.
+func (p *Provider) verifyRequestedBodyLoaded(loaded []core.ID) error {
+	n, ok := numberedAsteroid(p.kernel)
+	if !ok {
+		return nil
+	}
+
+	want := core.SmallBodyID(n)
+	if slices.Contains(loaded, want) {
+		return nil
+	}
+
+	return fmt.Errorf("%w: asked for %q and Horizons returned %v, which does not include %s; "+
+		"a bare number resolves against the major-body and comet indices before the "+
+		"numbered-asteroid record, so the object loaded is not the one requested",
+		ErrWrongSmallBody, p.kernel, loaded, want)
 }
 
 // addKernelPath is AddKernel with a known file path, used internally by

--- a/ephemeris/jpl/smallbody_designation_guard_test.go
+++ b/ephemeris/jpl/smallbody_designation_guard_test.go
@@ -1,0 +1,105 @@
+//go:build network
+
+package jpl_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	atime "github.com/TuSKan/astrogo/time"
+)
+
+// TestBareNumberDoesNotReturnADifferentBody covers the quietest failure this
+// path had.
+//
+// Asking Horizons for "1" returns comet 1000036, not 1 Ceres, because a bare
+// number resolves against the major-body and comet indices before the
+// numbered-asteroid record. Every mechanical check passed: a kernel arrived,
+// a segment parsed, and a new body appeared in SupportedBodies. The caller
+// simply got somebody else, and nothing said so.
+func TestBareNumberDoesNotReturnADifferentBody(t *testing.T) {
+	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
+
+	start := atime.FromJD(2460305.5, atime.TDB)
+	stop := atime.FromJD(2460355.5, atime.TDB)
+
+	p, err := jpl.NewProvider(context.Background(), core.SmallBody, "1",
+		jpl.WithTimeInterval(start, stop))
+	if err == nil {
+		bodies := p.SupportedBodies()
+
+		_ = p.Close()
+
+		t.Fatalf(`NewProvider(..., "1") succeeded with bodies %v; it must not hand back `+
+			`whatever Horizons resolves a bare "1" to`, bodies)
+	}
+
+	if !errors.Is(err, jpl.ErrWrongSmallBody) {
+		t.Fatalf(`NewProvider(..., "1") = %v, want ErrWrongSmallBody`, err)
+	}
+
+	t.Logf("refused as it should: %v", err)
+}
+
+// TestSemicolonDesignationLoadsTheRequestedBody is the other half: the guard
+// must not reject the form that works.
+func TestSemicolonDesignationLoadsTheRequestedBody(t *testing.T) {
+	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
+
+	start := atime.FromJD(2460305.5, atime.TDB)
+	stop := atime.FromJD(2460355.5, atime.TDB)
+
+	for _, designation := range []string{"1;", "433;", "433"} {
+		t.Run(designation, func(t *testing.T) {
+			p, err := jpl.NewProvider(context.Background(), core.SmallBody, designation,
+				jpl.WithTimeInterval(start, stop))
+			if err != nil {
+				t.Fatalf("%q: %v", designation, err)
+			}
+
+			defer func() { _ = p.Close() }()
+
+			t.Logf("%q -> %v", designation, p.SupportedBodies())
+		})
+	}
+}
+
+// TestHorizonsRefusalIsReported covers the other silent mode: Horizons
+// answering with an explanation that was thrown away.
+//
+// Asked for 101955 Bennu it says "SPK creation is not available for
+// pre-computed objects in the major body index" — a complete answer, which
+// arrived as an empty kernel list and a nil error, leaving the caller to
+// guess at designation syntax that was never wrong.
+func TestHorizonsRefusalIsReported(t *testing.T) {
+	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
+
+	start := atime.FromJD(2460305.5, atime.TDB)
+	stop := atime.FromJD(2460355.5, atime.TDB)
+
+	p, err := jpl.NewProvider(context.Background(), core.SmallBody, "101955;",
+		jpl.WithTimeInterval(start, stop))
+	if err == nil {
+		_ = p.Close()
+
+		t.Skip("Horizons now generates an SPK for 101955; the refusal this covers is gone")
+	}
+
+	if !errors.Is(err, spk.ErrHorizonsRefused) {
+		t.Fatalf("NewProvider for 101955; = %v, want ErrHorizonsRefused", err)
+	}
+
+	// The service's own sentence has to survive to the caller, because it
+	// is more specific than anything this package could infer.
+	if !strings.Contains(err.Error(), "pre-computed objects") {
+		t.Errorf("error does not carry Horizons' explanation: %v", err)
+	}
+
+	t.Logf("reported: %v", err)
+}

--- a/ephemeris/jpl/smallbody_designation_test.go
+++ b/ephemeris/jpl/smallbody_designation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	atime "github.com/TuSKan/astrogo/time"
 )
@@ -24,25 +25,36 @@ import (
 // way to notice was to ask for a state and get ErrNoSegment much later, in
 // code far from the mistake.
 //
-// Counting readers is not sufficient either: "1;" and "4;" both return a
-// non-empty kernel carrying no small-body segment, so the check is on the
-// body set rather than on the file.
+// Counting readers is not sufficient either: a non-empty kernel can still
+// carry no small-body segment, so the check is on the body set rather than
+// on the file.
+//
+// Two cases moved out of this list as the causes behind them were fixed.
+// "1;" is no longer a failure at all: it returned a kernel whose segment
+// target was 20000001, which the identifier collision folded onto core.ID(1)
+// — Mercury — so the body was dropped as a duplicate. It now loads Ceres,
+// and is covered by TestSemicolonDesignationLoadsTheRequestedBody. "Ceres"
+// still fails, but with ErrHorizonsRefused: Horizons explains itself, and
+// that explanation now reaches the caller rather than being discarded.
 func TestSmallBodyDesignationFailuresAreLoud(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
 	start := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
 
-	for _, des := range []string{
-		"Ceres",     // a name: Horizons matches small bodies by number
-		"bogus-xyz", // nothing at all
-		"1;",        // valid syntax, kernel with no small-body segment
+	for _, tc := range []struct {
+		des  string
+		want error
+		why  string
+	}{
+		{"bogus-xyz", jpl.ErrNoSmallBodyKernel, "nothing at all"},
+		{"Ceres", spk.ErrHorizonsRefused, "a name: Horizons matches small bodies by number, and says so"},
 	} {
-		t.Run(des, func(t *testing.T) {
-			_, err := jpl.NewProvider(context.Background(), core.SmallBody, des,
+		t.Run(tc.des, func(t *testing.T) {
+			_, err := jpl.NewProvider(context.Background(), core.SmallBody, tc.des,
 				jpl.WithTimeInterval(start.AddDays(-5), start.AddDays(5)))
 
-			if !errors.Is(err, jpl.ErrNoSmallBodyKernel) {
-				t.Fatalf("NewProvider(%q) error = %v, want ErrNoSmallBodyKernel", des, err)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("NewProvider(%q) error = %v, want %v (%s)", tc.des, err, tc.want, tc.why)
 			}
 		})
 	}

--- a/ephemeris/jpl/spk/api.go
+++ b/ephemeris/jpl/spk/api.go
@@ -38,6 +38,15 @@ type HorizonsResponse struct {
 	} `json:"signature"`
 	Spk       string `json:"spk"`
 	SpkFileID string `json:"spk_file_id"`
+
+	// Error is Horizons' own explanation when it declines a request.
+	//
+	// It was not parsed at all, so a refusal arrived as an empty kernel
+	// list and a nil error, and the caller was left to guess. Horizons is
+	// specific when it declines — for 101955 Bennu it answers "SPK creation
+	// is not available for pre-computed objects in the major body index" —
+	// and that sentence is worth more than anything this package can infer.
+	Error string `json:"error"`
 }
 
 // maxNumberedAsteroidRecord is Horizons' own documented ceiling for a bare
@@ -135,7 +144,10 @@ func CacheAPI(ctx context.Context, bucket *file.Bucket, prefix, kernel string, s
 	// plan.VisibleTonight's Stage 2) takes this path, so skipping the
 	// doomed bare attempt roughly halves live network round trips for
 	// that real workload.
-	var resp *HorizonsResponse
+	var (
+		resp    *HorizonsResponse
+		refusal string
+	)
 
 	for _, command := range commandCandidates(kernel) {
 		r, err := apiHorizonsRequest(ctx, command, startTime, endTime)
@@ -147,6 +159,17 @@ func CacheAPI(ctx context.Context, bucket *file.Bucket, prefix, kernel string, s
 		if resp.SpkFileID != "" && resp.Spk != "" {
 			break
 		}
+
+		if r.Error != "" {
+			refusal = r.Error
+		}
+	}
+
+	// Horizons answered, and declined. Say why it declined rather than
+	// returning an empty list with a nil error, which reads as success and
+	// surfaces much later as a body that is simply missing.
+	if refusal != "" && (resp == nil || resp.Spk == "") {
+		return nil, fmt.Errorf("%w: %s (kernel %q)", ErrHorizonsRefused, collapseWhitespace(refusal), kernel)
 	}
 
 	if resp.SpkFileID != "" && resp.Spk != "" {
@@ -360,4 +383,13 @@ func openKernel(ctx context.Context, bucket *file.Bucket, key string) (*Reader, 
 	}
 
 	return reader, nil
+}
+
+// collapseWhitespace folds Horizons' multi-line refusal onto one line.
+//
+// The service formats these for a terminal, with embedded newlines and runs
+// of spaces; an error string carrying those wraps badly in a log and reads as
+// several failures rather than one.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }

--- a/ephemeris/jpl/spk/errors.go
+++ b/ephemeris/jpl/spk/errors.go
@@ -15,6 +15,18 @@ var (
 	// ErrHorizonsUnexpected indicates an unexpected HTTP status from JPL Horizons.
 	ErrHorizonsUnexpected = errors.New("jpl: horizons unexpected status")
 
+	// ErrHorizonsRefused is returned when Horizons answers a request and
+	// declines it, carrying the service's own explanation.
+	//
+	// It exists because a refusal used to arrive as an empty kernel list and
+	// a nil error, which reads as success: the provider carried on with only
+	// its planetary base, and the caller learned about it much later as a
+	// body that was simply missing. Horizons is specific about why — asked
+	// for 101955 Bennu it answers "SPK creation is not available for
+	// pre-computed objects in the major body index" — and discarding that
+	// left the caller to guess at designation syntax that was never wrong.
+	ErrHorizonsRefused = errors.New("jpl: horizons declined to generate an SPK")
+
 	// ErrCorruptSPK indicates a malformed SPK binary kernel.
 	ErrCorruptSPK = errors.New("jpl/spk: corrupt file")
 	// ErrInvalidWordBounds indicates invalid double-precision word boundaries in an SPK record.


### PR DESCRIPTION
The two items flagged at the end of #61. Both are ways a small-body load could **succeed while being wrong**, which is the failure mode this repository keeps finding.

## Horizons explained itself and we threw it away

Asked to generate an SPK for 101955 Bennu, Horizons answers:

> SPK creation is not available for pre-computed objects in the major body index

That is a complete answer. `HorizonsResponse` had no field for `error`, so it was never parsed — the caller got an **empty kernel list and a nil error**, and then `ErrNoSmallBodyKernel` blaming designation syntax that was never wrong.

The service's own sentence now reaches the caller as `spk.ErrHorizonsRefused`, collapsed onto one line because Horizons formats these for a terminal and an embedded newline reads as several failures rather than one.

## A bare number could hand back a different object

```go
jpl.NewProvider(ctx, core.SmallBody, "1")   // returns comet 1000036, not 1 Ceres
```

A bare number is matched against Horizons' major-body and comet indices **before** the numbered-asteroid record. Every mechanical check passed: a kernel arrived, a segment parsed, a new body appeared in `SupportedBodies`. The caller simply worked with somebody else, and nothing said so.

Same failure as `DES=433;` resolving to 248370 rather than Eros, found in #51. Quieter than an error, and worse.

**The check is on the result, not the syntax.** A numbered asteroid has a knowable identifier: asteroid *n* must arrive as `core.SmallBodyID(n)`, or the load fails with `jpl.ErrWrongSmallBody`. Guessing at which designation forms are safe would have been another rule to get wrong; verifying what came back cannot be. A designation that is not a bare number names nothing predictable and is left alone.

```
refused as it should: jpl: horizons returned a different small body:
  asked for "1" and Horizons returned [Earth Jupiter Uranus ...],
  which does not include SmallBody(1)
```

## An existing test loses two cases, and should

`TestSmallBodyDesignationFailuresAreLoud` failed after these changes. Both cases were pinning the *symptom of a defect*, not a property worth keeping:

- **`"1;"` is no longer a failure at all.** Its kernel's segment target is 20000001, which the identifier collision fixed in #61 folded onto `core.ID(1)` — Mercury — so the body was dropped as a duplicate. It now loads Ceres, and is covered by the new `TestSemicolonDesignationLoadsTheRequestedBody`.
- **`"Ceres"` still fails**, but with the more specific `ErrHorizonsRefused` rather than `ErrNoSmallBodyKernel`.

The comment about "some numbers it accepts return a kernel with no small-body segment" was describing the collision bug, not a Horizons quirk. It is gone.

## A pre-existing failure I did not touch

While running the full network suite: **`TestGenerateCorpus` fails on `main`**, and has nothing to do with this branch — I checked out `main` and reproduced it.

15 of 255 entries differ, all at one epoch, **JD 2461390.5 = 2026-12-16**, by 3e-5 to 8e-5 degrees in azimuth and elevation. That is a future date, so Horizons' answer depends on *predicted* Earth orientation, which has firmed up since the corpus was generated on 2026-08-28.

The generator's guard is working exactly as designed — it refuses to overwrite silently. But an entry whose reference value is a prediction cannot be compared byte-for-byte against a fresh fetch, so this test now fails permanently, which is as useless as one that can never fail. Worth fixing separately; I did not want to fold a corpus change into this.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, the default suite, and the `network` suite for `ephemeris/...` — clean apart from the pre-existing `TestGenerateCorpus` above.

`nilerr` caught the shape of the new guard: a `strconv.Atoi` error used as a predicate reads like a swallowed failure. It is an explicit `numberedAsteroid(designation) (int, bool)` now, which is what it always meant.
