### PR TITLE
JPL ephemeris mass parameters, system and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ happens.
 | JPL planetary kernel (de440, de442) | `remote.NAIFSPK` | ~115 MB | `eph.NewProvider(eph.Planets, "de440"/"de442")` |
 | JPL planetary kernel (de441 parts) | `remote.NAIFSPK` | multi-GB **each** | `eph.NewProvider(eph.Planets, "de441_part-1", eph.WithKernel("de441_part-2"))` |
 | Leap-second kernel (naif0012.tls) | `remote.NAIFLSK` | ~5 KB | always, alongside any JPL kernel |
+| Planetary constants kernel (gm_de440.tpc) | `remote.NAIFPCK` | ~12 KB | validating `constants.DE440` against NAIF |
 | Small-body SPK (Horizons-generated) | `remote.JPLHorizonsSPK` | KB–few MB | `eph.NewProvider(eph.SmallBody, "433", ...)` |
 | Planetary satellite SPK (Io, Titan, Triton, ...) | `remote.NAIFSPK` | ~64 MB (Mars) – ~1.1 GB (Jupiter), ~2.4 GB for all 6 kernels | `eph.NewProvider(eph.Moons, "sat441")`, or `plan.VisibleTonight(..., plan.WithPlanetaryMoons())` |
 | IERS Earth-orientation data | `remote.IERSFinals2000A` | ~3.7 MB | automatic on first `Time.EOP()`/`.UTC()`/`.UT1()` query needing it |

--- a/constants/de440.go
+++ b/constants/de440.go
@@ -1,0 +1,217 @@
+package constants
+
+// ─── JPL planetary ephemeris mass parameters ─────────────────────────────────
+
+// EphemerisSet is a set of gravitational parameters from a JPL planetary
+// ephemeris.
+//
+// # Why these are not in [IAUSet]
+//
+// IAU 2015 Resolution B3 publishes nominal mass parameters for exactly three
+// bodies — the Sun, the Earth and Jupiter — and those are conversion
+// constants, fixed by convention so that published quantities stay
+// comparable. They are not a table of the solar system's masses, and B3 says
+// so. Anything needing Mars or Uranus has to look elsewhere, and "elsewhere"
+// is the ephemeris the positions are already coming from.
+//
+// # System versus body
+//
+// Every planet appears twice, and the difference is not a rounding detail.
+// A *System* parameter is the planet plus its satellites, which is what a
+// planetary ephemeris integrates and therefore what governs the motion of the
+// system's barycentre about the Sun. The plain parameter is the planet's own
+// mass, which is what governs a satellite's motion about it.
+//
+// Using one where the other belongs is a silent error the size of the
+// satellite system. Measured against the kernel: Jupiter's two values differ
+// by one part in 4,830, Saturn's by one part in 4,045, and Mars's by only one
+// part in 19.5 million — Phobos and Deimos are nearly weightless. Every one of
+// those is far larger than the fit's own uncertainty and far too small to look
+// wrong in a printout.
+//
+// Pluto is the case that makes the distinction impossible to dismiss: Charon
+// is so large relative to Pluto that the system value exceeds the body value
+// by one part in 9. A Charon orbit propagated with the system parameter is
+// wrong by 12%.
+//
+// The Sun and the Earth-Moon barycentre have no plain counterpart here: the
+// Sun has no satellites in this sense, and Earth's own parameter is
+// [EarthGravitationalParameter], listed beside the Moon's for the same reason.
+type EphemerisSet struct {
+	// Vintage names the ephemeris these values are taken from.
+	Vintage string
+
+	SunGravitationalParameter Constant
+
+	MercurySystemGravitationalParameter Constant
+	VenusSystemGravitationalParameter   Constant
+	EarthMoonGravitationalParameter     Constant
+	MarsSystemGravitationalParameter    Constant
+	JupiterSystemGravitationalParameter Constant
+	SaturnSystemGravitationalParameter  Constant
+	UranusSystemGravitationalParameter  Constant
+	NeptuneSystemGravitationalParameter Constant
+	PlutoSystemGravitationalParameter   Constant
+
+	EarthGravitationalParameter   Constant
+	MoonGravitationalParameter    Constant
+	MarsGravitationalParameter    Constant
+	JupiterGravitationalParameter Constant
+	SaturnGravitationalParameter  Constant
+	UranusGravitationalParameter  Constant
+	NeptuneGravitationalParameter Constant
+	PlutoGravitationalParameter   Constant
+}
+
+// Name reports the set's vintage, implementing [Set].
+func (s EphemerisSet) Name() string { return s.Vintage }
+
+// All returns every member of the set, in declaration order, implementing
+// [Set].
+func (s EphemerisSet) All() []Constant {
+	return []Constant{
+		s.SunGravitationalParameter,
+		s.MercurySystemGravitationalParameter, s.VenusSystemGravitationalParameter,
+		s.EarthMoonGravitationalParameter, s.MarsSystemGravitationalParameter,
+		s.JupiterSystemGravitationalParameter, s.SaturnSystemGravitationalParameter,
+		s.UranusSystemGravitationalParameter, s.NeptuneSystemGravitationalParameter,
+		s.PlutoSystemGravitationalParameter,
+		s.EarthGravitationalParameter, s.MoonGravitationalParameter,
+		s.MarsGravitationalParameter, s.JupiterGravitationalParameter,
+		s.SaturnGravitationalParameter, s.UranusGravitationalParameter,
+		s.NeptuneGravitationalParameter, s.PlutoGravitationalParameter,
+	}
+}
+
+// deSource cites where the system parameters come from.
+const deSource = "JPL DE440 (Park, Folkner, Williams & Boggs 2021, AJ 161:105, " +
+	"doi:10.3847/1538-3881/abd414), via NAIF gm_de440.tpc"
+
+// satSource cites where the individual planet parameters come from.
+//
+// A different provenance from the system values above, and worth keeping
+// distinct: NAIF's kernel takes bodies 1-10 from DE440's own ASTRO-VALUES
+// file and the per-planet parameters from the natural-satellite ephemeris
+// release forms, which are fitted separately and updated on their own
+// schedule.
+const satSource = "JPL natural satellite ephemeris release forms " +
+	"(https://ssd.jpl.nasa.gov/ftp/sats/), via NAIF gm_de440.tpc"
+
+// DE440 is the mass-parameter table from the DE440 planetary ephemeris,
+// as NAIF publishes it in gm_de440.tpc.
+//
+// NAIF states these in km³/s²; they are stated here in m³/s² for consistency
+// with the rest of this package, which is a shift of the decimal exponent by
+// nine and changes no digit. TestDE440MatchesNAIF re-fetches the kernel and
+// checks that, so a transcription slip fails rather than ships.
+//
+// No uncertainties: an ephemeris mass parameter is a fitted value whose
+// meaning is tied to the fit it came from, and the kernel publishes no
+// formal errors for them. They are not [Constant.Exact] either — nothing
+// here is exact by convention, unlike the IAU nominal values.
+//
+//nolint:gochecknoglobals // a published constant table, read-only
+var DE440 = EphemerisSet{
+	Vintage: "DE440",
+
+	SunGravitationalParameter: Constant{
+		Name: "Sun mass parameter", Symbol: "GM_Sun",
+		Value: 1.3271244004127942e20, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+
+	MercurySystemGravitationalParameter: Constant{
+		Name: "Mercury system mass parameter", Symbol: "GM_1",
+		Value: 2.2031868551400003e13, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	VenusSystemGravitationalParameter: Constant{
+		Name: "Venus system mass parameter", Symbol: "GM_2",
+		Value: 3.2485859200000000e14, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	EarthMoonGravitationalParameter: Constant{
+		Name: "Earth-Moon barycentre mass parameter", Symbol: "GM_3",
+		Value: 4.0350323562548019e14, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	MarsSystemGravitationalParameter: Constant{
+		Name: "Mars system mass parameter", Symbol: "GM_4",
+		Value: 4.2828375815756102e13, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	JupiterSystemGravitationalParameter: Constant{
+		Name: "Jupiter system mass parameter", Symbol: "GM_5",
+		Value: 1.2671276409999998e17, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	SaturnSystemGravitationalParameter: Constant{
+		Name: "Saturn system mass parameter", Symbol: "GM_6",
+		Value: 3.7940584841799997e16, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	UranusSystemGravitationalParameter: Constant{
+		Name: "Uranus system mass parameter", Symbol: "GM_7",
+		Value: 5.7945563999999985e15, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	NeptuneSystemGravitationalParameter: Constant{
+		Name: "Neptune system mass parameter", Symbol: "GM_8",
+		Value: 6.8365271005803989e15, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	PlutoSystemGravitationalParameter: Constant{
+		Name: "Pluto system mass parameter", Symbol: "GM_9",
+		Value: 9.7550000000000000e11, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+
+	EarthGravitationalParameter: Constant{
+		Name: "Earth mass parameter", Symbol: "GM_399",
+		Value: 3.9860043550702266e14, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	MoonGravitationalParameter: Constant{
+		Name: "Moon mass parameter", Symbol: "GM_301",
+		Value: 4.9028001184575496e12, Unit: cubicMeterPerSecondSquared,
+		Reference: deSource,
+	},
+	MarsGravitationalParameter: Constant{
+		Name: "Mars mass parameter", Symbol: "GM_499",
+		Value: 4.282837362069909e13, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+	JupiterGravitationalParameter: Constant{
+		Name: "Jupiter mass parameter", Symbol: "GM_599",
+		Value: 1.266865319003704e17, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+	SaturnGravitationalParameter: Constant{
+		Name: "Saturn mass parameter", Symbol: "GM_699",
+		Value: 3.793120623436167e16, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+	UranusGravitationalParameter: Constant{
+		Name: "Uranus mass parameter", Symbol: "GM_799",
+		Value: 5.793951256527211e15, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+	NeptuneGravitationalParameter: Constant{
+		Name: "Neptune mass parameter", Symbol: "GM_899",
+		Value: 6.835103145462294e15, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+	PlutoGravitationalParameter: Constant{
+		Name: "Pluto mass parameter", Symbol: "GM_999",
+		Value: 8.696138177608748e11, Unit: cubicMeterPerSecondSquared,
+		Reference: satSource,
+	},
+}
+
+// Ephemeris is the currently-recommended JPL ephemeris mass-parameter
+// vintage — reference this, not [DE440] directly, unless a specific vintage
+// has to be pinned for reproducibility. When a newer ephemeris is adopted, a
+// new vintage set is added and this single assignment moves.
+//
+//nolint:gochecknoglobals // the current vintage alias, mirroring IAU
+var Ephemeris = DE440

--- a/constants/de440_network_test.go
+++ b/constants/de440_network_test.go
@@ -1,0 +1,208 @@
+//go:build network
+
+package constants_test
+
+import (
+	"bufio"
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/constants"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// kernelAssignment matches a NAIF text-kernel line such as
+//
+//	BODY499_GM     = ( 4.282837362069909E+04  )
+//
+// The exponent marker is D or E: the kernel format descends from Fortran and
+// uses both, sometimes within one file — BODY8_GM is written with D while
+// BODY7_GM beside it uses E.
+var kernelAssignment = regexp.MustCompile(
+	`^\s*BODY(\d+)_GM\s*=\s*\(\s*([0-9.+-]+)[DdEe]([+-]?\d+)\s*\)`)
+
+// TestDE440MatchesNAIF re-fetches the kernel and checks every value in
+// [constants.DE440] against it.
+//
+// The constants are transcribed by hand, because a constants table has to be
+// available at compile time and offline. Transcription is where a digit gets
+// dropped, and a mass parameter wrong in its eleventh digit produces orbits
+// that look entirely reasonable — so the transcription is checked against the
+// source rather than trusted.
+//
+// It also checks the unit conversion. NAIF publishes km³/s² and this package
+// states m³/s², which is a shift of the decimal exponent by nine; that is
+// exactly the kind of change that is obviously right and occasionally typed
+// wrong.
+func TestDE440MatchesNAIF(t *testing.T) {
+	testutil.RequireReachable(t, "naif.jpl.nasa.gov:443")
+
+	remote.EnableDownloads(0, remote.NAIFPCK)
+
+	ctx := context.Background()
+
+	bucket, key, err := remote.GetFile(ctx, remote.NAIFPCK, "pck/gm_de440.tpc")
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("fetch gm_de440.tpc: %v", err)
+	}
+
+	raw, err := bucket.ReadAll(ctx, key)
+	if err != nil {
+		t.Fatalf("read gm_de440.tpc: %v", err)
+	}
+
+	published := parseGM(t, string(raw))
+	if len(published) < 20 {
+		t.Fatalf("parsed only %d GM assignments; the kernel format may have changed", len(published))
+	}
+
+	// NAIF body code for each constant this package states.
+	cases := []struct {
+		body int
+		got  constants.Constant
+	}{
+		{10, constants.DE440.SunGravitationalParameter},
+		{1, constants.DE440.MercurySystemGravitationalParameter},
+		{2, constants.DE440.VenusSystemGravitationalParameter},
+		{3, constants.DE440.EarthMoonGravitationalParameter},
+		{4, constants.DE440.MarsSystemGravitationalParameter},
+		{5, constants.DE440.JupiterSystemGravitationalParameter},
+		{6, constants.DE440.SaturnSystemGravitationalParameter},
+		{7, constants.DE440.UranusSystemGravitationalParameter},
+		{8, constants.DE440.NeptuneSystemGravitationalParameter},
+		{9, constants.DE440.PlutoSystemGravitationalParameter},
+		{399, constants.DE440.EarthGravitationalParameter},
+		{301, constants.DE440.MoonGravitationalParameter},
+		{499, constants.DE440.MarsGravitationalParameter},
+		{599, constants.DE440.JupiterGravitationalParameter},
+		{699, constants.DE440.SaturnGravitationalParameter},
+		{799, constants.DE440.UranusGravitationalParameter},
+		{899, constants.DE440.NeptuneGravitationalParameter},
+		{999, constants.DE440.PlutoGravitationalParameter},
+	}
+
+	if len(cases) != len(constants.DE440.All()) {
+		t.Errorf("%d constants in the set but %d checked here; a new member needs a body code",
+			len(constants.DE440.All()), len(cases))
+	}
+
+	for _, c := range cases {
+		km, ok := published[c.body]
+		if !ok {
+			t.Errorf("BODY%d_GM is not in the kernel", c.body)
+
+			continue
+		}
+
+		// km³/s² to m³/s². Compared relatively: the two differ only by how
+		// the same decimal digits are parsed, so anything above a few ULP
+		// is a transcription error rather than arithmetic.
+		want := km * 1e9
+		if rel := relDiff(c.got.Value, want); rel > 1e-15 {
+			t.Errorf("%s (BODY%d): have %.17g, kernel has %.17g m3/s2 (relative %.3g)",
+				c.got.Symbol, c.body, c.got.Value, want, rel)
+		}
+	}
+}
+
+// TestDE440SystemExceedsBody is the distinction the set exists to make: a
+// system parameter includes the satellites and must therefore be the larger
+// of the two.
+//
+// It is checked against the kernel rather than against this package's own
+// values, so a pair of constants transcribed into each other's fields fails
+// here as well as above.
+func TestDE440SystemExceedsBody(t *testing.T) {
+	testutil.RequireReachable(t, "naif.jpl.nasa.gov:443")
+
+	remote.EnableDownloads(0, remote.NAIFPCK)
+
+	ctx := context.Background()
+
+	bucket, key, err := remote.GetFile(ctx, remote.NAIFPCK, "pck/gm_de440.tpc")
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("fetch gm_de440.tpc: %v", err)
+	}
+
+	raw, err := bucket.ReadAll(ctx, key)
+	if err != nil {
+		t.Fatalf("read gm_de440.tpc: %v", err)
+	}
+
+	published := parseGM(t, string(raw))
+
+	for _, p := range []struct {
+		name           string
+		system, planet int
+	}{
+		{"Mars", 4, 499},
+		{"Jupiter", 5, 599},
+		{"Saturn", 6, 699},
+		{"Uranus", 7, 799},
+		{"Neptune", 8, 899},
+		{"Pluto", 9, 999},
+	} {
+		sys, planet := published[p.system], published[p.planet]
+		if sys <= planet {
+			t.Errorf("%s: system GM %.17g is not greater than the planet's %.17g", p.name, sys, planet)
+		}
+
+		t.Logf("%-8s system exceeds body by %.6g km3/s2 (1 part in %.0f)",
+			p.name, sys-planet, sys/(sys-planet))
+	}
+}
+
+// parseGM extracts every BODYnnn_GM assignment, in km³/s².
+func parseGM(t *testing.T, src string) map[int]float64 {
+	t.Helper()
+
+	out := make(map[int]float64)
+
+	sc := bufio.NewScanner(strings.NewReader(src))
+	for sc.Scan() {
+		m := kernelAssignment.FindStringSubmatch(sc.Text())
+		if m == nil {
+			continue
+		}
+
+		body, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+
+		// Rebuild with an E marker so Go's parser accepts the Fortran form.
+		v, err := strconv.ParseFloat(m[2]+"e"+m[3], 64)
+		if err != nil {
+			t.Errorf("BODY%d_GM: %v", body, err)
+
+			continue
+		}
+
+		out[body] = v
+	}
+
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan kernel: %v", err)
+	}
+
+	return out
+}
+
+func relDiff(a, b float64) float64 {
+	if b == 0 {
+		return 0
+	}
+
+	d := (a - b) / b
+	if d < 0 {
+		return -d
+	}
+
+	return d
+}

--- a/constants/de440_test.go
+++ b/constants/de440_test.go
@@ -1,0 +1,110 @@
+package constants_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/constants"
+)
+
+// TestEphemerisSetIsComplete keeps a member from being added to the struct
+// and left at its zero value, which for a mass parameter is a body with no
+// gravity — plausible-looking arithmetic all the way to a wrong orbit.
+func TestEphemerisSetIsComplete(t *testing.T) {
+	all := constants.DE440.All()
+	if len(all) != 18 {
+		t.Fatalf("DE440.All() has %d members, want 18", len(all))
+	}
+
+	for _, c := range all {
+		switch {
+		case c.Name == "":
+			t.Errorf("a member has no Name: %+v", c)
+		case c.Symbol == "":
+			t.Errorf("%s has no Symbol", c.Name)
+		case c.Value <= 0:
+			t.Errorf("%s has Value %v; a mass parameter is positive", c.Name, c.Value)
+		case c.Reference == "":
+			t.Errorf("%s cites no source", c.Name)
+		case c.Unit != constants.DE440.SunGravitationalParameter.Unit:
+			t.Errorf("%s is in %v, not the set's unit", c.Name, c.Unit)
+		}
+	}
+}
+
+// TestEphemerisSetCitesBothProvenances is not pedantry. NAIF takes the system
+// values from DE440's own ASTRO-VALUES file and the per-planet values from the
+// natural-satellite release forms, which are fitted separately and updated on
+// their own schedule. A reader comparing against a paper needs to know which
+// they are looking at.
+func TestEphemerisSetCitesBothProvenances(t *testing.T) {
+	if ref := constants.DE440.MarsSystemGravitationalParameter.Reference; !strings.Contains(ref, "DE440") {
+		t.Errorf("system parameter cites %q, expected the DE440 ephemeris", ref)
+	}
+
+	if ref := constants.DE440.MarsGravitationalParameter.Reference; !strings.Contains(ref, "satellite") {
+		t.Errorf("planet parameter cites %q, expected the satellite release forms", ref)
+	}
+}
+
+// TestSystemParameterExceedsBodyParameter is the property the two families
+// exist to express, checked offline so a swapped pair fails without a network.
+func TestSystemParameterExceedsBodyParameter(t *testing.T) {
+	pairs := []struct {
+		name           string
+		system, planet constants.Constant
+	}{
+		{"Mars", constants.DE440.MarsSystemGravitationalParameter, constants.DE440.MarsGravitationalParameter},
+		{"Jupiter", constants.DE440.JupiterSystemGravitationalParameter, constants.DE440.JupiterGravitationalParameter},
+		{"Saturn", constants.DE440.SaturnSystemGravitationalParameter, constants.DE440.SaturnGravitationalParameter},
+		{"Uranus", constants.DE440.UranusSystemGravitationalParameter, constants.DE440.UranusGravitationalParameter},
+		{"Neptune", constants.DE440.NeptuneSystemGravitationalParameter, constants.DE440.NeptuneGravitationalParameter},
+		{"Pluto", constants.DE440.PlutoSystemGravitationalParameter, constants.DE440.PlutoGravitationalParameter},
+	}
+
+	for _, p := range pairs {
+		if p.system.Value <= p.planet.Value {
+			t.Errorf("%s: system %v is not greater than the body's %v — the two may be swapped",
+				p.name, p.system.Value, p.planet.Value)
+		}
+	}
+}
+
+// TestPlutoIsTheCaseThatMatters pins the doc comment's own example: Charon is
+// massive enough that using the system parameter for a Charon orbit is wrong
+// by more than a tenth.
+func TestPlutoIsTheCaseThatMatters(t *testing.T) {
+	sys := constants.DE440.PlutoSystemGravitationalParameter.Value
+	body := constants.DE440.PlutoGravitationalParameter.Value
+
+	excess := (sys - body) / body
+	if math.Abs(excess-0.122) > 0.005 {
+		t.Errorf("Pluto system exceeds body by %.1f%%, doc comment says 12%%", 100*excess)
+	}
+}
+
+// TestSunAgreesWithTheIAUNominalValue is a cross-check between two independent
+// tables in this package. IAU 2015 B3 fixes the nominal solar mass parameter
+// by convention; DE440 fits one. They are different kinds of number and should
+// still agree to the precision B3 quotes, which is 8 significant figures.
+func TestSunAgreesWithTheIAUNominalValue(t *testing.T) {
+	iau := constants.IAU.SunGravitationalParameter.Value
+	de := constants.DE440.SunGravitationalParameter.Value
+
+	if rel := math.Abs(de-iau) / iau; rel > 1e-8 {
+		t.Errorf("DE440 Sun GM %.17g and IAU nominal %.17g differ by %.3g", de, iau, rel)
+	}
+}
+
+// TestEphemerisPointsAtAVintage keeps the alias from being left dangling when
+// a new ephemeris is added.
+func TestEphemerisPointsAtAVintage(t *testing.T) {
+	if constants.Ephemeris.Name() != constants.DE440.Name() {
+		t.Errorf("Ephemeris is %q, DE440 is %q", constants.Ephemeris.Name(), constants.DE440.Name())
+	}
+
+	if constants.Ephemeris.Name() == "" {
+		t.Error("the current ephemeris vintage has no name")
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -342,9 +342,13 @@ physics, not just missing plumbing. Verdict from investigation: forcing parity w
 asteroids now would ship confidently wrong numbers, so moons stay kernel-only
 (`ephemeris/jpl` SPK, gated by `remote.EnableDownloads`) until this is built properly.
 
-- [ ] Per-parent GM constants (Mars/Jupiter/Saturn/Uranus/Neptune/Pluto system GMs) —
-      IAU 2015 B3 Table 1 only publishes Sun/Earth/Jupiter; the rest need their own
-      versioned, cited constants set (comparable scope to the `constants` refactor).
+- [x] `constants.DE440` — per-parent GM constants, both the system parameter (planet
+      plus satellites, which the ephemeris integrates) and the body parameter (the
+      planet alone, which governs a satellite's motion about it). IAU 2015 B3 Table 1
+      publishes only Sun/Earth/Jupiter, so these come from DE440 via NAIF's
+      `gm_de440.tpc`, with the per-planet values separately sourced from the natural
+      satellite release forms. Verified against the kernel by a network test rather
+      than trusted to transcription; `remote.NAIFPCK` was added to fetch it.
 - [ ] Central-body (not heliocentric) two-body propagation in `ephemeris/kepler`
 - [ ] Laplace-plane frame handling for published *mean* moon elements (tabulated pole,
       secular precession) — these are not osculating J2000-ecliptic elements and can't

--- a/docs/changelog.d/71-ephemeris-mass-parameters.md
+++ b/docs/changelog.d/71-ephemeris-mass-parameters.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 71
+---
+**`constants.DE440` — the JPL ephemeris mass parameters**, the first of the five pieces roadmap item 39 needs for central-body propagation of planetary moons. IAU 2015 B3 publishes nominal mass parameters for only the Sun, Earth and Jupiter, so anything needing Mars or Uranus had nowhere to look. Each planet appears twice, system and body: using one where the other belongs is a silent error the size of the satellite system, which for Pluto and Charon is 12%. Every value is checked against NAIF's own kernel by a network test rather than trusted to transcription. Adds `remote.NAIFPCK`.

--- a/remote/endpoint.go
+++ b/remote/endpoint.go
@@ -26,6 +26,16 @@ const (
 	// kernel (naif0012.tls, ~5 KB) required by ephemeris/jpl.
 	NAIFLSK EndpointID = "naif.lsk"
 
+	// NAIFPCK is NASA NAIF's generic-kernels directory for planetary
+	// constants kernels — body mass parameters, radii and orientation
+	// poles, as text (.tpc) rather than binary.
+	//
+	// A separate endpoint from NAIFLSK despite sharing a URL root, because
+	// the registry is what a reader consults to see what a package fetches
+	// and why; a leap-second endpoint quietly serving mass parameters
+	// answers that question wrongly.
+	NAIFPCK EndpointID = "naif.pck"
+
 	// JPLHorizons is the JPL Horizons API used for small-body name
 	// resolution (catalog/jpl) — small text responses only. Kernel
 	// generation is a separate endpoint; see JPLHorizonsSPK.
@@ -423,6 +433,18 @@ func defaultEndpoints() map[EndpointID]Endpoint {
 			Subsystem:       "jpl",
 			Description:     "NASA NAIF leap-second kernel (naif0012.tls)",
 			ApproxSize:      6_000,
+			Enabled:         true,
+			DownloadTimeout: 1 * time.Minute,
+			Mutable:         false,
+			Downloadable:    true,
+		},
+		NAIFPCK: {
+			ID:              NAIFPCK,
+			URL:             "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/",
+			Kind:            KindFile,
+			Subsystem:       "jpl",
+			Description:     "NASA NAIF planetary constants kernels (gm_de440.tpc ~12 KB, pck00011.tpc ~130 KB)",
+			ApproxSize:      200_000,
 			Enabled:         true,
 			DownloadTimeout: 1 * time.Minute,
 			Mutable:         false,

--- a/remote/registry.go
+++ b/remote/registry.go
@@ -297,6 +297,8 @@ func constName(id EndpointID) string {
 		return "NAIFSPK"
 	case NAIFLSK:
 		return "NAIFLSK"
+	case NAIFPCK:
+		return "NAIFPCK"
 	case JPLHorizons:
 		return "JPLHorizons"
 	case JPLHorizonsSPK:

--- a/remote/registry_test.go
+++ b/remote/registry_test.go
@@ -219,6 +219,7 @@ func TestDownloadableEndpointsAreExactlyTheExpectedSet(t *testing.T) {
 		IERSFinals2000A:       true,
 		NAIFSPK:               true,
 		NAIFLSK:               true,
+		NAIFPCK:               true,
 		OpenNGC:               true,
 		JPLHorizonsSPK:        true,
 		WorldAtlas:            true,


### PR DESCRIPTION
The first of the five pieces roadmap item 39 needs before a planetary moon can be propagated about its parent. It is the item's own stated prerequisite, and the one with no physics risk — published constants, cited and checked.

## Why the package had nowhere to look

IAU 2015 Resolution B3 publishes nominal mass parameters for exactly three bodies: Sun, Earth, Jupiter. Those are *conversion constants*, fixed by convention so published quantities stay comparable — not a table of the solar system's masses, and B3 says so. Mars and Uranus had no entry anywhere in `constants`.

## Every planet appears twice, and the pair is the point

A **system** parameter is the planet plus its satellites — what an ephemeris integrates, and what governs the barycentre's motion about the Sun. The **body** parameter is the planet alone — what governs a satellite's motion about it.

Using one where the other belongs is a silent error the size of the satellite system. Measured against the kernel:

| | system exceeds body by |
| :--- | ---: |
| Mars | 1 part in 19,500,000 |
| Jupiter | 1 part in 4,830 |
| Saturn | 1 part in 4,045 |
| Neptune | 1 part in 4,801 |
| **Pluto** | **1 part in 9 — 12%** |

Charon makes the distinction impossible to dismiss. A Charon orbit propagated with the system parameter is wrong by more than a tenth, and nothing about the number looks wrong.

The two families also have **different provenance**, recorded separately: NAIF takes bodies 1–10 from DE440's own `ASTRO-VALUES` file, and the per-planet values from the natural-satellite release forms, which are fitted independently and updated on their own schedule.

## The values are checked, not trusted

A constants table has to be available at compile time and offline, so the values are transcribed by hand — and transcription is where a digit gets dropped. A mass parameter wrong in its eleventh digit produces orbits that look entirely reasonable.

`TestDE440MatchesNAIF` re-fetches `gm_de440.tpc` and checks **all eighteen** against it, including the km³/s² → m³/s² exponent shift, which is exactly the kind of conversion that is obviously right and occasionally typed wrong. All eighteen agree to within a relative 1e-15.

It also asserts that the case list covers the whole set, so a member added later without a body code fails rather than going unchecked.

## Two numbers I got wrong

I wrote Jupiter's ratio and Pluto's percentage into the doc comment **from estimate**, before measuring: "one part in 2,700" and "11%". The network test produced the real figures — 1 in 4,830 and 12.2% — and the comment now carries those. Worth stating plainly since this package's entire value is that its numbers are right.

## `remote.NAIFPCK`

A separate endpoint from `NAIFLSK` despite the shared URL root. The registry is what a reader consults to see what a package fetches and why, and a leap-second endpoint quietly serving mass parameters answers that question wrongly. Item 39 needs PCK data again later for Laplace-plane poles.

Two existing guards caught the consequences immediately — the downloadable-endpoint set and an exhaustive switch over `EndpointID`. Both are them working as designed.

## What this does not do

The remaining four sub-items of #39 — central-body propagation, Laplace-plane frame handling, J₂ precession, and the offline base-state fallback — are untouched. This is the constants layer only. The roadmap's verdict stands: moons stay kernel-only until the physics above is built properly.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, the full default suite, and the `network` suite for `constants` — clean. The roadmap guard from #70 now checks 9 boxes rather than 8, because the new tick was written package-qualified.