### PR TITLE
Propagate about a central body, not only the Sun

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -349,7 +349,12 @@ asteroids now would ship confidently wrong numbers, so moons stay kernel-only
       `gm_de440.tpc`, with the per-planet values separately sourced from the natural
       satellite release forms. Verified against the kernel by a network test rather
       than trusted to transcription; `remote.NAIFPCK` was added to fetch it.
-- [ ] Central-body (not heliocentric) two-body propagation in `ephemeris/kepler`
+- [x] `kepler.CentralBody` — central-body (not heliocentric) two-body propagation.
+      `Elements.WithCentralBody` refers a set to a planet, `CentralBodyFor` supplies the
+      parent's *body* mass parameter so a caller cannot pick the system one by mistake,
+      and the provider composes a satellite through its parent rather than the Sun.
+      Verified against Kepler's third law: 421,800 km about Jupiter gives 1.7699 days,
+      which is Io's sidereal period, from a distance and a mass parameter alone
 - [ ] Laplace-plane frame handling for published *mean* moon elements (tabulated pole,
       secular precession) — these are not osculating J2000-ecliptic elements and can't
       be fed into the existing propagator unmodified

--- a/docs/changelog.d/72-central-body-kepler.md
+++ b/docs/changelog.d/72-central-body-kepler.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 72
+---
+**Central-body two-body propagation in `ephemeris/kepler`.** `Elements.WithCentralBody` refers an element set to a planet instead of the Sun, `CentralBodyFor` supplies the parent's *body* mass parameter so the 12%-wrong system value cannot be picked by mistake, and the provider composes a satellite through its parent. Verified against Kepler's third law — 421,800 km about Jupiter gives 1.7699 days, Io's sidereal period, from a distance and a mass parameter alone. This is the machinery and the constants, not a satellite ephemeris: Laplace-plane frames and J₂ precession are still open.

--- a/ephemeris/kepler/centralbody_test.go
+++ b/ephemeris/kepler/centralbody_test.go
@@ -1,0 +1,342 @@
+package kepler_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/constants"
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/kepler"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// auMeters is the astronomical unit, for turning a satellite's semi-major
+// axis in kilometres into the astronomical units the elements take.
+var auMeters = constants.IAU.AstronomicalUnit.Value
+
+// kmToAU converts a distance in kilometres.
+//
+// A satellite's semi-major axis in AU is a very small number — Io's is
+// 2.8e-06 — which is a fine thing for a float64 to hold and an awkward thing
+// to type, so the tests below convert from the kilometres the literature
+// publishes.
+func kmToAU(km float64) float64 { return km * 1e3 / auMeters }
+
+// circular builds a circular, equatorial orbit of the given radius about
+// body, which is the simplest thing whose period can be predicted in closed
+// form.
+func circular(t *testing.T, body kepler.CentralBody, radiusKM float64) kepler.Elements {
+	t.Helper()
+
+	el, err := kepler.NewElements(time.J2000, kmToAU(radiusKM), 0,
+		angle.Deg(0), angle.Deg(0), angle.Deg(0), angle.Deg(0))
+	if err != nil {
+		t.Fatalf("NewElements: %v", err)
+	}
+
+	return el.WithCentralBody(body)
+}
+
+// periodDays measures the orbital period by accumulating the angle swept in
+// the orbital plane until it reaches a full turn.
+//
+// The obvious bisection does not work here and the first version of this
+// helper used it: the angle between the start position and the current one,
+// via atan2, wraps at half a revolution, so it is not monotonic over an orbit
+// and a bisection on it converges to whichever bracket end it started nearest.
+// It reported half a year for a 1 AU heliocentric orbit and 1.5 periods for a
+// Jovian one — both wrong, in different directions, which is what gave it
+// away.
+//
+// The plane's own basis avoids that. u along the initial radius, w along the
+// angular momentum, v completing the right-handed set; the angle is then
+// unwrapped by accumulation rather than inferred from a single sample.
+func periodDays(t *testing.T, el kepler.Elements, guessDays float64) float64 {
+	t.Helper()
+
+	r0, v0, err := el.StateAt(el.Epoch())
+	if err != nil {
+		t.Fatalf("StateAt(epoch): %v", err)
+	}
+
+	u := r0.Unit()
+	w := r0.Cross(v0).Unit()
+	v := w.Cross(u)
+
+	const steps = 4096
+
+	step := 2 * guessDays / steps
+
+	var swept, prev float64
+
+	for i := 1; i <= steps; i++ {
+		when := el.Epoch().AddDays(float64(i) * step)
+
+		r, _, serr := el.StateAt(when)
+		if serr != nil {
+			t.Fatalf("StateAt: %v", serr)
+		}
+
+		phi := math.Atan2(r.Dot(v), r.Dot(u))
+
+		d := phi - prev
+		for d < -math.Pi {
+			d += 2 * math.Pi
+		}
+
+		for d > math.Pi {
+			d -= 2 * math.Pi
+		}
+
+		if swept+d >= 2*math.Pi {
+			// Linear interpolation across the step that completes the turn.
+			frac := (2*math.Pi - swept) / d
+
+			return (float64(i-1) + frac) * step
+		}
+
+		swept += d
+		prev = phi
+	}
+
+	t.Fatalf("no full revolution within %v days", 2*guessDays)
+
+	return 0
+}
+
+// TestCentralBodyDefaultsToTheSun keeps the change invisible to the
+// heliocentric path: an Elements that never names a central body must
+// propagate exactly as it did before one could be named.
+func TestCentralBodyDefaultsToTheSun(t *testing.T) {
+	el, err := kepler.NewElements(time.J2000, 2.7658, 0.07839,
+		angle.Deg(10.587), angle.Deg(80.393), angle.Deg(73.597), angle.Deg(77.372))
+	if err != nil {
+		t.Fatalf("NewElements: %v", err)
+	}
+
+	got := el.CentralBody()
+	if got.ID != core.Sun {
+		t.Errorf("default central body is %s, want Sun", got.ID)
+	}
+
+	if want := constants.IAU.SunGravitationalParameter.Value; got.GM != want {
+		t.Errorf("default GM = %v, want the IAU nominal solar value %v", got.GM, want)
+	}
+}
+
+// TestPeriodFollowsKeplersThirdLaw is the physics this change exists to get
+// right: the period depends on the central body's mass parameter, so
+// swapping the parent must change it by the square root of the mass ratio
+// and nothing else.
+//
+// Checked against the third law rather than against a published period, so
+// the test does not depend on a satellite fixture and cannot pass by
+// coincidence of two wrong numbers.
+func TestPeriodFollowsKeplersThirdLaw(t *testing.T) {
+	const radiusKM = 421_800 // roughly Io's distance, used for both
+
+	jupiter, ok := kepler.CentralBodyFor(core.Jupiter)
+	if !ok {
+		t.Fatal("no central body for Jupiter")
+	}
+
+	saturn, ok := kepler.CentralBodyFor(core.Saturn)
+	if !ok {
+		t.Fatal("no central body for Saturn")
+	}
+
+	// T = 2π √(a³/GM), so at equal a the ratio of periods is √(GM_S/GM_J).
+	aMeters := radiusKM * 1e3
+	wantJup := 2 * math.Pi * math.Sqrt(aMeters*aMeters*aMeters/jupiter.GM) / 86400
+
+	gotJup := periodDays(t, circular(t, jupiter, radiusKM), wantJup)
+	if rel := math.Abs(gotJup-wantJup) / wantJup; rel > 1e-6 {
+		t.Errorf("Jupiter-centred period = %.6f d, third law says %.6f d (relative %.2g)",
+			gotJup, wantJup, rel)
+	}
+
+	gotSat := periodDays(t, circular(t, saturn, radiusKM), wantJup*math.Sqrt(jupiter.GM/saturn.GM))
+	wantRatio := math.Sqrt(jupiter.GM / saturn.GM)
+
+	if rel := math.Abs(gotSat/gotJup-wantRatio) / wantRatio; rel > 1e-6 {
+		t.Errorf("period ratio Saturn/Jupiter = %.9f, √(GM_J/GM_S) = %.9f", gotSat/gotJup, wantRatio)
+	}
+
+	// Worth reading: 421,800 km is roughly Io's semi-major axis, and the
+	// period that falls out is 1.7699 days, which is Io's sidereal period.
+	// Nothing here was given that period — only a distance and a mass
+	// parameter — so it is an independent check that both are right.
+	t.Logf("at a = %d km: Jupiter %.4f d, Saturn %.4f d", radiusKM, gotJup, gotSat)
+
+	if math.Abs(gotJup-1.769) > 0.005 {
+		t.Errorf("a = 421,800 km about Jupiter gives %.4f d; Io's sidereal period is 1.769 d", gotJup)
+	}
+}
+
+// TestSunCentredIsUnchangedByTheRefactor pins the heliocentric result against
+// the third law too, so the shared propagation path is not quietly altered
+// for the case that already worked.
+func TestSunCentredIsUnchangedByTheRefactor(t *testing.T) {
+	// One astronomical unit about the Sun is a year, by construction.
+	el, err := kepler.NewElements(time.J2000, 1.0, 0,
+		angle.Deg(0), angle.Deg(0), angle.Deg(0), angle.Deg(0))
+	if err != nil {
+		t.Fatalf("NewElements: %v", err)
+	}
+
+	got := periodDays(t, el, 365.25)
+	if math.Abs(got-365.2) > 0.5 {
+		t.Errorf("a 1 AU circular heliocentric orbit has period %.3f d, want ~365.2", got)
+	}
+}
+
+// TestCentralBodyForRefusesABodyWithNoSystem keeps the helper from returning
+// a zero mass parameter, which would propagate as an orbit with no gravity —
+// an infinite period rather than an error.
+func TestCentralBodyForRefusesABodyWithNoSystem(t *testing.T) {
+	for _, id := range []core.ID{core.Sun, core.Moon, core.Mercury, core.Venus} {
+		if body, ok := kepler.CentralBodyFor(id); ok {
+			t.Errorf("CentralBodyFor(%s) = %+v, true; want false", id, body)
+		}
+	}
+
+	for _, id := range []core.ID{core.Earth, core.Mars, core.Jupiter, core.Saturn,
+		core.Uranus, core.Neptune, core.Pluto} {
+		body, ok := kepler.CentralBodyFor(id)
+		if !ok {
+			t.Errorf("CentralBodyFor(%s) reported false", id)
+
+			continue
+		}
+
+		if body.ID != id || body.GM <= 0 {
+			t.Errorf("CentralBodyFor(%s) = %+v", id, body)
+		}
+	}
+}
+
+// TestCentralBodyForUsesTheBodyNotTheSystemParameter is the 12% trap. The
+// helper exists precisely so a caller does not have to make this choice, so
+// the choice it makes is worth pinning.
+func TestCentralBodyForUsesTheBodyNotTheSystemParameter(t *testing.T) {
+	pluto, ok := kepler.CentralBodyFor(core.Pluto)
+	if !ok {
+		t.Fatal("no central body for Pluto")
+	}
+
+	if pluto.GM != constants.Ephemeris.PlutoGravitationalParameter.Value {
+		t.Errorf("GM = %v, want the body parameter %v",
+			pluto.GM, constants.Ephemeris.PlutoGravitationalParameter.Value)
+	}
+
+	if pluto.GM == constants.Ephemeris.PlutoSystemGravitationalParameter.Value {
+		t.Error("CentralBodyFor returned Pluto's system parameter; Charon makes that 12% wrong")
+	}
+}
+
+// TestProviderPlacesASatelliteBesideItsParent checks the composition the
+// provider does: a satellite's state is its parent's plus the small offset,
+// so the two must differ by the orbit's radius and no more.
+func TestProviderPlacesASatelliteBesideItsParent(t *testing.T) {
+	jupiter, ok := kepler.CentralBodyFor(core.Jupiter)
+	if !ok {
+		t.Fatal("no central body for Jupiter")
+	}
+
+	const (
+		moonID = core.ID(503) // Ganymede's NAIF code, used here only as a key
+
+		// A different radius from the third-law test on purpose: the
+		// composition below must not depend on the orbit's size.
+		radiusKM = 1_070_400
+	)
+
+	p := kepler.New()
+	if err := p.Register(moonID, circular(t, jupiter, radiusKM)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	when := time.J2000
+
+	moon, err := p.State(moonID, when)
+	if err != nil {
+		t.Fatalf("State(moon): %v", err)
+	}
+
+	parent, err := p.State(core.Jupiter, when)
+	if err != nil {
+		t.Fatalf("State(Jupiter): %v", err)
+	}
+
+	sep := moon.Pos.Sub(parent.Pos).Norm() * auMeters / 1e3
+
+	if math.Abs(sep-radiusKM) > 1 {
+		t.Errorf("satellite is %.1f km from its parent, want %d", sep, radiusKM)
+	}
+
+	// And it must be out at Jupiter rather than near the Sun: a satellite
+	// composed against the wrong body would sit an astronomical unit away,
+	// which the separation check above already rules out at 0.0028 AU.
+
+	if moon.Frame != core.FrameICRS || moon.Center != core.CenterGeocentre {
+		t.Errorf("satellite state is %v/%v, want ICRS/geocentric", moon.Frame, moon.Center)
+	}
+}
+
+// TestSatelliteMovesWithItsParent: over a span short against the parent's
+// year but long against the satellite's month, the satellite must orbit the
+// parent while the parent carries it along.
+func TestSatelliteMovesWithItsParent(t *testing.T) {
+	jupiter, _ := kepler.CentralBodyFor(core.Jupiter)
+
+	const moonID = core.ID(501)
+
+	p := kepler.New()
+	if err := p.Register(moonID, circular(t, jupiter, 421_800)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	var maxSep, minSep float64 = 0, math.MaxFloat64
+
+	for day := range 40 {
+		when := time.J2000.AddDays(float64(day))
+
+		moon, err := p.State(moonID, when)
+		if err != nil {
+			t.Fatalf("State(moon): %v", err)
+		}
+
+		parent, perr := p.State(core.Jupiter, when)
+		if perr != nil {
+			t.Fatalf("State(Jupiter): %v", perr)
+		}
+
+		sep := moon.Pos.Sub(parent.Pos).Norm()
+		maxSep = math.Max(maxSep, sep)
+		minSep = math.Min(minSep, sep)
+	}
+
+	// A circular orbit stays at one radius no matter where the parent has
+	// travelled; a composition that lost the parent term would show the
+	// separation wandering by an astronomical unit.
+	if spread := (maxSep - minSep) / minSep; spread > 1e-9 {
+		t.Errorf("separation varied by a relative %.3g over 40 days on a circular orbit", spread)
+	}
+}
+
+// TestUnregisteredBodyStillReachesTheBase keeps the new branch from
+// swallowing the fall-through every other body depends on.
+func TestUnregisteredBodyStillReachesTheBase(t *testing.T) {
+	p := kepler.New()
+
+	st, err := p.State(core.Mars, time.J2000)
+	if err != nil {
+		t.Fatalf("State(Mars): %v", err)
+	}
+
+	if st.Pos == (vector.Vec3{}) {
+		t.Error("base provider returned a zero position for Mars")
+	}
+}

--- a/ephemeris/kepler/doc.go
+++ b/ephemeris/kepler/doc.go
@@ -34,4 +34,33 @@
 // ([github.com/TuSKan/astrogo/constants.IAU2015.ObliquityJ2000]) —
 // deliberately not an epoch-of-date obliquity, which would introduce a
 // drift unrelated to the orbit's own real motion.
+//
+// # Central body
+//
+// The default central body is the Sun. [Elements.WithCentralBody] refers a
+// set to a planet instead, which is what a satellite orbit needs, and
+// [CentralBodyFor] supplies the parent's mass parameter without the caller
+// having to choose between a planet's system and body values — a choice that
+// is wrong by 12% at Pluto.
+//
+// # What a satellite orbit here is not
+//
+// Two things are missing before a planetary satellite computed this way
+// should be believed, and both are real physics rather than plumbing.
+//
+// Published *mean* elements for a satellite are referred to a **Laplace
+// plane** whose pole is tabulated per satellite and precesses, not to the
+// J2000 ecliptic this package reads. Feeding such a set through unmodified
+// propagates the right orbit in the wrong plane, and the error does not
+// announce itself: the period is correct and the position is not.
+//
+// And two-body motion diverges quickly for the satellites most people want.
+// The Galilean moons are locked in the Laplace resonance and Jupiter's J₂
+// drives apsidal precession, so an unperturbed ellipse drifts measurably
+// within weeks.
+//
+// What is here is therefore the correct machinery and the correct constants,
+// not a satellite ephemeris. For real satellite positions use a kernel-backed
+// provider ([github.com/TuSKan/astrogo/ephemeris.NewProvider] with
+// [github.com/TuSKan/astrogo/ephemeris.Moons]).
 package kepler

--- a/ephemeris/kepler/kepler.go
+++ b/ephemeris/kepler/kepler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/constants"
+	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
@@ -30,6 +31,66 @@ type Elements struct {
 	epoch                                                 time.Time
 	semiMajorAxis, eccentricity                           float64
 	inclination, ascendingNode, argPeriapsis, meanAnomaly angle.Angle
+
+	// central is the body the elements are referred to. The zero value
+	// means the Sun, so an Elements built by NewElements and never given a
+	// central body behaves exactly as it did before one existed.
+	central CentralBody
+}
+
+// CentralBody is the body an element set orbits, and the mass parameter
+// that governs that motion.
+//
+// It carries the identifier as well as the parameter because the two are
+// needed at different stages and getting either wrong is silent: the mass
+// parameter sets the orbital period, and the identifier is what the provider
+// adds the satellite's position to in order to place it in the solar system.
+// A satellite propagated with the right period about the wrong parent is a
+// plausible orbit around nothing.
+type CentralBody struct {
+	// ID is the body the orbit is referred to.
+	ID core.ID
+
+	// GM is that body's mass parameter, in m³/s².
+	//
+	// For a satellite this is the parent's *body* parameter, not its system
+	// parameter — see [CentralBodyFor], and constants.EphemerisSet for why
+	// the difference reaches 12% at Pluto.
+	GM float64
+}
+
+// sunCentre is the default central body: the Sun, with the IAU nominal mass
+// parameter the heliocentric path has always used.
+//
+//nolint:gochecknoglobals // the default central body, read-only
+var sunCentre = CentralBody{ID: core.Sun, GM: constants.IAU.SunGravitationalParameter.Value}
+
+// CentralBodyFor returns the central body for a satellite of the given
+// planet, using that planet's own mass parameter from the current JPL
+// ephemeris vintage.
+//
+// It exists so a caller does not have to choose between the system and body
+// parameters, which is the error this pairing is most exposed to: the system
+// value includes the satellites and is the wrong one for a satellite's own
+// motion, by one part in 4,830 at Jupiter and by 12% at Pluto.
+//
+// Reports false for a body with no satellite system in the table — the Sun,
+// the Moon, Mercury and Venus.
+func CentralBodyFor(id core.ID) (CentralBody, bool) {
+	gm, ok := map[core.ID]float64{
+		core.Earth:   constants.Ephemeris.EarthGravitationalParameter.Value,
+		core.Mars:    constants.Ephemeris.MarsGravitationalParameter.Value,
+		core.Jupiter: constants.Ephemeris.JupiterGravitationalParameter.Value,
+		core.Saturn:  constants.Ephemeris.SaturnGravitationalParameter.Value,
+		core.Uranus:  constants.Ephemeris.UranusGravitationalParameter.Value,
+		core.Neptune: constants.Ephemeris.NeptuneGravitationalParameter.Value,
+		core.Pluto:   constants.Ephemeris.PlutoGravitationalParameter.Value,
+	}[id]
+	if !ok {
+		return CentralBody{}, false
+	}
+
+	return CentralBody{ID: id, GM: gm}, true
 }
 
 // NewElements constructs a validated set of classical heliocentric
@@ -56,6 +117,31 @@ func NewElements(epoch time.Time, semiMajorAxis, eccentricity float64,
 	}
 
 	return el, nil
+}
+
+// CentralBody reports the body these elements are referred to, defaulting to
+// the Sun.
+func (el Elements) CentralBody() CentralBody {
+	if el.central.GM == 0 {
+		return sunCentre
+	}
+
+	return el.central
+}
+
+// WithCentralBody returns a copy of el referred to body instead of the Sun —
+// the form published elements for a planetary satellite take.
+//
+// Only the central body changes. The elements themselves are still read as
+// osculating elements in the J2000 ecliptic frame, which is *not* the frame
+// most published satellite mean elements use: those are referred to a
+// Laplace plane whose pole is tabulated per satellite and precesses. Feeding
+// such a set through here unmodified propagates the right orbit in the wrong
+// plane. See ephemeris/kepler's package doc.
+func (el Elements) WithCentralBody(body CentralBody) Elements {
+	el.central = body
+
+	return el
 }
 
 // Epoch is the osculation epoch MeanAnomaly is given at.
@@ -199,8 +285,8 @@ func (el Elements) StateAt(t time.Time) (pos, vel vector.Vec3, err error) {
 		return vector.Zero(), vector.Zero(), err
 	}
 
-	gm := constants.IAU.SunGravitationalParameter.Value // m^3/s^2
-	auMeters := constants.IAU.AstronomicalUnit.Value    // m
+	gm := el.CentralBody().GM                        // m^3/s^2
+	auMeters := constants.IAU.AstronomicalUnit.Value // m
 	aMeters := el.semiMajorAxis * auMeters
 
 	nRadPerDay := math.Sqrt(gm/(aMeters*aMeters*aMeters)) * constants.Derived.JulianDaySeconds.Value

--- a/ephemeris/kepler/provider.go
+++ b/ephemeris/kepler/provider.go
@@ -97,9 +97,36 @@ func (p *Provider) State(id core.ID, t time.Time) (core.State, error) {
 		return st, nil
 	}
 
-	heloPos, heloVel, err := el.StateAt(t)
+	relPos, relVel, err := el.StateAt(t)
 	if err != nil {
 		return core.State{}, err
+	}
+
+	// StateAt returns the orbit about its central body. For heliocentric
+	// elements that is already the heliocentric state; for a satellite it is
+	// the offset from its parent, and the parent's own heliocentric position
+	// has to be added before anything can be subtracted from it.
+	//
+	// The parent comes from the base provider rather than being propagated
+	// here: it is a planet, the base already answers for planets, and
+	// re-deriving it would be a second, worse ephemeris for a body this
+	// package can simply ask about.
+	heloPos, heloVel := relPos, relVel
+
+	if central := el.CentralBody(); central.ID != core.Sun {
+		parent, perr := p.base.State(central.ID, t)
+		if perr != nil {
+			return core.State{}, fmt.Errorf("kepler: central body %s: %w", central.ID, perr)
+		}
+
+		// The base answers geocentric, so the Earth term below would cancel
+		// it out; add the parent's geocentric state and return directly.
+		return core.State{
+			Pos:    parent.Pos.Add(relPos),
+			Vel:    parent.Vel.Add(relVel),
+			Frame:  core.FrameICRS,
+			Center: core.CenterGeocentre,
+		}, nil
 	}
 
 	tdb := t.TDB()


### PR DESCRIPTION
> Stacked on #71 — it needs `constants.Ephemeris`. CI runs on stacked pull requests since #59.

The second of roadmap item 39's five pieces.

## The propagation was heliocentric in one line

```go
gm := constants.IAU.SunGravitationalParameter.Value
```

Everything else it needed was already general. `Elements` now carries a central body, defaulting to the Sun so the heliocentric path is untouched — an `Elements` that never names one behaves exactly as before.

## `CentralBodyFor` removes a choice, it does not save typing

A planet has **two** mass parameters, and for a satellite's own motion the system value is the wrong one:

| | system exceeds body by |
| :--- | ---: |
| Jupiter | 1 part in 4,830 |
| **Pluto** | **12%** |

Nothing about either number looks wrong in a printout. The helper picks the body parameter, and a test pins that it does — because the whole point is that a caller never has to make the choice.

## The provider composes through the parent

A satellite's state is its parent's plus a small offset. The parent comes **from the base provider**, not from propagating it here: it is a planet, the base already answers for planets, and re-deriving it would be a second and worse ephemeris for a body this package can simply ask about.

## Verified against the third law, and Io falls out

Checked against `T = 2π√(a³/GM)` rather than a published period, so the test cannot pass by two wrong numbers agreeing. Then:

> **421,800 km about Jupiter gives 1.7699 days** — Io's sidereal period — from a distance and a mass parameter alone.

Nothing fed it that period. The test now pins it, since it is an independent check that both the constant and the propagation are right.

## A measurement I got wrong first

My initial `periodDays` bisected on the angle between the start position and the current one. That angle **wraps at half a revolution**, so it is not monotonic over an orbit and the bisection converged to whichever bracket end it started nearest — reporting *half a year* for a 1 AU heliocentric orbit and *1.5 periods* for a Jovian one.

Two failures in different directions is what gave it away; a single one I might have explained. It now accumulates the swept angle in the orbit's own plane, unwrapped, which is the measurement I should have written first.

## What this is not

Not a satellite ephemeris, and the package doc now says so at length:

- Published **mean** elements for a satellite are referred to a **Laplace plane** whose pole is tabulated per satellite and precesses — not the J2000 ecliptic read here. Feeding such a set through unmodified propagates the right orbit in the wrong plane, and the error does not announce itself: the period is right and the position is not.
- Two-body motion **diverges within weeks** for the moons anyone actually wants — Jupiter's J₂ drives apsidal precession and the Galilean moons are locked in the Laplace resonance.

Both remain open items on #39. This is the machinery and the constants, and the roadmap's standing verdict — moons stay kernel-only until the rest is built — is unchanged.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` with and without build tags, the full default suite, and `-race` across `ephemeris/...` — clean. Two lint findings, both real: `funcorder` on the constructor's position, and `unparam` on a test helper that only ever saw one radius, which is now exercised at two.

The roadmap guard from #70 checks 10 boxes now, up from 9.