### PR TITLE
Sample the Horizons corpus only at settled epochs

### DIFF
--- a/changelog.d/63-corpus-settled-epochs.md
+++ b/changelog.d/63-corpus-settled-epochs.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 63
+---
+**The Horizons corpus sampled epochs whose reference values were still moving.** Its regular span ran to 2027-01-01, so the last epoch depended on *predicted* Earth orientation and shifted by up to 8.4e-05 degrees after generation — `TestGenerateCorpus` then reported a dirty diff on every run, for a corpus nobody had touched. The span now ends well inside the settled past, and `TestCorpusEpochsAreSettled` enforces it. 255 entries become 300, all with final Earth orientation.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -49,21 +49,21 @@ generated table existed.
 
 | Suite | Reference | Independence | N | p50 | p95 | p99 | Max | Contract | Status | Last verified |
 |---|---|---|---:|---:|---:|---:|---:|---:|---|---|
-| `coord.rv.barycentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `coord.rv.heliocentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `coord.topocentric.corpus` | JPL Horizons OBSERVER + VECTORS, AIRLESS | independent | 103 | 0.433 | 1.9 | 1.99 | 2.07 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `coord.topocentric.crosstrack` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.379 | 1.88 | 1.93 | 1.96 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `coord.topocentric.elevation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.0665 | 0.272 | 0.352 | 0.372 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `coord.topocentric.separation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.388 | 1.88 | 1.94 | 1.97 | 3 arcsec | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.jpl.horizons.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 5.49e-14 | 4.05e-12 | 4.41e-12 | 4.5e-12 | 1e-09 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.jpl.horizons.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 1.22e-14 | 9.02e-13 | 9.81e-13 | 1e-12 | 1e-10 AU/day | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.jpl.smallbody.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 1.72e-13 | 1.94e-13 | 2.07e-13 | 2.19e-13 | 1e-11 AU | ✅ verified | 2026-08-29 · `dd92fe32` |
-| `ephemeris.jpl.smallbody.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 3.96e-14 | 4.61e-14 | 4.62e-14 | 4.62e-14 | 1e-12 AU/day | ✅ verified | 2026-08-29 · `dd92fe32` |
-| `ephemeris.sofa.moon` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 3.65e-08 | 4.5e-08 | 4.58e-08 | 4.6e-08 | 4e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `ephemeris.sofa.sun` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 2.03e-08 | 2.76e-08 | 2.82e-08 | 2.84e-08 | 1.5e-07 AU | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `skybrightness.gambons.band_medians` | GAMBONS (Masana, Carrasco, Bara & Ribas) 2021 MNRAS 501, 5443; 2024 | independent | 6 | 0.207 | 0.273 | 0.28 | 0.282 | 1 mag | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `time.scale.roundtrip.arithmetic` | scale round trip, A to B and back | independent | 120 | 0 | 9.41e-12 | 9.59e-12 | 9.59e-12 | 1e-06 s | ✅ verified | 2026-08-29 · `5e53d9fc` |
-| `time.scale.roundtrip.modelled` | scale round trip, A to B and back | independent | 180 | 0 | 6.83e-06 | 0.943 | 0.943 | 5 s | ✅ verified | 2026-08-29 · `5e53d9fc` |
+| `coord.rv.barycentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `coord.rv.heliocentric` | Astropy SkyCoord.radial_velocity_correction 8.0.1 | shares SOFA/ERFA epv00 — consistency check | 175 | 3.64e-07 | 1.93e-06 | 2.1e-06 | 2.42e-06 | 0.001 km/s | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `coord.topocentric.corpus` | JPL Horizons OBSERVER + VECTORS, AIRLESS | independent | 116 | 0.434 | 1.92 | 2.11 | 2.15 | 3 arcsec | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `coord.topocentric.crosstrack` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.379 | 1.88 | 1.93 | 1.96 | 3 arcsec | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `coord.topocentric.elevation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.0665 | 0.272 | 0.352 | 0.372 | 3 arcsec | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `coord.topocentric.separation` | JPL Horizons OBSERVER ephemeris, AIRLESS | independent | 68 | 0.388 | 1.88 | 1.94 | 1.97 | 3 arcsec | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.jpl.horizons.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 5.49e-14 | 4.05e-12 | 4.41e-12 | 4.5e-12 | 1e-09 AU | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.jpl.horizons.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL DE — consistency check | 3 | 1.22e-14 | 9.02e-13 | 9.81e-13 | 1e-12 | 1e-10 AU/day | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.jpl.smallbody.position` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 1.72e-13 | 1.94e-13 | 2.07e-13 | 2.19e-13 | 1e-11 AU | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.jpl.smallbody.velocity` | JPL Horizons VECTORS, geocentric, ICRF | shares JPL small-body solution — consistency check | 66 | 3.96e-14 | 4.61e-14 | 4.62e-14 | 4.62e-14 | 1e-12 AU/day | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.sofa.moon` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 3.65e-08 | 4.5e-08 | 4.58e-08 | 4.6e-08 | 4e-07 AU | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `ephemeris.sofa.sun` | gofa (Epv00 / Moon98) v1.19.1 | shares SOFA — consistency check | 3 | 2.03e-08 | 2.76e-08 | 2.82e-08 | 2.84e-08 | 1.5e-07 AU | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `skybrightness.gambons.band_medians` | GAMBONS (Masana, Carrasco, Bara & Ribas) 2021 MNRAS 501, 5443; 2024 | independent | 6 | 0.207 | 0.273 | 0.28 | 0.282 | 1 mag | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `time.scale.roundtrip.arithmetic` | scale round trip, A to B and back | independent | 120 | 0 | 9.41e-12 | 9.59e-12 | 9.59e-12 | 1e-06 s | ✅ verified | 2026-08-29 · `c6e09cf0` |
+| `time.scale.roundtrip.modelled` | scale round trip, A to B and back | independent | 180 | 0 | 6.83e-06 | 0.943 | 0.943 | 5 s | ✅ verified | 2026-08-29 · `c6e09cf0` |
 
 Every figure above is a **measured** value over the corpus named in its suite, not a bound. The contract column is the bound, and it is a separate claim: it says what the software must achieve and why, and it does not move when a measurement does. See `internal/metrology` for the reasoning, and each suite's own doc comment for the rationale behind its contract.
 

--- a/ephemeris/jpl/validation/corpus/horizons.json
+++ b/ephemeris/jpl/validation/corpus/horizons.json
@@ -1,8 +1,8 @@
 {
   "manifest": {
     "schema_version": 1,
-    "generated": "2026-08-28T12:22:49Z",
-    "astrogo_commit": "3536d3cd8846848375a7d9694948f232306d22a7",
+    "generated": "2026-08-29T20:35:56Z",
+    "astrogo_commit": "c6e09cf0f655a925fe7a7d70a724eb0a80512906",
     "reference": "JPL Horizons (https://ssd.jpl.nasa.gov/api/horizons.api)",
     "reference_query": "EPHEM_TYPE=OBSERVER CENTER='coord@399' QUANTITIES='1,2,4,20' CAL_FORMAT=JD; EPHEM_TYPE=VECTORS CENTER='@399' OUT_UNITS=AU-D REF_PLANE=FRAME VEC_TABLE=2 TIME_TYPE=UT",
     "refraction": "AIRLESS — no APPARENT parameter is sent, so Horizons applies its default and states it in the response header",
@@ -43,7 +43,7 @@
         "provenance": "synthetic; targets transit near the zenith, where azimuth is ill-conditioned"
       }
     ],
-    "sampling": "regular: even sampling across three years, which is what catches secular drift (2024-01-01 00:00..2027-01-01 00:00 step 120d); boundary: straddles the 2017-01-01 leap second: the day before, the day of, and the day after (2016-12-30 00:00..2017-01-02 00:00 step 1d); boundary: straddles J2000.0, the origin every reduction in the pipeline is expressed against (1999-12-31 12:00..2000-01-02 12:00 step 1d); no pseudo-random class: Horizons serves evenly spaced series, so each random epoch would cost its own request for no coverage that boundary and adversarial sampling do not already provide",
+    "sampling": "regular: even sampling across four years, which is what catches secular drift, and ends far enough in the past that every epoch has final Earth orientation rather than a prediction (2021-01-01 00:00..2025-01-01 00:00 step 120d); boundary: straddles the 2017-01-01 leap second: the day before, the day of, and the day after (2016-12-30 00:00..2017-01-02 00:00 step 1d); boundary: straddles J2000.0, the origin every reduction in the pipeline is expressed against (1999-12-31 12:00..2000-01-02 12:00 step 1d); no pseudo-random class: Horizons serves evenly spaced series, so each random epoch would cost its own request for no coverage that boundary and adversarial sampling do not already provide",
     "not_pinned": [
       "planetary kernel and its hash: no astrogo kernel takes part in producing these values, and the consumer feeds the geocentric state through a linear mock provider on purpose",
       "Earth-orientation data: the consumer builds a coord.Context and so depends on whichever IERS series is on the machine when the comparison runs"
@@ -237,25 +237,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        3.659031087292524,
-        2.409382612596195,
-        0.9433772420100425
+        3.220614359853353,
+        -4.617549006443141,
+        -2.057563082241604
       ],
       "geo_velocity_au_per_day": [
-        0.01175899473570973,
-        0.00786081439847964,
-        0.003515247056181798
+        0.0231595350515104,
+        0.007456468014043755,
+        0.003065443138537445
       ],
       "observed": {
-        "astro_ra_deg": 33.36095833333333,
-        "astro_dec_deg": 12.151194444444444,
-        "app_ra_deg": 33.685,
-        "app_dec_deg": 12.264027777777779,
-        "azimuth_deg": 283.338445,
-        "elevation_deg": 22.965507,
-        "range_au": 4.48148703765879
+        "astro_ra_deg": 304.89191666666665,
+        "astro_dec_deg": -20.07675,
+        "app_ra_deg": 305.1856666666667,
+        "app_dec_deg": -20.012194444444443,
+        "azimuth_deg": 228.513455,
+        "elevation_deg": -58.895382,
+        "range_au": 5.99403787242308
       }
     },
     {
@@ -263,25 +263,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        3.554017105697379,
-        4.447763497539288,
-        1.841624016701625
+        4.470143222516899,
+        -2.528960629807749,
+        -1.171239066425376
       ],
       "geo_velocity_au_per_day": [
-        -0.0171007066134842,
-        0.01631100602118493,
-        0.007205854869956682
+        -0.005849165673825978,
+        0.01751165444948337,
+        0.007441101576084937
       ],
       "observed": {
-        "astro_ra_deg": 51.37041666666667,
-        "astro_dec_deg": 17.92413888888889,
-        "app_ra_deg": 51.708875000000006,
-        "app_dec_deg": 18.008583333333334,
-        "azimuth_deg": 324.754429,
-        "elevation_deg": -67.755888,
-        "range_au": 5.98378996952984
+        "astro_ra_deg": 330.4992083333333,
+        "astro_dec_deg": -12.847305555555556,
+        "app_ra_deg": 330.7794166666667,
+        "app_dec_deg": -12.746388888888887,
+        "azimuth_deg": 103.677636,
+        "elevation_deg": -21.079141,
+        "range_au": 5.26777085575515
       }
     },
     {
@@ -289,25 +289,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        1.058906415658519,
-        4.677115991383578,
-        1.958628432836888
+        3.32634876872877,
+        -2.043815739744144,
+        -0.9775249140254597
       ],
       "geo_velocity_au_per_day": [
-        -0.01407636378699276,
-        -0.01124723975050244,
-        -0.00471842712636332
+        -0.002890398726048254,
+        -0.00807882648471369,
+        -0.003627773464902677
       ],
       "observed": {
-        "astro_ra_deg": 77.241,
-        "astro_dec_deg": 22.21636111111111,
-        "app_ra_deg": 77.60962500000001,
-        "app_dec_deg": 22.24863888888889,
-        "azimuth_deg": 67.383316,
-        "elevation_deg": -10.081367,
-        "range_au": 5.18000408675271
+        "astro_ra_deg": 328.42949999999996,
+        "astro_dec_deg": -14.05802777777778,
+        "app_ra_deg": 328.72433333333333,
+        "app_dec_deg": -13.955305555555555,
+        "azimuth_deg": 211.315519,
+        "elevation_deg": 73.603109,
+        "range_au": 4.02456257761902
       }
     },
     {
@@ -315,25 +315,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        1.175501201631793,
-        3.6686645807608,
-        1.541318908321323
+        4.732841808699676,
+        -2.540790035225524,
+        -1.206488160278314
       ],
       "geo_velocity_au_per_day": [
-        0.009978816299972989,
-        0.003016863174536286,
-        0.001480180734514877
+        0.02009746356054267,
+        0.008275852410189669,
+        0.00348864642449044
       ],
       "observed": {
-        "astro_ra_deg": 72.23070833333334,
-        "astro_dec_deg": 21.80591666666667,
-        "app_ra_deg": 72.60933333333332,
-        "app_dec_deg": 21.850805555555556,
-        "azimuth_deg": 316.48844,
-        "elevation_deg": 59.122771,
-        "range_au": 4.14925348383339
+        "astro_ra_deg": 331.76837500000005,
+        "astro_dec_deg": -12.659361111111112,
+        "app_ra_deg": 332.056,
+        "app_dec_deg": -12.55463888888889,
+        "azimuth_deg": 255.024241,
+        "elevation_deg": -32.734693,
+        "range_au": 5.50561392432748
       }
     },
     {
@@ -341,25 +341,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        1.019647022735552,
-        5.230845150711308,
-        2.239940777054897
+        5.704588499328,
+        -0.2660622501131578,
+        -0.2303531261482116
       ],
       "geo_velocity_au_per_day": [
-        -0.01714889336320539,
-        0.01356208512337897,
-        0.006063030985161307
+        -0.008389130028348964,
+        0.02008548978719906,
+        0.0086404499993086
       ],
       "observed": {
-        "astro_ra_deg": 78.966625,
-        "astro_dec_deg": 22.797,
-        "app_ra_deg": 79.34466666666665,
-        "app_dec_deg": 22.825777777777777,
-        "azimuth_deg": 300.298112,
-        "elevation_deg": -39.741062,
-        "range_au": 5.78094708160176
+        "astro_ra_deg": 357.32754166666666,
+        "astro_dec_deg": -2.310861111111111,
+        "app_ra_deg": 357.6057916666666,
+        "app_dec_deg": -2.190138888888889,
+        "azimuth_deg": 93.690063,
+        "elevation_deg": -53.573635,
+        "range_au": 5.71543997819572
       }
     },
     {
@@ -367,25 +367,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -1.595829972383448,
-        5.160509381191641,
-        2.231781257735082
+        4.075898642678372,
+        0.5232831210404036,
+        0.1058808442733735
       ],
       "geo_velocity_au_per_day": [
-        -0.01595075868375904,
-        -0.01429870375834157,
-        -0.006011205092435462
+        -0.008318684437688297,
+        -0.006417118678976323,
+        -0.002813766406305089
       ],
       "observed": {
-        "astro_ra_deg": 107.18129166666668,
-        "astro_dec_deg": 22.449,
-        "app_ra_deg": 107.56333333333333,
-        "app_dec_deg": 22.409138888888886,
-        "azimuth_deg": 59.296688,
-        "elevation_deg": -41.70169,
-        "range_au": 5.84449843102464
+        "astro_ra_deg": 7.313833333333333,
+        "astro_dec_deg": 1.4749444444444446,
+        "app_ra_deg": 7.605666666666666,
+        "app_dec_deg": 1.6008055555555556,
+        "azimuth_deg": 87.234706,
+        "elevation_deg": 54.617019,
+        "range_au": 4.11066036697513
       }
     },
     {
@@ -393,25 +393,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        -1.631382522580588,
-        3.634065377489432,
-        1.592568744257962
+        4.850707865785497,
+        0.03005800495028349,
+        -0.1096738046085555
       ],
       "geo_velocity_au_per_day": [
-        0.01021883804280087,
-        -0.002105229133106922,
-        -0.0007262166495747829
+        0.01592589431743472,
+        0.00711926233931227,
+        0.003088865563731987
       ],
       "observed": {
-        "astro_ra_deg": 114.17358333333333,
-        "astro_dec_deg": 21.79191666666667,
-        "app_ra_deg": 114.56645833333333,
-        "app_dec_deg": 21.733166666666666,
-        "azimuth_deg": 46.400538,
-        "elevation_deg": 57.524045,
-        "range_au": 4.28994290460832
+        "astro_ra_deg": 0.3521666666666667,
+        "astro_dec_deg": -1.2962222222222222,
+        "app_ra_deg": 0.6436666666666666,
+        "app_dec_deg": -1.1696944444444446,
+        "azimuth_deg": 268.830296,
+        "elevation_deg": 0.111752,
+        "range_au": 4.85208512380402
       }
     },
     {
@@ -419,25 +419,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        -1.584381350650671,
-        4.697794396433091,
-        2.075641923365488
+        5.449944812238964,
+        2.231312704099765,
+        0.8471096353390408
       ],
       "geo_velocity_au_per_day": [
-        -0.01497908586249715,
-        0.01080629594872169,
-        0.004863538740503643
+        -0.01136151966045957,
+        0.02041525220793278,
+        0.008889719488252665
       ],
       "observed": {
-        "astro_ra_deg": 108.63408333333334,
-        "astro_dec_deg": 22.717527777777775,
-        "app_ra_deg": 109.02975,
-        "app_dec_deg": 22.672555555555558,
-        "azimuth_deg": 292.929987,
-        "elevation_deg": -8.362228,
-        "range_au": 5.37477831974306
+        "astro_ra_deg": 22.26275,
+        "astro_dec_deg": 8.184555555555555,
+        "app_ra_deg": 22.559916666666666,
+        "app_dec_deg": 8.302138888888889,
+        "azimuth_deg": 36.72398,
+        "elevation_deg": -79.621635,
+        "range_au": 5.94967653545581
       }
     },
     {
@@ -445,25 +445,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -4.056189219430359,
-        4.360980463335164,
-        1.950459391246745
+        3.316824080862674,
+        3.063850093548056,
+        1.214782729339548
       ],
       "geo_velocity_au_per_day": [
-        -0.01572408222991063,
-        -0.01680004268593127,
-        -0.00711579704667975
+        -0.0137020169175737,
+        -0.006853735673413031,
+        -0.002898252686048443
       ],
       "observed": {
-        "astro_ra_deg": 132.92379166666666,
-        "astro_dec_deg": 18.13372222222222,
-        "app_ra_deg": 133.29783333333333,
-        "app_dec_deg": 18.034833333333335,
-        "azimuth_deg": 34.799587,
-        "elevation_deg": -67.850492,
-        "range_au": 6.26700076698708
+        "astro_ra_deg": 42.727583333333335,
+        "astro_dec_deg": 15.057194444444445,
+        "app_ra_deg": 43.053250000000006,
+        "app_dec_deg": 15.155027777777779,
+        "azimuth_deg": 74.40103,
+        "elevation_deg": 13.537625,
+        "range_au": 4.67586081999668
       }
     },
     {
@@ -471,25 +471,103 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -4.017557776247482,
-        2.398845706204791,
-        1.119005442189166
+        3.478926283349484,
+        2.32189125009488,
+        0.9038511183238048
       ],
       "geo_velocity_au_per_day": [
-        0.01215825387064964,
-        -0.006493228530330381,
-        -0.002663667759503783
+        0.0120600714032732,
+        0.003794836115861949,
+        0.001749827460276976
       ],
       "observed": {
-        "astro_ra_deg": 149.157125,
-        "astro_dec_deg": 13.450111111111111,
-        "app_ra_deg": 149.52629166666668,
-        "app_dec_deg": 13.320083333333333,
-        "azimuth_deg": 75.344847,
-        "elevation_deg": 24.406973,
-        "range_au": 4.81111543758063
+        "astro_ra_deg": 33.716833333333334,
+        "astro_dec_deg": 12.193194444444444,
+        "app_ra_deg": 34.041583333333335,
+        "app_dec_deg": 12.305750000000002,
+        "azimuth_deg": 285.611235,
+        "elevation_deg": 37.629115,
+        "range_au": 4.27914015797418
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        3.78293409959322,
+        4.18493361183619,
+        1.725693520662671
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01331924144483628,
+        0.01860055439281013,
+        0.00819514252283471
+      ],
+      "observed": {
+        "astro_ra_deg": 47.8855,
+        "astro_dec_deg": 17.008222222222223,
+        "app_ra_deg": 48.220333333333336,
+        "app_dec_deg": 17.098694444444444,
+        "azimuth_deg": 306.487915,
+        "elevation_deg": -60.367345,
+        "range_au": 5.89939702665385
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        1.297563139948168,
+        4.829793333952151,
+        2.0224712882608
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01764630526363336,
+        -0.008980294593722207,
+        -0.003738810659399622
+      ],
+      "observed": {
+        "astro_ra_deg": 74.959875,
+        "astro_dec_deg": 22.018472222222222,
+        "app_ra_deg": 75.32545833333333,
+        "app_dec_deg": 22.055777777777777,
+        "azimuth_deg": 66.1797,
+        "elevation_deg": -21.599788,
+        "range_au": 5.39449405311816
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        1.02610109976449,
+        3.653691954815205,
+        1.532249698867453
+      ],
+      "geo_velocity_au_per_day": [
+        0.00974858669202192,
+        -0.001004561661155435,
+        -0.0002635760589759495
+      ],
+      "observed": {
+        "astro_ra_deg": 74.31037500000001,
+        "astro_dec_deg": 21.986305555555557,
+        "app_ra_deg": 74.68958333333333,
+        "app_dec_deg": 22.026305555555556,
+        "azimuth_deg": 346.645556,
+        "elevation_deg": 67.328018,
+        "range_au": 4.09264852840497
       }
     },
     {
@@ -679,25 +757,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        3.659031087292524,
-        2.409382612596195,
-        0.9433772420100425
+        3.220614359853353,
+        -4.617549006443141,
+        -2.057563082241604
       ],
       "geo_velocity_au_per_day": [
-        0.01175899473570973,
-        0.00786081439847964,
-        0.003515247056181798
+        0.0231595350515104,
+        0.007456468014043755,
+        0.003065443138537445
       ],
       "observed": {
-        "astro_ra_deg": 33.36133333333334,
-        "astro_dec_deg": 12.150638888888889,
-        "app_ra_deg": 33.685375,
-        "app_dec_deg": 12.263472222222223,
-        "azimuth_deg": 249.358359,
-        "elevation_deg": 16.791438,
-        "range_au": 4.48149137523044
+        "astro_ra_deg": 304.89204166666667,
+        "astro_dec_deg": -20.077222222222222,
+        "app_ra_deg": 305.18587499999995,
+        "app_dec_deg": -20.012666666666668,
+        "azimuth_deg": 333.207605,
+        "elevation_deg": -30.848403,
+        "range_au": 5.99402320360088
       }
     },
     {
@@ -705,25 +783,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        3.554017105697379,
-        4.447763497539288,
-        1.841624016701625
+        4.470143222516899,
+        -2.528960629807749,
+        -1.171239066425376
       ],
       "geo_velocity_au_per_day": [
-        -0.0171007066134842,
-        0.01631100602118493,
-        0.007205854869956682
+        -0.005849165673825978,
+        0.01751165444948337,
+        0.007441101576084937
       ],
       "observed": {
-        "astro_ra_deg": 51.37049999999999,
-        "astro_dec_deg": 17.923861111111112,
-        "app_ra_deg": 51.709,
-        "app_dec_deg": 18.008305555555555,
-        "azimuth_deg": 347.303676,
-        "elevation_deg": 6.312981,
-        "range_au": 5.98374589047893
+        "astro_ra_deg": 330.4988333333333,
+        "astro_dec_deg": -12.847777777777779,
+        "app_ra_deg": 330.77908333333335,
+        "app_dec_deg": -12.746888888888888,
+        "azimuth_deg": 71.35488,
+        "elevation_deg": -16.893681,
+        "range_au": 5.26776788805541
       }
     },
     {
@@ -731,25 +809,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        1.058906415658519,
-        4.677115991383578,
-        1.958628432836888
+        3.32634876872877,
+        -2.043815739744144,
+        -0.9775249140254597
       ],
       "geo_velocity_au_per_day": [
-        -0.01407636378699276,
-        -0.01124723975050244,
-        -0.00471842712636332
+        -0.002890398726048254,
+        -0.00807882648471369,
+        -0.003627773464902677
       ],
       "observed": {
-        "astro_ra_deg": 77.240625,
-        "astro_dec_deg": 22.215944444444442,
-        "app_ra_deg": 77.60925,
-        "app_dec_deg": 22.248250000000002,
-        "azimuth_deg": 74.624192,
-        "elevation_deg": 19.509041,
-        "range_au": 5.17998244505465
+        "astro_ra_deg": 328.42954166666664,
+        "astro_dec_deg": -14.0585,
+        "app_ra_deg": 328.72433333333333,
+        "app_dec_deg": -13.95575,
+        "azimuth_deg": 188.442942,
+        "elevation_deg": -2.08874,
+        "range_au": 4.02460497075667
       }
     },
     {
@@ -757,25 +835,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        1.175501201631793,
-        3.6686645807608,
-        1.541318908321323
+        4.732841808699676,
+        -2.540790035225524,
+        -1.206488160278314
       ],
       "geo_velocity_au_per_day": [
-        0.009978816299972989,
-        0.003016863174536286,
-        0.001480180734514877
+        0.02009746356054267,
+        0.008275852410189669,
+        0.00348864642449044
       ],
       "observed": {
-        "astro_ra_deg": 72.23091666666666,
-        "astro_dec_deg": 21.805222222222223,
-        "app_ra_deg": 72.60945833333334,
-        "app_dec_deg": 21.85011111111111,
-        "azimuth_deg": 204.873586,
-        "elevation_deg": 32.85339,
-        "range_au": 4.14926697616997
+        "astro_ra_deg": 331.7686666666667,
+        "astro_dec_deg": -12.659833333333333,
+        "app_ra_deg": 332.056375,
+        "app_dec_deg": -12.555083333333334,
+        "azimuth_deg": 300.764775,
+        "elevation_deg": -18.968968,
+        "range_au": 5.50560471235793
       }
     },
     {
@@ -783,25 +861,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        1.019647022735552,
-        5.230845150711308,
-        2.239940777054897
+        5.704588499328,
+        -0.2660622501131578,
+        -0.2303531261482116
       ],
       "geo_velocity_au_per_day": [
-        -0.01714889336320539,
-        0.01356208512337897,
-        0.006063030985161307
+        -0.008389130028348964,
+        0.02008548978719906,
+        0.0086404499993086
       ],
       "observed": {
-        "astro_ra_deg": 78.966875,
-        "astro_dec_deg": 22.796694444444444,
-        "app_ra_deg": 79.345,
-        "app_dec_deg": 22.82547222222222,
-        "azimuth_deg": 316.759986,
-        "elevation_deg": 14.272009,
-        "range_au": 5.78090938957313
+        "astro_ra_deg": 357.3273333333333,
+        "astro_dec_deg": -2.3112777777777778,
+        "app_ra_deg": 357.60566666666665,
+        "app_dec_deg": -2.190555555555555,
+        "azimuth_deg": 37.256527,
+        "elevation_deg": -11.810556,
+        "range_au": 5.71541441409013
       }
     },
     {
@@ -809,25 +887,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -1.595829972383448,
-        5.160509381191641,
-        2.231781257735082
+        4.075898642678372,
+        0.5232831210404036,
+        0.1058808442733735
       ],
       "geo_velocity_au_per_day": [
-        -0.01595075868375904,
-        -0.01429870375834157,
-        -0.006011205092435462
+        -0.008318684437688297,
+        -0.006417118678976323,
+        -0.002813766406305089
       ],
       "observed": {
-        "astro_ra_deg": 107.18104166666667,
-        "astro_dec_deg": 22.448722222222223,
-        "app_ra_deg": 107.56312500000001,
-        "app_dec_deg": 22.40888888888889,
-        "azimuth_deg": 41.329984,
-        "elevation_deg": 13.566325,
-        "range_au": 5.84446014027792
+        "astro_ra_deg": 7.313583333333334,
+        "astro_dec_deg": 1.4743333333333335,
+        "app_ra_deg": 7.605333333333334,
+        "app_dec_deg": 1.6002222222222222,
+        "azimuth_deg": 143.850569,
+        "elevation_deg": 11.351479,
+        "range_au": 4.11068671911371
       }
     },
     {
@@ -835,25 +913,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        -1.631382522580588,
-        3.634065377489432,
-        1.592568744257962
+        4.850707865785497,
+        0.03005800495028349,
+        -0.1096738046085555
       ],
       "geo_velocity_au_per_day": [
-        0.01021883804280087,
-        -0.002105229133106922,
-        -0.0007262166495747829
+        0.01592589431743472,
+        0.00711926233931227,
+        0.003088865563731987
       ],
       "observed": {
-        "astro_ra_deg": 114.173375,
-        "astro_dec_deg": 21.79125,
-        "app_ra_deg": 114.56620833333334,
-        "app_dec_deg": 21.732499999999998,
-        "azimuth_deg": 152.539488,
-        "elevation_deg": 32.519193,
-        "range_au": 4.28995598281941
+        "astro_ra_deg": 0.35258333333333336,
+        "astro_dec_deg": -1.2966944444444444,
+        "app_ra_deg": 0.6440416666666667,
+        "app_dec_deg": -1.1701944444444445,
+        "azimuth_deg": 269.647192,
+        "elevation_deg": -1.121345,
+        "range_au": 4.85208603818778
       }
     },
     {
@@ -861,25 +939,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        -1.584381350650671,
-        4.697794396433091,
-        2.075641923365488
+        5.449944812238964,
+        2.231312704099765,
+        0.8471096353390408
       ],
       "geo_velocity_au_per_day": [
-        -0.01497908586249715,
-        0.01080629594872169,
-        0.004863538740503643
+        -0.01136151966045957,
+        0.02041525220793278,
+        0.008889719488252665
       ],
       "observed": {
-        "astro_ra_deg": 108.6345,
-        "astro_dec_deg": 22.717138888888886,
-        "app_ra_deg": 109.030125,
-        "app_dec_deg": 22.67213888888889,
-        "azimuth_deg": 283.716122,
-        "elevation_deg": 20.291515,
-        "range_au": 5.37475739456992
+        "astro_ra_deg": 22.262708333333336,
+        "astro_dec_deg": 8.184194444444445,
+        "app_ra_deg": 22.559958333333334,
+        "app_dec_deg": 8.301777777777778,
+        "azimuth_deg": 6.196987,
+        "elevation_deg": -3.628007,
+        "range_au": 5.94963734303322
       }
     },
     {
@@ -887,25 +965,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -4.056189219430359,
-        4.360980463335164,
-        1.950459391246745
+        3.316824080862674,
+        3.063850093548056,
+        1.214782729339548
       ],
       "geo_velocity_au_per_day": [
-        -0.01572408222991063,
-        -0.01680004268593127,
-        -0.00711579704667975
+        -0.0137020169175737,
+        -0.006853735673413031,
+        -0.002898252686048443
       ],
       "observed": {
-        "astro_ra_deg": 132.92370833333334,
-        "astro_dec_deg": 18.13347222222222,
-        "app_ra_deg": 133.29783333333333,
-        "app_dec_deg": 18.034555555555556,
-        "azimuth_deg": 12.503454,
-        "elevation_deg": 6.330132,
-        "range_au": 6.26695664893331
+        "astro_ra_deg": 42.72716666666667,
+        "astro_dec_deg": 15.056666666666667,
+        "app_ra_deg": 43.05279166666667,
+        "app_dec_deg": 15.154527777777778,
+        "azimuth_deg": 100.563857,
+        "elevation_deg": 17.721022,
+        "range_au": 4.67585785523133
       }
     },
     {
@@ -913,25 +991,103 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -4.017557776247482,
-        2.398845706204791,
-        1.119005442189166
+        3.478926283349484,
+        2.32189125009488,
+        0.9038511183238048
       ],
       "geo_velocity_au_per_day": [
-        0.01215825387064964,
-        -0.006493228530330381,
-        -0.002663667759503783
+        0.0120600714032732,
+        0.003794836115861949,
+        0.001749827460276976
       ],
       "observed": {
-        "astro_ra_deg": 149.15675000000002,
-        "astro_dec_deg": 13.449583333333333,
-        "app_ra_deg": 149.525875,
-        "app_dec_deg": 13.319583333333332,
-        "azimuth_deg": 112.019623,
-        "elevation_deg": 18.13536,
-        "range_au": 4.81111980670581
+        "astro_ra_deg": 33.71720833333333,
+        "astro_dec_deg": 12.19261111111111,
+        "app_ra_deg": 34.041916666666665,
+        "app_dec_deg": 12.305138888888889,
+        "azimuth_deg": 234.063109,
+        "elevation_deg": 19.596948,
+        "range_au": 4.27915190183509
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        3.78293409959322,
+        4.18493361183619,
+        1.725693520662671
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01331924144483628,
+        0.01860055439281013,
+        0.00819514252283471
+      ],
+      "observed": {
+        "astro_ra_deg": 47.885625,
+        "astro_dec_deg": 17.007916666666667,
+        "app_ra_deg": 48.22054166666667,
+        "app_dec_deg": 17.098388888888888,
+        "azimuth_deg": 336.434002,
+        "elevation_deg": 6.134828,
+        "range_au": 5.89935547915678
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        1.297563139948168,
+        4.829793333952151,
+        2.0224712882608
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01764630526363336,
+        -0.008980294593722207,
+        -0.003738810659399622
+      ],
+      "observed": {
+        "astro_ra_deg": 74.9595,
+        "astro_dec_deg": 22.01811111111111,
+        "app_ra_deg": 75.325125,
+        "app_dec_deg": 22.055444444444444,
+        "azimuth_deg": 62.747013,
+        "elevation_deg": 16.903692,
+        "range_au": 5.39446602554562
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        1.02610109976449,
+        3.653691954815205,
+        1.532249698867453
+      ],
+      "geo_velocity_au_per_day": [
+        0.00974858669202192,
+        -0.001004561661155435,
+        -0.0002635760589759495
+      ],
+      "observed": {
+        "astro_ra_deg": 74.31041666666667,
+        "astro_dec_deg": 21.985583333333334,
+        "app_ra_deg": 74.68954166666667,
+        "app_dec_deg": 22.025583333333334,
+        "azimuth_deg": 186.162764,
+        "elevation_deg": 33.963999,
+        "range_au": 4.09266407845549
       }
     },
     {
@@ -1121,25 +1277,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        -0.127481831597179,
-        -2.211417333279142,
-        -0.9840108553082422
+        0.7999953845207415,
+        0.3697023904666935,
+        0.1751579278264976
       ],
       "geo_velocity_au_per_day": [
-        0.03147831607982139,
-        0.001426580757543807,
-        0.0002010419153804935
+        0.004966249841833065,
+        0.009127205730021078,
+        0.004442931193408566
       ],
       "observed": {
-        "astro_ra_deg": 266.69579166666665,
-        "astro_dec_deg": -23.951638888888887,
-        "app_ra_deg": 267.05458333333337,
-        "app_dec_deg": -23.96097222222222,
-        "azimuth_deg": 152.984089,
-        "elevation_deg": -62.879886,
-        "range_au": 2.42384470181542
+        "astro_ra_deg": 24.796791666666664,
+        "astro_dec_deg": 11.239694444444444,
+        "app_ra_deg": 25.072916666666664,
+        "app_dec_deg": 11.344916666666668,
+        "azimuth_deg": 281.69324,
+        "elevation_deg": 13.925742,
+        "range_au": 0.89855794636001
       }
     },
     {
@@ -1147,25 +1303,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        1.979755538326635,
-        -0.008886433968211602,
-        -0.05152694615469958
+        -0.1504633865079821,
+        1.828068721987227,
+        0.8480662987290226
       ],
       "geo_velocity_au_per_day": [
-        -0.003373884149163749,
-        0.02445362192343284,
-        0.01071104989179131
+        -0.02197703208877377,
+        0.005917274937760017,
+        0.002708883768722003
       ],
       "observed": {
-        "astro_ra_deg": 359.73949999999996,
-        "astro_dec_deg": -1.4927222222222223,
-        "app_ra_deg": 0.04583333333333334,
-        "app_dec_deg": -1.359527777777778,
-        "azimuth_deg": 92.188896,
-        "elevation_deg": -51.596606,
-        "range_au": 1.98039739623953
+        "astro_ra_deg": 94.69995833333333,
+        "astro_dec_deg": 24.813222222222223,
+        "app_ra_deg": 95.01895833333333,
+        "app_dec_deg": 24.804361111111113,
+        "azimuth_deg": 299.173185,
+        "elevation_deg": -30.611192,
+        "range_au": 2.02090366556758
       }
     },
     {
@@ -1173,25 +1329,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        0.1304381785151843,
-        1.330708480509628,
-        0.5722624637347401
+        -2.571626796132021,
+        0.4509218536094981,
+        0.2417594334911025
       ],
       "geo_velocity_au_per_day": [
-        -0.01627886677871082,
-        -0.004126938789947162,
-        -0.001284992903733402
+        -0.00709655901192413,
+        -0.02592998549405322,
+        -0.01152539107603955
       ],
       "observed": {
-        "astro_ra_deg": 84.39975000000001,
-        "astro_dec_deg": 23.170055555555557,
-        "app_ra_deg": 84.7715,
-        "app_dec_deg": 23.185472222222224,
-        "azimuth_deg": 65.748215,
-        "elevation_deg": -16.560735,
-        "range_au": 1.45432680659833
+        "astro_ra_deg": 170.05054166666667,
+        "astro_dec_deg": 5.291972222222222,
+        "app_ra_deg": 170.321,
+        "app_dec_deg": 5.177194444444445,
+        "azimuth_deg": 292.087791,
+        "elevation_deg": -76.115101,
+        "range_au": 2.62210535997592
       }
     },
     {
@@ -1199,25 +1355,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        -0.3701300605235104,
-        0.4989915667774544,
-        0.2635358271016043
+        -0.8382394755030914,
+        -2.029709024550213,
+        -0.883357694545514
       ],
       "geo_velocity_au_per_day": [
-        0.004521638521702022,
-        -0.001314490704020353,
-        -0.0002866647181839665
+        0.02913250248720493,
+        -0.00496589375124172,
+        -0.002631302557023038
       ],
       "observed": {
-        "astro_ra_deg": 126.56420833333333,
-        "astro_dec_deg": 22.987972222222222,
-        "app_ra_deg": 126.93729166666665,
-        "app_dec_deg": 22.905277777777776,
-        "azimuth_deg": 51.395483,
-        "elevation_deg": 51.406489,
-        "range_au": 0.67481068506599
+        "astro_ra_deg": 247.555875,
+        "astro_dec_deg": -21.911777777777775,
+        "app_ra_deg": 247.8730833333333,
+        "app_dec_deg": -21.95786111111111,
+        "azimuth_deg": 130.818954,
+        "elevation_deg": -55.107544,
+        "range_au": 2.36699864047397
       }
     },
     {
@@ -1225,25 +1381,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        -0.7343753880751505,
-        1.035512131449795,
-        0.503842129053235
+        1.535624738829637,
+        -0.5544799776342721,
+        -0.287139614302004
       ],
       "geo_velocity_au_per_day": [
-        -0.01384694105538139,
-        0.002157512030062682,
-        0.0007786502073812648
+        0.002865323555180188,
+        0.02063300439667002,
+        0.00879970422155033
       ],
       "observed": {
-        "astro_ra_deg": 125.3385,
-        "astro_dec_deg": 21.648222222222223,
-        "app_ra_deg": 125.70879166666668,
-        "app_dec_deg": 21.56872222222222,
-        "azimuth_deg": 291.586576,
-        "elevation_deg": 2.273962,
-        "range_au": 1.36587385902783
+        "astro_ra_deg": 340.1437916666667,
+        "astro_dec_deg": -9.976138888888888,
+        "app_ra_deg": 340.43050000000005,
+        "app_dec_deg": -9.862277777777777,
+        "azimuth_deg": 102.196504,
+        "elevation_deg": -35.832099,
+        "range_au": 1.65766501949472
       }
     },
     {
@@ -1251,25 +1407,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -2.193466607166804,
-        -0.3516648684856351,
-        -0.1374659750642815
+        0.4742980710631119,
+        0.8220298456428374,
+        0.3290104675152845
       ],
       "geo_velocity_au_per_day": [
-        -0.00005639064890470092,
-        -0.02297806676685939,
-        -0.01042241361678611
+        -0.01150480828969359,
+        -0.0003975315960609559,
+        0.0002520322059228121
       ],
       "observed": {
-        "astro_ra_deg": 189.10416666666666,
-        "astro_dec_deg": -3.5392777777777775,
-        "app_ra_deg": 189.43104166666666,
-        "app_dec_deg": -3.679333333333333,
-        "azimuth_deg": 264.02237,
-        "elevation_deg": -51.959934,
-        "range_au": 2.22584351910113
+        "astro_ra_deg": 60.01500000000001,
+        "astro_dec_deg": 19.11927777777778,
+        "app_ra_deg": 60.33941666666667,
+        "app_dec_deg": 19.183,
+        "azimuth_deg": 70.807054,
+        "elevation_deg": 1.808424,
+        "range_au": 1.00439280853837
       }
     },
     {
@@ -1277,25 +1433,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        0.1663968436105412,
-        -2.199383390739455,
-        -0.9910184431967967
+        0.191228955940762,
+        0.4987801492316052,
+        0.2462526054389587
       ],
       "geo_velocity_au_per_day": [
-        0.03189703690703926,
-        0.002641553946360385,
-        0.0008286003936815563
+        0.00413818913418458,
+        0.002547529249329024,
+        0.001528078653892531
       ],
       "observed": {
-        "astro_ra_deg": 274.32116666666667,
-        "astro_dec_deg": -24.19425,
-        "app_ra_deg": 274.7138333333333,
-        "app_dec_deg": -24.18525,
-        "azimuth_deg": 190.75472,
-        "elevation_deg": -65.353855,
-        "range_au": 2.4181426960054
+        "astro_ra_deg": 69.017,
+        "astro_dec_deg": 24.750083333333333,
+        "app_ra_deg": 69.36879166666667,
+        "app_dec_deg": 24.797555555555558,
+        "azimuth_deg": 321.99543,
+        "elevation_deg": 57.840601,
+        "range_au": 0.5881787315005
       }
     },
     {
@@ -1303,25 +1459,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        2.244545534858756,
-        0.2878317505991867,
-        0.08358652074169941
+        -0.377218037652249,
+        1.44826393481251,
+        0.6861363505783173
       ],
       "geo_velocity_au_per_day": [
-        -0.005676257712769054,
-        0.02749511248353483,
-        0.01219545375434315
+        -0.0171256553893615,
+        0.005136107774762868,
+        0.002246882436367731
       ],
       "observed": {
-        "astro_ra_deg": 7.3035,
-        "astro_dec_deg": 2.1133611111111112,
-        "app_ra_deg": 7.6375,
-        "app_dec_deg": 2.257361111111111,
-        "azimuth_deg": 83.566101,
-        "elevation_deg": -69.420707,
-        "range_au": 2.26444979540346
+        "astro_ra_deg": 104.59358333333333,
+        "astro_dec_deg": 24.630083333333335,
+        "app_ra_deg": 104.94483333333334,
+        "app_dec_deg": 24.599805555555555,
+        "azimuth_deg": 295.247221,
+        "elevation_deg": -12.584677,
+        "range_au": 1.64644983619754
       }
     },
     {
@@ -1329,25 +1485,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -0.1343418453184868,
-        1.754675906630777,
-        0.7726506257751409
+        -2.435151993348373,
+        0.2130601563528054,
+        0.1276752347380855
       ],
       "geo_velocity_au_per_day": [
-        -0.02154108417645187,
-        -0.006002249579209105,
-        -0.002109457648427775
+        -0.006147760521644694,
+        -0.02429513917066216,
+        -0.0109077287068934
       ],
       "observed": {
-        "astro_ra_deg": 94.375125,
-        "astro_dec_deg": 23.703694444444444,
-        "app_ra_deg": 94.78016666666666,
-        "app_dec_deg": 23.694083333333335,
-        "azimuth_deg": 60.75115,
-        "elevation_deg": -34.668932,
-        "range_au": 1.92188881904832
+        "astro_ra_deg": 174.99558333333334,
+        "astro_dec_deg": 2.9915000000000003,
+        "app_ra_deg": 175.2926666666667,
+        "app_dec_deg": 2.8633888888888888,
+        "azimuth_deg": 276.041148,
+        "elevation_deg": -61.662695,
+        "range_au": 2.44788915751926
       }
     },
     {
@@ -1355,25 +1511,103 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -0.958113565016507,
-        0.3644374910539417,
-        0.2126826062560103
+        -0.5987351609961756,
+        -2.188218027155928,
+        -0.9674697347065054
       ],
       "geo_velocity_au_per_day": [
-        0.005951829234409446,
-        -0.007317106447188714,
-        -0.003005107767402819
+        0.03111768631513348,
+        -0.004511118475785529,
+        -0.002401898784474935
       ],
       "observed": {
-        "astro_ra_deg": 159.17383333333333,
-        "astro_dec_deg": 11.722777777777777,
-        "app_ra_deg": 159.534625,
-        "app_dec_deg": 11.581111111111111,
-        "azimuth_deg": 78.015431,
-        "elevation_deg": 14.804535,
-        "range_au": 1.04685515090281
+        "astro_ra_deg": 254.6925416666666,
+        "astro_dec_deg": -23.09488888888889,
+        "app_ra_deg": 255.0460416666667,
+        "app_dec_deg": -23.131027777777778,
+        "azimuth_deg": 157.247601,
+        "elevation_deg": -64.787087,
+        "range_au": 2.46636672400333
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        1.988839062231803,
+        -0.3845396902065834,
+        -0.215414879557498
+      ],
+      "geo_velocity_au_per_day": [
+        0.002227818499745652,
+        0.02545249843164074,
+        0.01106300118358349
+      ],
+      "observed": {
+        "astro_ra_deg": 349.05341666666664,
+        "astro_dec_deg": -6.071888888888888,
+        "app_ra_deg": 349.361875,
+        "app_dec_deg": -5.941805555555556,
+        "azimuth_deg": 100.468662,
+        "elevation_deg": -55.2687,
+        "range_au": 2.03705389366573
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        0.390841377139252,
+        1.368098936300063,
+        0.5809853118372811
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01830414173906738,
+        -0.0007602351208335673,
+        0.0001616710472571904
+      ],
+      "observed": {
+        "astro_ra_deg": 74.05416666666666,
+        "astro_dec_deg": 22.21088888888889,
+        "app_ra_deg": 74.42008333333334,
+        "app_dec_deg": 22.25025,
+        "azimuth_deg": 66.11554,
+        "elevation_deg": -20.741092,
+        "range_au": 1.53680305506461
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        -0.4343223237298839,
+        0.5387348404883778,
+        0.2761408836733528
+      ],
+      "geo_velocity_au_per_day": [
+        0.003877104495879179,
+        -0.003954717323809497,
+        -0.001381124568339023
+      ],
+      "observed": {
+        "astro_ra_deg": 128.874125,
+        "astro_dec_deg": 21.755972222222223,
+        "app_ra_deg": 129.241,
+        "app_dec_deg": 21.669194444444447,
+        "azimuth_deg": 62.249312,
+        "elevation_deg": 37.531943,
+        "range_au": 0.74501114745601
       }
     },
     {
@@ -1563,25 +1797,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        -0.127481831597179,
-        -2.211417333279142,
-        -0.9840108553082422
+        0.7999953845207415,
+        0.3697023904666935,
+        0.1751579278264976
       ],
       "geo_velocity_au_per_day": [
-        0.03147831607982139,
-        0.001426580757543807,
-        0.0002010419153804935
+        0.004966249841833065,
+        0.009127205730021078,
+        0.004442931193408566
       ],
       "observed": {
-        "astro_ra_deg": 266.69558333333333,
-        "astro_dec_deg": -23.952861111111112,
-        "app_ra_deg": 267.05445833333334,
-        "app_dec_deg": -23.962194444444442,
-        "azimuth_deg": 14.756455,
-        "elevation_deg": -35.613126,
-        "range_au": 2.42383154645831
+        "astro_ra_deg": 24.798916666666667,
+        "astro_dec_deg": 11.236999999999998,
+        "app_ra_deg": 25.075041666666664,
+        "app_dec_deg": 11.342194444444445,
+        "azimuth_deg": 258.432241,
+        "elevation_deg": 14.029065,
+        "range_au": 0.89855789320996
       }
     },
     {
@@ -1589,25 +1823,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        1.979755538326635,
-        -0.008886433968211602,
-        -0.05152694615469958
+        -0.1504633865079821,
+        1.828068721987227,
+        0.8480662987290226
       ],
       "geo_velocity_au_per_day": [
-        -0.003373884149163749,
-        0.02445362192343284,
-        0.01071104989179131
+        -0.02197703208877377,
+        0.005917274937760017,
+        0.002708883768722003
       ],
       "observed": {
-        "astro_ra_deg": 359.7389166666667,
-        "astro_dec_deg": -1.4939444444444445,
-        "app_ra_deg": 0.04529166666666667,
-        "app_dec_deg": -1.3607500000000001,
-        "azimuth_deg": 39.182983,
-        "elevation_deg": -10.72861,
-        "range_au": 1.98037193868542
+        "astro_ra_deg": 94.70083333333332,
+        "astro_dec_deg": 24.81238888888889,
+        "app_ra_deg": 95.01987499999998,
+        "app_dec_deg": 24.8035,
+        "azimuth_deg": 307.913824,
+        "elevation_deg": 17.726265,
+        "range_au": 2.02086905040692
       }
     },
     {
@@ -1615,25 +1849,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        0.1304381785151843,
-        1.330708480509628,
-        0.5722624637347401
+        -2.571626796132021,
+        0.4509218536094981,
+        0.2417594334911025
       ],
       "geo_velocity_au_per_day": [
-        -0.01627886677871082,
-        -0.004126938789947162,
-        -0.001284992903733402
+        -0.00709655901192413,
+        -0.02592998549405322,
+        -0.01152539107603955
       ],
       "observed": {
-        "astro_ra_deg": 84.398375,
-        "astro_dec_deg": 23.168694444444444,
-        "app_ra_deg": 84.77016666666667,
-        "app_dec_deg": 23.18413888888889,
-        "azimuth_deg": 67.576782,
-        "elevation_deg": 19.015789,
-        "range_au": 1.45430082847763
+        "astro_ra_deg": 170.05070833333335,
+        "astro_dec_deg": 5.291138888888889,
+        "app_ra_deg": 170.32125,
+        "app_dec_deg": 5.176333333333334,
+        "azimuth_deg": 347.067334,
+        "elevation_deg": -6.522137,
+        "range_au": 2.6220688555382
       }
     },
     {
@@ -1641,25 +1875,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        -0.3701300605235104,
-        0.4989915667774544,
-        0.2635358271016043
+        -0.8382394755030914,
+        -2.029709024550213,
+        -0.883357694545514
       ],
       "geo_velocity_au_per_day": [
-        0.004521638521702022,
-        -0.001314490704020353,
-        -0.0002866647181839665
+        0.02913250248720493,
+        -0.00496589375124172,
+        -0.002631302557023038
       ],
       "observed": {
-        "astro_ra_deg": 126.56258333333332,
-        "astro_dec_deg": 22.983777777777778,
-        "app_ra_deg": 126.93558333333331,
-        "app_dec_deg": 22.90111111111111,
-        "azimuth_deg": 144.509914,
-        "elevation_deg": 32.898244,
-        "range_au": 0.67482088525287
+        "astro_ra_deg": 247.55545833333332,
+        "astro_dec_deg": -21.91297222222222,
+        "app_ra_deg": 247.87270833333332,
+        "app_dec_deg": -21.959083333333332,
+        "azimuth_deg": 30.858162,
+        "elevation_deg": -32.432453,
+        "range_au": 2.36698650350304
       }
     },
     {
@@ -1667,25 +1901,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        -0.7343753880751505,
-        1.035512131449795,
-        0.503842129053235
+        1.535624738829637,
+        -0.5544799776342721,
+        -0.287139614302004
       ],
       "geo_velocity_au_per_day": [
-        -0.01384694105538139,
-        0.002157512030062682,
-        0.0007786502073812648
+        0.002865323555180188,
+        0.02063300439667002,
+        0.00879970422155033
       ],
       "observed": {
-        "astro_ra_deg": 125.34,
-        "astro_dec_deg": 21.646583333333332,
-        "app_ra_deg": 125.71033333333334,
-        "app_dec_deg": 21.567055555555555,
-        "azimuth_deg": 272.317317,
-        "elevation_deg": 21.580621,
-        "range_au": 1.36585992120425
+        "astro_ra_deg": 340.142875,
+        "astro_dec_deg": -9.977666666666666,
+        "app_ra_deg": 340.42958333333337,
+        "app_dec_deg": -9.863805555555555,
+        "azimuth_deg": 55.877621,
+        "elevation_deg": -16.814401,
+        "range_au": 1.65765238346575
       }
     },
     {
@@ -1693,25 +1927,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -2.193466607166804,
-        -0.3516648684856351,
-        -0.1374659750642815
+        0.4742980710631119,
+        0.8220298456428374,
+        0.3290104675152845
       ],
       "geo_velocity_au_per_day": [
-        -0.00005639064890470092,
-        -0.02297806676685939,
-        -0.01042241361678611
+        -0.01150480828969359,
+        -0.0003975315960609559,
+        0.0002520322059228121
       ],
       "observed": {
-        "astro_ra_deg": 189.10470833333332,
-        "astro_dec_deg": -3.540388888888889,
-        "app_ra_deg": 189.43162500000003,
-        "app_dec_deg": -3.6804444444444444,
-        "azimuth_deg": 321.0074,
-        "elevation_deg": -13.093202,
-        "range_au": 2.22581961358272
+        "astro_ra_deg": 60.01295833333333,
+        "astro_dec_deg": 19.11702777777778,
+        "app_ra_deg": 60.337374999999994,
+        "app_dec_deg": 19.180777777777777,
+        "azimuth_deg": 87.731061,
+        "elevation_deg": 19.143789,
+        "range_au": 1.00438022022124
       }
     },
     {
@@ -1719,25 +1953,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        0.1663968436105412,
-        -2.199383390739455,
-        -0.9910184431967967
+        0.191228955940762,
+        0.4987801492316052,
+        0.2462526054389587
       ],
       "geo_velocity_au_per_day": [
-        0.03189703690703926,
-        0.002641553946360385,
-        0.0008286003936815563
+        0.00413818913418458,
+        0.002547529249329024,
+        0.001528078653892531
       ],
       "observed": {
-        "astro_ra_deg": 274.32120833333335,
-        "astro_dec_deg": -24.19547222222222,
-        "app_ra_deg": 274.7139583333333,
-        "app_dec_deg": -24.18647222222222,
-        "azimuth_deg": 354.471037,
-        "elevation_deg": -36.13741,
-        "range_au": 2.41812905375007
+        "astro_ra_deg": 69.01829166666667,
+        "astro_dec_deg": 24.74511111111111,
+        "app_ra_deg": 69.37004166666667,
+        "app_dec_deg": 24.792583333333337,
+        "azimuth_deg": 203.861291,
+        "elevation_deg": 35.887201,
+        "range_au": 0.58818986899151
       }
     },
     {
@@ -1745,25 +1979,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        2.244545534858756,
-        0.2878317505991867,
-        0.08358652074169941
+        -0.377218037652249,
+        1.44826393481251,
+        0.6861363505783173
       ],
       "geo_velocity_au_per_day": [
-        -0.005676257712769054,
-        0.02749511248353483,
-        0.01219545375434315
+        -0.0171256553893615,
+        0.005136107774762868,
+        0.002246882436367731
       ],
       "observed": {
-        "astro_ra_deg": 7.303208333333333,
-        "astro_dec_deg": 2.1123333333333334,
-        "app_ra_deg": 7.637291666666667,
-        "app_dec_deg": 2.256361111111111,
-        "azimuth_deg": 20.710072,
-        "elevation_deg": -8.982515,
-        "range_au": 2.26441656812948
+        "astro_ra_deg": 104.59483333333333,
+        "astro_dec_deg": 24.628888888888888,
+        "app_ra_deg": 104.946125,
+        "app_dec_deg": 24.598583333333334,
+        "azimuth_deg": 288.750113,
+        "elevation_deg": 21.214681,
+        "range_au": 1.64642518570321
       }
     },
     {
@@ -1771,25 +2005,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -0.1343418453184868,
-        1.754675906630777,
-        0.7726506257751409
+        -2.435151993348373,
+        0.2130601563528054,
+        0.1276752347380855
       ],
       "geo_velocity_au_per_day": [
-        -0.02154108417645187,
-        -0.006002249579209105,
-        -0.002109457648427775
+        -0.006147760521644694,
+        -0.02429513917066216,
+        -0.0109077287068934
       ],
       "observed": {
-        "astro_ra_deg": 94.37429166666666,
-        "astro_dec_deg": 23.702805555555553,
-        "app_ra_deg": 94.779375,
-        "app_dec_deg": 23.69322222222222,
-        "azimuth_deg": 48.274653,
-        "elevation_deg": 15.949729,
-        "range_au": 1.92185292568158
+        "astro_ra_deg": 174.99595833333333,
+        "astro_dec_deg": 2.9905555555555554,
+        "app_ra_deg": 175.29308333333336,
+        "app_dec_deg": 2.8624444444444443,
+        "azimuth_deg": 331.554061,
+        "elevation_deg": -7.709511,
+        "range_au": 2.4478573848028
       }
     },
     {
@@ -1797,25 +2031,103 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -0.958113565016507,
-        0.3644374910539417,
-        0.2126826062560103
+        -0.5987351609961756,
+        -2.188218027155928,
+        -0.9674697347065054
       ],
       "geo_velocity_au_per_day": [
-        0.005951829234409446,
-        -0.007317106447188714,
-        -0.003005107767402819
+        0.03111768631513348,
+        -0.004511118475785529,
+        -0.002401898784474935
       ],
       "observed": {
-        "astro_ra_deg": 159.17204166666664,
-        "astro_dec_deg": 11.720444444444444,
-        "app_ra_deg": 159.53279166666667,
-        "app_dec_deg": 11.578805555555554,
-        "azimuth_deg": 102.418137,
-        "elevation_deg": 14.44577,
-        "range_au": 1.04685543141982
+        "astro_ra_deg": 254.69241666666662,
+        "astro_dec_deg": -23.096083333333333,
+        "app_ra_deg": 255.04595833333332,
+        "app_dec_deg": -23.13222222222222,
+        "azimuth_deg": 11.590723,
+        "elevation_deg": -34.915792,
+        "range_au": 2.46635252200456
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        1.988839062231803,
+        -0.3845396902065834,
+        -0.215414879557498
+      ],
+      "geo_velocity_au_per_day": [
+        0.002227818499745652,
+        0.02545249843164074,
+        0.01106300118358349
+      ],
+      "observed": {
+        "astro_ra_deg": 349.052875,
+        "astro_dec_deg": -6.073138888888889,
+        "app_ra_deg": 349.3614166666667,
+        "app_dec_deg": -5.9430555555555555,
+        "azimuth_deg": 35.60775,
+        "elevation_deg": -15.791874,
+        "range_au": 2.03703046375186
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        0.390841377139252,
+        1.368098936300063,
+        0.5809853118372811
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01830414173906738,
+        -0.0007602351208335673,
+        0.0001616710472571904
+      ],
+      "observed": {
+        "astro_ra_deg": 74.05291666666666,
+        "astro_dec_deg": 22.20963888888889,
+        "app_ra_deg": 74.418875,
+        "app_dec_deg": 22.24902777777778,
+        "azimuth_deg": 63.56676,
+        "elevation_deg": 17.261468,
+        "range_au": 1.53677537027574
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        -0.4343223237298839,
+        0.5387348404883778,
+        0.2761408836733528
+      ],
+      "geo_velocity_au_per_day": [
+        0.003877104495879179,
+        -0.003954717323809497,
+        -0.001381124568339023
+      ],
+      "observed": {
+        "astro_ra_deg": 128.8720416666667,
+        "astro_dec_deg": 21.75236111111111,
+        "app_ra_deg": 129.23883333333333,
+        "app_dec_deg": 21.665611111111108,
+        "azimuth_deg": 126.493572,
+        "elevation_deg": 29.195539,
+        "range_au": 0.74501636074749
       }
     },
     {
@@ -2005,25 +2317,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        9.161938680560144,
-        -4.18206712865634,
-        -2.132881008994687
+        5.669493401374993,
+        -8.511568734626051,
+        -3.770251211524874
       ],
       "geo_velocity_au_per_day": [
-        0.01905198380894553,
-        0.007506678948347601,
-        0.003077578975058576
+        0.02154790804249204,
+        0.005827912398774828,
+        0.002279749448901465
       ],
       "observed": {
-        "astro_ra_deg": 335.46320833333334,
-        "astro_dec_deg": -11.957888888888888,
-        "app_ra_deg": 335.7780416666667,
-        "app_dec_deg": -11.839083333333335,
-        "azimuth_deg": 255.749767,
-        "elevation_deg": -33.543627,
-        "range_au": 10.2947242467374
+        "astro_ra_deg": 303.66537500000004,
+        "astro_dec_deg": -20.237111111111112,
+        "app_ra_deg": 303.959875,
+        "app_dec_deg": -20.174583333333334,
+        "azimuth_deg": 226.873358,
+        "elevation_deg": -59.701949,
+        "range_au": 10.8998176671864
       }
     },
     {
@@ -2031,25 +2343,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        9.966791578363022,
-        -2.119093772238966,
-        -1.259001078000066
+        6.766353520409509,
+        -6.65974424782074,
+        -2.996906186288015
       ],
       "geo_velocity_au_per_day": [
-        -0.00926575807393705,
-        0.01709403423284245,
-        0.007246612841380801
+        -0.006750152306028179,
+        0.01521504602934802,
+        0.006352137812271386
       ],
       "observed": {
-        "astro_ra_deg": 347.99525,
-        "astro_dec_deg": -7.044277777777777,
-        "app_ra_deg": 348.306,
-        "app_dec_deg": -6.914000000000001,
-        "azimuth_deg": 98.979152,
-        "elevation_deg": -39.529897,
-        "range_au": 10.2670795135733
+        "astro_ra_deg": 315.45341666666667,
+        "astro_dec_deg": -17.519444444444442,
+        "app_ra_deg": 315.74783333333335,
+        "app_dec_deg": -17.436527777777776,
+        "azimuth_deg": 107.545955,
+        "elevation_deg": -6.301758,
+        "range_au": 9.95574482473648
       }
     },
     {
@@ -2057,25 +2369,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        8.432574839072291,
-        -1.722358745920582,
-        -1.105792640863175
+        5.565778789771198,
+        -6.482724286458221,
+        -2.94909521950581
       ],
       "geo_velocity_au_per_day": [
-        -0.00593747257219218,
-        -0.00922945640831641,
-        -0.004150103325545598
+        -0.002911232840788826,
+        -0.01089080264208594,
+        -0.004959610446633339
       ],
       "observed": {
-        "astro_ra_deg": 348.45441666666665,
-        "astro_dec_deg": -7.322,
-        "app_ra_deg": 348.77891666666665,
-        "app_dec_deg": -7.1859166666666665,
-        "azimuth_deg": 121.085303,
-        "elevation_deg": 75.979215,
-        "range_au": 8.67738710596585
+        "astro_ra_deg": 310.64595833333334,
+        "astro_dec_deg": -19.042944444444448,
+        "app_ra_deg": 310.95604166666664,
+        "app_dec_deg": -18.96486111111111,
+        "azimuth_deg": 232.362917,
+        "elevation_deg": 57.846203,
+        "range_au": 9.03883473747904
       }
     },
     {
@@ -2083,25 +2395,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        9.531422016220812,
-        -2.411611104945534,
-        -1.421678989134372
+        7.029738453470491,
+        -7.339229692796889,
+        -3.348713807895955
       ],
       "geo_velocity_au_per_day": [
-        0.0181664691153462,
-        0.006323705123618,
-        0.002605417160119831
+        0.02109388371240891,
+        0.005128695490352784,
+        0.00199000671410687
       ],
       "observed": {
-        "astro_ra_deg": 345.79925,
-        "astro_dec_deg": -8.22861111111111,
-        "app_ra_deg": 346.1225,
-        "app_dec_deg": -8.095277777777778,
-        "azimuth_deg": 261.45188,
-        "elevation_deg": -18.668243,
-        "range_au": 9.93409539364352
+        "astro_ra_deg": 313.7641666666667,
+        "astro_dec_deg": -18.237861111111112,
+        "app_ra_deg": 314.0662083333333,
+        "app_dec_deg": -18.156277777777778,
+        "azimuth_deg": 242.15159,
+        "elevation_deg": -48.158854,
+        "range_au": 10.7003159085047
       }
     },
     {
@@ -2109,25 +2421,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        10.34848386712778,
-        -0.3750187894896339,
-        -0.5541426308467658
+        8.18706250647186,
+        -5.45174229247736,
+        -2.558100293494052
       ],
       "geo_velocity_au_per_day": [
-        -0.009164619033500892,
-        0.01816105367022833,
-        0.007753650201144451
+        -0.006281324236164681,
+        0.0168162349766243,
+        0.007063082513219061
       ],
       "observed": {
-        "astro_ra_deg": 357.923,
-        "astro_dec_deg": -3.063833333333333,
-        "app_ra_deg": 358.24345833333336,
-        "app_dec_deg": -2.92475,
-        "azimuth_deg": 95.087622,
-        "elevation_deg": -54.873572,
-        "range_au": 10.3701244986485
+        "astro_ra_deg": 326.3389583333333,
+        "astro_dec_deg": -14.578583333333333,
+        "app_ra_deg": 326.63716666666664,
+        "app_dec_deg": -14.477722222222223,
+        "azimuth_deg": 105.631881,
+        "elevation_deg": -21.904194,
+        "range_au": 10.1633326150888
       }
     },
     {
@@ -2135,25 +2447,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        8.666198555513423,
-        0.1822881517417485,
-        -0.3259534935503385
+        6.880319183526448,
+        -5.050843733250445,
+        -2.411025946372626
       ],
       "geo_velocity_au_per_day": [
-        -0.008421693851488788,
-        -0.008446008021485991,
-        -0.003765359452427075
+        -0.005056489700451602,
+        -0.009582562294614728,
+        -0.004372136877371697
       ],
       "observed": {
-        "astro_ra_deg": 1.2034583333333333,
-        "astro_dec_deg": -2.1542222222222223,
-        "app_ra_deg": 1.5375833333333333,
-        "app_dec_deg": -2.0089166666666665,
-        "azimuth_deg": 94.013495,
-        "elevation_deg": 59.943958,
-        "range_au": 8.6742051023308
+        "astro_ra_deg": 323.7157916666667,
+        "astro_dec_deg": -15.774500000000002,
+        "app_ra_deg": 324.02970833333336,
+        "app_dec_deg": -15.673,
+        "azimuth_deg": 207.014632,
+        "elevation_deg": 72.348157,
+        "range_au": 8.86918450040923
       }
     },
     {
@@ -2161,25 +2473,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        9.495117000588953,
-        -0.5702620760421724,
-        -0.6636034828520035
+        8.115382164819389,
+        -5.905639092575692,
+        -2.807323959913588
       ],
       "geo_velocity_au_per_day": [
-        0.01706161342329413,
-        0.004923870425501271,
-        0.002047777015607316
+        0.02032847099890566,
+        0.004297608497428625,
+        0.00165190264726205
       ],
       "observed": {
-        "astro_ra_deg": 356.56108333333333,
-        "astro_dec_deg": -3.9913611111111114,
-        "app_ra_deg": 356.8955,
-        "app_dec_deg": -3.8469722222222225,
-        "azimuth_deg": 266.148019,
-        "elevation_deg": -2.918181,
-        "range_au": 9.5353958653342
+        "astro_ra_deg": 323.9542916666666,
+        "astro_dec_deg": -15.627027777777778,
+        "app_ra_deg": 324.26325,
+        "app_dec_deg": -15.526750000000002,
+        "azimuth_deg": 250.986497,
+        "elevation_deg": -34.749032,
+        "range_au": 10.422015668587
       }
     },
     {
@@ -2187,25 +2499,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        10.31115564588462,
-        1.402292713250083,
-        0.1820916804620778
+        9.30834618599121,
+        -4.010860757731018,
+        -2.010583741583301
       ],
       "geo_velocity_au_per_day": [
-        -0.009037306476043278,
-        0.01890202712575994,
-        0.00812459759418714
+        -0.005885028393067955,
+        0.0181666775486019,
+        0.007675854819162161
       ],
       "observed": {
-        "astro_ra_deg": 7.742958333333333,
-        "astro_dec_deg": 1.0017777777777779,
-        "app_ra_deg": 8.076666666666666,
-        "app_dec_deg": 1.1456944444444443,
-        "azimuth_deg": 86.656951,
-        "elevation_deg": -69.947274,
-        "range_au": 10.4077108875464
+        "astro_ra_deg": 336.68779166666667,
+        "astro_dec_deg": -11.2205,
+        "app_ra_deg": 336.9907916666666,
+        "app_dec_deg": -11.10425,
+        "azimuth_deg": 104.019374,
+        "elevation_deg": -37.342405,
+        "range_au": 10.3332008911625
       }
     },
     {
@@ -2213,25 +2525,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        8.489168173794486,
-        2.094194898380382,
-        0.4747813521195802
+        7.890940098413336,
+        -3.402830595627485,
+        -1.770392564317749
       ],
       "geo_velocity_au_per_day": [
-        -0.01086449677750823,
-        -0.00777537966005968,
-        -0.003422340653222391
+        -0.007275192362975836,
+        -0.00831324933183832,
+        -0.003793880258761276
       ],
       "observed": {
-        "astro_ra_deg": 13.856125,
-        "astro_dec_deg": 3.107416666666667,
-        "app_ra_deg": 14.204958333333334,
-        "app_dec_deg": 3.2543888888888888,
-        "azimuth_deg": 85.612799,
-        "elevation_deg": 42.087894,
-        "range_au": 8.75650644048502
+        "astro_ra_deg": 336.67104166666667,
+        "astro_dec_deg": -11.64175,
+        "app_ra_deg": 336.988375,
+        "app_dec_deg": -11.520361111111113,
+        "azimuth_deg": 139.851754,
+        "elevation_deg": 74.854021,
+        "range_au": 8.7738201597354
       }
     },
     {
@@ -2239,25 +2551,103 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Equator (synthetic, 0N 0E)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        9.037984585850833,
-        1.262662785604759,
-        0.109270441585738
+        8.873082854907661,
+        -4.263257528287816,
+        -2.165424817818546
       ],
       "geo_velocity_au_per_day": [
-        0.01577790101423161,
-        0.003297765705293493,
-        0.001397434676983488
+        0.01926899897638471,
+        0.003307589542271192,
+        0.001256415797365792
       ],
       "observed": {
-        "astro_ra_deg": 7.951125000000001,
-        "astro_dec_deg": 0.6853055555555556,
-        "app_ra_deg": 8.300583333333334,
-        "app_dec_deg": 0.8355,
-        "azimuth_deg": 270.859777,
-        "elevation_deg": 13.64504,
-        "range_au": 9.12644911849073
+        "astro_ra_deg": 334.335125,
+        "astro_dec_deg": -12.406416666666667,
+        "app_ra_deg": 334.6512916666667,
+        "app_dec_deg": -12.288583333333333,
+        "azimuth_deg": 256.890507,
+        "elevation_deg": -20.219445,
+        "range_au": 10.079545693825
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        10.07859655293539,
+        -2.392559955234406,
+        -1.375076968985813
+      ],
+      "geo_velocity_au_per_day": [
+        -0.00554050048660469,
+        0.01923564723391554,
+        0.008173381696714305
+      ],
+      "observed": {
+        "astro_ra_deg": 346.6441666666667,
+        "astro_dec_deg": -7.562222222222222,
+        "app_ra_deg": 346.9542083333333,
+        "app_dec_deg": -7.433305555555556,
+        "azimuth_deg": 102.317908,
+        "elevation_deg": -52.668582,
+        "range_au": 10.4495880890676
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        8.549329538136652,
+        -1.598775703124963,
+        -1.049969232683365
+      ],
+      "geo_velocity_au_per_day": [
+        -0.009531460614140187,
+        -0.007119243906326336,
+        -0.003237863894617312
+      ],
+      "observed": {
+        "astro_ra_deg": 349.40612500000003,
+        "astro_dec_deg": -6.884166666666666,
+        "app_ra_deg": 349.729,
+        "app_dec_deg": -6.747972222222223,
+        "azimuth_deg": 104.232841,
+        "elevation_deg": 61.450486,
+        "range_au": 8.76064611473219
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Equator (synthetic, 0N 0E)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        9.259118943864722,
+        -2.474955223565741,
+        -1.447093344207675
+      ],
+      "geo_velocity_au_per_day": [
+        0.01794506137002327,
+        0.002139986138257225,
+        0.0007913128496279117
+      ],
+      "observed": {
+        "astro_ra_deg": 345.0327916666667,
+        "astro_dec_deg": -8.58675,
+        "app_ra_deg": 345.3570833333333,
+        "app_dec_deg": -8.453722222222222,
+        "azimuth_deg": 261.516424,
+        "elevation_deg": -4.790919,
+        "range_au": 9.69287162012607
       }
     },
     {
@@ -2447,25 +2837,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        9.161938680560144,
-        -4.18206712865634,
-        -2.132881008994687
+        5.669493401374993,
+        -8.511568734626051,
+        -3.770251211524874
       ],
       "geo_velocity_au_per_day": [
-        0.01905198380894553,
-        0.007506678948347601,
-        0.003077578975058576
+        0.02154790804249204,
+        0.005827912398774828,
+        0.002279749448901465
       ],
       "observed": {
-        "astro_ra_deg": 335.46337500000004,
-        "astro_dec_deg": -11.958138888888888,
-        "app_ra_deg": 335.77820833333334,
-        "app_dec_deg": -11.839305555555557,
-        "azimuth_deg": 301.644601,
-        "elevation_deg": -18.395248,
-        "range_au": 10.2947141283841
+        "astro_ra_deg": 303.66541666666666,
+        "astro_dec_deg": -20.23738888888889,
+        "app_ra_deg": 303.96,
+        "app_dec_deg": -20.174833333333336,
+        "azimuth_deg": 334.525647,
+        "elevation_deg": -31.122052,
+        "range_au": 10.8998028663756
       }
     },
     {
@@ -2473,25 +2863,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        9.966791578363022,
-        -2.119093772238966,
-        -1.259001078000066
+        6.766353520409509,
+        -6.65974424782074,
+        -2.996906186288015
       ],
       "geo_velocity_au_per_day": [
-        -0.00926575807393705,
-        0.01709403423284245,
-        0.007246612841380801
+        -0.006750152306028179,
+        0.01521504602934802,
+        0.006352137812271386
       ],
       "observed": {
-        "astro_ra_deg": 347.995125,
-        "astro_dec_deg": -7.044527777777778,
-        "app_ra_deg": 348.30587499999996,
-        "app_dec_deg": -6.91425,
-        "azimuth_deg": 51.892074,
-        "elevation_deg": -14.482437,
-        "range_au": 10.2670630376081
+        "astro_ra_deg": 315.4532083333333,
+        "astro_dec_deg": -17.519666666666666,
+        "app_ra_deg": 315.747625,
+        "app_dec_deg": -17.436777777777777,
+        "azimuth_deg": 87.278324,
+        "elevation_deg": -18.416599,
+        "range_au": 9.95575357356276
       }
     },
     {
@@ -2499,25 +2889,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        8.432574839072291,
-        -1.722358745920582,
-        -1.105792640863175
+        5.565778789771198,
+        -6.482724286458221,
+        -2.94909521950581
       ],
       "geo_velocity_au_per_day": [
-        -0.00593747257219218,
-        -0.00922945640831641,
-        -0.004150103325545598
+        -0.002911232840788826,
+        -0.01089080264208594,
+        -0.004959610446633339
       ],
       "observed": {
-        "astro_ra_deg": 348.45437499999997,
-        "astro_dec_deg": -7.3222499999999995,
-        "app_ra_deg": 348.7787916666666,
-        "app_dec_deg": -7.186166666666667,
-        "azimuth_deg": 167.987346,
-        "elevation_deg": 4.551664,
-        "range_au": 8.6774250436539
+        "astro_ra_deg": 310.64608333333337,
+        "astro_dec_deg": -19.043111111111113,
+        "app_ra_deg": 310.9560833333333,
+        "app_dec_deg": -18.965027777777777,
+        "azimuth_deg": 205.198329,
+        "elevation_deg": -8.155919,
+        "range_au": 9.03887680983063
       }
     },
     {
@@ -2525,25 +2915,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        9.531422016220812,
-        -2.411611104945534,
-        -1.421678989134372
+        7.029738453470491,
+        -7.339229692796889,
+        -3.348713807895955
       ],
       "geo_velocity_au_per_day": [
-        0.0181664691153462,
-        0.006323705123618,
-        0.002605417160119831
+        0.02109388371240891,
+        0.005128695490352784,
+        0.00199000671410687
       ],
       "observed": {
-        "astro_ra_deg": 345.79941666666673,
-        "astro_dec_deg": -8.228833333333334,
-        "app_ra_deg": 346.1227083333333,
-        "app_dec_deg": -8.095527777777779,
-        "azimuth_deg": 286.853891,
-        "elevation_deg": -11.788354,
-        "range_au": 9.93409044573314
+        "astro_ra_deg": 313.76425,
+        "astro_dec_deg": -18.238111111111113,
+        "app_ra_deg": 314.066375,
+        "app_dec_deg": -18.156527777777775,
+        "azimuth_deg": 318.383361,
+        "elevation_deg": -27.367632,
+        "range_au": 10.700303720987
       }
     },
     {
@@ -2551,25 +2941,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        10.34848386712778,
-        -0.3750187894896339,
-        -0.5541426308467658
+        8.18706250647186,
+        -5.45174229247736,
+        -2.558100293494052
       ],
       "geo_velocity_au_per_day": [
-        -0.009164619033500892,
-        0.01816105367022833,
-        0.007753650201144451
+        -0.006281324236164681,
+        0.0168162349766243,
+        0.007063082513219061
       ],
       "observed": {
-        "astro_ra_deg": 357.9229166666667,
-        "astro_dec_deg": -3.064083333333333,
-        "app_ra_deg": 358.2434166666667,
-        "app_dec_deg": -2.925,
-        "azimuth_deg": 35.980695,
-        "elevation_deg": -12.706683,
-        "range_au": 10.3700990191234
+        "astro_ra_deg": 326.33875,
+        "astro_dec_deg": -14.578805555555554,
+        "app_ra_deg": 326.637,
+        "app_dec_deg": -14.477972222222222,
+        "azimuth_deg": 70.699187,
+        "elevation_deg": -18.790253,
+        "range_au": 10.1633304155535
       }
     },
     {
@@ -2577,25 +2967,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        8.666198555513423,
-        0.1822881517417485,
-        -0.3259534935503385
+        6.880319183526448,
+        -5.050843733250445,
+        -2.411025946372626
       ],
       "geo_velocity_au_per_day": [
-        -0.008421693851488788,
-        -0.008446008021485991,
-        -0.003765359452427075
+        -0.005056489700451602,
+        -0.009582562294614728,
+        -0.004372136877371697
       ],
       "observed": {
-        "astro_ra_deg": 1.2033333333333334,
-        "astro_dec_deg": -2.1545,
-        "app_ra_deg": 1.5374166666666667,
-        "app_dec_deg": -2.0091944444444443,
-        "azimuth_deg": 149.669031,
-        "elevation_deg": 8.375657,
-        "range_au": 8.6742357672231
+        "astro_ra_deg": 323.7158333333333,
+        "astro_dec_deg": -15.774694444444446,
+        "app_ra_deg": 324.0296666666667,
+        "app_dec_deg": -15.673194444444444,
+        "azimuth_deg": 187.934657,
+        "elevation_deg": -3.791424,
+        "range_au": 8.86922788139265
       }
     },
     {
@@ -2603,25 +2993,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        9.495117000588953,
-        -0.5702620760421724,
-        -0.6636034828520035
+        8.115382164819389,
+        -5.905639092575692,
+        -2.807323959913588
       ],
       "geo_velocity_au_per_day": [
-        0.01706161342329413,
-        0.004923870425501271,
-        0.002047777015607316
+        0.02032847099890566,
+        0.004297608497428625,
+        0.00165190264726205
       ],
       "observed": {
-        "astro_ra_deg": 356.56129166666665,
-        "astro_dec_deg": -3.991611111111111,
-        "app_ra_deg": 356.89570833333335,
-        "app_dec_deg": -3.8472222222222223,
-        "azimuth_deg": 272.060528,
-        "elevation_deg": -4.371067,
-        "range_au": 9.5353969358109
+        "astro_ra_deg": 323.9544583333333,
+        "astro_dec_deg": -15.627277777777778,
+        "app_ra_deg": 324.26345833333335,
+        "app_dec_deg": -15.527000000000001,
+        "azimuth_deg": 302.864579,
+        "elevation_deg": -22.355279,
+        "range_au": 10.4220075612777
       }
     },
     {
@@ -2629,25 +3019,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        10.31115564588462,
-        1.402292713250083,
-        0.1820916804620778
+        9.30834618599121,
+        -4.010860757731018,
+        -2.010583741583301
       ],
       "geo_velocity_au_per_day": [
-        -0.009037306476043278,
-        0.01890202712575994,
-        0.00812459759418714
+        -0.005885028393067955,
+        0.0181666775486019,
+        0.007675854819162161
       ],
       "observed": {
-        "astro_ra_deg": 7.742875000000001,
-        "astro_dec_deg": 1.0015555555555555,
-        "app_ra_deg": 8.076666666666666,
-        "app_dec_deg": 1.1454722222222222,
-        "azimuth_deg": 20.348077,
-        "elevation_deg": -10.122462,
-        "range_au": 10.4076783573909
+        "astro_ra_deg": 336.68766666666664,
+        "astro_dec_deg": -11.22075,
+        "app_ra_deg": 336.99066666666664,
+        "app_dec_deg": -11.1045,
+        "azimuth_deg": 54.349166,
+        "elevation_deg": -18.330802,
+        "range_au": 10.3331884254242
       }
     },
     {
@@ -2655,25 +3045,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        8.489168173794486,
-        2.094194898380382,
-        0.4747813521195802
+        7.890940098413336,
+        -3.402830595627485,
+        -1.770392564317749
       ],
       "geo_velocity_au_per_day": [
-        -0.01086449677750823,
-        -0.00777537966005968,
-        -0.003422340653222391
+        -0.007275192362975836,
+        -0.00831324933183832,
+        -0.003793880258761276
       ],
       "observed": {
-        "astro_ra_deg": 13.855958333333332,
-        "astro_dec_deg": 3.107138888888889,
-        "app_ra_deg": 14.20475,
-        "app_dec_deg": 3.254111111111111,
-        "azimuth_deg": 131.027038,
-        "elevation_deg": 11.237873,
-        "range_au": 8.7565267005472
+        "astro_ra_deg": 336.671,
+        "astro_dec_deg": -11.641972222222222,
+        "app_ra_deg": 336.98829166666667,
+        "app_dec_deg": -11.520583333333335,
+        "azimuth_deg": 170.301986,
+        "elevation_deg": 0.305618,
+        "range_au": 8.77386103160745
       }
     },
     {
@@ -2681,25 +3071,103 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Polar (synthetic, 78N)",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        9.037984585850833,
-        1.262662785604759,
-        0.109270441585738
+        8.873082854907661,
+        -4.263257528287816,
+        -2.165424817818546
       ],
       "geo_velocity_au_per_day": [
-        0.01577790101423161,
-        0.003297765705293493,
-        0.001397434676983488
+        0.01926899897638471,
+        0.003307589542271192,
+        0.001256415797365792
       ],
       "observed": {
-        "astro_ra_deg": 7.951333333333334,
-        "astro_dec_deg": 0.6850555555555555,
-        "app_ra_deg": 8.300791666666667,
-        "app_dec_deg": 0.83525,
-        "azimuth_deg": 256.810389,
-        "elevation_deg": 3.629571,
-        "range_au": 9.12645647222305
+        "astro_ra_deg": 334.3352916666667,
+        "astro_dec_deg": -12.406638888888889,
+        "app_ra_deg": 334.65150000000006,
+        "app_dec_deg": -12.288805555555555,
+        "azimuth_deg": 287.821904,
+        "elevation_deg": -16.262966,
+        "range_au": 10.0795428774224
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        10.07859655293539,
+        -2.392559955234406,
+        -1.375076968985813
+      ],
+      "geo_velocity_au_per_day": [
+        -0.00554050048660469,
+        0.01923564723391554,
+        0.008173381696714305
+      ],
+      "observed": {
+        "astro_ra_deg": 346.64408333333336,
+        "astro_dec_deg": -7.5624722222222225,
+        "app_ra_deg": 346.95416666666665,
+        "app_dec_deg": -7.4335555555555555,
+        "azimuth_deg": 38.275409,
+        "elevation_deg": -16.969769,
+        "range_au": 10.4495666329338
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        8.549329538136652,
+        -1.598775703124963,
+        -1.049969232683365
+      ],
+      "geo_velocity_au_per_day": [
+        -0.009531460614140187,
+        -0.007119243906326336,
+        -0.003237863894617312
+      ],
+      "observed": {
+        "astro_ra_deg": 349.40600000000006,
+        "astro_dec_deg": -6.884388888888888,
+        "app_ra_deg": 349.72883333333334,
+        "app_dec_deg": -6.748222222222222,
+        "azimuth_deg": 152.334997,
+        "elevation_deg": 3.881482,
+        "range_au": 8.7606806399895
+      }
+    },
+    {
+      "class": "adversarial",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Polar (synthetic, 78N)",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        9.259118943864722,
+        -2.474955223565741,
+        -1.447093344207675
+      ],
+      "geo_velocity_au_per_day": [
+        0.01794506137002327,
+        0.002139986138257225,
+        0.0007913128496279117
+      ],
+      "observed": {
+        "astro_ra_deg": 345.03299999999996,
+        "astro_dec_deg": -8.586972222222222,
+        "app_ra_deg": 345.35729166666664,
+        "app_dec_deg": -8.453944444444444,
+        "azimuth_deg": 272.969784,
+        "elevation_deg": -9.274661,
+        "range_au": 9.69287491158502
       }
     },
     {
@@ -4345,25 +4813,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        3.659031087292524,
-        2.409382612596195,
-        0.9433772420100425
+        3.220614359853353,
+        -4.617549006443141,
+        -2.057563082241604
       ],
       "geo_velocity_au_per_day": [
-        0.01175899473570973,
-        0.00786081439847964,
-        0.003515247056181798
+        0.0231595350515104,
+        0.007456468014043755,
+        0.003065443138537445
       ],
       "observed": {
-        "astro_ra_deg": 33.361125,
-        "astro_dec_deg": 12.15075,
-        "app_ra_deg": 33.685208333333335,
-        "app_dec_deg": 12.26361111111111,
-        "azimuth_deg": 259.072697,
-        "elevation_deg": 24.154258,
-        "range_au": 4.48148623819745
+        "astro_ra_deg": 304.8919583333333,
+        "astro_dec_deg": -20.077111111111112,
+        "app_ra_deg": 305.18575,
+        "app_dec_deg": -20.012527777777777,
+        "azimuth_deg": 319.724965,
+        "elevation_deg": -53.227831,
+        "range_au": 5.99403551245952
       }
     },
     {
@@ -4371,25 +4839,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        3.554017105697379,
-        4.447763497539288,
-        1.841624016701625
+        4.470143222516899,
+        -2.528960629807749,
+        -1.171239066425376
       ],
       "geo_velocity_au_per_day": [
-        -0.0171007066134842,
-        0.01631100602118493,
-        0.007205854869956682
+        -0.005849165673825978,
+        0.01751165444948337,
+        0.007441101576084937
       ],
       "observed": {
-        "astro_ra_deg": 51.37045833333333,
-        "astro_dec_deg": 17.92388888888889,
-        "app_ra_deg": 51.708916666666674,
-        "app_dec_deg": 18.008333333333333,
-        "azimuth_deg": 346.595869,
-        "elevation_deg": -19.548534,
-        "range_au": 5.9837648713963
+        "astro_ra_deg": 330.49904166666664,
+        "astro_dec_deg": -12.847666666666667,
+        "app_ra_deg": 330.77925000000005,
+        "app_dec_deg": -12.746777777777776,
+        "azimuth_deg": 80.97779,
+        "elevation_deg": -23.367201,
+        "range_au": 5.26777241649317
       }
     },
     {
@@ -4397,25 +4865,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        1.058906415658519,
-        4.677115991383578,
-        1.958628432836888
+        3.32634876872877,
+        -2.043815739744144,
+        -0.9775249140254597
       ],
       "geo_velocity_au_per_day": [
-        -0.01407636378699276,
-        -0.01124723975050244,
-        -0.00471842712636332
+        -0.002890398726048254,
+        -0.00807882648471369,
+        -0.003627773464902677
       ],
       "observed": {
-        "astro_ra_deg": 77.24083333333334,
-        "astro_dec_deg": 22.21602777777778,
-        "app_ra_deg": 77.60945833333334,
-        "app_dec_deg": 22.248305555555557,
-        "azimuth_deg": 67.6992,
-        "elevation_deg": 10.789305,
-        "range_au": 5.17998871042696
+        "astro_ra_deg": 328.42954166666664,
+        "astro_dec_deg": -14.058444444444445,
+        "app_ra_deg": 328.72433333333333,
+        "app_dec_deg": -13.95572222222222,
+        "azimuth_deg": 189.251587,
+        "elevation_deg": 24.130152,
+        "range_au": 4.02458595981734
       }
     },
     {
@@ -4423,25 +4891,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        1.175501201631793,
-        3.6686645807608,
-        1.541318908321323
+        4.732841808699676,
+        -2.540790035225524,
+        -1.206488160278314
       ],
       "geo_velocity_au_per_day": [
-        0.009978816299972989,
-        0.003016863174536286,
-        0.001480180734514877
+        0.02009746356054267,
+        0.008275852410189669,
+        0.00348864642449044
       ],
       "observed": {
-        "astro_ra_deg": 72.23079166666666,
-        "astro_dec_deg": 21.805416666666666,
-        "app_ra_deg": 72.60937499999999,
-        "app_dec_deg": 21.850305555555558,
-        "azimuth_deg": 218.78693,
-        "elevation_deg": 55.663079,
-        "range_au": 4.14925488143418
+        "astro_ra_deg": 331.76849999999996,
+        "astro_dec_deg": -12.659722222222223,
+        "app_ra_deg": 332.0561666666666,
+        "app_dec_deg": -12.555000000000001,
+        "azimuth_deg": 289.49442,
+        "elevation_deg": -30.454816,
+        "range_au": 5.50561247526
       }
     },
     {
@@ -4449,25 +4917,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        1.019647022735552,
-        5.230845150711308,
-        2.239940777054897
+        5.704588499328,
+        -0.2660622501131578,
+        -0.2303531261482116
       ],
       "geo_velocity_au_per_day": [
-        -0.01714889336320539,
-        0.01356208512337897,
-        0.006063030985161307
+        -0.008389130028348964,
+        0.02008548978719906,
+        0.0086404499993086
       ],
       "observed": {
-        "astro_ra_deg": 78.96675,
-        "astro_dec_deg": 22.796722222222225,
-        "app_ra_deg": 79.34483333333333,
-        "app_dec_deg": 22.825499999999998,
-        "azimuth_deg": 318.170876,
-        "elevation_deg": -5.433323,
-        "range_au": 5.78092395674735
+        "astro_ra_deg": 357.32741666666664,
+        "astro_dec_deg": -2.3111944444444443,
+        "app_ra_deg": 357.60575,
+        "app_dec_deg": -2.190472222222222,
+        "azimuth_deg": 44.371982,
+        "elevation_deg": -32.075766,
+        "range_au": 5.71542835044993
       }
     },
     {
@@ -4475,25 +4943,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -1.595829972383448,
-        5.160509381191641,
-        2.231781257735082
+        4.075898642678372,
+        0.5232831210404036,
+        0.1058808442733735
       ],
       "geo_velocity_au_per_day": [
-        -0.01595075868375904,
-        -0.01429870375834157,
-        -0.006011205092435462
+        -0.008318684437688297,
+        -0.006417118678976323,
+        -0.002813766406305089
       ],
       "observed": {
-        "astro_ra_deg": 107.18116666666667,
-        "astro_dec_deg": 22.44875,
-        "app_ra_deg": 107.56320833333334,
-        "app_dec_deg": 22.40888888888889,
-        "azimuth_deg": 40.265724,
-        "elevation_deg": -6.666439,
-        "range_au": 5.84447511235985
+        "astro_ra_deg": 7.3137083333333335,
+        "astro_dec_deg": 1.4744722222222224,
+        "app_ra_deg": 7.605541666666667,
+        "app_dec_deg": 1.6003333333333334,
+        "azimuth_deg": 137.011539,
+        "elevation_deg": 31.98121,
+        "range_au": 4.11067250746021
       }
     },
     {
@@ -4501,25 +4969,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        -1.631382522580588,
-        3.634065377489432,
-        1.592568744257962
+        4.850707865785497,
+        0.03005800495028349,
+        -0.1096738046085555
       ],
       "geo_velocity_au_per_day": [
-        0.01021883804280087,
-        -0.002105229133106922,
-        -0.0007262166495747829
+        0.01592589431743472,
+        0.00711926233931227,
+        0.003088865563731987
       ],
       "observed": {
-        "astro_ra_deg": 114.1735,
-        "astro_dec_deg": 21.791416666666667,
-        "app_ra_deg": 114.56633333333332,
-        "app_dec_deg": 21.732694444444444,
-        "azimuth_deg": 137.837516,
-        "elevation_deg": 54.599146,
-        "range_au": 4.28994413086344
+        "astro_ra_deg": 0.352375,
+        "astro_dec_deg": -1.296611111111111,
+        "app_ra_deg": 0.6438333333333334,
+        "app_dec_deg": -1.1700833333333334,
+        "azimuth_deg": 269.183643,
+        "elevation_deg": -0.845723,
+        "range_au": 4.85208583291106
       }
     },
     {
@@ -4527,25 +4995,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        -1.584381350650671,
-        4.697794396433091,
-        2.075641923365488
+        5.449944812238964,
+        2.231312704099765,
+        0.8471096353390408
       ],
       "geo_velocity_au_per_day": [
-        -0.01497908586249715,
-        0.01080629594872169,
-        0.004863538740503643
+        -0.01136151966045957,
+        0.02041525220793278,
+        0.008889719488252665
       ],
       "observed": {
-        "astro_ra_deg": 108.63429166666667,
-        "astro_dec_deg": 22.71722222222222,
-        "app_ra_deg": 109.02991666666667,
-        "app_dec_deg": 22.672222222222224,
-        "azimuth_deg": 291.223193,
-        "elevation_deg": 12.180355,
-        "range_au": 5.37476319171344
+        "astro_ra_deg": 22.262708333333336,
+        "astro_dec_deg": 8.18425,
+        "app_ra_deg": 22.559958333333334,
+        "app_dec_deg": 8.301833333333335,
+        "azimuth_deg": 7.143888,
+        "elevation_deg": -29.978383,
+        "range_au": 5.94965597633679
       }
     },
     {
@@ -4553,25 +5021,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -4.056189219430359,
-        4.360980463335164,
-        1.950459391246745
+        3.316824080862674,
+        3.063850093548056,
+        1.214782729339548
       ],
       "geo_velocity_au_per_day": [
-        -0.01572408222991063,
-        -0.01680004268593127,
-        -0.00711579704667975
+        -0.0137020169175737,
+        -0.006853735673413031,
+        -0.002898252686048443
       ],
       "observed": {
-        "astro_ra_deg": 132.92375,
-        "astro_dec_deg": 18.13347222222222,
-        "app_ra_deg": 133.29783333333333,
-        "app_dec_deg": 18.034583333333334,
-        "azimuth_deg": 13.199287,
-        "elevation_deg": -19.551388,
-        "range_au": 6.26697564508911
+        "astro_ra_deg": 42.72741666666667,
+        "astro_dec_deg": 15.056777777777778,
+        "app_ra_deg": 43.053041666666665,
+        "app_dec_deg": 15.15461111111111,
+        "azimuth_deg": 91.243164,
+        "elevation_deg": 20.507243,
+        "range_au": 4.6758558923004
       }
     },
     {
@@ -4579,25 +5047,103 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -4.017557776247482,
-        2.398845706204791,
-        1.119005442189166
+        3.478926283349484,
+        2.32189125009488,
+        0.9038511183238048
       ],
       "geo_velocity_au_per_day": [
-        0.01215825387064964,
-        -0.006493228530330381,
-        -0.002663667759503783
+        0.0120600714032732,
+        0.003794836115861949,
+        0.001749827460276976
       ],
       "observed": {
-        "astro_ra_deg": 149.15695833333334,
-        "astro_dec_deg": 13.449722222222222,
-        "app_ra_deg": 149.52608333333333,
-        "app_dec_deg": 13.319694444444444,
-        "azimuth_deg": 101.534678,
-        "elevation_deg": 25.95136,
-        "range_au": 4.81111441074223
+        "astro_ra_deg": 33.717000000000006,
+        "astro_dec_deg": 12.19275,
+        "app_ra_deg": 34.04175,
+        "app_dec_deg": 12.305277777777778,
+        "azimuth_deg": 245.666818,
+        "elevation_deg": 33.161677,
+        "range_au": 4.27914286670973
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        3.78293409959322,
+        4.18493361183619,
+        1.725693520662671
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01331924144483628,
+        0.01860055439281013,
+        0.00819514252283471
+      ],
+      "observed": {
+        "astro_ra_deg": 47.88558333333333,
+        "astro_dec_deg": 17.007944444444444,
+        "app_ra_deg": 48.220416666666665,
+        "app_dec_deg": 17.098444444444443,
+        "azimuth_deg": 335.272047,
+        "elevation_deg": -18.140271,
+        "range_au": 5.89937333472722
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        1.297563139948168,
+        4.829793333952151,
+        2.0224712882608
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01764630526363336,
+        -0.008980294593722207,
+        -0.003738810659399622
+      ],
+      "observed": {
+        "astro_ra_deg": 74.95970833333334,
+        "astro_dec_deg": 22.018166666666666,
+        "app_ra_deg": 75.32529166666667,
+        "app_dec_deg": 22.055472222222225,
+        "azimuth_deg": 58.468768,
+        "elevation_deg": 3.698525,
+        "range_au": 5.39447568572376
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        1.02610109976449,
+        3.653691954815205,
+        1.532249698867453
+      ],
+      "geo_velocity_au_per_day": [
+        0.00974858669202192,
+        -0.001004561661155435,
+        -0.0002635760589759495
+      ],
+      "observed": {
+        "astro_ra_deg": 74.31037500000001,
+        "astro_dec_deg": 21.985777777777777,
+        "app_ra_deg": 74.68958333333333,
+        "app_dec_deg": 22.025777777777776,
+        "azimuth_deg": 190.332634,
+        "elevation_deg": 60.239041,
+        "range_au": 4.09265086508598
       }
     },
     {
@@ -4605,25 +5151,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        3.659031087292524,
-        2.409382612596195,
-        0.9433772420100425
+        3.220614359853353,
+        -4.617549006443141,
+        -2.057563082241604
       ],
       "geo_velocity_au_per_day": [
-        0.01175899473570973,
-        0.00786081439847964,
-        0.003515247056181798
+        0.0231595350515104,
+        0.007456468014043755,
+        0.003065443138537445
       ],
       "observed": {
-        "astro_ra_deg": 33.362,
-        "astro_dec_deg": 12.150972222222222,
-        "app_ra_deg": 33.686,
-        "app_dec_deg": 12.263777777777777,
-        "azimuth_deg": 78.764289,
-        "elevation_deg": 5.04511,
-        "range_au": 4.48149993724459
+        "astro_ra_deg": 304.89208333333335,
+        "astro_dec_deg": -20.07713888888889,
+        "app_ra_deg": 305.1860416666666,
+        "app_dec_deg": -20.012583333333332,
+        "azimuth_deg": 180.298354,
+        "elevation_deg": 50.160628,
+        "range_au": 5.99396856322037
       }
     },
     {
@@ -4631,25 +5177,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        3.554017105697379,
-        4.447763497539288,
-        1.841624016701625
+        4.470143222516899,
+        -2.528960629807749,
+        -1.171239066425376
       ],
       "geo_velocity_au_per_day": [
-        -0.0171007066134842,
-        0.01631100602118493,
-        0.007205854869956682
+        -0.005849165673825978,
+        0.01751165444948337,
+        0.007441101576084937
       ],
       "observed": {
-        "astro_ra_deg": 51.37045833333333,
-        "astro_dec_deg": 17.92425,
-        "app_ra_deg": 51.70904166666667,
-        "app_dec_deg": 18.008694444444444,
-        "azimuth_deg": 262.163363,
-        "elevation_deg": 79.210245,
-        "range_au": 5.98370861282074
+        "astro_ra_deg": 330.49829166666666,
+        "astro_dec_deg": -12.847472222222223,
+        "app_ra_deg": 330.77858333333336,
+        "app_dec_deg": -12.746611111111111,
+        "azimuth_deg": 258.912528,
+        "elevation_deg": -6.953677,
+        "range_au": 5.26776066487384
       }
     },
     {
@@ -4657,25 +5203,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        1.058906415658519,
-        4.677115991383578,
-        1.958628432836888
+        3.32634876872877,
+        -2.043815739744144,
+        -0.9775249140254597
       ],
       "geo_velocity_au_per_day": [
-        -0.01407636378699276,
-        -0.01124723975050244,
-        -0.00471842712636332
+        -0.002890398726048254,
+        -0.00807882648471369,
+        -0.003627773464902677
       ],
       "observed": {
-        "astro_ra_deg": 77.24004166666667,
-        "astro_dec_deg": 22.216194444444444,
-        "app_ra_deg": 77.60866666666668,
-        "app_dec_deg": 22.248555555555555,
-        "azimuth_deg": 295.556387,
-        "elevation_deg": -4.397845,
-        "range_au": 5.17999993127623
+        "astro_ra_deg": 328.42991666666666,
+        "astro_dec_deg": -14.057972222222222,
+        "app_ra_deg": 328.7245833333333,
+        "app_dec_deg": -13.955222222222222,
+        "azimuth_deg": 84.788629,
+        "elevation_deg": -57.730484,
+        "range_au": 4.02463954029163
       }
     },
     {
@@ -4683,25 +5229,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        1.175501201631793,
-        3.6686645807608,
-        1.541318908321323
+        4.732841808699676,
+        -2.540790035225524,
+        -1.206488160278314
       ],
       "geo_velocity_au_per_day": [
-        0.009978816299972989,
-        0.003016863174536286,
-        0.001480180734514877
+        0.02009746356054267,
+        0.008275852410189669,
+        0.00348864642449044
       ],
       "observed": {
-        "astro_ra_deg": 72.23137499999999,
-        "astro_dec_deg": 21.80538888888889,
-        "app_ra_deg": 72.60987499999999,
-        "app_dec_deg": 21.850250000000003,
-        "azimuth_deg": 50.17231,
-        "elevation_deg": -28.056862,
-        "range_au": 4.1493101825961
+        "astro_ra_deg": 331.76895833333333,
+        "astro_dec_deg": -12.659638888888889,
+        "app_ra_deg": 332.05675,
+        "app_dec_deg": -12.55488888888889,
+        "azimuth_deg": 133.334826,
+        "elevation_deg": 44.941719,
+        "range_au": 5.50556070227828
       }
     },
     {
@@ -4709,25 +5255,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        1.019647022735552,
-        5.230845150711308,
-        2.239940777054897
+        5.704588499328,
+        -0.2660622501131578,
+        -0.2303531261482116
       ],
       "geo_velocity_au_per_day": [
-        -0.01714889336320539,
-        0.01356208512337897,
-        0.006063030985161307
+        -0.008389130028348964,
+        0.02008548978719906,
+        0.0086404499993086
       ],
       "observed": {
-        "astro_ra_deg": 78.967125,
-        "astro_dec_deg": 22.797111111111114,
-        "app_ra_deg": 79.34533333333333,
-        "app_dec_deg": 22.82586111111111,
-        "azimuth_deg": 77.642286,
-        "elevation_deg": 69.716003,
-        "range_au": 5.78087983202828
+        "astro_ra_deg": 357.32691666666665,
+        "astro_dec_deg": -2.3110277777777775,
+        "app_ra_deg": 357.6053333333333,
+        "app_dec_deg": -2.1903055555555553,
+        "azimuth_deg": 257.047635,
+        "elevation_deg": 26.376898,
+        "range_au": 5.71538670334414
       }
     },
     {
@@ -4735,25 +5281,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -1.595829972383448,
-        5.160509381191641,
-        2.231781257735082
+        4.075898642678372,
+        0.5232831210404036,
+        0.1058808442733735
       ],
       "geo_velocity_au_per_day": [
-        -0.01595075868375904,
-        -0.01429870375834157,
-        -0.006011205092435462
+        -0.008318684437688297,
+        -0.006417118678976323,
+        -0.002813766406305089
       ],
       "observed": {
-        "astro_ra_deg": 107.18058333333335,
-        "astro_dec_deg": 22.44902777777778,
-        "app_ra_deg": 107.56270833333333,
-        "app_dec_deg": 22.40925,
-        "azimuth_deg": 285.819856,
-        "elevation_deg": 26.61312,
-        "range_au": 5.84445098163359
+        "astro_ra_deg": 7.313375,
+        "astro_dec_deg": 1.4746944444444445,
+        "app_ra_deg": 7.605083333333334,
+        "app_dec_deg": 1.6005833333333335,
+        "azimuth_deg": 332.410637,
+        "elevation_deg": -66.085344,
+        "range_au": 4.11073414806192
       }
     },
     {
@@ -4761,25 +5307,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        -1.631382522580588,
-        3.634065377489432,
-        1.592568744257962
+        4.850707865785497,
+        0.03005800495028349,
+        -0.1096738046085555
       ],
       "geo_velocity_au_per_day": [
-        0.01021883804280087,
-        -0.002105229133106922,
-        -0.0007262166495747829
+        0.01592589431743472,
+        0.00711926233931227,
+        0.003088865563731987
       ],
       "observed": {
-        "astro_ra_deg": 114.17333333333333,
-        "astro_dec_deg": 21.791333333333334,
-        "app_ra_deg": 114.56604166666666,
-        "app_dec_deg": 21.732611111111108,
-        "azimuth_deg": 359.691692,
-        "elevation_deg": -48.44053,
-        "range_au": 4.29001084443935
+        "astro_ra_deg": 0.35312499999999997,
+        "astro_dec_deg": -1.2963888888888888,
+        "app_ra_deg": 0.644625,
+        "app_dec_deg": -1.1698611111111112,
+        "azimuth_deg": 99.928609,
+        "elevation_deg": 22.445453,
+        "range_au": 4.85206890962655
       }
     },
     {
@@ -4787,25 +5333,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        -1.584381350650671,
-        4.697794396433091,
-        2.075641923365488
+        5.449944812238964,
+        2.231312704099765,
+        0.8471096353390408
       ],
       "geo_velocity_au_per_day": [
-        -0.01497908586249715,
-        0.01080629594872169,
-        0.004863538740503643
+        -0.01136151966045957,
+        0.02041525220793278,
+        0.008889719488252665
       ],
       "observed": {
-        "astro_ra_deg": 108.63495833333333,
-        "astro_dec_deg": 22.717499999999998,
-        "app_ra_deg": 109.03066666666666,
-        "app_dec_deg": 22.672472222222222,
-        "azimuth_deg": 76.153159,
-        "elevation_deg": 37.662343,
-        "range_au": 5.37474608055926
+        "astro_ra_deg": 22.2625,
+        "astro_dec_deg": 8.184527777777777,
+        "app_ra_deg": 22.559833333333334,
+        "app_dec_deg": 8.302111111111111,
+        "azimuth_deg": 253.235689,
+        "elevation_deg": 58.076602,
+        "range_au": 5.94959838508252
       }
     },
     {
@@ -4813,25 +5359,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -4.056189219430359,
-        4.360980463335164,
-        1.950459391246745
+        3.316824080862674,
+        3.063850093548056,
+        1.214782729339548
       ],
       "geo_velocity_au_per_day": [
-        -0.01572408222991063,
-        -0.01680004268593127,
-        -0.00711579704667975
+        -0.0137020169175737,
+        -0.006853735673413031,
+        -0.002898252686048443
       ],
       "observed": {
-        "astro_ra_deg": 132.92345833333331,
-        "astro_dec_deg": 18.133805555555554,
-        "app_ra_deg": 133.29766666666666,
-        "app_dec_deg": 18.034944444444445,
-        "azimuth_deg": 273.525051,
-        "elevation_deg": 54.456204,
-        "range_au": 6.26692657807698
+        "astro_ra_deg": 42.72666666666667,
+        "astro_dec_deg": 15.056916666666668,
+        "app_ra_deg": 43.05225,
+        "app_dec_deg": 15.154777777777777,
+        "azimuth_deg": 300.804776,
+        "elevation_deg": -28.512249,
+        "range_au": 4.67589119958975
       }
     },
     {
@@ -4839,25 +5385,103 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -4.017557776247482,
-        2.398845706204791,
-        1.119005442189166
+        3.478926283349484,
+        2.32189125009488,
+        0.9038511183238048
       ],
       "geo_velocity_au_per_day": [
-        0.01215825387064964,
-        -0.006493228530330381,
-        -0.002663667759503783
+        0.0120600714032732,
+        0.003794836115861949,
+        0.001749827460276976
       ],
       "observed": {
-        "astro_ra_deg": 149.15633333333335,
-        "astro_dec_deg": 13.449805555555557,
-        "app_ra_deg": 149.525375,
-        "app_dec_deg": 13.319805555555556,
-        "azimuth_deg": 306.623945,
-        "elevation_deg": -38.283137,
-        "range_au": 4.81115952132477
+        "astro_ra_deg": 33.71783333333334,
+        "astro_dec_deg": 12.192916666666667,
+        "app_ra_deg": 34.0425,
+        "app_dec_deg": 12.305444444444445,
+        "azimuth_deg": 73.451305,
+        "elevation_deg": -8.766715,
+        "range_au": 4.27917271027938
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        3.78293409959322,
+        4.18493361183619,
+        1.725693520662671
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01331924144483628,
+        0.01860055439281013,
+        0.00819514252283471
+      ],
+      "observed": {
+        "astro_ra_deg": 47.885666666666665,
+        "astro_dec_deg": 17.008305555555555,
+        "app_ra_deg": 48.220666666666666,
+        "app_dec_deg": 17.098777777777777,
+        "azimuth_deg": 178.977328,
+        "elevation_deg": 87.272061,
+        "range_au": 5.89931736667291
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        1.297563139948168,
+        4.829793333952151,
+        2.0224712882608
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01764630526363336,
+        -0.008980294593722207,
+        -0.003738810659399622
+      ],
+      "observed": {
+        "astro_ra_deg": 74.95895833333333,
+        "astro_dec_deg": 22.01838888888889,
+        "app_ra_deg": 75.32458333333334,
+        "app_dec_deg": 22.05575,
+        "azimuth_deg": 291.199792,
+        "elevation_deg": 6.330264,
+        "range_au": 5.39447368562916
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        1.02610109976449,
+        3.653691954815205,
+        1.532249698867453
+      ],
+      "geo_velocity_au_per_day": [
+        0.00974858669202192,
+        -0.001004561661155435,
+        -0.0002635760589759495
+      ],
+      "observed": {
+        "astro_ra_deg": 74.31075000000001,
+        "astro_dec_deg": 21.985722222222222,
+        "app_ra_deg": 74.68979166666666,
+        "app_dec_deg": 22.025694444444444,
+        "azimuth_deg": 36.592044,
+        "elevation_deg": -38.884893,
+        "range_au": 4.09271469553075
       }
     },
     {
@@ -4865,25 +5489,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        3.659031087292524,
-        2.409382612596195,
-        0.9433772420100425
+        3.220614359853353,
+        -4.617549006443141,
+        -2.057563082241604
       ],
       "geo_velocity_au_per_day": [
-        0.01175899473570973,
-        0.00786081439847964,
-        0.003515247056181798
+        0.0231595350515104,
+        0.007456468014043755,
+        0.003065443138537445
       ],
       "observed": {
-        "astro_ra_deg": 33.3615,
-        "astro_dec_deg": 12.151472222222223,
-        "app_ra_deg": 33.685625,
-        "app_dec_deg": 12.264305555555556,
-        "azimuth_deg": 6.389737,
-        "elevation_deg": 52.908713,
-        "range_au": 4.48146960266328
+        "astro_ra_deg": 304.8917083333333,
+        "astro_dec_deg": -20.076722222222223,
+        "app_ra_deg": 305.18554166666667,
+        "app_dec_deg": -20.012194444444443,
+        "azimuth_deg": 253.418462,
+        "elevation_deg": 12.296999,
+        "range_au": 5.99399231618189
       }
     },
     {
@@ -4891,25 +5515,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        3.554017105697379,
-        4.447763497539288,
-        1.841624016701625
+        4.470143222516899,
+        -2.528960629807749,
+        -1.171239066425376
       ],
       "geo_velocity_au_per_day": [
-        -0.0171007066134842,
-        0.01631100602118493,
-        0.007205854869956682
+        -0.005849165673825978,
+        0.01751165444948337,
+        0.007441101576084937
       ],
       "observed": {
-        "astro_ra_deg": 51.370124999999994,
-        "astro_dec_deg": 17.92441666666667,
-        "app_ra_deg": 51.70866666666667,
-        "app_dec_deg": 18.008861111111113,
-        "azimuth_deg": 284.101,
-        "elevation_deg": -12.940479,
-        "range_au": 5.9837600254929
+        "astro_ra_deg": 330.49875,
+        "astro_dec_deg": -12.847055555555556,
+        "app_ra_deg": 330.77891666666665,
+        "app_dec_deg": -12.746166666666666,
+        "azimuth_deg": 183.278061,
+        "elevation_deg": -52.573498,
+        "range_au": 5.26778943868071
       }
     },
     {
@@ -4917,25 +5541,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        1.058906415658519,
-        4.677115991383578,
-        1.958628432836888
+        3.32634876872877,
+        -2.043815739744144,
+        -0.9775249140254597
       ],
       "geo_velocity_au_per_day": [
-        -0.01407636378699276,
-        -0.01124723975050244,
-        -0.00471842712636332
+        -0.002890398726048254,
+        -0.00807882648471369,
+        -0.003627773464902677
       ],
       "observed": {
-        "astro_ra_deg": 77.24058333333333,
-        "astro_dec_deg": 22.21638888888889,
-        "app_ra_deg": 77.609125,
-        "app_dec_deg": 22.248722222222224,
-        "azimuth_deg": 104.839242,
-        "elevation_deg": -81.677864,
-        "range_au": 5.1800388058283
+        "astro_ra_deg": 328.4300833333333,
+        "astro_dec_deg": -14.057722222222223,
+        "app_ra_deg": 328.724875,
+        "app_dec_deg": -13.95497222222222,
+        "azimuth_deg": 91.846668,
+        "elevation_deg": 31.239282,
+        "range_au": 4.02458136976567
       }
     },
     {
@@ -4943,25 +5567,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        1.175501201631793,
-        3.6686645807608,
-        1.541318908321323
+        4.732841808699676,
+        -2.540790035225524,
+        -1.206488160278314
       ],
       "geo_velocity_au_per_day": [
-        0.009978816299972989,
-        0.003016863174536286,
-        0.001480180734514877
+        0.02009746356054267,
+        0.008275852410189669,
+        0.00348864642449044
       ],
       "observed": {
-        "astro_ra_deg": 72.23137499999999,
-        "astro_dec_deg": 21.806055555555556,
-        "app_ra_deg": 72.60995833333334,
-        "app_dec_deg": 21.850916666666667,
-        "azimuth_deg": 49.135747,
-        "elevation_deg": 24.151819,
-        "range_au": 4.14927256570106
+        "astro_ra_deg": 331.76841666666667,
+        "astro_dec_deg": -12.659277777777778,
+        "app_ra_deg": 332.0561666666666,
+        "app_dec_deg": -12.554555555555556,
+        "azimuth_deg": 273.35516,
+        "elevation_deg": 38.435501,
+        "range_au": 5.50556436543162
       }
     },
     {
@@ -4969,25 +5593,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        1.019647022735552,
-        5.230845150711308,
-        2.239940777054897
+        5.704588499328,
+        -0.2660622501131578,
+        -0.2303531261482116
       ],
       "geo_velocity_au_per_day": [
-        -0.01714889336320539,
-        0.01356208512337897,
-        0.006063030985161307
+        -0.008389130028348964,
+        0.02008548978719906,
+        0.0086404499993086
       ],
       "observed": {
-        "astro_ra_deg": 78.96658333333333,
-        "astro_dec_deg": 22.797333333333334,
-        "app_ra_deg": 79.34475,
-        "app_dec_deg": 22.826138888888888,
-        "azimuth_deg": 302.42002,
-        "elevation_deg": 12.239407,
-        "range_au": 5.78091073010482
+        "astro_ra_deg": 357.3270416666667,
+        "astro_dec_deg": -2.310694444444444,
+        "app_ra_deg": 357.6053333333333,
+        "app_dec_deg": -2.189972222222222,
+        "azimuth_deg": 235.818836,
+        "elevation_deg": -47.463756,
+        "range_au": 5.71543712169294
       }
     },
     {
@@ -4995,25 +5619,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -1.595829972383448,
-        5.160509381191641,
-        2.231781257735082
+        4.075898642678372,
+        0.5232831210404036,
+        0.1058808442733735
       ],
       "geo_velocity_au_per_day": [
-        -0.01595075868375904,
-        -0.01429870375834157,
-        -0.006011205092435462
+        -0.008318684437688297,
+        -0.006417118678976323,
+        -0.002813766406305089
       ],
       "observed": {
-        "astro_ra_deg": 107.18079166666668,
-        "astro_dec_deg": 22.44913888888889,
-        "app_ra_deg": 107.56283333333333,
-        "app_dec_deg": 22.409333333333333,
-        "azimuth_deg": 270.215831,
-        "elevation_deg": -65.70626,
-        "range_au": 5.84450891749082
+        "astro_ra_deg": 7.314,
+        "astro_dec_deg": 1.4751666666666667,
+        "app_ra_deg": 7.6057500000000005,
+        "app_dec_deg": 1.601027777777778,
+        "azimuth_deg": 95.209253,
+        "elevation_deg": -14.974151,
+        "range_au": 4.11070614955372
       }
     },
     {
@@ -5021,25 +5645,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        -1.631382522580588,
-        3.634065377489432,
-        1.592568744257962
+        4.850707865785497,
+        0.03005800495028349,
+        -0.1096738046085555
       ],
       "geo_velocity_au_per_day": [
-        0.01021883804280087,
-        -0.002105229133106922,
-        -0.0007262166495747829
+        0.01592589431743472,
+        0.00711926233931227,
+        0.003088865563731987
       ],
       "observed": {
-        "astro_ra_deg": 114.173875,
-        "astro_dec_deg": 21.79191666666667,
-        "app_ra_deg": 114.56666666666666,
-        "app_dec_deg": 21.733166666666666,
-        "azimuth_deg": 71.930169,
-        "elevation_deg": -13.303463,
-        "range_au": 4.28998864656059
+        "astro_ra_deg": 0.3525416666666667,
+        "astro_dec_deg": -1.2960277777777776,
+        "app_ra_deg": 0.6440833333333333,
+        "app_dec_deg": -1.1695,
+        "azimuth_deg": 318.295328,
+        "elevation_deg": 59.918179,
+        "range_au": 4.85204827981372
       }
     },
     {
@@ -5047,25 +5671,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        -1.584381350650671,
-        4.697794396433091,
-        2.075641923365488
+        5.449944812238964,
+        2.231312704099765,
+        0.8471096353390408
       ],
       "geo_velocity_au_per_day": [
-        -0.01497908586249715,
-        0.01080629594872169,
-        0.004863538740503643
+        -0.01136151966045957,
+        0.02041525220793278,
+        0.008889719488252665
       ],
       "observed": {
-        "astro_ra_deg": 108.634375,
-        "astro_dec_deg": 22.71786111111111,
-        "app_ra_deg": 109.030125,
-        "app_dec_deg": 22.67286111111111,
-        "azimuth_deg": 327.238497,
-        "elevation_deg": 35.125218,
-        "range_au": 5.3747475183654
+        "astro_ra_deg": 22.262333333333334,
+        "astro_dec_deg": 8.184750000000001,
+        "app_ra_deg": 22.559583333333332,
+        "app_dec_deg": 8.302333333333333,
+        "azimuth_deg": 266.882631,
+        "elevation_deg": -26.892339,
+        "range_au": 5.94965388135903
       }
     },
     {
@@ -5073,25 +5697,25 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -4.056189219430359,
-        4.360980463335164,
-        1.950459391246745
+        3.316824080862674,
+        3.063850093548056,
+        1.214782729339548
       ],
       "geo_velocity_au_per_day": [
-        -0.01572408222991063,
-        -0.01680004268593127,
-        -0.00711579704667975
+        -0.0137020169175737,
+        -0.006853735673413031,
+        -0.002898252686048443
       ],
       "observed": {
-        "astro_ra_deg": 132.923375,
-        "astro_dec_deg": 18.133944444444445,
-        "app_ra_deg": 133.2974583333333,
-        "app_dec_deg": 18.035083333333336,
-        "azimuth_deg": 274.821963,
-        "elevation_deg": -36.560048,
-        "range_au": 6.26698665832647
+        "astro_ra_deg": 42.727333333333334,
+        "astro_dec_deg": 15.057250000000002,
+        "app_ra_deg": 43.05291666666667,
+        "app_dec_deg": 15.155111111111111,
+        "azimuth_deg": 100.309593,
+        "elevation_deg": -57.087439,
+        "range_au": 4.67590659705406
       }
     },
     {
@@ -5099,25 +5723,103 @@
       "target_id": 599,
       "target_name": "Jupiter",
       "site": "Paranal",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -4.017557776247482,
-        2.398845706204791,
-        1.119005442189166
+        3.478926283349484,
+        2.32189125009488,
+        0.9038511183238048
       ],
       "geo_velocity_au_per_day": [
-        0.01215825387064964,
-        -0.006493228530330381,
-        -0.002663667759503783
+        0.0120600714032732,
+        0.003794836115861949,
+        0.001749827460276976
       ],
       "observed": {
-        "astro_ra_deg": 149.15699999999998,
-        "astro_dec_deg": 13.450194444444444,
-        "app_ra_deg": 149.52604166666666,
-        "app_dec_deg": 13.320166666666667,
-        "azimuth_deg": 96.554336,
-        "elevation_deg": -46.428048,
-        "range_au": 4.81116394833512
+        "astro_ra_deg": 33.71745833333334,
+        "astro_dec_deg": 12.193472222222223,
+        "app_ra_deg": 34.042249999999996,
+        "app_dec_deg": 12.306000000000001,
+        "azimuth_deg": 28.901496,
+        "elevation_deg": 48.63751,
+        "range_au": 4.27913412866803
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        3.78293409959322,
+        4.18493361183619,
+        1.725693520662671
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01331924144483628,
+        0.01860055439281013,
+        0.00819514252283471
+      ],
+      "observed": {
+        "astro_ra_deg": 47.88529166666666,
+        "astro_dec_deg": 17.0085,
+        "app_ra_deg": 48.22020833333334,
+        "app_dec_deg": 17.099,
+        "azimuth_deg": 287.589217,
+        "elevation_deg": -2.699446,
+        "range_au": 5.89936194126086
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        1.297563139948168,
+        4.829793333952151,
+        2.0224712882608
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01764630526363336,
+        -0.008980294593722207,
+        -0.003738810659399622
+      ],
+      "observed": {
+        "astro_ra_deg": 74.959375,
+        "astro_dec_deg": 22.018555555555555,
+        "app_ra_deg": 75.32491666666667,
+        "app_dec_deg": 22.05588888888889,
+        "azimuth_deg": 234.421368,
+        "elevation_deg": -85.661759,
+        "range_au": 5.39452086703296
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 599,
+      "target_name": "Jupiter",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        1.02610109976449,
+        3.653691954815205,
+        1.532249698867453
+      ],
+      "geo_velocity_au_per_day": [
+        0.00974858669202192,
+        -0.001004561661155435,
+        -0.0002635760589759495
+      ],
+      "observed": {
+        "astro_ra_deg": 74.31095833333333,
+        "astro_dec_deg": 21.98638888888889,
+        "app_ra_deg": 74.690125,
+        "app_dec_deg": 22.02636111111111,
+        "azimuth_deg": 58.977595,
+        "elevation_deg": 11.611434,
+        "range_au": 4.09267923029907
       }
     },
     {
@@ -5125,25 +5827,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        -0.127481831597179,
-        -2.211417333279142,
-        -0.9840108553082422
+        0.7999953845207415,
+        0.3697023904666935,
+        0.1751579278264976
       ],
       "geo_velocity_au_per_day": [
-        0.03147831607982139,
-        0.001426580757543807,
-        0.0002010419153804935
+        0.004966249841833065,
+        0.009127205730021078,
+        0.004442931193408566
       ],
       "observed": {
-        "astro_ra_deg": 266.69570833333336,
-        "astro_dec_deg": -23.9525,
-        "app_ra_deg": 267.0545,
-        "app_dec_deg": -23.961861111111112,
-        "azimuth_deg": 25.033135,
-        "elevation_deg": -60.701575,
-        "range_au": 2.4238439211448
+        "astro_ra_deg": 24.797791666666665,
+        "astro_dec_deg": 11.237583333333333,
+        "app_ra_deg": 25.073916666666666,
+        "app_dec_deg": 11.342777777777778,
+        "azimuth_deg": 266.039626,
+        "elevation_deg": 17.684523,
+        "range_au": 0.89855527278719
       }
     },
     {
@@ -5151,25 +5853,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        1.979755538326635,
-        -0.008886433968211602,
-        -0.05152694615469958
+        -0.1504633865079821,
+        1.828068721987227,
+        0.8480662987290226
       ],
       "geo_velocity_au_per_day": [
-        -0.003373884149163749,
-        0.02445362192343284,
-        0.01071104989179131
+        -0.02197703208877377,
+        0.005917274937760017,
+        0.002708883768722003
       ],
       "observed": {
-        "astro_ra_deg": 359.73924999999997,
-        "astro_dec_deg": -1.4936944444444444,
-        "app_ra_deg": 0.04558333333333333,
-        "app_dec_deg": -1.3605,
-        "azimuth_deg": 46.054355,
-        "elevation_deg": -30.441234,
-        "range_au": 1.9803856240602
+        "astro_ra_deg": 94.70037500000001,
+        "astro_dec_deg": 24.812472222222222,
+        "app_ra_deg": 95.01941666666666,
+        "app_dec_deg": 24.803611111111113,
+        "azimuth_deg": 311.277486,
+        "elevation_deg": 0.633632,
+        "range_au": 2.02088157674393
       }
     },
     {
@@ -5177,25 +5879,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        0.1304381785151843,
-        1.330708480509628,
-        0.5722624637347401
+        -2.571626796132021,
+        0.4509218536094981,
+        0.2417594334911025
       ],
       "geo_velocity_au_per_day": [
-        -0.01627886677871082,
-        -0.004126938789947162,
-        -0.001284992903733402
+        -0.00709655901192413,
+        -0.02592998549405322,
+        -0.01152539107603955
       ],
       "observed": {
-        "astro_ra_deg": 84.39908333333334,
-        "astro_dec_deg": 23.168916666666668,
-        "app_ra_deg": 84.770875,
-        "app_dec_deg": 23.184361111111112,
-        "azimuth_deg": 61.820961,
-        "elevation_deg": 7.497859,
-        "range_au": 1.45430916787311
+        "astro_ra_deg": 170.05062500000003,
+        "astro_dec_deg": 5.291305555555556,
+        "app_ra_deg": 170.321125,
+        "app_dec_deg": 5.1765,
+        "azimuth_deg": 344.751521,
+        "elevation_deg": -32.278825,
+        "range_au": 2.62208680764573
       }
     },
     {
@@ -5203,25 +5905,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        -0.3701300605235104,
-        0.4989915667774544,
-        0.2635358271016043
+        -0.8382394755030914,
+        -2.029709024550213,
+        -0.883357694545514
       ],
       "geo_velocity_au_per_day": [
-        0.004521638521702022,
-        -0.001314490704020353,
-        -0.0002866647181839665
+        0.02913250248720493,
+        -0.00496589375124172,
+        -0.002631302557023038
       ],
       "observed": {
-        "astro_ra_deg": 126.56341666666668,
-        "astro_dec_deg": 22.984916666666667,
-        "app_ra_deg": 126.9365,
-        "app_dec_deg": 22.90225,
-        "azimuth_deg": 127.133901,
-        "elevation_deg": 52.304776,
-        "range_au": 0.6748102896435
+        "astro_ra_deg": 247.55570833333334,
+        "astro_dec_deg": -21.91263888888889,
+        "app_ra_deg": 247.87291666666667,
+        "app_dec_deg": -21.95875,
+        "azimuth_deg": 46.639921,
+        "elevation_deg": -53.456918,
+        "range_au": 2.36699791021175
       }
     },
     {
@@ -5229,25 +5931,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        -0.7343753880751505,
-        1.035512131449795,
-        0.503842129053235
+        1.535624738829637,
+        -0.5544799776342721,
+        -0.287139614302004
       ],
       "geo_velocity_au_per_day": [
-        -0.01384694105538139,
-        0.002157512030062682,
-        0.0007786502073812648
+        0.002865323555180188,
+        0.02063300439667002,
+        0.00879970422155033
       ],
       "observed": {
-        "astro_ra_deg": 125.33920833333332,
-        "astro_dec_deg": 21.646916666666666,
-        "app_ra_deg": 125.70954166666668,
-        "app_dec_deg": 21.567416666666666,
-        "azimuth_deg": 282.023816,
-        "elevation_deg": 18.198534,
-        "range_au": 1.36586228976735
+        "astro_ra_deg": 340.14337500000005,
+        "astro_dec_deg": -9.977305555555557,
+        "app_ra_deg": 340.4300416666667,
+        "app_dec_deg": -9.863444444444443,
+        "azimuth_deg": 66.09133,
+        "elevation_deg": -29.908893,
+        "range_au": 1.65766132352425
       }
     },
     {
@@ -5255,25 +5957,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -2.193466607166804,
-        -0.3516648684856351,
-        -0.1374659750642815
+        0.4742980710631119,
+        0.8220298456428374,
+        0.3290104675152845
       ],
       "geo_velocity_au_per_day": [
-        -0.00005639064890470092,
-        -0.02297806676685939,
-        -0.01042241361678611
+        -0.01150480828969359,
+        -0.0003975315960609559,
+        0.0002520322059228121
       ],
       "observed": {
-        "astro_ra_deg": 189.10441666666668,
-        "astro_dec_deg": -3.5401666666666665,
-        "app_ra_deg": 189.43133333333333,
-        "app_dec_deg": -3.680222222222222,
-        "azimuth_deg": 313.233518,
-        "elevation_deg": -32.734149,
-        "range_au": 2.22583302945718
+        "astro_ra_deg": 60.014041666666664,
+        "astro_dec_deg": 19.117472222222222,
+        "app_ra_deg": 60.33845833333333,
+        "app_dec_deg": 19.181222222222225,
+        "azimuth_deg": 79.208147,
+        "elevation_deg": 16.06433,
+        "range_au": 1.00438240612944
       }
     },
     {
@@ -5281,25 +5983,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        0.1663968436105412,
-        -2.199383390739455,
-        -0.9910184431967967
+        0.191228955940762,
+        0.4987801492316052,
+        0.2462526054389587
       ],
       "geo_velocity_au_per_day": [
-        0.03189703690703926,
-        0.002641553946360385,
-        0.0008286003936815563
+        0.00413818913418458,
+        0.002547529249329024,
+        0.001528078653892531
       ],
       "observed": {
-        "astro_ra_deg": 274.32116666666667,
-        "astro_dec_deg": -24.195138888888888,
-        "app_ra_deg": 274.71387500000003,
-        "app_dec_deg": -24.18611111111111,
-        "azimuth_deg": 350.313986,
-        "elevation_deg": -62.451255,
-        "range_au": 2.41814173221626
+        "astro_ra_deg": 69.017625,
+        "astro_dec_deg": 24.74652777777778,
+        "app_ra_deg": 69.36937500000002,
+        "app_dec_deg": 24.794,
+        "azimuth_deg": 219.24807,
+        "elevation_deg": 58.80081,
+        "range_au": 0.58817837492816
       }
     },
     {
@@ -5307,25 +6009,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        2.244545534858756,
-        0.2878317505991867,
-        0.08358652074169941
+        -0.377218037652249,
+        1.44826393481251,
+        0.6861363505783173
       ],
       "geo_velocity_au_per_day": [
-        -0.005676257712769054,
-        0.02749511248353483,
-        0.01219545375434315
+        -0.0171256553893615,
+        0.005136107774762868,
+        0.002246882436367731
       ],
       "observed": {
-        "astro_ra_deg": 7.303333333333333,
-        "astro_dec_deg": 2.112527777777778,
-        "app_ra_deg": 7.637416666666666,
-        "app_dec_deg": 2.2565555555555554,
-        "azimuth_deg": 24.770694,
-        "elevation_deg": -33.523304,
-        "range_au": 2.26443348317931
+        "astro_ra_deg": 104.59416666666667,
+        "astro_dec_deg": 24.629083333333334,
+        "app_ra_deg": 104.94545833333333,
+        "app_dec_deg": 24.598805555555554,
+        "azimuth_deg": 295.956398,
+        "elevation_deg": 10.950864,
+        "range_au": 1.6464325237915
       }
     },
     {
@@ -5333,25 +6035,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -0.1343418453184868,
-        1.754675906630777,
-        0.7726506257751409
+        -2.435151993348373,
+        0.2130601563528054,
+        0.1276752347380855
       ],
       "geo_velocity_au_per_day": [
-        -0.02154108417645187,
-        -0.006002249579209105,
-        -0.002109457648427775
+        -0.006147760521644694,
+        -0.02429513917066216,
+        -0.0109077287068934
       ],
       "observed": {
-        "astro_ra_deg": 94.37474999999999,
-        "astro_dec_deg": 23.702916666666667,
-        "app_ra_deg": 94.77979166666667,
-        "app_dec_deg": 23.693305555555554,
-        "azimuth_deg": 45.904077,
-        "elevation_deg": -2.286598,
-        "range_au": 1.92186636137093
+        "astro_ra_deg": 174.99579166666666,
+        "astro_dec_deg": 2.9907500000000002,
+        "app_ra_deg": 175.292875,
+        "app_dec_deg": 2.862611111111111,
+        "azimuth_deg": 326.741009,
+        "elevation_deg": -30.605215,
+        "range_au": 2.44787339481843
       }
     },
     {
@@ -5359,25 +6061,103 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -0.958113565016507,
-        0.3644374910539417,
-        0.2126826062560103
+        -0.5987351609961756,
+        -2.188218027155928,
+        -0.9674697347065054
       ],
       "geo_velocity_au_per_day": [
-        0.005951829234409446,
-        -0.007317106447188714,
-        -0.003005107767402819
+        0.03111768631513348,
+        -0.004511118475785529,
+        -0.002401898784474935
       ],
       "observed": {
-        "astro_ra_deg": 159.17299999999997,
-        "astro_dec_deg": 11.720944444444445,
-        "app_ra_deg": 159.53375,
-        "app_dec_deg": 11.579305555555555,
-        "azimuth_deg": 94.528761,
-        "elevation_deg": 18.432997,
-        "range_au": 1.04685258125409
+        "astro_ra_deg": 254.69245833333332,
+        "astro_dec_deg": -23.09572222222222,
+        "app_ra_deg": 255.046,
+        "app_dec_deg": -23.131888888888888,
+        "azimuth_deg": 19.581458,
+        "elevation_deg": -60.555902,
+        "range_au": 2.46636526756959
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        1.988839062231803,
+        -0.3845396902065834,
+        -0.215414879557498
+      ],
+      "geo_velocity_au_per_day": [
+        0.002227818499745652,
+        0.02545249843164074,
+        0.01106300118358349
+      ],
+      "observed": {
+        "astro_ra_deg": 349.05316666666664,
+        "astro_dec_deg": -6.072861111111111,
+        "app_ra_deg": 349.3616666666667,
+        "app_dec_deg": -5.942777777777778,
+        "azimuth_deg": 44.082723,
+        "elevation_deg": -36.360063,
+        "range_au": 2.03704415872901
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        0.390841377139252,
+        1.368098936300063,
+        0.5809853118372811
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01830414173906738,
+        -0.0007602351208335673,
+        0.0001616710472571904
+      ],
+      "observed": {
+        "astro_ra_deg": 74.05358333333334,
+        "astro_dec_deg": 22.209833333333332,
+        "app_ra_deg": 74.41950000000001,
+        "app_dec_deg": 22.249194444444445,
+        "azimuth_deg": 59.045213,
+        "elevation_deg": 4.339356,
+        "range_au": 1.5367848084044
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        -0.4343223237298839,
+        0.5387348404883778,
+        0.2761408836733528
+      ],
+      "geo_velocity_au_per_day": [
+        0.003877104495879179,
+        -0.003954717323809497,
+        -0.001381124568339023
+      ],
+      "observed": {
+        "astro_ra_deg": 128.87312500000002,
+        "astro_dec_deg": 21.75327777777778,
+        "app_ra_deg": 129.2399583333333,
+        "app_dec_deg": 21.666527777777777,
+        "azimuth_deg": 109.366757,
+        "elevation_deg": 41.935539,
+        "range_au": 0.74500865227054
       }
     },
     {
@@ -5385,25 +6165,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        -0.127481831597179,
-        -2.211417333279142,
-        -0.9840108553082422
+        0.7999953845207415,
+        0.3697023904666935,
+        0.1751579278264976
       ],
       "geo_velocity_au_per_day": [
-        0.03147831607982139,
-        0.001426580757543807,
-        0.0002010419153804935
+        0.004966249841833065,
+        0.009127205730021078,
+        0.004442931193408566
       ],
       "observed": {
-        "astro_ra_deg": 266.69491666666664,
-        "astro_dec_deg": -23.952638888888888,
-        "app_ra_deg": 267.053875,
-        "app_dec_deg": -23.962027777777777,
-        "azimuth_deg": 221.635285,
-        "elevation_deg": 32.897164,
-        "range_au": 2.42378353116404
+        "astro_ra_deg": 24.802041666666668,
+        "astro_dec_deg": 11.23875,
+        "app_ra_deg": 25.078166666666664,
+        "app_dec_deg": 11.343944444444444,
+        "azimuth_deg": 82.586473,
+        "elevation_deg": 13.403682,
+        "range_au": 0.8985583306911
       }
     },
     {
@@ -5411,25 +6191,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        1.979755538326635,
-        -0.008886433968211602,
-        -0.05152694615469958
+        -0.1504633865079821,
+        1.828068721987227,
+        0.8480662987290226
       ],
       "geo_velocity_au_per_day": [
-        -0.003373884149163749,
-        0.02445362192343284,
-        0.01071104989179131
+        -0.02197703208877377,
+        0.005917274937760017,
+        0.002708883768722003
       ],
       "observed": {
-        "astro_ra_deg": 359.73770833333333,
-        "astro_dec_deg": -1.4931666666666668,
-        "app_ra_deg": 0.044125,
-        "app_dec_deg": -1.3599722222222224,
-        "azimuth_deg": 258.768843,
-        "elevation_deg": 24.848589,
-        "range_au": 1.98034604488777
+        "astro_ra_deg": 94.70170833333333,
+        "astro_dec_deg": 24.813555555555556,
+        "app_ra_deg": 95.02083333333333,
+        "app_dec_deg": 24.80463888888889,
+        "azimuth_deg": 74.41525,
+        "elevation_deg": 60.636397,
+        "range_au": 2.02084480121951
       }
     },
     {
@@ -5437,25 +6217,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        0.1304381785151843,
-        1.330708480509628,
-        0.5722624637347401
+        -2.571626796132021,
+        0.4509218536094981,
+        0.2417594334911025
       ],
       "geo_velocity_au_per_day": [
-        -0.01627886677871082,
-        -0.004126938789947162,
-        -0.001284992903733402
+        -0.00709655901192413,
+        -0.02592998549405322,
+        -0.01152539107603955
       ],
       "observed": {
-        "astro_ra_deg": 84.39629166666667,
-        "astro_dec_deg": 23.169666666666668,
-        "app_ra_deg": 84.76808333333335,
-        "app_dec_deg": 23.18513888888889,
-        "azimuth_deg": 293.937413,
-        "elevation_deg": 2.072335,
-        "range_au": 1.45431314715306
+        "astro_ra_deg": 170.05058333333332,
+        "astro_dec_deg": 5.291833333333333,
+        "app_ra_deg": 170.32120833333335,
+        "app_dec_deg": 5.177027777777778,
+        "azimuth_deg": 219.20797,
+        "elevation_deg": 71.491576,
+        "range_au": 2.6220235068219
       }
     },
     {
@@ -5463,25 +6243,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        -0.3701300605235104,
-        0.4989915667774544,
-        0.2635358271016043
+        -0.8382394755030914,
+        -2.029709024550213,
+        -0.883357694545514
       ],
       "geo_velocity_au_per_day": [
-        0.004521638521702022,
-        -0.001314490704020353,
-        -0.0002866647181839665
+        0.02913250248720493,
+        -0.00496589375124172,
+        -0.002631302557023038
       ],
       "observed": {
-        "astro_ra_deg": 126.56166666666667,
-        "astro_dec_deg": 22.984333333333336,
-        "app_ra_deg": 126.93458333333331,
-        "app_dec_deg": 22.901666666666664,
-        "azimuth_deg": 350.013523,
-        "elevation_deg": -46.662219,
-        "range_au": 0.67487508705815
+        "astro_ra_deg": 247.55454166666664,
+        "astro_dec_deg": -21.912666666666667,
+        "app_ra_deg": 247.871875,
+        "app_dec_deg": -21.958777777777776,
+        "azimuth_deg": 233.472799,
+        "elevation_deg": 23.959857,
+        "range_au": 2.36694629821303
       }
     },
     {
@@ -5489,25 +6269,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        -0.7343753880751505,
-        1.035512131449795,
-        0.503842129053235
+        1.535624738829637,
+        -0.5544799776342721,
+        -0.287139614302004
       ],
       "geo_velocity_au_per_day": [
-        -0.01384694105538139,
-        0.002157512030062682,
-        0.0007786502073812648
+        0.002865323555180188,
+        0.02063300439667002,
+        0.00879970422155033
       ],
       "observed": {
-        "astro_ra_deg": 125.34208333333333,
-        "astro_dec_deg": 21.64788888888889,
-        "app_ra_deg": 125.71245833333334,
-        "app_dec_deg": 21.568305555555554,
-        "azimuth_deg": 75.226475,
-        "elevation_deg": 26.968055,
-        "range_au": 1.36585623093914
+        "astro_ra_deg": 340.14125,
+        "astro_dec_deg": -9.976805555555556,
+        "app_ra_deg": 340.4279583333333,
+        "app_dec_deg": -9.862972222222222,
+        "azimuth_deg": 256.568919,
+        "elevation_deg": 7.668732,
+        "range_au": 1.65763434555444
       }
     },
     {
@@ -5515,25 +6295,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -2.193466607166804,
-        -0.3516648684856351,
-        -0.1374659750642815
+        0.4742980710631119,
+        0.8220298456428374,
+        0.3290104675152845
       ],
       "geo_velocity_au_per_day": [
-        -0.00005639064890470092,
-        -0.02297806676685939,
-        -0.01042241361678611
+        -0.01150480828969359,
+        -0.0003975315960609559,
+        0.0002520322059228121
       ],
       "observed": {
-        "astro_ra_deg": 189.1050833333333,
-        "astro_dec_deg": -3.5397777777777777,
-        "app_ra_deg": 189.432125,
-        "app_dec_deg": -3.6798333333333333,
-        "azimuth_deg": 149.377738,
-        "elevation_deg": 63.074495,
-        "range_au": 2.22577188197347
+        "astro_ra_deg": 60.01024999999999,
+        "astro_dec_deg": 19.11813888888889,
+        "app_ra_deg": 60.334624999999996,
+        "app_dec_deg": 19.18191666666667,
+        "azimuth_deg": 298.111455,
+        "elevation_deg": -16.513579,
+        "range_au": 1.00440631624893
       }
     },
     {
@@ -5541,25 +6321,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        0.1663968436105412,
-        -2.199383390739455,
-        -0.9910184431967967
+        0.191228955940762,
+        0.4987801492316052,
+        0.2462526054389587
       ],
       "geo_velocity_au_per_day": [
-        0.03189703690703926,
-        0.002641553946360385,
-        0.0008286003936815563
+        0.00413818913418458,
+        0.002547529249329024,
+        0.001528078653892531
       ],
       "observed": {
-        "astro_ra_deg": 274.32087500000006,
-        "astro_dec_deg": -24.195333333333334,
-        "app_ra_deg": 274.71375,
-        "app_dec_deg": -24.186333333333334,
-        "azimuth_deg": 204.362219,
-        "elevation_deg": 42.013205,
-        "range_au": 2.41807533774888
+        "astro_ra_deg": 69.02170833333334,
+        "astro_dec_deg": 24.74602777777778,
+        "app_ra_deg": 69.37337500000001,
+        "app_dec_deg": 24.793472222222224,
+        "azimuth_deg": 46.817143,
+        "elevation_deg": -27.026074,
+        "range_au": 0.5882342553222
       }
     },
     {
@@ -5567,25 +6347,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        2.244545534858756,
-        0.2878317505991867,
-        0.08358652074169941
+        -0.377218037652249,
+        1.44826393481251,
+        0.6861363505783173
       ],
       "geo_velocity_au_per_day": [
-        -0.005676257712769054,
-        0.02749511248353483,
-        0.01219545375434315
+        -0.0171256553893615,
+        0.005136107774762868,
+        0.002246882436367731
       ],
       "observed": {
-        "astro_ra_deg": 7.3023750000000005,
-        "astro_dec_deg": 2.1130555555555555,
-        "app_ra_deg": 7.636583333333334,
-        "app_dec_deg": 2.2570833333333336,
-        "azimuth_deg": 253.993049,
-        "elevation_deg": 42.702057,
-        "range_au": 2.26438093769474
+        "astro_ra_deg": 104.59637500000001,
+        "astro_dec_deg": 24.63013888888889,
+        "app_ra_deg": 104.94770833333334,
+        "app_dec_deg": 24.599805555555555,
+        "azimuth_deg": 74.316763,
+        "elevation_deg": 42.247662,
+        "range_au": 1.64641189277934
       }
     },
     {
@@ -5593,25 +6373,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -0.1343418453184868,
-        1.754675906630777,
-        0.7726506257751409
+        -2.435151993348373,
+        0.2130601563528054,
+        0.1276752347380855
       ],
       "geo_velocity_au_per_day": [
-        -0.02154108417645187,
-        -0.006002249579209105,
-        -0.002109457648427775
+        -0.006147760521644694,
+        -0.02429513917066216,
+        -0.0109077287068934
       ],
       "observed": {
-        "astro_ra_deg": 94.37279166666666,
-        "astro_dec_deg": 23.703722222222222,
-        "app_ra_deg": 94.77791666666667,
-        "app_dec_deg": 23.694194444444445,
-        "azimuth_deg": 288.853042,
-        "elevation_deg": 20.052632,
-        "range_au": 1.92184996896456
+        "astro_ra_deg": 174.996125,
+        "astro_dec_deg": 2.99125,
+        "app_ra_deg": 175.29333333333332,
+        "app_dec_deg": 2.863138888888889,
+        "azimuth_deg": 167.581345,
+        "elevation_deg": 72.660567,
+        "range_au": 2.44781089653398
       }
     },
     {
@@ -5619,25 +6399,103 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -0.958113565016507,
-        0.3644374910539417,
-        0.2126826062560103
+        -0.5987351609961756,
+        -2.188218027155928,
+        -0.9674697347065054
       ],
       "geo_velocity_au_per_day": [
-        0.005951829234409446,
-        -0.007317106447188714,
-        -0.003005107767402819
+        0.03111768631513348,
+        -0.004511118475785529,
+        -0.002401898784474935
       ],
       "observed": {
-        "astro_ra_deg": 159.16983333333334,
-        "astro_dec_deg": 11.721583333333333,
-        "app_ra_deg": 159.5305,
-        "app_dec_deg": 11.579972222222223,
-        "azimuth_deg": 297.987289,
-        "elevation_deg": -31.32961,
-        "range_au": 1.04688825638416
+        "astro_ra_deg": 254.69179166666666,
+        "astro_dec_deg": -23.09586111111111,
+        "app_ra_deg": 255.04545833333333,
+        "app_dec_deg": -23.132055555555556,
+        "azimuth_deg": 220.029698,
+        "elevation_deg": 35.220599,
+        "range_au": 2.46630349550295
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        1.988839062231803,
+        -0.3845396902065834,
+        -0.215414879557498
+      ],
+      "geo_velocity_au_per_day": [
+        0.002227818499745652,
+        0.02545249843164074,
+        0.01106300118358349
+      ],
+      "observed": {
+        "astro_ra_deg": 349.05179166666665,
+        "astro_dec_deg": -6.072444444444444,
+        "app_ra_deg": 349.36033333333336,
+        "app_dec_deg": -5.942388888888889,
+        "azimuth_deg": 252.26593,
+        "elevation_deg": 26.708859,
+        "range_au": 2.03699965899704
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        0.390841377139252,
+        1.368098936300063,
+        0.5809853118372811
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01830414173906738,
+        -0.0007602351208335673,
+        0.0001616710472571904
+      ],
+      "observed": {
+        "astro_ra_deg": 74.05095833333334,
+        "astro_dec_deg": 22.21061111111111,
+        "app_ra_deg": 74.41691666666667,
+        "app_dec_deg": 22.250027777777778,
+        "azimuth_deg": 291.659735,
+        "elevation_deg": 5.59871,
+        "range_au": 1.53678382668191
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        -0.4343223237298839,
+        0.5387348404883778,
+        0.2761408836733528
+      ],
+      "geo_velocity_au_per_day": [
+        0.003877104495879179,
+        -0.003954717323809497,
+        -0.001381124568339023
+      ],
+      "observed": {
+        "astro_ra_deg": 128.87008333333335,
+        "astro_dec_deg": 21.753083333333333,
+        "app_ra_deg": 129.23679166666668,
+        "app_dec_deg": 21.66638888888889,
+        "azimuth_deg": 328.700075,
+        "elevation_deg": -42.086874,
+        "range_au": 0.74506576324396
       }
     },
     {
@@ -5645,25 +6503,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        -0.127481831597179,
-        -2.211417333279142,
-        -0.9840108553082422
+        0.7999953845207415,
+        0.3697023904666935,
+        0.1751579278264976
       ],
       "geo_velocity_au_per_day": [
-        0.03147831607982139,
-        0.001426580757543807,
-        0.0002010419153804935
+        0.004966249841833065,
+        0.009127205730021078,
+        0.004442931193408566
       ],
       "observed": {
-        "astro_ra_deg": 266.6947083333333,
-        "astro_dec_deg": -23.951444444444444,
-        "app_ra_deg": 267.05354166666666,
-        "app_dec_deg": -23.960833333333333,
-        "azimuth_deg": 233.222028,
-        "elevation_deg": -16.228423,
-        "range_au": 2.42381872522355
+        "astro_ra_deg": 24.799249999999997,
+        "astro_dec_deg": 11.241166666666667,
+        "app_ra_deg": 25.075416666666666,
+        "app_dec_deg": 11.346361111111111,
+        "azimuth_deg": 351.07162,
+        "elevation_deg": 53.644591,
+        "range_au": 0.8985338112749
       }
     },
     {
@@ -5671,25 +6529,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        1.979755538326635,
-        -0.008886433968211602,
-        -0.05152694615469958
+        -0.1504633865079821,
+        1.828068721987227,
+        0.8480662987290226
       ],
       "geo_velocity_au_per_day": [
-        -0.003373884149163749,
-        0.02445362192343284,
-        0.01071104989179131
+        -0.02197703208877377,
+        0.005917274937760017,
+        0.002708883768722003
       ],
       "observed": {
-        "astro_ra_deg": 359.73816666666664,
-        "astro_dec_deg": -1.4921944444444446,
-        "app_ra_deg": 0.04445833333333333,
-        "app_dec_deg": -1.359027777777778,
-        "azimuth_deg": 234.738107,
-        "elevation_deg": -49.520801,
-        "range_au": 1.98039644728366
+        "astro_ra_deg": 94.70008333333332,
+        "astro_dec_deg": 24.814222222222224,
+        "app_ra_deg": 95.01920833333332,
+        "app_dec_deg": 24.80536111111111,
+        "azimuth_deg": 309.594022,
+        "elevation_deg": 18.268902,
+        "range_au": 2.02086852575605
       }
     },
     {
@@ -5697,25 +6555,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        0.1304381785151843,
-        1.330708480509628,
-        0.5722624637347401
+        -2.571626796132021,
+        0.4509218536094981,
+        0.2417594334911025
       ],
       "geo_velocity_au_per_day": [
-        -0.01627886677871082,
-        -0.004126938789947162,
-        -0.001284992903733402
+        -0.00709655901192413,
+        -0.02592998549405322,
+        -0.01152539107603955
       ],
       "observed": {
-        "astro_ra_deg": 84.39804166666667,
-        "astro_dec_deg": 23.170305555555558,
-        "app_ra_deg": 84.76975,
-        "app_dec_deg": 23.18575,
-        "azimuth_deg": 135.476816,
-        "elevation_deg": -87.989023,
-        "range_au": 1.45435725619075
+        "astro_ra_deg": 170.04991666666666,
+        "astro_dec_deg": 5.2924444444444445,
+        "app_ra_deg": 170.32045833333333,
+        "app_dec_deg": 5.17763888888889,
+        "azimuth_deg": 271.948457,
+        "elevation_deg": -8.230475,
+        "range_au": 2.62207006525148
       }
     },
     {
@@ -5723,25 +6581,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        -0.3701300605235104,
-        0.4989915667774544,
-        0.2635358271016043
+        -0.8382394755030914,
+        -2.029709024550213,
+        -0.883357694545514
       ],
       "geo_velocity_au_per_day": [
-        0.004521638521702022,
-        -0.001314490704020353,
-        -0.0002866647181839665
+        0.02913250248720493,
+        -0.00496589375124172,
+        -0.002631302557023038
       ],
       "observed": {
-        "astro_ra_deg": 126.565625,
-        "astro_dec_deg": 22.98788888888889,
-        "app_ra_deg": 126.93862499999999,
-        "app_dec_deg": 22.905194444444444,
-        "azimuth_deg": 73.200618,
-        "elevation_deg": -19.961332,
-        "range_au": 0.67485852829038
+        "astro_ra_deg": 247.55466666666666,
+        "astro_dec_deg": -21.91147222222222,
+        "app_ra_deg": 247.871875,
+        "app_dec_deg": -21.957583333333332,
+        "azimuth_deg": 225.138321,
+        "elevation_deg": -27.710166,
+        "range_au": 2.3669835551908
       }
     },
     {
@@ -5749,25 +6607,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        -0.7343753880751505,
-        1.035512131449795,
-        0.503842129053235
+        1.535624738829637,
+        -0.5544799776342721,
+        -0.287139614302004
       ],
       "geo_velocity_au_per_day": [
-        -0.01384694105538139,
-        0.002157512030062682,
-        0.0007786502073812648
+        0.002865323555180188,
+        0.02063300439667002,
+        0.00879970422155033
       ],
       "observed": {
-        "astro_ra_deg": 125.33987499999999,
-        "astro_dec_deg": 21.649472222222222,
-        "app_ra_deg": 125.71029166666668,
-        "app_dec_deg": 21.569944444444445,
-        "azimuth_deg": 338.732642,
-        "elevation_deg": 40.888894,
-        "range_au": 1.36584756939929
+        "astro_ra_deg": 340.1422083333334,
+        "astro_dec_deg": -9.975444444444445,
+        "app_ra_deg": 340.428875,
+        "app_dec_deg": -9.861611111111111,
+        "azimuth_deg": 207.51031,
+        "elevation_deg": -51.790163,
+        "range_au": 1.65767361245025
       }
     },
     {
@@ -5775,25 +6633,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        -2.193466607166804,
-        -0.3516648684856351,
-        -0.1374659750642815
+        0.4742980710631119,
+        0.8220298456428374,
+        0.3290104675152845
       ],
       "geo_velocity_au_per_day": [
-        -0.00005639064890470092,
-        -0.02297806676685939,
-        -0.01042241361678611
+        -0.01150480828969359,
+        -0.0003975315960609559,
+        0.0002520322059228121
       ],
       "observed": {
-        "astro_ra_deg": 189.10391666666666,
-        "astro_dec_deg": -3.5388888888888888,
-        "app_ra_deg": 189.43087500000001,
-        "app_dec_deg": -3.678972222222222,
-        "azimuth_deg": 274.357163,
-        "elevation_deg": 18.147815,
-        "range_au": 2.22579665220726
+        "astro_ra_deg": 60.01325,
+        "astro_dec_deg": 19.11952777777778,
+        "app_ra_deg": 60.337625,
+        "app_dec_deg": 19.18327777777778,
+        "azimuth_deg": 101.02117,
+        "elevation_deg": -69.338352,
+        "range_au": 1.00443404561589
       }
     },
     {
@@ -5801,25 +6659,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        0.1663968436105412,
-        -2.199383390739455,
-        -0.9910184431967967
+        0.191228955940762,
+        0.4987801492316052,
+        0.2462526054389587
       ],
       "geo_velocity_au_per_day": [
-        0.03189703690703926,
-        0.002641553946360385,
-        0.0008286003936815563
+        0.00413818913418458,
+        0.002547529249329024,
+        0.001528078653892531
       ],
       "observed": {
-        "astro_ra_deg": 274.32025,
-        "astro_dec_deg": -24.194194444444445,
-        "app_ra_deg": 274.71299999999997,
-        "app_dec_deg": -24.185222222222222,
-        "azimuth_deg": 242.012748,
-        "elevation_deg": -2.278105,
-        "range_au": 2.41810568592904
+        "astro_ra_deg": 69.02179166666666,
+        "astro_dec_deg": 24.751055555555556,
+        "app_ra_deg": 69.37358333333334,
+        "app_dec_deg": 24.7985,
+        "azimuth_deg": 47.586271,
+        "elevation_deg": 21.341799,
+        "range_au": 0.58819923845318
       }
     },
     {
@@ -5827,25 +6685,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        2.244545534858756,
-        0.2878317505991867,
-        0.08358652074169941
+        -0.377218037652249,
+        1.44826393481251,
+        0.6861363505783173
       ],
       "geo_velocity_au_per_day": [
-        -0.005676257712769054,
-        0.02749511248353483,
-        0.01219545375434315
+        -0.0171256553893615,
+        0.005136107774762868,
+        0.002246882436367731
       ],
       "observed": {
-        "astro_ra_deg": 7.3023750000000005,
-        "astro_dec_deg": 2.1138055555555555,
-        "app_ra_deg": 7.636416666666666,
-        "app_dec_deg": 2.257833333333333,
-        "azimuth_deg": 253.11438,
-        "elevation_deg": -36.940006,
-        "range_au": 2.26443552153044
+        "astro_ra_deg": 104.59433333333334,
+        "astro_dec_deg": 24.63125,
+        "app_ra_deg": 104.94570833333333,
+        "app_dec_deg": 24.600972222222225,
+        "azimuth_deg": 324.178428,
+        "elevation_deg": 31.069075,
+        "range_au": 1.6464184716608
       }
     },
     {
@@ -5853,25 +6711,25 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        -0.1343418453184868,
-        1.754675906630777,
-        0.7726506257751409
+        -2.435151993348373,
+        0.2130601563528054,
+        0.1276752347380855
       ],
       "geo_velocity_au_per_day": [
-        -0.02154108417645187,
-        -0.006002249579209105,
-        -0.002109457648427775
+        -0.006147760521644694,
+        -0.02429513917066216,
+        -0.0109077287068934
       ],
       "observed": {
-        "astro_ra_deg": 94.37366666666667,
-        "astro_dec_deg": 23.704055555555556,
-        "app_ra_deg": 94.77866666666667,
-        "app_dec_deg": 23.6945,
-        "azimuth_deg": 270.79437,
-        "elevation_deg": -72.829082,
-        "range_au": 1.92190529091149
+        "astro_ra_deg": 174.99516666666668,
+        "astro_dec_deg": 2.9919722222222225,
+        "app_ra_deg": 175.29233333333335,
+        "app_dec_deg": 2.8638333333333335,
+        "azimuth_deg": 276.2249,
+        "elevation_deg": 6.607616,
+        "range_au": 2.44784671101168
       }
     },
     {
@@ -5879,25 +6737,103 @@
       "target_id": 499,
       "target_name": "Mars",
       "site": "Paranal",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        -0.958113565016507,
-        0.3644374910539417,
-        0.2126826062560103
+        -0.5987351609961756,
+        -2.188218027155928,
+        -0.9674697347065054
       ],
       "geo_velocity_au_per_day": [
-        0.005951829234409446,
-        -0.007317106447188714,
-        -0.003005107767402819
+        0.03111768631513348,
+        -0.004511118475785529,
+        -0.002401898784474935
       ],
       "observed": {
-        "astro_ra_deg": 159.17279166666665,
-        "astro_dec_deg": 11.72325,
-        "app_ra_deg": 159.53345833333333,
-        "app_dec_deg": 11.581583333333333,
-        "azimuth_deg": 105.340566,
-        "elevation_deg": -54.652573,
-        "range_au": 1.04690083075253
+        "astro_ra_deg": 254.6915,
+        "astro_dec_deg": -23.094694444444443,
+        "app_ra_deg": 255.04504166666666,
+        "app_dec_deg": -23.13088888888889,
+        "azimuth_deg": 235.479698,
+        "elevation_deg": -14.668988,
+        "range_au": 2.46633900034304
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        1.988839062231803,
+        -0.3845396902065834,
+        -0.215414879557498
+      ],
+      "geo_velocity_au_per_day": [
+        0.002227818499745652,
+        0.02545249843164074,
+        0.01106300118358349
+      ],
+      "observed": {
+        "astro_ra_deg": 349.0520833333333,
+        "astro_dec_deg": -6.071416666666666,
+        "app_ra_deg": 349.3605416666667,
+        "app_dec_deg": -5.941333333333334,
+        "azimuth_deg": 233.814182,
+        "elevation_deg": -43.410707,
+        "range_au": 2.03704819318109
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        0.390841377139252,
+        1.368098936300063,
+        0.5809853118372811
+      ],
+      "geo_velocity_au_per_day": [
+        -0.01830414173906738,
+        -0.0007602351208335673,
+        0.0001616710472571904
+      ],
+      "observed": {
+        "astro_ra_deg": 74.0525,
+        "astro_dec_deg": 22.211194444444445,
+        "app_ra_deg": 74.418375,
+        "app_dec_deg": 22.250583333333335,
+        "azimuth_deg": 228.808454,
+        "elevation_deg": -86.432931,
+        "range_au": 1.53683050313605
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 499,
+      "target_name": "Mars",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        -0.4343223237298839,
+        0.5387348404883778,
+        0.2761408836733528
+      ],
+      "geo_velocity_au_per_day": [
+        0.003877104495879179,
+        -0.003954717323809497,
+        -0.001381124568339023
+      ],
+      "observed": {
+        "astro_ra_deg": 128.8742916666667,
+        "astro_dec_deg": 21.75588888888889,
+        "app_ra_deg": 129.241,
+        "app_dec_deg": 21.66911111111111,
+        "azimuth_deg": 79.822426,
+        "elevation_deg": -34.691278,
+        "range_au": 0.74506136505704
       }
     },
     {
@@ -5905,25 +6841,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        9.161938680560144,
-        -4.18206712865634,
-        -2.132881008994687
+        5.669493401374993,
+        -8.511568734626051,
+        -3.770251211524874
       ],
       "geo_velocity_au_per_day": [
-        0.01905198380894553,
-        0.007506678948347601,
-        0.003077578975058576
+        0.02154790804249204,
+        0.005827912398774828,
+        0.002279749448901465
       ],
       "observed": {
-        "astro_ra_deg": 335.4632916666667,
-        "astro_dec_deg": -11.958083333333333,
-        "app_ra_deg": 335.778125,
-        "app_dec_deg": -11.83925,
-        "azimuth_deg": 290.65512,
-        "elevation_deg": -30.309442,
-        "range_au": 10.2947222027866
+        "astro_ra_deg": 303.66537500000004,
+        "astro_dec_deg": -20.237305555555558,
+        "app_ra_deg": 303.9599166666667,
+        "app_dec_deg": -20.17475,
+        "azimuth_deg": 321.36694,
+        "elevation_deg": -53.860116,
+        "range_au": 10.8998152803547
       }
     },
     {
@@ -5931,25 +6867,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        9.966791578363022,
-        -2.119093772238966,
-        -1.259001078000066
+        6.766353520409509,
+        -6.65974424782074,
+        -2.996906186288015
       ],
       "geo_velocity_au_per_day": [
-        -0.00926575807393705,
-        0.01709403423284245,
-        0.007246612841380801
+        -0.006750152306028179,
+        0.01521504602934802,
+        0.006352137812271386
       ],
       "observed": {
-        "astro_ra_deg": 347.9951666666667,
-        "astro_dec_deg": -7.044472222222222,
-        "app_ra_deg": 348.3059583333333,
-        "app_dec_deg": -6.914194444444445,
-        "azimuth_deg": 60.960807,
-        "elevation_deg": -29.379887,
-        "range_au": 10.2670733085877
+        "astro_ra_deg": 315.4533333333333,
+        "astro_dec_deg": -17.51961111111111,
+        "app_ra_deg": 315.7477083333333,
+        "app_dec_deg": -17.436722222222222,
+        "azimuth_deg": 96.068763,
+        "elevation_deg": -17.625729,
+        "range_au": 9.95575301419981
       }
     },
     {
@@ -5957,25 +6893,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        8.432574839072291,
-        -1.722358745920582,
-        -1.105792640863175
+        5.565778789771198,
+        -6.482724286458221,
+        -2.94909521950581
       ],
       "geo_velocity_au_per_day": [
-        -0.00593747257219218,
-        -0.00922945640831641,
-        -0.004150103325545598
+        -0.002911232840788826,
+        -0.01089080264208594,
+        -0.004959610446633339
       ],
       "observed": {
-        "astro_ra_deg": 348.45441666666665,
-        "astro_dec_deg": -7.3221944444444444,
-        "app_ra_deg": 348.77887499999997,
-        "app_dec_deg": -7.186111111111112,
-        "azimuth_deg": 166.077294,
-        "elevation_deg": 30.424546,
-        "range_au": 8.67740680933528
+        "astro_ra_deg": 310.64604166666663,
+        "astro_dec_deg": -19.043111111111113,
+        "app_ra_deg": 310.9560833333333,
+        "app_dec_deg": -18.965027777777777,
+        "azimuth_deg": 205.981967,
+        "elevation_deg": 15.845098,
+        "range_au": 9.03885909566961
       }
     },
     {
@@ -5983,25 +6919,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        9.531422016220812,
-        -2.411611104945534,
-        -1.421678989134372
+        7.029738453470491,
+        -7.339229692796889,
+        -3.348713807895955
       ],
       "geo_velocity_au_per_day": [
-        0.0181664691153462,
-        0.006323705123618,
-        0.002605417160119831
+        0.02109388371240891,
+        0.005128695490352784,
+        0.00199000671410687
       ],
       "observed": {
-        "astro_ra_deg": 345.7993333333333,
-        "astro_dec_deg": -8.228805555555555,
-        "app_ra_deg": 346.1225833333333,
-        "app_dec_deg": -8.095472222222222,
-        "azimuth_deg": 279.852933,
-        "elevation_deg": -18.031112,
-        "range_au": 9.93409493926337
+        "astro_ra_deg": 313.7642083333334,
+        "astro_dec_deg": -18.238055555555558,
+        "app_ra_deg": 314.06629166666664,
+        "app_dec_deg": -18.15647222222222,
+        "azimuth_deg": 303.390927,
+        "elevation_deg": -45.055937,
+        "range_au": 10.7003143149056
       }
     },
     {
@@ -6009,25 +6945,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        10.34848386712778,
-        -0.3750187894896339,
-        -0.5541426308467658
+        8.18706250647186,
+        -5.45174229247736,
+        -2.558100293494052
       ],
       "geo_velocity_au_per_day": [
-        -0.009164619033500892,
-        0.01816105367022833,
-        0.007753650201144451
+        -0.006281324236164681,
+        0.0168162349766243,
+        0.007063082513219061
       ],
       "observed": {
-        "astro_ra_deg": 357.9229583333334,
-        "astro_dec_deg": -3.0640277777777776,
-        "app_ra_deg": 358.24345833333336,
-        "app_dec_deg": -2.9249444444444443,
-        "azimuth_deg": 43.303781,
-        "elevation_deg": -33.320417,
-        "range_au": 10.3701130835221
+        "astro_ra_deg": 326.33887500000003,
+        "astro_dec_deg": -14.57875,
+        "app_ra_deg": 326.6370833333333,
+        "app_dec_deg": -14.477916666666667,
+        "azimuth_deg": 81.335933,
+        "elevation_deg": -25.337005,
+        "range_au": 10.1633349360646
       }
     },
     {
@@ -6035,25 +6971,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        8.666198555513423,
-        0.1822881517417485,
-        -0.3259534935503385
+        6.880319183526448,
+        -5.050843733250445,
+        -2.411025946372626
       ],
       "geo_velocity_au_per_day": [
-        -0.008421693851488788,
-        -0.008446008021485991,
-        -0.003765359452427075
+        -0.005056489700451602,
+        -0.009582562294614728,
+        -0.004372136877371697
       ],
       "observed": {
-        "astro_ra_deg": 1.203375,
-        "astro_dec_deg": -2.154444444444444,
-        "app_ra_deg": 1.5375,
-        "app_dec_deg": -2.009138888888889,
-        "azimuth_deg": 144.444364,
-        "elevation_deg": 30.773853,
-        "range_au": 8.67422013925964
+        "astro_ra_deg": 323.7157916666667,
+        "astro_dec_deg": -15.774694444444446,
+        "app_ra_deg": 324.0296666666667,
+        "app_dec_deg": -15.673166666666667,
+        "azimuth_deg": 188.571773,
+        "elevation_deg": 22.466683,
+        "range_au": 8.86920874192819
       }
     },
     {
@@ -6061,25 +6997,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        9.495117000588953,
-        -0.5702620760421724,
-        -0.6636034828520035
+        8.115382164819389,
+        -5.905639092575692,
+        -2.807323959913588
       ],
       "geo_velocity_au_per_day": [
-        0.01706161342329413,
-        0.004923870425501271,
-        0.002047777015607316
+        0.02032847099890566,
+        0.004297608497428625,
+        0.00165190264726205
       ],
       "observed": {
-        "astro_ra_deg": 356.5611666666666,
-        "astro_dec_deg": -3.9915555555555557,
-        "app_ra_deg": 356.895625,
-        "app_dec_deg": -3.847166666666667,
-        "azimuth_deg": 269.887369,
-        "elevation_deg": -4.830075,
-        "range_au": 9.53539727696334
+        "astro_ra_deg": 323.954375,
+        "astro_dec_deg": -15.627222222222223,
+        "app_ra_deg": 324.2633333333333,
+        "app_dec_deg": -15.526944444444446,
+        "azimuth_deg": 289.769362,
+        "elevation_deg": -34.36277,
+        "range_au": 10.422015421602
       }
     },
     {
@@ -6087,25 +7023,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        10.31115564588462,
-        1.402292713250083,
-        0.1820916804620778
+        9.30834618599121,
+        -4.010860757731018,
+        -2.010583741583301
       ],
       "geo_velocity_au_per_day": [
-        -0.009037306476043278,
-        0.01890202712575994,
-        0.00812459759418714
+        -0.005885028393067955,
+        0.0181666775486019,
+        0.007675854819162161
       ],
       "observed": {
-        "astro_ra_deg": 7.742916666666666,
-        "astro_dec_deg": 1.0015833333333333,
-        "app_ra_deg": 8.076666666666666,
-        "app_dec_deg": 1.1455277777777777,
-        "azimuth_deg": 24.60793,
-        "elevation_deg": -34.710306,
-        "range_au": 10.4076951674679
+        "astro_ra_deg": 336.68775,
+        "astro_dec_deg": -11.220694444444444,
+        "app_ra_deg": 336.99075,
+        "app_dec_deg": -11.104444444444445,
+        "azimuth_deg": 65.310742,
+        "elevation_deg": -31.902208,
+        "range_au": 10.3331975631243
       }
     },
     {
@@ -6113,25 +7049,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        8.489168173794486,
-        2.094194898380382,
-        0.4747813521195802
+        7.890940098413336,
+        -3.402830595627485,
+        -1.770392564317749
       ],
       "geo_velocity_au_per_day": [
-        -0.01086449677750823,
-        -0.00777537966005968,
-        -0.003422340653222391
+        -0.007275192362975836,
+        -0.00831324933183832,
+        -0.003793880258761276
       ],
       "observed": {
-        "astro_ra_deg": 13.856041666666666,
-        "astro_dec_deg": 3.1071944444444446,
-        "app_ra_deg": 14.204875,
-        "app_dec_deg": 3.254166666666667,
-        "azimuth_deg": 123.461427,
-        "elevation_deg": 27.508123,
-        "range_au": 8.75651529922076
+        "astro_ra_deg": 336.671,
+        "astro_dec_deg": -11.641944444444444,
+        "app_ra_deg": 336.9883333333333,
+        "app_dec_deg": -11.520555555555557,
+        "azimuth_deg": 169.157703,
+        "elevation_deg": 26.419395,
+        "range_au": 8.77384226139171
       }
     },
     {
@@ -6139,25 +7075,103 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Greenwich",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        9.037984585850833,
-        1.262662785604759,
-        0.109270441585738
+        8.873082854907661,
+        -4.263257528287816,
+        -2.165424817818546
       ],
       "geo_velocity_au_per_day": [
-        0.01577790101423161,
-        0.003297765705293493,
-        0.001397434676983488
+        0.01926899897638471,
+        0.003307589542271192,
+        0.001256415797365792
       ],
       "observed": {
-        "astro_ra_deg": 7.95125,
-        "astro_dec_deg": 0.6851111111111111,
-        "app_ra_deg": 8.300666666666668,
-        "app_dec_deg": 0.8353055555555556,
-        "azimuth_deg": 259.762692,
-        "elevation_deg": 9.110191,
-        "range_au": 9.12645241497032
+        "astro_ra_deg": 334.33520833333336,
+        "astro_dec_deg": -12.406583333333334,
+        "app_ra_deg": 334.65137500000003,
+        "app_dec_deg": -12.28875,
+        "azimuth_deg": 278.576548,
+        "elevation_deg": -22.443683,
+        "range_au": 10.0795472213702
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        10.07859655293539,
+        -2.392559955234406,
+        -1.375076968985813
+      ],
+      "geo_velocity_au_per_day": [
+        -0.00554050048660469,
+        0.01923564723391554,
+        0.008173381696714305
+      ],
+      "observed": {
+        "astro_ra_deg": 346.64412500000003,
+        "astro_dec_deg": -7.562416666666667,
+        "app_ra_deg": 346.95416666666665,
+        "app_dec_deg": -7.4335,
+        "azimuth_deg": 47.573043,
+        "elevation_deg": -36.616176,
+        "range_au": 10.449579639704
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        8.549329538136652,
+        -1.598775703124963,
+        -1.049969232683365
+      ],
+      "geo_velocity_au_per_day": [
+        -0.009531460614140187,
+        -0.007119243906326336,
+        -0.003237863894617312
+      ],
+      "observed": {
+        "astro_ra_deg": 349.40608333333336,
+        "astro_dec_deg": -6.884361111111111,
+        "app_ra_deg": 349.7289166666667,
+        "app_dec_deg": -6.748194444444445,
+        "azimuth_deg": 148.650283,
+        "elevation_deg": 27.075365,
+        "range_au": 8.76066409515524
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Greenwich",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        9.259118943864722,
+        -2.474955223565741,
+        -1.447093344207675
+      ],
+      "geo_velocity_au_per_day": [
+        0.01794506137002327,
+        0.002139986138257225,
+        0.0007913128496279117
+      ],
+      "observed": {
+        "astro_ra_deg": 345.03287500000005,
+        "astro_dec_deg": -8.586944444444445,
+        "app_ra_deg": 345.35720833333335,
+        "app_dec_deg": -8.453916666666666,
+        "azimuth_deg": 268.476046,
+        "elevation_deg": -9.615541,
+        "range_au": 9.69287516255804
       }
     },
     {
@@ -6165,25 +7179,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        9.161938680560144,
-        -4.18206712865634,
-        -2.132881008994687
+        5.669493401374993,
+        -8.511568734626051,
+        -3.770251211524874
       ],
       "geo_velocity_au_per_day": [
-        0.01905198380894553,
-        0.007506678948347601,
-        0.003077578975058576
+        0.02154790804249204,
+        0.005827912398774828,
+        0.002279749448901465
       ],
       "observed": {
-        "astro_ra_deg": 335.4635416666667,
-        "astro_dec_deg": -11.958055555555555,
-        "app_ra_deg": 335.77845833333333,
-        "app_dec_deg": -11.839194444444445,
-        "azimuth_deg": 133.349019,
-        "elevation_deg": 45.953609,
-        "range_au": 10.2946699931882
+        "astro_ra_deg": 303.6654583333334,
+        "astro_dec_deg": -20.237333333333336,
+        "app_ra_deg": 303.960125,
+        "app_dec_deg": -20.17477777777778,
+        "azimuth_deg": 182.086315,
+        "elevation_deg": 49.974441,
+        "range_au": 10.8997481404227
       }
     },
     {
@@ -6191,25 +7205,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        9.966791578363022,
-        -2.119093772238966,
-        -1.259001078000066
+        6.766353520409509,
+        -6.65974424782074,
+        -2.996906186288015
       ],
       "geo_velocity_au_per_day": [
-        -0.00926575807393705,
-        0.01709403423284245,
-        0.007246612841380801
+        -0.006750152306028179,
+        0.01521504602934802,
+        0.006352137812271386
       ],
       "observed": {
-        "astro_ra_deg": 347.994875,
-        "astro_dec_deg": -7.044388888888888,
-        "app_ra_deg": 348.30566666666664,
-        "app_dec_deg": -6.914138888888889,
-        "azimuth_deg": 258.062933,
-        "elevation_deg": 11.911612,
-        "range_au": 10.2670435518921
+        "astro_ra_deg": 315.4529166666667,
+        "astro_dec_deg": -17.5195,
+        "app_ra_deg": 315.74733333333336,
+        "app_dec_deg": -17.43663888888889,
+        "azimuth_deg": 258.643027,
+        "elevation_deg": -22.195893,
+        "range_au": 9.95575623854203
       }
     },
     {
@@ -6217,25 +7231,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        8.432574839072291,
-        -1.722358745920582,
-        -1.105792640863175
+        5.565778789771198,
+        -6.482724286458221,
+        -2.94909521950581
       ],
       "geo_velocity_au_per_day": [
-        -0.00593747257219218,
-        -0.00922945640831641,
-        -0.004150103325545598
+        -0.002911232840788826,
+        -0.01089080264208594,
+        -0.004959610446633339
       ],
       "observed": {
-        "astro_ra_deg": 348.45441666666665,
-        "astro_dec_deg": -7.322027777777778,
-        "app_ra_deg": 348.77875,
-        "app_dec_deg": -7.185944444444445,
-        "azimuth_deg": 45.412637,
-        "elevation_deg": -72.515621,
-        "range_au": 8.6774691666657
+        "astro_ra_deg": 310.6462916666666,
+        "astro_dec_deg": -19.04288888888889,
+        "app_ra_deg": 310.95625,
+        "app_dec_deg": -18.964777777777776,
+        "azimuth_deg": 98.041248,
+        "elevation_deg": -42.085554,
+        "range_au": 9.03889940309576
       }
     },
     {
@@ -6243,25 +7257,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        9.531422016220812,
-        -2.411611104945534,
-        -1.421678989134372
+        7.029738453470491,
+        -7.339229692796889,
+        -3.348713807895955
       ],
       "geo_velocity_au_per_day": [
-        0.0181664691153462,
-        0.006323705123618,
-        0.002605417160119831
+        0.02109388371240891,
+        0.005128695490352784,
+        0.00199000671410687
       ],
       "observed": {
-        "astro_ra_deg": 345.79966666666667,
-        "astro_dec_deg": -8.228722222222222,
-        "app_ra_deg": 346.123,
-        "app_dec_deg": -8.09538888888889,
-        "azimuth_deg": 116.781531,
-        "elevation_deg": 36.300381,
-        "range_au": 9.93405646771772
+        "astro_ra_deg": 313.76433333333335,
+        "astro_dec_deg": -18.238055555555558,
+        "app_ra_deg": 314.0665416666667,
+        "app_dec_deg": -18.156444444444443,
+        "azimuth_deg": 159.437207,
+        "elevation_deg": 49.661348,
+        "range_au": 10.7002515854726
       }
     },
     {
@@ -6269,25 +7283,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        10.34848386712778,
-        -0.3750187894896339,
-        -0.5541426308467658
+        8.18706250647186,
+        -5.45174229247736,
+        -2.558100293494052
       ],
       "geo_velocity_au_per_day": [
-        -0.009164619033500892,
-        0.01816105367022833,
-        0.007753650201144451
+        -0.006281324236164681,
+        0.0168162349766243,
+        0.007063082513219061
       ],
       "observed": {
-        "astro_ra_deg": 357.9226666666667,
-        "astro_dec_deg": -3.063944444444444,
-        "app_ra_deg": 358.24325,
-        "app_dec_deg": -2.924861111111111,
-        "azimuth_deg": 255.684885,
-        "elevation_deg": 27.314734,
-        "range_au": 10.370070033551
+        "astro_ra_deg": 326.33845833333334,
+        "astro_dec_deg": -14.578666666666667,
+        "app_ra_deg": 326.63675,
+        "app_dec_deg": -14.47786111111111,
+        "azimuth_deg": 256.939014,
+        "elevation_deg": -6.570456,
+        "range_au": 10.1633215664908
       }
     },
     {
@@ -6295,25 +7309,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        8.666198555513423,
-        0.1822881517417485,
-        -0.3259534935503385
+        6.880319183526448,
+        -5.050843733250445,
+        -2.411025946372626
       ],
       "geo_velocity_au_per_day": [
-        -0.008421693851488788,
-        -0.008446008021485991,
-        -0.003765359452427075
+        -0.005056489700451602,
+        -0.009582562294614728,
+        -0.004372136877371697
       ],
       "observed": {
-        "astro_ra_deg": 1.2032916666666666,
-        "astro_dec_deg": -2.1543055555555553,
-        "app_ra_deg": 1.5372500000000002,
-        "app_dec_deg": -2.009,
-        "azimuth_deg": 342.626261,
-        "elevation_deg": -71.397957,
-        "range_au": 8.6742824533003
+        "astro_ra_deg": 323.71595833333333,
+        "astro_dec_deg": -15.774472222222222,
+        "app_ra_deg": 324.02970833333336,
+        "app_dec_deg": -15.672944444444443,
+        "azimuth_deg": 87.74436,
+        "elevation_deg": -58.582847,
+        "range_au": 8.86926152175802
       }
     },
     {
@@ -6321,25 +7335,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        9.495117000588953,
-        -0.5702620760421724,
-        -0.6636034828520035
+        8.115382164819389,
+        -5.905639092575692,
+        -2.807323959913588
       ],
       "geo_velocity_au_per_day": [
-        0.01706161342329413,
-        0.004923870425501271,
-        0.002047777015607316
+        0.02032847099890566,
+        0.004297608497428625,
+        0.00165190264726205
       ],
       "observed": {
-        "astro_ra_deg": 356.56154166666664,
-        "astro_dec_deg": -3.9914444444444444,
-        "app_ra_deg": 356.8960416666667,
-        "app_dec_deg": -3.847055555555556,
-        "azimuth_deg": 103.899616,
-        "elevation_deg": 24.199455,
-        "range_au": 9.5353761935788
+        "astro_ra_deg": 323.954625,
+        "astro_dec_deg": -15.627194444444445,
+        "app_ra_deg": 324.26366666666667,
+        "app_dec_deg": -15.52688888888889,
+        "azimuth_deg": 138.801347,
+        "elevation_deg": 44.456708,
+        "range_au": 10.4219614523359
       }
     },
     {
@@ -6347,25 +7361,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        10.31115564588462,
-        1.402292713250083,
-        0.1820916804620778
+        9.30834618599121,
+        -4.010860757731018,
+        -2.010583741583301
       ],
       "geo_velocity_au_per_day": [
-        -0.009037306476043278,
-        0.01890202712575994,
-        0.00812459759418714
+        -0.005885028393067955,
+        0.0181666775486019,
+        0.007675854819162161
       ],
       "observed": {
-        "astro_ra_deg": 7.742708333333333,
-        "astro_dec_deg": 1.0016944444444444,
-        "app_ra_deg": 8.076583333333334,
-        "app_dec_deg": 1.1456388888888889,
-        "azimuth_deg": 252.371894,
-        "elevation_deg": 42.615834,
-        "range_au": 10.4076419374525
+        "astro_ra_deg": 336.687375,
+        "astro_dec_deg": -11.220611111111111,
+        "app_ra_deg": 336.9904583333333,
+        "app_dec_deg": -11.104388888888888,
+        "azimuth_deg": 254.761864,
+        "elevation_deg": 8.777909,
+        "range_au": 10.333168493623
       }
     },
     {
@@ -6373,25 +7387,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        8.489168173794486,
-        2.094194898380382,
-        0.4747813521195802
+        7.890940098413336,
+        -3.402830595627485,
+        -1.770392564317749
       ],
       "geo_velocity_au_per_day": [
-        -0.01086449677750823,
-        -0.00777537966005968,
-        -0.003422340653222391
+        -0.007275192362975836,
+        -0.00831324933183832,
+        -0.003793880258761276
       ],
       "observed": {
-        "astro_ra_deg": 13.855791666666667,
-        "astro_dec_deg": 3.1073055555555555,
-        "app_ra_deg": 14.204500000000001,
-        "app_dec_deg": 3.254277777777778,
-        "azimuth_deg": 312.69662,
-        "elevation_deg": -57.494796,
-        "range_au": 8.75657101967027
+        "astro_ra_deg": 336.67104166666667,
+        "astro_dec_deg": -11.64175,
+        "app_ra_deg": 336.98825,
+        "app_dec_deg": -11.520361111111113,
+        "azimuth_deg": 61.615816,
+        "elevation_deg": -73.666587,
+        "range_au": 8.77390225124148
       }
     },
     {
@@ -6399,25 +7413,103 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Mauna Kea",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        9.037984585850833,
-        1.262662785604759,
-        0.109270441585738
+        8.873082854907661,
+        -4.263257528287816,
+        -2.165424817818546
       ],
       "geo_velocity_au_per_day": [
-        0.01577790101423161,
-        0.003297765705293493,
-        0.001397434676983488
+        0.01926899897638471,
+        0.003307589542271192,
+        0.001256415797365792
       ],
       "observed": {
-        "astro_ra_deg": 7.951625000000001,
-        "astro_dec_deg": 0.6852222222222223,
-        "app_ra_deg": 8.301083333333334,
-        "app_dec_deg": 0.8354166666666667,
-        "azimuth_deg": 92.93176,
-        "elevation_deg": 10.513493,
-        "range_au": 9.12645138839308
+        "astro_ra_deg": 334.3355,
+        "astro_dec_deg": -12.406527777777779,
+        "app_ra_deg": 334.65175,
+        "app_dec_deg": -12.288666666666666,
+        "azimuth_deg": 122.335576,
+        "elevation_deg": 35.484498,
+        "range_au": 10.0795061650317
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        10.07859655293539,
+        -2.392559955234406,
+        -1.375076968985813
+      ],
+      "geo_velocity_au_per_day": [
+        -0.00554050048660469,
+        0.01923564723391554,
+        0.008173381696714305
+      ],
+      "observed": {
+        "astro_ra_deg": 346.64383333333336,
+        "astro_dec_deg": -7.562333333333333,
+        "app_ra_deg": 346.954,
+        "app_dec_deg": -7.4334444444444445,
+        "azimuth_deg": 251.92439,
+        "elevation_deg": 23.908931,
+        "range_au": 10.4495368733414
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        8.549329538136652,
+        -1.598775703124963,
+        -1.049969232683365
+      ],
+      "geo_velocity_au_per_day": [
+        -0.009531460614140187,
+        -0.007119243906326336,
+        -0.003237863894617312
+      ],
+      "observed": {
+        "astro_ra_deg": 349.4059583333334,
+        "astro_dec_deg": -6.884194444444444,
+        "app_ra_deg": 349.7286666666667,
+        "app_dec_deg": -6.748027777777778,
+        "azimuth_deg": 345.870718,
+        "elevation_deg": -76.539659,
+        "range_au": 8.7607250633181
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Mauna Kea",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        9.259118943864722,
+        -2.474955223565741,
+        -1.447093344207675
+      ],
+      "geo_velocity_au_per_day": [
+        0.01794506137002327,
+        0.002139986138257225,
+        0.0007913128496279117
+      ],
+      "observed": {
+        "astro_ra_deg": 345.03325,
+        "astro_dec_deg": -8.586833333333335,
+        "app_ra_deg": 345.357625,
+        "app_dec_deg": -8.453805555555554,
+        "azimuth_deg": 109.356591,
+        "elevation_deg": 23.984102,
+        "range_au": 9.69285069703773
       }
     },
     {
@@ -6425,25 +7517,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460310.5,
+      "epoch_jd_ut": 2459215.5,
       "geo_vector_au": [
-        9.161938680560144,
-        -4.18206712865634,
-        -2.132881008994687
+        5.669493401374993,
+        -8.511568734626051,
+        -3.770251211524874
       ],
       "geo_velocity_au_per_day": [
-        0.01905198380894553,
-        0.007506678948347601,
-        0.003077578975058576
+        0.02154790804249204,
+        0.005827912398774828,
+        0.002279749448901465
       ],
       "observed": {
-        "astro_ra_deg": 335.46325,
-        "astro_dec_deg": -11.95786111111111,
-        "app_ra_deg": 335.778125,
-        "app_dec_deg": -11.839027777777778,
-        "azimuth_deg": 273.860106,
-        "elevation_deg": 37.505449,
-        "range_au": 10.2946747286723
+        "astro_ra_deg": 303.66525,
+        "astro_dec_deg": -20.237111111111112,
+        "app_ra_deg": 303.95983333333334,
+        "app_dec_deg": -20.174583333333334,
+        "azimuth_deg": 252.821578,
+        "elevation_deg": 11.291996,
+        "range_au": 10.8997725376967
       }
     },
     {
@@ -6451,25 +7543,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460430.5,
+      "epoch_jd_ut": 2459335.5,
       "geo_vector_au": [
-        9.966791578363022,
-        -2.119093772238966,
-        -1.259001078000066
+        6.766353520409509,
+        -6.65974424782074,
+        -2.996906186288015
       ],
       "geo_velocity_au_per_day": [
-        -0.00926575807393705,
-        0.01709403423284245,
-        0.007246612841380801
+        -0.006750152306028179,
+        0.01521504602934802,
+        0.006352137812271386
       ],
       "observed": {
-        "astro_ra_deg": 347.995,
-        "astro_dec_deg": -7.0441666666666665,
-        "app_ra_deg": 348.3057083333333,
-        "app_dec_deg": -6.913916666666667,
-        "azimuth_deg": 214.672289,
-        "elevation_deg": -52.779893,
-        "range_au": 10.2670863741686
+        "astro_ra_deg": 315.4532083333333,
+        "astro_dec_deg": -17.519277777777777,
+        "app_ra_deg": 315.7475416666667,
+        "app_dec_deg": -17.43638888888889,
+        "azimuth_deg": 161.994651,
+        "elevation_deg": -46.071753,
+        "range_au": 9.95577091724787
       }
     },
     {
@@ -6477,25 +7569,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460550.5,
+      "epoch_jd_ut": 2459455.5,
       "geo_vector_au": [
-        8.432574839072291,
-        -1.722358745920582,
-        -1.105792640863175
+        5.565778789771198,
+        -6.482724286458221,
+        -2.94909521950581
       ],
       "geo_velocity_au_per_day": [
-        -0.00593747257219218,
-        -0.00922945640831641,
-        -0.004150103325545598
+        -0.002911232840788826,
+        -0.01089080264208594,
+        -0.004959610446633339
       ],
       "observed": {
-        "astro_ra_deg": 348.454625,
-        "astro_dec_deg": -7.321861111111111,
-        "app_ra_deg": 348.77904166666667,
-        "app_dec_deg": -7.1857500000000005,
-        "azimuth_deg": 93.465657,
-        "elevation_deg": 9.801209,
-        "range_au": 8.67742121732348
+        "astro_ra_deg": 310.6462916666666,
+        "astro_dec_deg": -19.042805555555557,
+        "app_ra_deg": 310.9563333333333,
+        "app_dec_deg": -18.964694444444444,
+        "azimuth_deg": 91.017423,
+        "elevation_deg": 48.977842,
+        "range_au": 9.03883866934665
       }
     },
     {
@@ -6503,25 +7595,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460670.5,
+      "epoch_jd_ut": 2459575.5,
       "geo_vector_au": [
-        9.531422016220812,
-        -2.411611104945534,
-        -1.421678989134372
+        7.029738453470491,
+        -7.339229692796889,
+        -3.348713807895955
       ],
       "geo_velocity_au_per_day": [
-        0.0181664691153462,
-        0.006323705123618,
-        0.002605417160119831
+        0.02109388371240891,
+        0.005128695490352784,
+        0.00199000671410687
       ],
       "observed": {
-        "astro_ra_deg": 345.7993333333333,
-        "astro_dec_deg": -8.228527777777778,
-        "app_ra_deg": 346.12266666666665,
-        "app_dec_deg": -8.095222222222223,
-        "azimuth_deg": 287.576253,
-        "elevation_deg": 49.766176,
-        "range_au": 9.93404918320781
+        "astro_ra_deg": 313.76408333333336,
+        "astro_dec_deg": -18.237833333333334,
+        "app_ra_deg": 314.06625,
+        "app_dec_deg": -18.156277777777778,
+        "azimuth_deg": 260.172854,
+        "elevation_deg": 24.068536,
+        "range_au": 10.700266776426
       }
     },
     {
@@ -6529,25 +7621,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460790.5,
+      "epoch_jd_ut": 2459695.5,
       "geo_vector_au": [
-        10.34848386712778,
-        -0.3750187894896339,
-        -0.5541426308467658
+        8.18706250647186,
+        -5.45174229247736,
+        -2.558100293494052
       ],
       "geo_velocity_au_per_day": [
-        -0.009164619033500892,
-        0.01816105367022833,
-        0.007753650201144451
+        -0.006281324236164681,
+        0.0168162349766243,
+        0.007063082513219061
       ],
       "observed": {
-        "astro_ra_deg": 357.92275,
-        "astro_dec_deg": -3.0637499999999998,
-        "app_ra_deg": 358.2432083333333,
-        "app_dec_deg": -2.9246666666666665,
-        "azimuth_deg": 236.299668,
-        "elevation_deg": -45.964019,
-        "range_au": 10.3701203121766
+        "astro_ra_deg": 326.33870833333333,
+        "astro_dec_deg": -14.578444444444445,
+        "app_ra_deg": 326.636875,
+        "app_dec_deg": -14.477611111111111,
+        "azimuth_deg": 184.697602,
+        "elevation_deg": -50.78089,
+        "range_au": 10.1633498022894
       }
     },
     {
@@ -6555,25 +7647,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2460910.5,
+      "epoch_jd_ut": 2459815.5,
       "geo_vector_au": [
-        8.666198555513423,
-        0.1822881517417485,
-        -0.3259534935503385
+        6.880319183526448,
+        -5.050843733250445,
+        -2.411025946372626
       ],
       "geo_velocity_au_per_day": [
-        -0.008421693851488788,
-        -0.008446008021485991,
-        -0.003765359452427075
+        -0.005056489700451602,
+        -0.009582562294614728,
+        -0.004372136877371697
       ],
       "observed": {
-        "astro_ra_deg": 1.2035416666666665,
-        "astro_dec_deg": -2.154111111111111,
-        "app_ra_deg": 1.537625,
-        "app_dec_deg": -2.008777777777778,
-        "azimuth_deg": 96.214566,
-        "elevation_deg": -8.59098,
-        "range_au": 8.67424838195875
+        "astro_ra_deg": 323.7160416666667,
+        "astro_dec_deg": -15.774361111111112,
+        "app_ra_deg": 324.0299166666667,
+        "app_dec_deg": -15.672833333333333,
+        "azimuth_deg": 93.918161,
+        "elevation_deg": 31.402365,
+        "range_au": 8.86920291890062
       }
     },
     {
@@ -6581,25 +7673,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2461030.5,
+      "epoch_jd_ut": 2459935.5,
       "geo_vector_au": [
-        9.495117000588953,
-        -0.5702620760421724,
-        -0.6636034828520035
+        8.115382164819389,
+        -5.905639092575692,
+        -2.807323959913588
       ],
       "geo_velocity_au_per_day": [
-        0.01706161342329413,
-        0.004923870425501271,
-        0.002047777015607316
+        0.02032847099890566,
+        0.004297608497428625,
+        0.00165190264726205
       ],
       "observed": {
-        "astro_ra_deg": 356.56125,
-        "astro_dec_deg": -3.991277777777778,
-        "app_ra_deg": 356.89575,
-        "app_dec_deg": -3.846888888888889,
-        "azimuth_deg": 310.212237,
-        "elevation_deg": 59.972302,
-        "range_au": 9.53535675327968
+        "astro_ra_deg": 323.9543333333333,
+        "astro_dec_deg": -15.627,
+        "app_ra_deg": 324.263375,
+        "app_dec_deg": -15.526722222222222,
+        "azimuth_deg": 268.704709,
+        "elevation_deg": 37.088167,
+        "range_au": 10.4219656627435
       }
     },
     {
@@ -6607,25 +7699,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2461150.5,
+      "epoch_jd_ut": 2460055.5,
       "geo_vector_au": [
-        10.31115564588462,
-        1.402292713250083,
-        0.1820916804620778
+        9.30834618599121,
+        -4.010860757731018,
+        -2.010583741583301
       ],
       "geo_velocity_au_per_day": [
-        -0.009037306476043278,
-        0.01890202712575994,
-        0.00812459759418714
+        -0.005885028393067955,
+        0.0181666775486019,
+        0.007675854819162161
       ],
       "observed": {
-        "astro_ra_deg": 7.742708333333333,
-        "astro_dec_deg": 1.0018888888888888,
-        "app_ra_deg": 8.076458333333333,
-        "app_dec_deg": 1.1458055555555555,
-        "azimuth_deg": 252.185455,
-        "elevation_deg": -36.00614,
-        "range_au": 10.4076959203428
+        "astro_ra_deg": 336.6875416666667,
+        "astro_dec_deg": -11.22038888888889,
+        "app_ra_deg": 336.9905,
+        "app_dec_deg": -11.104166666666666,
+        "azimuth_deg": 209.066695,
+        "elevation_deg": -49.928918,
+        "range_au": 10.3332077093761
       }
     },
     {
@@ -6633,25 +7725,25 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2461270.5,
+      "epoch_jd_ut": 2460175.5,
       "geo_vector_au": [
-        8.489168173794486,
-        2.094194898380382,
-        0.4747813521195802
+        7.890940098413336,
+        -3.402830595627485,
+        -1.770392564317749
       ],
       "geo_velocity_au_per_day": [
-        -0.01086449677750823,
-        -0.00777537966005968,
-        -0.003422340653222391
+        -0.007275192362975836,
+        -0.00831324933183832,
+        -0.003793880258761276
       ],
       "observed": {
-        "astro_ra_deg": 13.856125,
-        "astro_dec_deg": 3.1075,
-        "app_ra_deg": 14.204875,
-        "app_dec_deg": 3.254472222222222,
-        "azimuth_deg": 99.373523,
-        "elevation_deg": -26.935379,
-        "range_au": 8.75655434259298
+        "astro_ra_deg": 336.67125,
+        "astro_dec_deg": -11.641583333333333,
+        "app_ra_deg": 336.9885,
+        "app_dec_deg": -11.520194444444446,
+        "azimuth_deg": 96.660048,
+        "elevation_deg": 13.487668,
+        "range_au": 8.7738513800149
       }
     },
     {
@@ -6659,25 +7751,103 @@
       "target_id": 699,
       "target_name": "Saturn",
       "site": "Paranal",
-      "epoch_jd_ut": 2461390.5,
+      "epoch_jd_ut": 2460295.5,
       "geo_vector_au": [
-        9.037984585850833,
-        1.262662785604759,
-        0.109270441585738
+        8.873082854907661,
+        -4.263257528287816,
+        -2.165424817818546
       ],
       "geo_velocity_au_per_day": [
-        0.01577790101423161,
-        0.003297765705293493,
-        0.001397434676983488
+        0.01926899897638471,
+        0.003307589542271192,
+        0.001256415797365792
       ],
       "observed": {
-        "astro_ra_deg": 7.951375000000001,
-        "astro_dec_deg": 0.6854166666666667,
-        "app_ra_deg": 8.300875000000001,
-        "app_dec_deg": 0.8356111111111112,
-        "azimuth_deg": 346.379074,
-        "elevation_deg": 63.8924,
-        "range_au": 9.12642085038288
+        "astro_ra_deg": 334.33520833333336,
+        "astro_dec_deg": -12.406361111111112,
+        "app_ra_deg": 334.6514583333333,
+        "app_dec_deg": -12.288527777777778,
+        "azimuth_deg": 280.48711,
+        "elevation_deg": 49.995434,
+        "range_au": 10.079498293464
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460415.5,
+      "geo_vector_au": [
+        10.07859655293539,
+        -2.392559955234406,
+        -1.375076968985813
+      ],
+      "geo_velocity_au_per_day": [
+        -0.00554050048660469,
+        0.01923564723391554,
+        0.008173381696714305
+      ],
+      "observed": {
+        "astro_ra_deg": 346.6439166666667,
+        "astro_dec_deg": -7.562138888888889,
+        "app_ra_deg": 346.9539583333334,
+        "app_dec_deg": -7.433222222222223,
+        "azimuth_deg": 230.030932,
+        "elevation_deg": -44.098225,
+        "range_au": 10.4495838995149
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460535.5,
+      "geo_vector_au": [
+        8.549329538136652,
+        -1.598775703124963,
+        -1.049969232683365
+      ],
+      "geo_velocity_au_per_day": [
+        -0.009531460614140187,
+        -0.007119243906326336,
+        -0.003237863894617312
+      ],
+      "observed": {
+        "astro_ra_deg": 349.40625000000006,
+        "astro_dec_deg": -6.8839999999999995,
+        "app_ra_deg": 349.729,
+        "app_dec_deg": -6.747833333333333,
+        "azimuth_deg": 99.580969,
+        "elevation_deg": -4.585854,
+        "range_au": 8.76068698954973
+      }
+    },
+    {
+      "class": "regular",
+      "target_id": 699,
+      "target_name": "Saturn",
+      "site": "Paranal",
+      "epoch_jd_ut": 2460655.5,
+      "geo_vector_au": [
+        9.259118943864722,
+        -2.474955223565741,
+        -1.447093344207675
+      ],
+      "geo_velocity_au_per_day": [
+        0.01794506137002327,
+        0.002139986138257225,
+        0.0007913128496279117
+      ],
+      "observed": {
+        "astro_ra_deg": 345.03295833333334,
+        "astro_dec_deg": -8.586666666666668,
+        "app_ra_deg": 345.3573333333333,
+        "app_dec_deg": -8.453638888888888,
+        "azimuth_deg": 300.558146,
+        "elevation_deg": 61.625197,
+        "range_au": 9.69283052670455
       }
     }
   ]

--- a/ephemeris/jpl/validation/corpus_settled_test.go
+++ b/ephemeris/jpl/validation/corpus_settled_test.go
@@ -1,0 +1,84 @@
+//go:build validation || network
+
+package jpl_test
+
+import (
+	"testing"
+	"time"
+)
+
+// settledMargin is how far behind the present a corpus epoch must sit.
+//
+// IERS Earth-orientation values reach final status roughly a year after the
+// fact; before that they are rapid-service or predicted, and they move. A
+// year and a half leaves room for that without demanding the corpus be
+// rebuilt to stay valid.
+const settledMargin = 18 * 30 * 24 * time.Hour
+
+// TestCorpusEpochsAreSettled fails if the corpus samples an epoch whose
+// reference value is still moving.
+//
+// The regular span used to run to 2027-01-01, which put its last epoch in the
+// future. Horizons' answer there depends on predicted Earth orientation, so
+// it changed between generation and the next run — by up to 8.4e-05 degrees —
+// and TestGenerateCorpus reported a dirty diff every time thereafter, for a
+// corpus nobody had touched.
+//
+// The failing test is the smaller half of the problem. A frozen entry whose
+// true value is still moving is a reference that goes quietly out of date:
+// the consumer compares astrogo, using today's IERS series, against a
+// prediction made on the day the corpus was written, and the two drift apart
+// for reasons that have nothing to do with astrogo. A tolerance wide enough
+// to absorb that is a tolerance wide enough to hide a regression.
+//
+// This is checked rather than left to the span comments because the spans are
+// written as date strings, where "2027" looks no different from "2025".
+func TestCorpusEpochsAreSettled(t *testing.T) {
+	c, err := loadCorpus()
+	if err != nil {
+		t.Skipf("corpus unavailable: %v", err)
+	}
+
+	if len(c.Entries) == 0 {
+		t.Fatal("corpus has no entries")
+	}
+
+	// Unix epoch as a Julian Date, for converting the corpus' own column.
+	const (
+		unixEpochJD = 2440587.5
+		secondsPerD = 86400
+	)
+
+	cutoff := time.Now().UTC().Add(-settledMargin)
+
+	var (
+		latest  time.Time
+		offense string
+		count   int
+	)
+
+	for _, e := range c.Entries {
+		when := time.Unix(int64((e.EpochJDUT-unixEpochJD)*secondsPerD), 0).UTC()
+
+		if when.After(latest) {
+			latest = when
+		}
+
+		if when.After(cutoff) {
+			count++
+
+			if offense == "" {
+				offense = e.key()
+			}
+		}
+	}
+
+	if count > 0 {
+		t.Errorf("%d corpus entries are inside the unsettled window (after %s); first is %s.\n"+
+			"Horizons' answer at such an epoch depends on predicted Earth orientation and "+
+			"moves after generation. Move the span in corpusSpans further into the past.",
+			count, cutoff.Format(time.DateOnly), offense)
+	}
+
+	t.Logf("latest corpus epoch %s, cutoff %s", latest.Format(time.DateOnly), cutoff.Format(time.DateOnly))
+}

--- a/ephemeris/jpl/validation/gen_corpus_test.go
+++ b/ephemeris/jpl/validation/gen_corpus_test.go
@@ -98,12 +98,31 @@ type corpusSpan struct {
 	why   string
 }
 
+// A span must end in the settled past, and that is not a detail.
+//
+// Horizons' answer for a future epoch depends on predicted Earth orientation,
+// which firms up as IERS publishes. The regular span used to run to
+// 2027-01-01, so its last epoch — 2026-12-16 — moved by up to 8.4e-05 degrees
+// between generation and the next run, and TestGenerateCorpus failed every
+// time thereafter. A generator that can never report a clean diff is as
+// useless as one that can never report a dirty one.
+//
+// It is worse than a failing test. A frozen entry whose true value is still
+// moving is a reference that goes quietly out of date: the consumer compares
+// astrogo, using whatever IERS series is on the machine today, against a
+// prediction made on the day the corpus was written, and the two diverge for
+// reasons that have nothing to do with astrogo.
+//
+// IERS values reach final status roughly a year after the fact, so the stop
+// date sits well behind that. [TestCorpusEpochsAreSettled] enforces it.
 func corpusSpans() []corpusSpan {
 	return []corpusSpan{
 		{
 			class: classRegular,
-			start: "2024-01-01 00:00", stop: "2027-01-01 00:00", step: "120d",
-			why: "even sampling across three years, which is what catches secular drift",
+			start: "2021-01-01 00:00", stop: "2025-01-01 00:00", step: "120d",
+			why: "even sampling across four years, which is what catches secular " +
+				"drift, and ends far enough in the past that every epoch has final Earth " +
+				"orientation rather than a prediction",
 		},
 		{
 			class: classBoundary,


### PR DESCRIPTION
Found while running the full network suite for #62, and reproduced on `main` before touching anything. Independent of #62.

## A corpus nobody had touched failed its own generator

```
on disk: 255 entries    fetched: 255 entries
added: 0   removed: 0   changed: 15
largest numeric change: 8.4e-05 at regular|Saturn|Paranal|JD2461390.500000 azimuth
```

Every one of the 15 was at the **same epoch**: JD 2461390.5 = **2026-12-16**. The regular span ran to 2027-01-01, so its last sample sits in the future, where Horizons' answer rests on *predicted* Earth orientation. IERS publishes, the prediction firms up, the number moves. `TestGenerateCorpus` had been reporting a dirty diff on every run since.

## The failing test is the smaller half

A generator that can never report a clean diff is as useless as one that can never report a dirty one. But the deeper problem is what a frozen prediction does as a **reference**:

> the consumer compares astrogo, using whatever IERS series is on the machine today, against a prediction made on the day the corpus was written, and the two drift apart for reasons that have nothing to do with astrogo.

A tolerance wide enough to absorb that is a tolerance wide enough to hide a regression — the same trap the contract/measured split exists to prevent.

## The fix, which increases coverage

The regular span now runs **2021-01-01 → 2025-01-01**, entirely inside the window where IERS values are final. That is four years of even sampling instead of three, and **300 entries instead of 255**.

`TestCorpusEpochsAreSettled` enforces it, with an 18-month margin behind the present. It exists because the spans are written as date strings, where `"2027"` looks no different from `"2025"` — nothing about the old span looked wrong on the page. Run against the old corpus it reports:

```
90 corpus entries are inside the unsettled window (after 2025-03-07)
latest corpus epoch 2026-12-16, cutoff 2025-03-07
```

I had to move the stop date twice: my first attempt at 2025-06-30 was *still* inside the window, and the guard caught it. That is the argument for the guard in one line.

## The consumer is unaffected in substance

| | before | after |
| :--- | ---: | ---: |
| n | 103 | **116** |
| worst residual | 2.0″ | 2.15″ |
| contract | 3″ | 3″ (unchanged) |

The worst case moved because the epoch set changed, not because anything got worse.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, the default suite, and the `validation` and `network` suites — clean. `TestGenerateCorpus` now reports a clean diff, which it could not do before.

The accuracy table is regenerated: **15 rows, all verified**. As last time, one row (GAMBONS) first came back NOT VERIFIED on a transient IRSA outage; re-run individually it verifies, and I did not publish the version that claimed otherwise.
