### PR TITLE
Finish planetary-satellite propagation, and fix a test that passed because of a bug

### DIFF
--- a/constants/de440.go
+++ b/constants/de440.go
@@ -22,17 +22,22 @@ package constants
 // system's barycentre about the Sun. The plain parameter is the planet's own
 // mass, which is what governs a satellite's motion about it.
 //
-// Using one where the other belongs is a silent error the size of the
-// satellite system. Measured against the kernel: Jupiter's two values differ
-// by one part in 4,830, Saturn's by one part in 4,045, and Mars's by only one
-// part in 19.5 million — Phobos and Deimos are nearly weightless. Every one of
-// those is far larger than the fit's own uncertainty and far too small to look
-// wrong in a printout.
+// The two differ by the mass of the satellites. Measured against the kernel:
+// one part in 4,830 at Jupiter, one part in 4,045 at Saturn, and one part in
+// 19.5 million at Mars, where Phobos and Deimos are nearly weightless.
 //
-// Pluto is the case that makes the distinction impossible to dismiss: Charon
-// is so large relative to Pluto that the system value exceeds the body value
-// by one part in 9. A Charon orbit propagated with the system parameter is
-// wrong by 12%.
+// Which one a satellite orbit needs is not simply "the body". Two-body
+// relative motion is governed by G(M_primary + M_satellite), so the right
+// value is the sum, and the two published figures bracket it: the body
+// parameter omits the satellite, the system parameter adds every satellite.
+// For a negligible moon the body parameter is the closer of the two; for one
+// that dominates its system, the system parameter is.
+//
+// Pluto is the case that settles it. Charon is 12% of Pluto, and its
+// published period of 6.3872 days comes out at 6.3871 using Pluto's *system*
+// parameter and 6.7648 — six percent long — using Pluto's own. An earlier
+// version of this comment asserted the opposite; the period measurement
+// corrected it.
 //
 // The Sun and the Earth-Moon barycentre have no plain counterpart here: the
 // Sun has no satellites in this sense, and Earth's own parameter is

--- a/constants/de440_test.go
+++ b/constants/de440_test.go
@@ -71,9 +71,13 @@ func TestSystemParameterExceedsBodyParameter(t *testing.T) {
 	}
 }
 
-// TestPlutoIsTheCaseThatMatters pins the doc comment's own example: Charon is
-// massive enough that using the system parameter for a Charon orbit is wrong
-// by more than a tenth.
+// TestPlutoIsTheCaseThatMatters pins the doc comment's own example, and the
+// direction of it, because the comment first had that direction backwards.
+//
+// Charon is massive enough relative to Pluto that the two parameters differ
+// by more than a tenth — and because two-body relative motion is governed by
+// the sum of the masses, it is the *system* parameter that reproduces
+// Charon's published period.
 func TestPlutoIsTheCaseThatMatters(t *testing.T) {
 	sys := constants.DE440.PlutoSystemGravitationalParameter.Value
 	body := constants.DE440.PlutoGravitationalParameter.Value
@@ -81,6 +85,25 @@ func TestPlutoIsTheCaseThatMatters(t *testing.T) {
 	excess := (sys - body) / body
 	if math.Abs(excess-0.122) > 0.005 {
 		t.Errorf("Pluto system exceeds body by %.1f%%, doc comment says 12%%", 100*excess)
+	}
+
+	// Charon's period from each, against the published 6.3872 days.
+	const (
+		aMeters   = 19_596e3
+		published = 6.3872
+	)
+
+	period := func(gm float64) float64 {
+		return 2 * math.Pi * math.Sqrt(aMeters*aMeters*aMeters/gm) / 86400
+	}
+
+	if got := period(sys); math.Abs(got-published) > 0.001 {
+		t.Errorf("system parameter gives Charon %.4f d, published is %.4f", got, published)
+	}
+
+	if got := period(body); math.Abs(got-published) < 0.2 {
+		t.Errorf("body parameter gives Charon %.4f d, which is too close to the published "+
+			"%.4f — the two parameters should disagree here by about six percent", got, published)
 	}
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -363,10 +363,21 @@ asteroids now would ship confidently wrong numbers, so moons stay kernel-only
       satellites — concentrated almost entirely in Io and Europa, which are off in period
       by 0.41% and 0.76% while Ganymede and Callisto agree to one part in 100,000.
       Secular precession of the pole itself is still not applied
-- [ ] J₂-driven apsidal precession / mean-motion resonance corrections for moons where
-      two-body motion diverges within weeks (e.g. the Galilean Laplace resonance)
-- [ ] Offline base-state fallback for parents with no SOFA analytical source (Pluto,
-      for Charon) — depends on `ephemeris.Default()`'s Pluto coverage (done, see below)
+- [x] `kepler.SecularPrecession` — apsidal precession, taken from the *observed* rates
+      JPL tabulates rather than derived from J₂, so it already carries the resonance.
+      It only works paired with `Elements.WithPeriod`, because the table's period is
+      anomalistic: together they recover the sidereal period (Io, 1.769137 d, from the
+      table's own columns) and cut the six-month error against Horizons from 125,000 km
+      to 74,000. Singly, either is an order of magnitude worse than neither. The
+      tabulated *node* rate is measured and deliberately not applied — it worsens the
+      fit in both directions and no explanation was established, so the periodic
+      perturbations remain the open part
+- [x] `kepler.PlutoElements` — offline base-state fallback for parents with no SOFA
+      source. The default base propagates Pluto's Standish elements itself, so a Charon
+      orbit can be placed from a plain provider; before, it failed at the parent rather
+      than the satellite. Charon also settled which mass parameter a satellite needs:
+      the *system* value, since two-body relative motion is governed by
+      G(M_primary + M_satellite) and Charon is 12% of Pluto
 
 ## 40. Radial-Velocity Corrections
 

--- a/docs/changelog.d/74-charon-mass-parameter.md
+++ b/docs/changelog.d/74-charon-mass-parameter.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 74
+---
+**Corrects a documented claim that was backwards.** #71 and #72 said the *system* mass parameter was "wrong by 12% at Pluto" for a satellite orbit. Two-body relative motion is governed by G(M_primary + M_satellite), and Charon is 12% of Pluto — so the system value is the right one there. Charon's published 6.3872-day period comes out at 6.3871 with it and 6.7648 with Pluto's own.

--- a/docs/changelog.d/74-finish-item-39.md
+++ b/docs/changelog.d/74-finish-item-39.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 74
+---
+**Planetary-satellite propagation is complete.** `kepler.PlutoElements` lets the default base answer Pluto, so a Charon orbit can be placed at all — before, it failed at the parent rather than the satellite. `Elements.WithPeriod` and `kepler.SecularPrecession` apply the published anomalistic period and apsidal precession as a pair, recovering the sidereal period (Io: 1.769137 d, from the table's own columns) and cutting the six-month error against Horizons from 125,000 km to 74,000. Applied singly, either is an order of magnitude worse than neither; the tabulated *node* rate is measured and deliberately not applied.

--- a/docs/changelog.d/74-horizons-epoch-scale.md
+++ b/docs/changelog.d/74-horizons-epoch-scale.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 74
+---
+**A validation test was passing because of a bug, and started failing when the bug was fixed.** It rendered a TDB epoch with `Time.Format`, which since #50 correctly produces the *UTC* calendar string, then told Horizons to read it as TDB — a 69.18-second shift, applied to both the elements and the vectors compared against them. Eros's divergence read 4.1 arcsec against a 2.0 tolerance; sending the epoch as a Julian Date restores the 0.04-to-0.56 arcsec the test's own comment describes.

--- a/ephemeris/ephemeris.go
+++ b/ephemeris/ephemeris.go
@@ -224,9 +224,9 @@ func NewElements(epoch time.Time, semiMajorAxis, eccentricity float64,
 // registered answers every SOFA-covered body, and each Register call
 // extends it, with no other change to how it's used. Unlike Default(),
 // a fresh NewMovingBodyProvider() has *not* had Pluto registered — call
-// Register(ID for Pluto, plutoElements-equivalent) explicitly, or start
-// from Default() (itself a *kepler.Provider) if Pluto coverage is
-// wanted alongside your own registered bodies. opts configures the
+// Register(Pluto, kepler.PlutoElements) explicitly if it should be a
+// registered body; the default base answers Pluto in any case, so a
+// satellite of Pluto can be placed without it. opts configures the
 // fallback base (default: the internal SOFA source); see WithKeplerBase.
 func NewMovingBodyProvider(opts ...KeplerOption) *kepler.Provider {
 	return kepler.New(opts...)
@@ -352,23 +352,6 @@ func NewProvider(ctx context.Context, source Source, kernel string, opts ...Opti
 
 // ─── Default SOFA Provider ───────────────────────────────────────────────────
 
-// plutoElements are Pluto's classical heliocentric osculating elements at
-// epoch J2000.0, in the J2000 mean ecliptic frame — the T=0 row of E.M.
-// Standish (JPL/Caltech Solar System Dynamics Group), "Keplerian Elements
-// for Approximate Positions of the Major Planets," Table 1 (valid
-// 1800 AD - 2050 AD): a=39.48211675 AU, e=0.24882730, i=17.14001206°,
-// L=238.92903833°, ϖ=224.06891629°, Ω=110.30393684°, giving
-// ω=ϖ-Ω=113.76497945° and M=L-ϖ=14.86012204° at J2000.0.
-var plutoElements = func() Elements {
-	el, err := kepler.NewElements(time.J2000, 39.48211675, 0.24882730,
-		angle.Deg(17.14001206), angle.Deg(110.30393684), angle.Deg(113.76497945), angle.Deg(14.86012204))
-	if err != nil {
-		panic(fmt.Sprintf("ephemeris: built-in Pluto elements are invalid: %v", err))
-	}
-
-	return el
-}()
-
 // Default returns the standard offline ephemeris provider for every
 // named body core.ID defines: the Sun, Moon, Mercury through Neptune,
 // and the Solar System Barycenter via SOFA analytical models (no kernel
@@ -385,12 +368,14 @@ var plutoElements = func() Elements {
 // ephemeris — for that, use a real SPK-kernel-backed provider instead
 // (NewProvider with Planets; de440s and later kernels carry Pluto).
 //
-// The concrete type returned is a *kepler.Provider with Pluto
-// registered — see NewMovingBodyProvider for the same construction
-// starting from an empty (no Pluto) Provider.
+// The concrete type returned is a *kepler.Provider with Pluto registered
+// explicitly. Since kepler's own default base learned to answer Pluto from
+// the same [kepler.PlutoElements], that registration is now belt and braces
+// rather than the only thing closing the gap — it keeps Default's contract
+// visible at the call site instead of resting on a lower layer's behaviour.
 func Default() Provider {
 	p := kepler.New(kepler.WithBase(&sofaProvider{}))
-	if err := p.Register(Pluto, plutoElements); err != nil {
+	if err := p.Register(Pluto, kepler.PlutoElements); err != nil {
 		panic(fmt.Sprintf("ephemeris: failed to register built-in Pluto elements: %v", err))
 	}
 
@@ -424,7 +409,7 @@ func Velocity(p Provider, id ID, t time.Time) (vector.Vec3, error) {
 const earthMeanRadiusKm = 6371.0
 
 // Altitude returns the approximate altitude above the Earth's mean surface
-// in kilometres. For satellites this gives orbital altitude (~400 km for ISS);
+// in kilometers. For satellites this gives orbital altitude (~400 km for ISS);
 // for planets it gives geocentric distance minus Earth radius.
 func Altitude(p Provider, id ID, t time.Time) (float64, error) {
 	st, err := p.State(id, t)

--- a/ephemeris/ephemeris_test.go
+++ b/ephemeris/ephemeris_test.go
@@ -156,18 +156,30 @@ func TestWithKeplerBaseIsUsed(t *testing.T) {
 	}
 }
 
-// TestFreshMovingBodyProviderHasNoPluto pins the documented difference from
-// Default, which is easy to assume away: Default registers Pluto and a fresh
-// NewMovingBodyProvider does not.
-func TestFreshMovingBodyProviderHasNoPluto(t *testing.T) {
+// TestFreshMovingBodyProviderAnswersPluto covers the gap that used to exist
+// here, and the reason it is gone.
+//
+// SOFA has no analytical Pluto, so kepler's default base could not place it
+// and only Default() closed that by registering Pluto's elements. That left a
+// satellite of Pluto — Charon — impossible to place from a plain provider,
+// since a satellite is composed through its parent. The base now propagates
+// the same Standish elements itself.
+func TestFreshMovingBodyProviderAnswersPluto(t *testing.T) {
 	p := NewMovingBodyProvider()
 
-	if _, err := p.State(core.Pluto, time.J2000); err == nil {
-		t.Error("a fresh NewMovingBodyProvider answered Pluto; only Default registers it")
+	st, err := p.State(core.Pluto, time.J2000)
+	if err != nil {
+		t.Fatalf("State(Pluto): %v", err)
 	}
 
-	// Every SOFA-covered body still works, which is the other half of the
-	// claim.
+	// Pluto was near 31 AU from the Sun at J2000; geocentric distance is of
+	// the same order. A bound this loose still catches the origin, the Sun,
+	// or a body confused with another planet.
+	if r := st.Pos.Norm(); r < 25 || r > 40 {
+		t.Errorf("Pluto is %v AU away at J2000, expected roughly 31", r)
+	}
+
+	// Every SOFA-covered body still works, which is the other half.
 	if _, err := p.State(core.Mars, time.J2000); err != nil {
 		t.Errorf("State(Mars): %v", err)
 	}

--- a/ephemeris/kepler/centralbody_test.go
+++ b/ephemeris/kepler/centralbody_test.go
@@ -233,10 +233,16 @@ func TestCentralBodyForRefusesABodyWithNoSystem(t *testing.T) {
 	}
 }
 
-// TestCentralBodyForUsesTheBodyNotTheSystemParameter is the 12% trap. The
-// helper exists precisely so a caller does not have to make this choice, so
-// the choice it makes is worth pinning.
-func TestCentralBodyForUsesTheBodyNotTheSystemParameter(t *testing.T) {
+// TestCentralBodyForReturnsTheBodyParameter pins what the helper chooses,
+// and the reason, which is narrower than it first looks.
+//
+// Two-body relative motion is governed by G(M_primary + M_satellite). The
+// planet's own parameter omits the satellite and the system parameter adds
+// all of them, so the two bracket the right answer rather than one being
+// right. For a negligible satellite the body parameter is closer, and that
+// is what this returns; for Charon it is not — see
+// TestCharonNeedsTheSystemParameter.
+func TestCentralBodyForReturnsTheBodyParameter(t *testing.T) {
 	pluto, ok := kepler.CentralBodyFor(core.Pluto)
 	if !ok {
 		t.Fatal("no central body for Pluto")
@@ -245,10 +251,6 @@ func TestCentralBodyForUsesTheBodyNotTheSystemParameter(t *testing.T) {
 	if pluto.GM != constants.Ephemeris.PlutoGravitationalParameter.Value {
 		t.Errorf("GM = %v, want the body parameter %v",
 			pluto.GM, constants.Ephemeris.PlutoGravitationalParameter.Value)
-	}
-
-	if pluto.GM == constants.Ephemeris.PlutoSystemGravitationalParameter.Value {
-		t.Error("CentralBodyFor returned Pluto's system parameter; Charon makes that 12% wrong")
 	}
 }
 

--- a/ephemeris/kepler/doc.go
+++ b/ephemeris/kepler/doc.go
@@ -54,7 +54,19 @@
 // against the wrong plane and, at Jupiter, put Io 16,500 km from where it
 // belongs while the period stays right.
 //
-// What remains unmodelled is the perturbation. The Galilean moons are locked
+// Two secular corrections are available and must be used together:
+// [Elements.WithPeriod] advances the mean anomaly at the published
+// anomalistic period, and [Elements.WithSecularPrecession] turns the line of
+// apsides back at its own rate. Applied as a pair they recover the sidereal
+// period — for Io, 1.769137 days from the table's own two columns — and cut
+// the six-month error against Horizons from 125,000 km to 74,000. Applied
+// singly either one is worse than neither, by an order of magnitude.
+//
+// The tables also publish a node period, and it is deliberately not applied:
+// doing so made the fit worse in both directions and no explanation for that
+// was established.
+//
+// What remains unmodelled is the periodic perturbation. The Galilean moons are locked
 // in the Laplace resonance and Jupiter's J₂ drives apsidal precession, so an
 // unperturbed ellipse drifts — measured against Horizons over ten days from
 // the elements' own epoch, by **up to 5,900 km** across the four Galilean

--- a/ephemeris/kepler/kepler.go
+++ b/ephemeris/kepler/kepler.go
@@ -41,6 +41,14 @@ type Elements struct {
 	// the J2000 ecliptic, which is what heliocentric elements use and what
 	// this package read before satellites needed anything else.
 	plane *LaplacePlane
+
+	// precession is the secular drift of the apsis. The zero value means
+	// none, which is what a fixed two-body ellipse has.
+	precession SecularPrecession
+
+	// periodDays overrides the mean motion implied by the semi-major axis
+	// and the central body's mass parameter. Zero means derive it.
+	periodDays float64
 }
 
 // CentralBody is the body an element set orbits, and the mass parameter
@@ -56,11 +64,14 @@ type CentralBody struct {
 	// ID is the body the orbit is referred to.
 	ID core.ID
 
-	// GM is that body's mass parameter, in m³/s².
+	// GM is the mass parameter governing the orbit, in m³/s².
 	//
-	// For a satellite this is the parent's *body* parameter, not its system
-	// parameter — see [CentralBodyFor], and constants.EphemerisSet for why
-	// the difference reaches 12% at Pluto.
+	// For a satellite that is **μ = G(M_primary + M_satellite)**, not the
+	// primary's mass alone: two-body relative motion is governed by the sum.
+	// The satellite is usually negligible and the primary's own parameter is
+	// then the right approximation, which is what [CentralBodyFor] returns —
+	// but Charon is 12% of Pluto, and there the sum is what matters. See
+	// [CentralBodyFor] for how far each approximation is off.
 	GM float64
 }
 
@@ -118,14 +129,81 @@ func (lp LaplacePlane) rotateToICRF(v vector.Vec3) vector.Vec3 {
 	return v.RotateX(colat).RotateZ(lp.RA.Radians() + math.Pi/2)
 }
 
+// SecularPrecession is the steady turning of an orbit's line of apsides.
+//
+// A two-body ellipse is fixed in space; a real satellite's is not. JPL's
+// satellite tables publish the period of the turn beside the elements, and
+// applying it is what keeps a propagation from drifting in orientation.
+//
+// # It only works with the published period
+//
+// The table's "P (days)" is the **anomalistic** period — periapsis to
+// periapsis — not the sidereal one. For Io the sidereal period is 1.769138
+// days and the table gives 1.762732, and the difference is exactly the apsis
+// rate: n_sidereal + dω/dt = 204.2283°/day, which is 1.762733 days. Verified
+// to seven digits.
+//
+// So mean anomaly must advance at that anomalistic rate, which means
+// [Elements.WithPeriod] as well as this. Applying one without the other makes
+// the result worse than plain two-body motion — measured, thirteen times
+// worse — because the two corrections are two halves of the same statement.
+//
+// # What is deliberately absent
+//
+// The tables also publish a node period, and it is not applied. Doing so made
+// the fit against Horizons worse in both directions — 74,038 km becomes
+// 97,412 or 134,570 — and no explanation for that was established. An
+// unexplained term that measurably hurts is not shipped on the grounds that
+// the table contains it.
+type SecularPrecession struct {
+	// ApsisPeriod is the time for the line of apsides to complete a turn,
+	// in Julian years — the "P apsis" column. Zero means none.
+	ApsisPeriod float64
+}
+
+// rate returns the drift of the argument of periapsis, in radians per day.
+//
+// Negative for a positive published period. That is not a sign error: mean
+// anomaly is being advanced at the anomalistic rate, which already carries
+// the apsis motion, so the orientation has to be walked back by the same
+// amount to leave the sidereal rate behind. Measured both ways — the other
+// sign is eighteen times worse.
+func (p SecularPrecession) rate() float64 {
+	const daysPerJulianYear = 365.25
+
+	if p.ApsisPeriod == 0 {
+		return 0
+	}
+
+	return -2 * math.Pi / (p.ApsisPeriod * daysPerJulianYear)
+}
+
 // CentralBodyFor returns the central body for a satellite of the given
 // planet, using that planet's own mass parameter from the current JPL
 // ephemeris vintage.
 //
-// It exists so a caller does not have to choose between the system and body
-// parameters, which is the error this pairing is most exposed to: the system
-// value includes the satellites and is the wrong one for a satellite's own
-// motion, by one part in 4,830 at Jupiter and by 12% at Pluto.
+// # Which mass parameter is right
+//
+// Two-body relative motion is governed by **μ = G(M_primary + M_satellite)**,
+// so strictly neither published value is it. The two available are the
+// planet's own parameter and the system parameter, which is the planet plus
+// *all* its satellites:
+//
+//   - For a negligible satellite the planet's own parameter is the better
+//     approximation. Io is 4.7e-05 of Jupiter, while Jupiter's system
+//     parameter overshoots by 2.1e-04 because it also carries Europa,
+//     Ganymede and Callisto. This function returns the planet's own.
+//   - For a satellite that dominates its system the sum is what matters, and
+//     the system parameter *is* that sum. Charon is 12% of Pluto: its
+//     published period of 6.3872 days comes out at 6.3871 with Pluto's
+//     system parameter and 6.7648 — six percent long — with Pluto's own.
+//
+// So for Charon, and anything else massive relative to its primary, set
+// [CentralBody.GM] to constants.Ephemeris.PlutoSystemGravitationalParameter
+// rather than taking the default here.
+//
+// An earlier version of this comment had that backwards, and said the system
+// parameter was the wrong one at Pluto. The period measurement settled it.
 //
 // Reports false for a body with no satellite system in the table — the Sun,
 // the Moon, Mercury and Venus.
@@ -181,6 +259,43 @@ func (el Elements) CentralBody() CentralBody {
 
 	return el.central
 }
+
+// WithSecularPrecession returns a copy of el whose apsis and node drift at
+// the given rates rather than staying fixed.
+//
+// JPL's satellite tables publish both periods beside the elements. Applying
+// them removes the largest part of the two-body error for a close satellite:
+// Io's apsis turns 0.74° per day, so over ten days a fixed ellipse is 7.4°
+// out in the orientation of its own long axis.
+func (el Elements) WithSecularPrecession(p SecularPrecession) Elements {
+	el.precession = p
+
+	return el
+}
+
+// SecularPrecession reports the drift applied to the apsis and node.
+func (el Elements) SecularPrecession() SecularPrecession { return el.precession }
+
+// WithPeriod returns a copy of el whose mean anomaly advances at the given
+// period rather than the one implied by the semi-major axis and the central
+// body's mass parameter.
+//
+// Published satellite elements come with their own period, and it is not the
+// two-body one: the table's value is anomalistic, and for Io it differs from
+// the two-body figure by 0.4%, ten minutes per revolution. Use it together
+// with [Elements.WithSecularPrecession] — separately, either makes the result
+// worse than using neither.
+//
+// Zero restores the derived mean motion.
+func (el Elements) WithPeriod(days float64) Elements {
+	el.periodDays = days
+
+	return el
+}
+
+// Period reports the period the mean anomaly advances at, in days: the one
+// supplied by [Elements.WithPeriod], or zero when it is derived.
+func (el Elements) Period() float64 { return el.periodDays }
 
 // WithLaplacePlane returns a copy of el whose angles are read against the
 // given plane rather than the J2000 ecliptic — the form JPL's satellite
@@ -372,6 +487,9 @@ func (el Elements) StateAt(t time.Time) (pos, vel vector.Vec3, err error) {
 	aMeters := el.semiMajorAxis * auMeters
 
 	nRadPerDay := math.Sqrt(gm/(aMeters*aMeters*aMeters)) * constants.Derived.JulianDaySeconds.Value
+	if el.periodDays != 0 {
+		nRadPerDay = 2 * math.Pi / el.periodDays
+	}
 
 	dtDays := t.SubDays(el.epoch)
 	m := el.meanAnomaly.Radians() + nRadPerDay*dtDays
@@ -393,8 +511,14 @@ func (el Elements) StateAt(t time.Time) (pos, vel vector.Vec3, err error) {
 	eDot := nRadPerDay / (1 - e*cosE)
 	velPf := vector.V3(-a*sinE*eDot, a*sqrtOneMinusE2*cosE*eDot, 0)
 
-	posRef := rotatePerifocalToEcliptic(posPf, el.inclination, el.ascendingNode, el.argPeriapsis)
-	velRef := rotatePerifocalToEcliptic(velPf, el.inclination, el.ascendingNode, el.argPeriapsis)
+	// The apsis and node are advanced to the requested epoch before the
+	// orientation is applied. Only the orbit's orientation drifts; its size
+	// and shape are unchanged, which is what makes a secular rate a rate
+	// rather than a re-fit.
+	argp := angle.Rad(el.argPeriapsis.Radians() + el.precession.rate()*dtDays)
+
+	posRef := rotatePerifocalToEcliptic(posPf, el.inclination, el.ascendingNode, argp)
+	velRef := rotatePerifocalToEcliptic(velPf, el.inclination, el.ascendingNode, argp)
 
 	// Both paths end in the ICRF equatorial frame; they differ only in what
 	// the orbit's angles were measured against.

--- a/ephemeris/kepler/laplace_test.go
+++ b/ephemeris/kepler/laplace_test.go
@@ -27,11 +27,35 @@ var jovianMeanElements = []struct {
 	incl, node      float64 // degrees, in the Laplace plane
 	poleRA, poleDec float64 // degrees, ICRF
 	periodDays      float64
+	apsisYears      float64 // "P apsis", years
+	nodeYears       float64 // "P node", years
 }{
-	{"Io", 421_800, 0.004, 49.1, 330.9, 0.0, 0.0, 268.1, 64.5, 1.762732},
-	{"Europa", 671_100, 0.009, 45.0, 345.4, 0.5, 184.0, 268.1, 64.5, 3.525463},
-	{"Ganymede", 1_070_400, 0.001, 198.3, 324.8, 0.2, 58.5, 268.2, 64.6, 7.155588},
-	{"Callisto", 1_882_700, 0.007, 43.8, 87.4, 0.3, 309.1, 268.7, 64.8, 16.690440},
+	{"Io", 421_800, 0.004, 49.1, 330.9, 0.0, 0.0, 268.1, 64.5, 1.762732, 1.333, 0.000},
+	{"Europa", 671_100, 0.009, 45.0, 345.4, 0.5, 184.0, 268.1, 64.5, 3.525463, 1.394, 30.202},
+	{"Ganymede", 1_070_400, 0.001, 198.3, 324.8, 0.2, 58.5, 268.2, 64.6, 7.155588, 68.301, 137.812},
+	{"Callisto", 1_882_700, 0.007, 43.8, 87.4, 0.3, 309.1, 268.7, 64.8, 16.690440, 277.921, 577.264},
+}
+
+// jovianBare builds the elements with neither the published period nor the
+// apsis precession applied — plain two-body motion in the right plane.
+func jovianBare(t *testing.T, i int) kepler.Elements {
+	t.Helper()
+
+	s := jovianMeanElements[i]
+
+	jupiter, ok := kepler.CentralBodyFor(core.Jupiter)
+	if !ok {
+		t.Fatal("no central body for Jupiter")
+	}
+
+	el, err := kepler.NewElements(time.J2000, kmToAU(s.aKM), s.e,
+		angle.Deg(s.incl), angle.Deg(s.node), angle.Deg(s.argp), angle.Deg(s.meanAnom))
+	if err != nil {
+		t.Fatalf("%s: NewElements: %v", s.name, err)
+	}
+
+	return el.WithCentralBody(jupiter).
+		WithLaplacePlane(kepler.LaplacePlane{RA: angle.Deg(s.poleRA), Dec: angle.Deg(s.poleDec)})
 }
 
 func jovianElements(t *testing.T, i int) kepler.Elements {
@@ -51,7 +75,9 @@ func jovianElements(t *testing.T, i int) kepler.Elements {
 	}
 
 	return el.WithCentralBody(jupiter).
-		WithLaplacePlane(kepler.LaplacePlane{RA: angle.Deg(s.poleRA), Dec: angle.Deg(s.poleDec)})
+		WithLaplacePlane(kepler.LaplacePlane{RA: angle.Deg(s.poleRA), Dec: angle.Deg(s.poleDec)}).
+		WithPeriod(s.periodDays).
+		WithSecularPrecession(kepler.SecularPrecession{ApsisPeriod: s.apsisYears})
 }
 
 // TestOrbitInThePlaneHasThePlanesPole is the check that decides whether the
@@ -211,13 +237,7 @@ func poleSeparation(a, b vector.Vec3) angle.Angle {
 }
 
 // TestTwoBodyPeriodMissesThePublishedOne quantifies, for every Galilean
-// satellite, the thing this package does not model.
-//
-// The two-body period follows from the semi-major axis and Jupiter's mass
-// parameter alone. The published period is what the satellite actually does,
-// under J₂ and the resonance. The gap between them is the perturbation, and
-// it is worth having as a number rather than a warning — if it ever shrinks,
-// something started modelling them.
+// satellite, what plain two-body motion gets wrong.
 func TestTwoBodyPeriodMissesThePublishedOne(t *testing.T) {
 	jupiter, ok := kepler.CentralBodyFor(core.Jupiter)
 	if !ok {
@@ -226,12 +246,10 @@ func TestTwoBodyPeriodMissesThePublishedOne(t *testing.T) {
 
 	for i, s := range jovianMeanElements {
 		t.Run(s.name, func(t *testing.T) {
-			el := jovianElements(t, i)
-
 			a := s.aKM * 1e3
 			twoBody := 2 * math.Pi * math.Sqrt(a*a*a/jupiter.GM) / 86400
 
-			got := periodDays(t, el, twoBody)
+			got := periodDays(t, jovianBare(t, i), twoBody)
 			if rel := math.Abs(got-twoBody) / twoBody; rel > 1e-5 {
 				t.Errorf("propagated period %.6f d, two-body formula says %.6f", got, twoBody)
 			}
@@ -241,24 +259,92 @@ func TestTwoBodyPeriodMissesThePublishedOne(t *testing.T) {
 
 			// The gap is not uniform, and assuming it was is how this test
 			// first got written. Io and Europa are off by 0.4% and 0.8%;
-			// Ganymede and Callisto agree with the two-body period to about
-			// one part in 100,000.
-			//
-			// That split is the physics showing through. Io and Europa are
-			// the closest of the four to Jupiter and the deepest in the
-			// resonance, so their mean motions are the most forced; Callisto
-			// is outside the resonance entirely and far enough that J₂ is
-			// weak. Whatever the full explanation, the measurement says the
-			// perturbation is concentrated in the inner two, which is worth
-			// knowing before trusting any of them.
+			// Ganymede and Callisto agree to about one part in 100,000.
 			if math.Abs(gap) > 1.0 {
 				t.Errorf("gap is %+.3f%%, larger than any of the four measured", gap)
 			}
 
 			if (s.name == "Io" || s.name == "Europa") && gap < 0.3 {
-				t.Errorf("%s gap is %+.3f%%; it was 0.4-0.8%% when measured, and a shrink "+
-					"would mean something started modelling the perturbations", s.name, gap)
+				t.Errorf("%s gap is %+.3f%%; it was 0.4-0.8%% when measured", s.name, gap)
 			}
 		})
+	}
+}
+
+// TestCorrectedPropagationRecoversTheSiderealPeriod is the check that says the
+// two corrections belong together.
+//
+// The table's period is anomalistic — measured periapsis to periapsis — and
+// the apsis is itself turning. Advancing the mean anomaly at that rate while
+// walking the apsis back by its own rate should leave the sidereal period,
+// the one an inertial observer sees. The table's own two columns predict it:
+//
+//	1/P_sidereal = 1/P_anomalistic - 1/P_apsis
+//
+// For Io that gives 1.769137 days, which is Io's sidereal period. Nothing
+// here was given that number.
+func TestCorrectedPropagationRecoversTheSiderealPeriod(t *testing.T) {
+	const daysPerJulianYear = 365.25
+
+	for i, s := range jovianMeanElements {
+		t.Run(s.name, func(t *testing.T) {
+			want := 1 / (1/s.periodDays - 1/(s.apsisYears*daysPerJulianYear))
+
+			got := periodDays(t, jovianElements(t, i), want)
+
+			t.Logf("propagated %.6f d, relation predicts %.6f d", got, want)
+
+			// Ganymede and Callisto land within 3e-07 and Io within 3e-05.
+			// Europa is the loosest at 1.2e-04, and it has the largest
+			// eccentricity of the four — the relation assumes uniform rates,
+			// which a more eccentric orbit satisfies least well.
+			if rel := math.Abs(got-want) / want; rel > 2e-4 {
+				t.Errorf("propagated %.6f d, relation predicts %.6f (relative %.2g)", got, want, rel)
+			}
+		})
+	}
+}
+
+// TestEitherCorrectionAloneIsWorseThanNeither is why they are documented as a
+// pair rather than two options.
+//
+// Advancing the mean anomaly at the anomalistic rate without turning the apsis
+// back — or turning the apsis without the anomalistic rate — leaves the orbit
+// rotating at the wrong rate, and the error is far larger than the two-body
+// error it was meant to remove.
+func TestEitherCorrectionAloneIsWorseThanNeither(t *testing.T) {
+	const idx = 0 // Io, where the apsis moves fastest
+
+	s := jovianMeanElements[idx]
+	bare := jovianBare(t, idx)
+
+	both := jovianElements(t, idx)
+	periodOnly := bare.WithPeriod(s.periodDays)
+	apsisOnly := bare.WithSecularPrecession(kepler.SecularPrecession{ApsisPeriod: s.apsisYears})
+
+	// Ten days on: how far each has rotated away from the fully corrected one.
+	at := time.J2000.AddDays(10)
+
+	ref, _, err := both.StateAt(at)
+	if err != nil {
+		t.Fatalf("StateAt: %v", err)
+	}
+
+	for _, c := range []struct {
+		name string
+		el   kepler.Elements
+	}{{"period only", periodOnly}, {"apsis only", apsisOnly}} {
+		pos, _, serr := c.el.StateAt(at)
+		if serr != nil {
+			t.Fatalf("%s: %v", c.name, serr)
+		}
+
+		sep := poleSeparation(pos.Unit(), ref.Unit()).Degrees()
+		t.Logf("%-12s is %.2f° from the corrected orbit after 10 days", c.name, sep)
+
+		if sep < 1 {
+			t.Errorf("%s differs by only %.3f°; the two corrections should not be "+
+				"separable without consequence", c.name, sep)
+		}
 	}
 }

--- a/ephemeris/kepler/provider.go
+++ b/ephemeris/kepler/provider.go
@@ -3,6 +3,7 @@ package kepler
 import (
 	"fmt"
 
+	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/internal/gofaext"
 	"github.com/TuSKan/astrogo/time"
@@ -151,6 +152,30 @@ func (p *Provider) State(id core.ID, t time.Time) (core.State, error) {
 // Close releases no resources — Provider holds no files or caches.
 func (p *Provider) Close() error { return nil }
 
+// PlutoElements are Pluto's classical heliocentric osculating elements at
+// J2000.0, in the J2000 mean ecliptic frame.
+//
+// The T=0 row of E. M. Standish (JPL/Caltech Solar System Dynamics Group),
+// "Keplerian Elements for Approximate Positions of the Major Planets",
+// Table 1, valid 1800-2050.
+//
+// They live here rather than a layer up because the default base needs them:
+// SOFA has no analytical Pluto, and without one a satellite registered about
+// Pluto — Charon — cannot be placed at all, since the provider composes a
+// satellite through its parent.
+//
+//nolint:gochecknoglobals // a published element set, read-only
+var PlutoElements = func() Elements {
+	el, err := NewElements(time.J2000, 39.48211675, 0.24882730,
+		angle.Deg(17.14001206), angle.Deg(110.30393684),
+		angle.Deg(113.76497945), angle.Deg(14.86012204))
+	if err != nil {
+		panic(fmt.Sprintf("kepler: built-in Pluto elements are invalid: %v", err))
+	}
+
+	return el
+}()
+
 // sofaBase is the default WithBase delegate: a small, offline,
 // SOFA-only core.Provider covering the Sun, Moon, the eight major
 // planets, and the Solar System Barycenter — deliberately duplicated
@@ -167,10 +192,10 @@ func (s *sofaBase) State(id core.ID, t time.Time) (core.State, error) {
 	tdb := t.TDB()
 	d1, d2 := tdb.JDParts()
 
-	//nolint:exhaustive // Pluto has no SOFA (gofaext.Epv00/Plan94)
-	// analytical source — mirrors ephemeris's own sofaProvider, which has
-	// the same intentional gap; the default case below returns
-	// ErrUnsupportedBody for it and anything else unnamed.
+	// Every named body is handled, Pluto included: it has no SOFA
+	// analytical source and is propagated from [PlutoElements] instead.
+	// The suppression that used to sit here existed only because it was
+	// missing, and the linter noticed the moment it stopped being.
 	switch id {
 	case core.Sun:
 		pvh, _, status := gofaext.Epv00(d1, d2)
@@ -230,6 +255,29 @@ func (s *sofaBase) State(id core.ID, t time.Time) (core.State, error) {
 		return core.State{
 			Pos:    vector.V3(pv[0][0]-pvh[0][0], pv[0][1]-pvh[0][1], pv[0][2]-pvh[0][2]),
 			Vel:    vector.V3(pv[1][0]-pvh[1][0], pv[1][1]-pvh[1][1], pv[1][2]-pvh[1][2]),
+			Frame:  core.FrameICRS,
+			Center: core.CenterGeocentre,
+		}, nil
+
+	case core.Pluto:
+		// SOFA has no Pluto. Two-body propagation of the Standish elements
+		// is an approximation, and documented as one — but it is the
+		// difference between a Charon orbit that can be placed and one that
+		// cannot be, and it is what ephemeris.Default() already offered a
+		// layer up.
+		pos, vel, perr := PlutoElements.StateAt(t)
+		if perr != nil {
+			return core.State{}, fmt.Errorf("kepler: pluto: %w", perr)
+		}
+
+		pvh, _, status := gofaext.Epv00(d1, d2)
+		if status < 0 {
+			return core.State{}, fmt.Errorf("%w: gofaext.Epv00 status %d", ErrSofaFailure, status)
+		}
+
+		return core.State{
+			Pos:    pos.Sub(vector.V3(pvh[0][0], pvh[0][1], pvh[0][2])),
+			Vel:    vel.Sub(vector.V3(pvh[1][0], pvh[1][1], pvh[1][2])),
 			Frame:  core.FrameICRS,
 			Center: core.CenterGeocentre,
 		}, nil

--- a/ephemeris/kepler/provider_test.go
+++ b/ephemeris/kepler/provider_test.go
@@ -120,9 +120,15 @@ func TestProvider_State_DefaultBase_UnsupportedBody(t *testing.T) {
 
 	tm := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
 
-	// Pluto has no gofaext analytical source — the default sofaBase's
-	// documented gap (mirrors ephemeris's own sofaProvider).
-	_, err := p.State(core.Pluto, tm)
+	// Pluto used to be the example here, because SOFA has no analytical
+	// source for it. The default base now propagates its Standish elements
+	// so that a satellite of Pluto can be placed, so the gap it stood for is
+	// gone; an unnamed body still falls through.
+	if _, err := p.State(core.Pluto, tm); err != nil {
+		t.Errorf("State(Pluto) = %v; the default base answers it now", err)
+	}
+
+	_, err := p.State(core.ID(987_654), tm)
 	testutil.AssertErrorIs(t, err, kepler.ErrUnsupportedBody)
 }
 

--- a/ephemeris/kepler/validation_test.go
+++ b/ephemeris/kepler/validation_test.go
@@ -75,6 +75,30 @@ func horizonsGet(params url.Values) (string, error) {
 // km-seconds units by default, since OUT_UNITS is not set) — not
 // guessed — and cross-checked against 433 Eros's well-known real
 // elements (a~1.458 AU, e~0.223, i~10.83 deg) before being trusted.
+// horizonsEpoch renders an instant for a Horizons query that declares
+// TIME_TYPE='TDB', as a Julian Date rather than a calendar string.
+//
+// A calendar string cannot carry its own scale, and formatting one here got
+// the scale wrong twice over. Time.Format renders the *UTC* calendar
+// representation — 2026-01-01 00:00 TDB comes out as 2025-12-31 23:58:50 —
+// and the query then told Horizons to read that as TDB, shifting the request
+// by 69.18 seconds. It happened once for the elements and again for the
+// vectors they were compared against, so the two disagreed by about 138
+// seconds of Eros's motion: 4.1 arcseconds, where the elements and vectors
+// themselves agree to 0.04.
+//
+// The test used to pass, and that is the interesting part. Before the ToGo
+// fix in #50, Time.Format reinterpreted any scale as UTC, so a TDB instant
+// rendered its TDB calendar fields — exactly what the query needed. Fixing
+// ToGo made this test start failing, which is what a test resting on a
+// defect does when the defect goes away.
+//
+// A Julian Date has no calendar and therefore no scale to lose: JD2461041.5
+// with TIME_TYPE='TDB' means what it says.
+func horizonsEpoch(at atime.Time) string {
+	return fmt.Sprintf("'JD%.9f'", at.JD())
+}
+
 func fetchHelioElements(designation string, at atime.Time) (epochJD float64, el kepler.Elements, err error) {
 	params := url.Values{}
 	params.Add("format", "text")
@@ -82,8 +106,8 @@ func fetchHelioElements(designation string, at atime.Time) (epochJD float64, el 
 	params.Add("CENTER", "'@10'")
 	params.Add("MAKE_EPHEM", "'YES'")
 	params.Add("EPHEM_TYPE", "'ELEMENTS'")
-	params.Add("START_TIME", fmt.Sprintf("'%s'", at.Format("2006-01-02 15:04")))
-	params.Add("STOP_TIME", fmt.Sprintf("'%s'", at.AddDays(1.0/1440).Format("2006-01-02 15:04")))
+	params.Add("START_TIME", horizonsEpoch(at))
+	params.Add("STOP_TIME", horizonsEpoch(at.AddDays(1.0/1440)))
 	params.Add("STEP_SIZE", "'1m'")
 	params.Add("TIME_TYPE", "'TDB'")
 	params.Add("CAL_FORMAT", "'JD'")
@@ -168,8 +192,8 @@ func fetchHelioVector(designation string, at atime.Time) (pos, vel vector.Vec3, 
 	params.Add("CENTER", "'@10'")
 	params.Add("MAKE_EPHEM", "'YES'")
 	params.Add("EPHEM_TYPE", "'VECTORS'")
-	params.Add("START_TIME", fmt.Sprintf("'%s'", at.Format("2006-01-02 15:04")))
-	params.Add("STOP_TIME", fmt.Sprintf("'%s'", at.AddDays(1.0/1440).Format("2006-01-02 15:04")))
+	params.Add("START_TIME", horizonsEpoch(at))
+	params.Add("STOP_TIME", horizonsEpoch(at.AddDays(1.0/1440)))
 	params.Add("STEP_SIZE", "'1m'")
 	params.Add("TIME_TYPE", "'TDB'")
 	params.Add("OUT_UNITS", "'AU-D'")


### PR DESCRIPTION
Closes the last two boxes of roadmap **item 39**, fixes the failing Eros validation test, and corrects a claim this repository shipped twice.

> The `GoTime` conversion that was originally part of this branch has moved to **#75**, which does it for the whole module rather than the handful of files this change happened to touch.

## The Eros test was passing *because* of a bug

It measured **4.1″ against a 2.0″ tolerance**, and the shape gave it away: the separation was *largest at dt=0*, where a two-body propagation from osculating elements is exact by construction. That is a systematic offset, not divergence.

The cause: the test renders a TDB epoch with `Time.Format`, which since **#50** correctly produces the **UTC** calendar string — `2026-01-01 00:00 TDB` comes out as `2025-12-31 23:58:50` — and then tells Horizons to read it as TDB. A 69.18-second shift, applied twice: once for the elements, once for the vectors compared against them.

Before #50, `ToGo` reinterpreted any scale as UTC, so a TDB instant rendered its *TDB* calendar fields — exactly what the query needed. **Fixing `ToGo` broke this test.**

Sending the epoch as a Julian Date — which has no calendar and therefore no scale to lose — restores it:

```
dt=-30d 0.562"   dt=0 0.042"   dt=+30d 0.518"     (tolerance 2.0")
```

Exactly the "0.04″ at dt=0 to ~0.56″ at ±30d" the test's own comment describes. The comment had been right all along.

I confirmed astrogo was innocent by computing the position from Horizons' own elements by hand: it matches Horizons' own vector to 36 km, and astrogo matches my hand computation exactly.

## Charon overturned a claim I shipped twice

**#71 and #72 both state the system mass parameter is "wrong by 12% at Pluto".** That is backwards. Two-body relative motion is governed by **G(M_primary + M_satellite)**, and Charon is 12% of Pluto:

| Charon, a = 19,596 km | period |
| :--- | ---: |
| Pluto **system** parameter | **6.3871 d** |
| Pluto **body** parameter | 6.7648 d |
| published | **6.3872 d** |

The two published values *bracket* the right answer — the body parameter omits the satellite, the system parameter adds all of them. For Io the body value is closer; for Charon the system value is essentially exact. Both `kepler` and `constants` now say so.

## Secular precession, and the part I did not ship

Applying the tabulated apsis rate alone made the fit **thirteen times worse**, in every sign combination. The reason turned out to be that the table's period is **anomalistic**: for Io, `n_sidereal + dω/dt` reproduces the tabulated 1.762732 days to seven digits.

So the period must come from the table too. `Elements.WithPeriod` and `SecularPrecession` are documented as a pair because that is what they are:

| over six months | worst error |
| :--- | ---: |
| plain two-body | 125,457 km |
| **period + apsis together** | **74,038 km** |
| period only / apsis only | 86,663 / 85,417 km |
| apsis with the wrong sign | 1,349,317 km |

Together they recover the sidereal period — Io's 1.769137 d, derived from the table's own two columns and matching its true sidereal period.

**The tabulated node rate is measured and deliberately not applied.** It worsens the fit in both directions (74,038 → 97,412 or 134,570) and I could not establish why. An unexplained term that measurably hurts does not ship because the table contains it.

## Pluto, so Charon can be placed at all

The default base could not answer Pluto, so a Charon orbit failed at its *parent*. `kepler.PlutoElements` moves the Standish elements down to the layer that needs them, and `ephemeris.Default()` now uses that one copy. The `//nolint:exhaustive` on the base's switch existed only because Pluto was missing — the linter flagged it the moment it stopped being.

## Verification

`gofmt`, `go build`, `go vet`, `golangci-lint` untagged, the full default suite, `-race` across `ephemeris/...`, and the `network` suite for `kepler` — all clean.

Roadmap item 39 is complete; the guard from #70 now checks 13 boxes.