### PR TITLE
Move changelog.d under docs, and write the pull-request guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!--
+docs/PULL_REQUESTS.md has the full workflow. The headings below are the ones
+that carry weight in this repository — a body that answers them is a body a
+reviewer can act on. Delete any that genuinely do not apply.
+-->
+
+## What was wrong
+
+<!-- The defect or gap, concretely. If it was silent, say what made it silent. -->
+
+## What changed
+
+<!-- The fix, and any design choice worth arguing. If you rejected an
+     alternative, one sentence on why. -->
+
+## Measured
+
+<!-- Numbers, not adjectives. Before and after. If a tolerance moved, say what
+     the bound is derived from — the smallest fault worth catching, not the
+     largest residual observed. -->
+
+## What this does not fix
+
+<!-- Anything you found and deliberately left. Leaving a bug alone is fine;
+     leaving it unmentioned is not. Name the decision if the fix needs one. -->
+
+## Verification
+
+<!-- Which gates ran. At minimum:
+
+     gofmt -l . && go build ./... && go vet ./...
+     go test ./...
+     golangci-lint run
+     golangci-lint run --build-tags="integration,network,validation"
+
+     Both linter runs, please — CI lints untagged, and a helper used only from
+     a tagged file reads as unused there. See docs/PULL_REQUESTS.md §5.
+
+     If you reproduced a pre-existing failure on main, say so, so nobody
+     assumes this change caused it. -->
+
+---
+
+- [ ] A changelog fragment in `docs/changelog.d/` (or: this change is not user-visible)
+- [ ] New exported symbols have tests in this change
+- [ ] `Closes #NN.` on its own line above, if this fixes a filed issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ By participating in this project, you agree to abide by our [Code of Conduct](./
 
 1. Fork the repository and create your branch from `main`.
 2. Ensure you have the latest Go version installed.
-3. If you've never used the JPL Horizons or SOFA algorithms, reviewing `VALIDATION.md` is a great place to start to understand how we test accuracy.
+3. If you've never used the JPL Horizons or SOFA algorithms, reviewing [docs/VALIDATION.md](docs/VALIDATION.md) is a great place to start to understand how we test accuracy.
+4. Read [docs/PULL_REQUESTS.md](docs/PULL_REQUESTS.md) before your first pull request. It is the operational detail behind this document — the linter trap above, changelog fragments, `-update`-gated golden data, and what a reviewer here expects a pull request body to contain.
 
 ## Development Workflow
 
@@ -35,10 +36,15 @@ go test -race ./...
 ```
 
 ### 2. Linting
-We mandate `golangci-lint` to maintain our code quality.
+We mandate `golangci-lint` to maintain our code quality. **Run it twice** —
+CI lints with no build tags, so a helper used only from a `network`- or
+`validation`-tagged file reads there as a symbol with no consumers, and the
+whole file reports as unused. Passing with tags and failing without them is the
+most common way a green local run turns red in CI.
+
 ```bash
-# Run the linter locally before submitting a PR
-golangci-lint run ./...
+golangci-lint run
+golangci-lint run --build-tags="integration,network,validation"
 ```
 
 ## Architectural Guidelines
@@ -47,6 +53,7 @@ When submitting code, please ensure your architectural choices match the project
 - **No cyclic dependencies**: We enforce strict, clean unidirectional imports.
 - **Explicit data models**: Use Go structures over magic mappings or empty interfaces.
 - **No hidden state**: Avoid package-level variables and `init()` side effects. Do not introduce implicit unit conversions.
+  - There is exactly one deliberate `init()` in the module, in `remote/eop.go`, which registers the EOP loader with `astrogo/time`. It exists so `time` need not import `remote`: that edge cost 17 MB of binary in cloud-storage and gRPC machinery for arithmetic that touches none of it. Inverting it is invisible to callers because download consent can only be granted through `remote`, so any program that could fetch EOP data already imports it. A second one needs an argument at least that good.
 - **Minimal allocations**: For hot paths (transformations, loops), avoid heap allocations. Write batch-friendly computational paths where possible.
 
 ## Testing Philosophy
@@ -58,10 +65,19 @@ Astronomical calculations require strict numerical tolerances:
 
 ## Pull Request Process
 
+See **[docs/PULL_REQUESTS.md](docs/PULL_REQUESTS.md)** for the full workflow,
+including the failures this project has actually had and how to avoid repeating
+them. In brief:
+
 1. Provide a clear and descriptive PR title (e.g., `feat(ephemeris): add support for XYZ...` or `fix(transform): resolve pole wrapping bug`).
 2. Clearly explain **why** the PR is needed.
-3. If applicable, provide numerical proofs or benchmarks demonstrating your changes.
-4. Ensure your PR passes all CI workflows (linting, tests, coverage).
+3. Provide numerical proofs or benchmarks. Numbers, not adjectives — and where a
+   tolerance moved, say what the new bound is derived from.
+4. Add a changelog fragment in [`docs/changelog.d/`](docs/changelog.d/README.md)
+   rather than editing `CHANGELOG.md`, so parallel pull requests cannot conflict
+   on it.
+5. Ship tests for every new exported symbol in the same change.
+6. Ensure your PR passes all CI workflows (linting, tests, coverage).
 
 ## For AI Assistant Users (Claude, GitHub Copilot, ChatGPT, etc.)
 

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -1,0 +1,272 @@
+# Opening a pull request
+
+How to get a change into astrogo, and the things that have actually gone wrong
+while doing it. Everything below is written from real failures in this
+repository — none of it is generic advice.
+
+[CONTRIBUTING.md](../CONTRIBUTING.md) covers the project's goals, architecture
+and testing philosophy, and is where to start. This is the operational
+companion to its "Pull Request Process" section.
+
+The short version: **branch, prove it, write a changelog fragment, run the full
+gate, then open a pull request whose body says what you measured.**
+
+---
+
+## 1. Branch first, always
+
+Never commit on `main`. Branch names follow the change:
+
+| prefix | for |
+| :--- | :--- |
+| `fix/` | a defect in shipped behaviour |
+| `feat/` | new capability |
+| `test/` | coverage or a new validation suite |
+| `docs/` | documentation and its guards |
+| `chore/` | releases, tooling, CI |
+| `refactor/` | structure, no behaviour change |
+
+On a branch you created, commit and push freely. **Opening a pull request needs
+an explicit instruction, and merging always does.**
+
+---
+
+## 2. Measure before you design
+
+This repository's whole argument is that its numbers can be trusted, and the
+practice that follows from it is: get a number *before* choosing an approach.
+
+Two examples from recent work.
+
+**The EOP dependency inversion** began by stubbing the import out and rebuilding
+to see whether the payoff was real — 19.4 MB against 2.5 MB — so the design was
+chosen against a measurement rather than a hope.
+
+**A small-body accuracy contract** was first written at `1e-9 AU`, matching the
+planetary path. Measured, that had **4,560× headroom**: a bound that cannot fail
+for the reason it exists. It is `1e-11 AU` now, roughly 45× the observed float
+scatter.
+
+If you are about to write a tolerance, measure first, then derive the bound from
+*the smallest fault worth catching* — never from what you happened to observe.
+See [`internal/metrology`](../internal/metrology) for the contract-versus-measured
+split this rests on.
+
+---
+
+## 3. Test what you add
+
+Every new exported symbol ships with tests **in the same change**. An untested
+front door is the worst one to leave: a broken constructor or option does not
+fail where it is written, it fails somewhere with no idea it was involved.
+
+A few conventions that are not obvious:
+
+- **Put the test where the code is.** A test in package `foo` covers `foo`.
+  Coverage is not attributed across packages, so a test for `ephemeris/core`
+  living in package `ephemeris` leaves `core` at zero.
+- **Prefer asserting the doc comment's own claim.** If a comment says "no named
+  body returns an error from here", that is a test, and it is the kind of
+  statement that quietly stops being true.
+- **Bounds beat point values for physical quantities**, but a bound spanning two
+  orders of magnitude is not a test. `0.1 AU < |r| < 5.0 AU` was the only
+  assertion on a small-body position for a long time, and it could not tell a
+  correct answer from one wrong by an astronomical unit.
+
+---
+
+## 4. Write a changelog fragment
+
+One file per entry in [`docs/changelog.d/`](changelog.d/README.md), assembled
+into `CHANGELOG.md` at release time:
+
+```markdown
+---
+type: Fixed
+pr: 61
+---
+**A thing.** Why it mattered, in one to three lines.
+```
+
+`type` is a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) section:
+`Added`, `Changed`, `Changed — BREAKING`, `Deprecated`, `Removed`, `Fixed`,
+`Security`.
+
+**Why fragments rather than editing `CHANGELOG.md`.** In one batch of parallel
+work, five of eight pull requests conflicted — every one of them on
+`CHANGELOG.md` alone, never on code. Resolving such a conflict textually is not
+harmless: merge markers carry no information about which heading a bullet
+belongs under, so an entry inherits whichever heading happens to precede it. An
+`Added` entry silently became a `Fixed` one, in a diff that looked like
+reordering. A file per entry cannot collide, and carries its own section.
+
+`go test ./internal/changelog/` validates every checked-in fragment, so a
+malformed one fails the pull request that added it rather than the release weeks
+later.
+
+Deep forensic detail — root cause, before-and-after numbers, what you refuted —
+belongs in the pull request body or the code's own doc comment. **The changelog
+is an index, not the record.**
+
+---
+
+## 5. Run the full gate
+
+```bash
+gofmt -l . && go build ./... && go vet ./... && go mod tidy
+go test ./...
+go test -race -short -count=1 ./...
+golangci-lint run
+golangci-lint run --build-tags="integration,network,validation"
+```
+
+**Run the linter twice, and understand why.** CI runs `golangci-lint` with **no
+build tags**. A helper used only from a `network`-tagged file is, to that run, a
+symbol with no consumers — and the whole file reports as unused. A change that
+passes with tags and fails without them is the single most common way a green
+local run turns red in CI. A declaration shared by two differently-tagged files
+needs a constraint covering both, e.g. `//go:build validation || network`.
+
+For a change touching external services, also run the relevant tagged suite:
+
+```bash
+go test -tags=network -count=1 ./ephemeris/...
+go test -tags=validation -count=1 ./...
+```
+
+---
+
+## 6. Linters that will bite
+
+`.golangci.yml` runs `default: all` with documented disables. Do not weaken it
+to pass. The ones that come up repeatedly:
+
+| linter | what it catches here |
+| :--- | :--- |
+| `nolintlint` | a `//nolint` nobody needs. Adding one "just in case" fails. |
+| `funcorder` | unexported methods after exported ones; constructors before methods. |
+| `err113` | `errors.New` inline in a test table — hoist it to a package-level `var`. |
+| `nilerr` | returning `nil` when an error is non-nil. Usually means an error is being used as a *predicate*: extract a `(T, bool)` helper and say so. |
+| `wsl_v5` | a blank line before `if` after a statement. |
+| `exhaustive` | a switch over a typed enum missing a case — including constants that are not really members, which is a hint the constant should be untyped. |
+| `gosec` G115 | `int → uint32` conversions. A preceding range check usually satisfies it; if it does, do not also add a `//nolint`, because `nolintlint` will then flag that. |
+
+**`//nolint` needs a scope and a reason**, both. `//nolint:gochecknoglobals // the
+canonical section order, read-only` is fine; a bare `//nolint` is not.
+
+---
+
+## 7. External services must not fail the build
+
+Network tests skip when an endpoint is unreachable — never fail CI for someone
+else's downtime. But **reachability is not health**: a host answering
+`500 Internal Server Error` opens a socket perfectly well, and a CelesTrak
+outage once failed pull requests that had never touched the network.
+
+Use `testutil.SkipOnUpstreamFailure(t, err)`, which classifies the *error*:
+
+- **Skips**: 5xx, 429, 408, timeouts, connection reset, broken pipe, truncated body.
+- **Still fails**: 400, 401, 403, 404, decode errors — because those mean
+  *astrogo built a bad request*, which is exactly what the test exists to catch.
+
+Keep `t.Fatal` for wrong data from a service that answered correctly.
+
+---
+
+## 8. Generated artefacts are `-update`-gated
+
+The Horizons corpus and the accuracy table are regenerated by a test behind a
+flag, never as a side effect of running the suite:
+
+```bash
+go test -tags=network -run TestGenerateCorpus ./ephemeris/jpl/validation/ -args -update-corpus
+go test -tags=validation -run TestRenderAccuracyReport ./internal/metrology/ -args -update-accuracy
+go test ./internal/changelog/ -run TestAssembleRelease -update -release-version X.Y.Z
+```
+
+**Never regenerate golden data because a test started failing.** Read the diff
+first and understand every number that moved. A corpus once drifted because it
+sampled an epoch in the *future*, where the reference depends on predicted Earth
+orientation — accepting that diff would have frozen a prediction as a reference
+and quietly widened every tolerance downstream.
+
+Equally: do not publish a generated table you have not looked at. An accuracy
+table was once rendered with three rows reading `NOT VERIFIED — JPL Horizons is
+unreachable`, in a run where Horizons had answered fine moments earlier. Retried
+individually they all verified; publishing the first version would have put a
+false claim into the document the whole exercise exists to make trustworthy.
+
+---
+
+## 9. Deprecating a public symbol
+
+Mark it with a **trailing** `// Deprecated: use X instead.` paragraph — after the
+description, which is both the Go convention and what `revive` enforces.
+Pre-1.0, a deprecated symbol survives **at least two minor releases**.
+
+`staticcheck`'s SA1019 runs, so deprecating a symbol means migrating every
+internal caller in the same change.
+
+---
+
+## 10. The pull request body
+
+Bodies here are long, and they are long for a reason: they carry the reasoning
+that does not belong in a commit message or a changelog. What earns its place:
+
+- **The measurement.** "19.4 MB → 2.5 MB", not "significantly smaller".
+- **What you rejected and why.** A separate module was considered for the EOP
+  work and rejected in one sentence — moving code across a module boundary does
+  not remove a dependency edge.
+- **What you got wrong on the way.** A first attempt at a corrected date was
+  still inside the unsettled window, and the guard caught it. That is the
+  argument for the guard, in one line.
+- **What you did not fix, and why.** Leaving a bug alone is fine; leaving it
+  *unmentioned* is not. If the fix needs a design decision that is not yours to
+  make, say so and name the decision.
+- **Verification, concretely.** Which gates ran, which suites, and any
+  pre-existing failure you reproduced on `main` so a reviewer does not think you
+  caused it.
+
+Avoid: adjectives standing in for numbers, and a summary of the diff. The
+reviewer can read the diff.
+
+### Referencing issues
+
+A commit that fixes a filed issue needs a real closing keyword on its own line
+in the body: `Closes #NN.` A bare `(#NN)` in the title is the changelog citation
+style and does **not** close anything. In a pull request body, repeat the keyword
+per issue — `Closes #20, closes #21` — because GitHub does not chain one keyword
+across a list.
+
+---
+
+## 11. What CI will tell you
+
+| check | note |
+| :--- | :--- |
+| Lint and Test | three platforms; the untagged lint trap in §5 lands here |
+| Race Detection | `-race -short` |
+| Integration Tests | external APIs; see §7 before assuming it is your change |
+| codecov/patch | 70% of changed lines |
+| codecov/project | 70% floor, not a ratchet |
+
+**`codecov/patch` can be structurally unsatisfiable.** Coverage is generated from
+an *untagged* `go test ./...`, so code reachable only under a build tag can never
+be counted. When that happens the answer is usually to extract the decision the
+gate is pointing at into something testable offline — which is a better change
+anyway — rather than to argue with the number.
+
+---
+
+## 12. Two git habits worth having
+
+**`git diff main branch` is not what a merge does.** Two-dot diff shows the
+branch against `main`'s current tip, so a branch cut before a big merge appears
+to delete everything that landed meanwhile. Use `git diff main...branch`
+(three dots) to see what the branch actually changes.
+
+**A branch that looks unmerged may be fully merged.** `git cherry` and
+`git branch --no-merged` compare patch identity, so anything rebased or squashed
+reads as unmerged forever. Check by content — does the symbol exist on `main`? —
+before concluding work was lost.

--- a/docs/changelog.d/66-contributing-guide.md
+++ b/docs/changelog.d/66-contributing-guide.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 66
+---
+**`docs/PULL_REQUESTS.md`**, written from the failures this repository actually had rather than generic advice: why the linter must be run twice, why reachability is not health, why a tolerance is derived from the smallest fault worth catching, and the two git habits that stop a branch looking like it deleted work it never touched. Adds a pull request template, and moves `changelog.d/` under `docs/` to sit with the rest of the written record.

--- a/docs/changelog.d/README.md
+++ b/docs/changelog.d/README.md
@@ -1,4 +1,4 @@
-# changelog.d
+# docs/changelog.d
 
 One file per changelog entry, assembled into `CHANGELOG.md` at release time.
 
@@ -17,7 +17,7 @@ file per entry cannot collide, and cannot lose its own section.
 
 ## Adding an entry
 
-Create `changelog.d/<PR-number>-<short-slug>.md`:
+Create `docs/changelog.d/<PR-number>-<short-slug>.md`:
 
 ```markdown
 ---
@@ -55,3 +55,5 @@ nothing rewrites a checked-in file as a side effect of running the tests.
 Without `-update`, `go test ./internal/changelog/` checks that every file here
 parses and names a valid type. A malformed entry fails ordinary CI rather than
 surfacing at release time.
+
+See [PULL_REQUESTS.md](../PULL_REQUESTS.md) for the rest of the workflow this fits into.

--- a/internal/changelog/assemble.go
+++ b/internal/changelog/assemble.go
@@ -33,7 +33,7 @@ var unreleasedLink = regexp.MustCompile(`(?m)^\[Unreleased\]: (\S+/compare/v)([0
 // Anything already written by hand under [Unreleased] is folded into the
 // release alongside the fragments, merged by heading. Appending the two
 // bodies instead would produce a second "### Fixed" under one release,
-// which is the same silently-wrong output that motivated changelog.d in the
+// which is the same silently-wrong output that motivated docs/changelog.d in the
 // first place; and dropping them would lose entries written before the
 // convention existed.
 func Assemble(src, version, date string, entries []Entry) (string, error) {

--- a/internal/changelog/assemble_test.go
+++ b/internal/changelog/assemble_test.go
@@ -12,17 +12,17 @@ import (
 
 //nolint:gochecknoglobals // test flags must be package-level to register
 var (
-	update  = flag.Bool("update", false, "assemble changelog.d into CHANGELOG.md and delete the consumed fragments")
+	update  = flag.Bool("update", false, "assemble docs/changelog.d into CHANGELOG.md and delete the consumed fragments")
 	version = flag.String("release-version", "", "version to assemble under, e.g. 0.17.0")
 )
 
 const (
 	changelogPath = "../../CHANGELOG.md"
-	fragmentDir   = "../../changelog.d"
+	fragmentDir   = "../../docs/changelog.d"
 	unreleased    = "## [Unreleased]"
 )
 
-// TestAssembleRelease folds changelog.d into CHANGELOG.md.
+// TestAssembleRelease folds docs/changelog.d into CHANGELOG.md.
 //
 // Gated behind -update like the Horizons corpus generator and the accuracy
 // table, so running the test suite never rewrites a checked-in file as a
@@ -49,7 +49,7 @@ func TestAssembleRelease(t *testing.T) {
 	}
 
 	if len(entries) == 0 {
-		t.Fatal("no fragments in changelog.d: nothing to release")
+		t.Fatal("no fragments in docs/changelog.d: nothing to release")
 	}
 
 	raw, err := os.ReadFile(changelogPath)
@@ -74,7 +74,7 @@ func TestAssembleRelease(t *testing.T) {
 		}
 	}
 
-	t.Logf("assembled %d entries into %s and cleared changelog.d", len(entries), *version)
+	t.Logf("assembled %d entries into %s and cleared docs/changelog.d", len(entries), *version)
 }
 
 func firstLine(s string) string {
@@ -202,7 +202,7 @@ func ExampleRender() {
 
 // TestAssembleMergesHandWrittenUnreleasedEntries is the case the end-to-end
 // trial caught: the file had entries written directly under [Unreleased]
-// before changelog.d existed, and appending the fragments below them
+// before docs/changelog.d existed, and appending the fragments below them
 // produced two "### Fixed" headings in one release — precisely the silent
 // mis-filing this package exists to prevent.
 func TestAssembleMergesHandWrittenUnreleasedEntries(t *testing.T) {

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,5 +1,5 @@
 // Package changelog assembles CHANGELOG.md from the one-file-per-entry
-// fragments in changelog.d.
+// fragments in docs/changelog.d.
 //
 // CHANGELOG.md was the only file five of eight pull requests conflicted on
 // in a single batch of parallel work — never the code, always the changelog,

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -86,7 +86,7 @@ func TestParseEntryNamesTheFile(t *testing.T) {
 
 func TestLoadEntriesSkipsReadme(t *testing.T) {
 	dir := fstest.MapFS{
-		"README.md":   {Data: []byte("# changelog.d\n\nNot an entry.\n")},
+		"README.md":   {Data: []byte("# docs/changelog.d\n\nNot an entry.\n")},
 		"58-thing.md": {Data: []byte("---\ntype: Added\npr: 58\n---\nbody\n")},
 		"59-other.md": {Data: []byte("---\ntype: Fixed\npr: 59\n---\nbody\n")},
 		"notes.txt":   {Data: []byte("ignored, not markdown")},
@@ -152,11 +152,11 @@ func TestRenderEmpty(t *testing.T) {
 // TestCheckedInFragmentsParse runs in ordinary CI, so a malformed fragment
 // fails the pull request that added it rather than the release weeks later.
 func TestCheckedInFragmentsParse(t *testing.T) {
-	dir := os.DirFS("../../changelog.d")
+	dir := os.DirFS("../../docs/changelog.d")
 
 	entries, err := LoadEntries(dir)
 	if err != nil {
-		t.Fatalf("changelog.d contains a malformed fragment: %v", err)
+		t.Fatalf("docs/changelog.d contains a malformed fragment: %v", err)
 	}
 
 	t.Logf("%d pending changelog entries", len(entries))


### PR DESCRIPTION
> Stacked on #66 — it moves the `changelog.d` directory that release empties. CI runs on stacked pull requests since #59.

Two things you asked for.

## Why `changelog.d` was not under `internal/`, and why `docs/` is right

`internal/` is a **compiler-enforced import boundary for Go packages**. `changelog.d` holds markdown fragments: nothing to import, nothing to hide. Putting them there would borrow that mechanism to do tidiness, while burying the one file a contributor needs to find.

`docs/changelog.d/` sits with the rest of the written record. The **code** that assembles it stays in `internal/changelog`, where the boundary means something — nobody outside should import it.

## `docs/PULL_REQUESTS.md`

The operational companion to `CONTRIBUTING.md`, written from what actually went wrong here rather than generic advice. The sections exist to stop someone rediscovering:

- **Run the linter twice.** CI lints *untagged*, so a helper used only from a `network`-tagged file reads there as a symbol with no consumers and the whole file reports unused. This is the single most common way a green local run turns red.
- **Reachability is not health.** A host answering `500` opens a socket perfectly well; that failed pull requests which had never touched the network.
- **Derive a tolerance from the smallest fault worth catching**, not the largest residual observed. A contract written the other way had 4,560× headroom and could not fail for the reason it existed.
- **Never regenerate golden data because a test started failing**, and never publish a generated table you have not read — an accuracy table was once rendered claiming Horizons was unreachable in a run where it had just answered.
- **`git diff main branch` is not what a merge does**, and a branch that looks unmerged may be fully merged. Both cost me real time this month.
- The linters that bite, with what each one is actually catching here.
- What a pull request body needs: the measurement, what you rejected, **what you got wrong on the way**, and what you did not fix and why.

`CONTRIBUTING.md` keeps its place as the entry point and links to it. Its lint instruction is corrected to both runs — it currently tells contributors to do the thing that fails CI.

## One contradiction recorded rather than left

`CONTRIBUTING.md` says "avoid `init()` side effects". #58 deliberately added one — `remote/eop.go` registering the EOP loader with `time` — so that `time` need not import `remote`, which cost 17 MB of binary. Left unrecorded that reads as a violation rather than a decision, so the guideline now carries the exception and the bar for a second one.

## Also

A `.github/pull_request_template.md` whose headings are the ones that carry weight here, with a checklist for the changelog fragment, tests for new exported symbols, and the `Closes #NN.` keyword that a bare `(#NN)` does not provide.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, the full default suite, and both doc guards — clean. The fragment loader reads from the new path, verified by running the assembler in report mode.