### PR TITLE
Check roadmap boxes against the code, and tick the one that lied

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,28 @@ on when to commit to the API-stability promise.
 
 ---
 
+## Writing a checkbox
+
+A box that **delivers** a symbol should name it package-qualified and put it
+first: `` - [ ] `plan.Weather` — constraint interface … ``. Written that way,
+`internal/docsguard` checks the box against the code in both directions — an
+unchecked box whose symbol already exists, and a tick whose symbol has been
+deleted, both fail the build.
+
+The qualifier is what makes it checkable. A bare `` `Horizon` `` matched a
+field in `atmosphere` and a `*Site` method in `plan`, neither of which is the
+constraint that box is about; a guard that reports three false alarms out of
+four gets switched off. Boxes that describe work rather than name a deliverable
+— "Cloud cover threshold", "Integration with `SatellitePasses`" — are skipped,
+deliberately, since the symbol they mention is the thing being built *on*.
+
+This is not decoration. `resolve.Target.HasRadialVelocity` sat unchecked while
+being declared, populated by `catalog/simbad`, preserved through the
+multi-provider merge and consumed by `plan` — finished work left looking open,
+which sends the next contributor to build it twice.
+
+---
+
 # ✅ Completed
 
 ## Phase 1 — Precision Astronomy
@@ -134,7 +156,7 @@ Kieffer & Stone (2005), Leinert et al. (1998), ESO SkyCalc.
 
 Per-azimuth altitude minimums from terrain data, replacing the flat-horizon assumption.
 
-- [x] `HorizonProfile` type — azimuth → altitude function (`plan.HorizonProfile`, `Site.WithHorizonProfile`/`HorizonAt`)
+- [x] `plan.HorizonProfile` type — azimuth → altitude function (`plan.HorizonProfile`, `Site.WithHorizonProfile`/`HorizonAt`)
 - [ ] Load from CSV/JSON (azimuth, altitude pairs)
 - [ ] Load from terrain raycasting (DEM/SRTM input)
 - [ ] `Horizon` constraint — rejects targets below the local terrain horizon at their azimuth
@@ -150,7 +172,7 @@ Per-azimuth altitude minimums from terrain data, replacing the flat-horizon assu
 
 Real-time or forecast-based weather gating for scheduling decisions.
 
-- [ ] `Weather` constraint interface — cloud cover, wind, humidity, dew point
+- [ ] `plan.Weather` constraint interface — cloud cover, wind, humidity, dew point
 - [ ] Provider abstraction for weather data sources (OpenMeteo, Visual Crossing, local station)
 - [ ] Cloud cover threshold (reject if > N% overcast)
 - [ ] Wind speed limit (telescope safety)
@@ -170,7 +192,7 @@ Real-time or forecast-based weather gating for scheduling decisions.
 Visual satellite observation requires three simultaneous conditions: the satellite is
 above the observer's horizon, the observer is in darkness, and the satellite is in sunlight.
 
-- [ ] `SatelliteIllumination` constraint — Earth shadow geometry
+- [ ] `plan.SatelliteIllumination` constraint — Earth shadow geometry
 - [ ] Cylindrical shadow model (sufficient for LEO/MEO)
 - [ ] Integration with `SatellitePasses` — filter passes by illumination status
 - [ ] Iridium flare prediction (specular reflection geometry)
@@ -184,7 +206,7 @@ above the observer's horizon, the observer is in darkness, and the satellite is 
 Companion to the existing `MoonSep` constraint: gate or penalize faint targets
 when lunar phase / sky brightness from moonlight is too high.
 
-- [x] `MoonIllumination` constraint — `plan.MoonIllum` rejects/penalizes above an
+- [x] `plan.MoonIllumination` constraint — `plan.MoonIllum` rejects/penalizes above an
       illumination fraction threshold, via the existing `plan.MoonIllumination` helper;
       always passes for the Moon itself. Implements `ConstraintCtx` (added to the
       compile-time assertion block alongside `MoonSep`).
@@ -343,9 +365,9 @@ motion, ~1 m/s accuracy) and are demonstrated end-to-end in
 pipeline too — `plan.TargetDetails.RadialVelocity` auto-populates for any target
 implementing `MeasuredRadialVelocity` (currently `*Star`).
 
-- [x] `Context.BarycentricVelocity` — observer's barycentric velocity from `Apco13`'s
+- [x] `coord.Context.BarycentricVelocity` — observer's barycentric velocity from `Apco13`'s
       already-computed astrometry, no new SOFA call
-- [x] `BarycentricRVCorrection`/`HeliocentricRVCorrection` — classical velocity
+- [x] `coord.BarycentricRVCorrection`/`HeliocentricRVCorrection` — classical velocity
       projection, sign convention documented and tested explicitly
 - [x] Analytic property tests (bounded magnitude, annual sinusoid, antipodal sign flip,
       diurnal amplitude vs. site latitude)
@@ -353,8 +375,11 @@ implementing `MeasuredRadialVelocity` (currently `*Star`).
       interface (mirroring `StaticMagnitude`) on `*Star`, wired into `computeDetails`
       alongside the magnitude dispatch block; `Context.ObservedRadialVelocity` is the
       inverse of `BarycentricRVCorrection`, tested to round-trip exactly
-- [ ] `resolve.Target.HasRadialVelocity` — distinguishes a true-zero measured RV from
-      "no RV on file" (today a zero `RadialVelocity` is ambiguous)
+- [x] `resolve.Target.HasRadialVelocity` — distinguishes a true-zero measured RV from
+      "no RV on file", which a zero `RadialVelocity` cannot. Set by `catalog/simbad`,
+      preserved through the multi-provider merge in `catalog`, and consumed by
+      `plan.NewStarFromTarget`; a genuine 0 km/s measurement is covered by tests in all
+      three packages
 - [x] Cross-implementation fixture test against Astropy's
       `SkyCoord.radial_velocity_correction` — 175 cases (5 named sites × 5 epochs × 7
       target directions) agreeing to 0.7 mm/s, generated by the locked

--- a/docs/changelog.d/70-roadmap-guard.md
+++ b/docs/changelog.d/70-roadmap-guard.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 70
+---
+**`internal/docsguard` now checks roadmap checkboxes against the code**, in both directions: an unchecked box whose symbol is already declared, and a tick whose symbol has been deleted, both fail the build. It found `resolve.Target.HasRadialVelocity` sitting unchecked while being declared, populated by `catalog/simbad`, preserved through the multi-provider merge and consumed by `plan` — finished work left looking open, which sends the next contributor to build it twice.

--- a/internal/docsguard/roadmap_test.go
+++ b/internal/docsguard/roadmap_test.go
@@ -1,0 +1,161 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const roadmapDoc = "../../docs/ROADMAP.md"
+
+// deliverable matches a roadmap checkbox whose text *begins* with a
+// package-qualified symbol in backticks — the form that means "this box
+// delivers this thing", as opposed to one that merely mentions it.
+//
+// The distinction is the whole reason this guard is narrow enough to be
+// worth having. An audit that matched any backticked name in any box
+// reported four stale entries, and three were wrong: "Integration with
+// `SatellitePasses`" and "Optional coupling with `MoonSep`" name symbols the
+// work would build *on*, not build, and a bare "`Horizon` constraint" matched
+// atmosphere.HorizonProfile, a different thing in a different package. A
+// guard that cries wolf three times out of four gets switched off.
+var deliverable = regexp.MustCompile("^- \\[([ x])\\] `([a-z][A-Za-z0-9_]*(?:/[a-z][A-Za-z0-9_]*)*)\\.([A-Za-z][A-Za-z0-9_.]*)`")
+
+// TestRoadmapBoxesMatchTheCode checks a roadmap checkbox against the package
+// it names.
+//
+// A stale *unchecked* box is the mirror of a stale tick, and the worse of the
+// two: it hides finished work and sends the next contributor to build
+// something twice. resolve.Target.HasRadialVelocity sat unchecked while being
+// declared, populated by catalog/simbad, preserved through the merge and
+// consumed by plan.
+//
+// Both directions are checked. A tick whose symbol has been deleted is a
+// promise the code no longer keeps.
+func TestRoadmapBoxesMatchTheCode(t *testing.T) {
+	raw, err := os.ReadFile(roadmapDoc)
+	if err != nil {
+		t.Fatalf("read %s: %v", roadmapDoc, err)
+	}
+
+	pkgs := packageDirs(t)
+
+	var checked int
+
+	for i, line := range strings.Split(string(raw), "\n") {
+		m := deliverable.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+
+		done, pkgPath, symbol := m[1] == "x", m[2], m[3]
+
+		// The last path element is the package name; a qualifier this guard
+		// cannot resolve is skipped rather than guessed at.
+		name := pkgPath[strings.LastIndex(pkgPath, "/")+1:]
+
+		dirs := pkgs[name]
+		if len(dirs) == 0 {
+			continue
+		}
+
+		checked++
+
+		leaf := symbol[strings.LastIndex(symbol, ".")+1:]
+		exists := declaredIn(t, dirs, leaf)
+
+		switch {
+		case !done && exists:
+			t.Errorf("%s:%d: box is unchecked but %s.%s is already declared — "+
+				"finished work left looking open sends the next contributor to build it twice",
+				roadmapDoc, i+1, pkgPath, symbol)
+		case done && !exists:
+			t.Errorf("%s:%d: box is checked but %s.%s is not declared in %v",
+				roadmapDoc, i+1, pkgPath, symbol, dirs)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no roadmap box named a resolvable package-qualified symbol; the format may have changed")
+	}
+
+	t.Logf("%d roadmap boxes checked against the code", checked)
+}
+
+// packageDirs maps a package name to the directories declaring it.
+func packageDirs(t *testing.T) map[string][]string {
+	t.Helper()
+
+	clause := regexp.MustCompile(`(?m)^package ([a-z][A-Za-z0-9_]*)`)
+	out := make(map[string][]string)
+	seen := make(map[string]bool)
+
+	root := filepath.Join("..", "..")
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // a file we cannot read contributes no package, and is not worth failing the walk for
+		}
+
+		m := clause.FindSubmatch(src)
+		if m == nil {
+			return nil
+		}
+
+		name, dir := string(m[1]), filepath.Dir(path)
+
+		key := name + "\x00" + dir
+		if seen[key] {
+			return nil
+		}
+
+		seen[key] = true
+
+		out[name] = append(out[name], dir)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	return out
+}
+
+// declaredIn reports whether leaf is declared in any of dirs, as a function,
+// method, type, var, const or struct field.
+func declaredIn(t *testing.T, dirs []string, leaf string) bool {
+	t.Helper()
+
+	decl := regexp.MustCompile(`(?m)^\s*(func\s+(\([^)]*\)\s*)?` + leaf + `\b` +
+		`|(type|var|const)\s+` + leaf + `\b` +
+		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*(` + "`" + `[^` + "`" + `]*` + "`" + `)?\s*$)`)
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+
+			src, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+			if rerr == nil && decl.Match(src) {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
You asked for the roadmap audit. Here it is, with a correction to what I told you first.

## What I found — and what I got wrong

I said "at least some boxes describe work that's already shipped", based on a probe that matched any backticked name in any box. That probe reported **four** stale entries. **Three were wrong:**

| box | why the flag was wrong |
| :--- | :--- |
| `Integration with `SatellitePasses`` | names a symbol the work builds **on**, not one it builds |
| `Optional coupling with `MoonSep`` | same |
| `` `Horizon` constraint`` | matched `atmosphere.HorizonProfile` and `*Site.Horizon` — different things |

**One was real**, and it is a good one:

```
- [ ] `resolve.Target.HasRadialVelocity` — distinguishes a true-zero measured RV
      from "no RV on file" (today a zero `RadialVelocity` is ambiguous)
```

That field is declared, **populated by `catalog/simbad`**, **preserved through the multi-provider merge** in `catalog`, **consumed by `plan/factory.go`**, and covered by tests for the genuine-zero case in all three packages. The box was simply never ticked.

So: the roadmap is in better shape than I implied — 1 stale box in 45, not "some". It is otherwise accurate and unusually well written.

## The guard, and why it is narrow

A guard wrong three times in four gets switched off. This one only reads a box that **begins with a package-qualified symbol** — the form that means *this box delivers this thing*. Boxes describing work rather than naming a deliverable are skipped deliberately.

It checks **both directions**:

- an **unchecked** box whose symbol is already declared — the case above
- a **tick** whose symbol has been deleted — a promise the code no longer keeps

Verified by breaking each, not by trusting a green run:

```
ROADMAP.md:356: box is unchecked but resolve.Target.HasRadialVelocity is already declared
ROADMAP.md:187: box is checked but plan.MoonIlluminationGone is not declared in [...]
```

## Narrowness cost coverage, so I bought it back

Only 2 boxes were qualified enough to check. Six more now are — `plan.MoonIllumination`, `plan.HorizonProfile`, `plan.Weather`, `plan.SatelliteIllumination`, `coord.BarycentricRVCorrection`, `coord.Context.BarycentricVelocity` — taking it from **2 to 8**.

`Horizon` stays unqualified **on purpose**: `plan.Horizon` exists as a `*Site` method, so qualifying it would manufacture exactly the false positive this guard exists to avoid. The box is genuinely open.

`ROADMAP.md` gains a short "Writing a checkbox" section so the convention spreads rather than depending on whoever remembers it.

## Where this leaves the roadmap

44 boxes remain genuinely open. The two most substantial:

- **#39 Central-body Keplerian propagation for planetary moons** — per-parent GM constants, Laplace-plane frames, J₂ apsidal precession. Nothing exists yet.
- **#37 Batch / high-throughput APIs** — batch ephemeris and event solving.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, and the full default suite — clean. Three lint findings on the way, all real: a `nilerr` where a walk callback swallows an error (deliberate, now scoped and justified) and two `wsl_v5` spacing complaints.