### PR TITLE
Make astrogo/time the module's only import of the standard library's time

### DIFF
--- a/atmosphere/atmosphere.go
+++ b/atmosphere/atmosphere.go
@@ -3,9 +3,9 @@ package atmosphere
 import (
 	"errors"
 	"math"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -155,7 +155,7 @@ type VerticalProfile struct{}
 // Provenance records where an Atmosphere came from and how current it is.
 type Provenance struct {
 	Source   SourceRef
-	IssueAt  time.Time // when the state was issued (nowcast/forecast)
+	IssueAt  time.GoTime // when the state was issued (nowcast/forecast)
 	LeadTime time.Duration
 }
 
@@ -195,7 +195,7 @@ type Atmosphere struct {
 	groundOptical SurfaceOptical
 	horizon       HorizonProfile
 	provenance    Provenance
-	issuedAt      time.Time
+	issuedAt      time.GoTime
 
 	// diffuseKappa scales the optical depth an extended source is attenuated
 	// by; see DiffuseKappa. Zero means unset and reads as DefaultDiffuseKappa.
@@ -281,7 +281,7 @@ func (s *Atmosphere) Provenance() Provenance { return s.provenance }
 
 // Age returns now minus the state's issue time (zero if it was never
 // set, e.g. a climatology default).
-func (s *Atmosphere) Age(now time.Time) time.Duration {
+func (s *Atmosphere) Age(now time.GoTime) time.Duration {
 	if s.issuedAt.IsZero() {
 		return 0
 	}
@@ -498,7 +498,7 @@ func (b *Builder) Source(ref SourceRef) *Builder {
 }
 
 // IssuedAt sets the state's issue time (for nowcast/forecast use).
-func (b *Builder) IssuedAt(t time.Time) *Builder {
+func (b *Builder) IssuedAt(t time.GoTime) *Builder {
 	b.s.issuedAt = t
 	b.s.provenance.IssueAt = t
 

--- a/atmosphere/builder_roundtrip_test.go
+++ b/atmosphere/builder_roundtrip_test.go
@@ -3,10 +3,10 @@ package atmosphere_test
 import (
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -33,7 +33,7 @@ func (h flatHorizon) AltitudeAt(_ angle.Angle) angle.Angle { return angle.Angle(
 func TestBuilderRoundTripsEveryField(t *testing.T) {
 	t.Parallel()
 
-	issued := gotime.Date(2026, gotime.March, 20, 3, 30, 0, 0, gotime.UTC)
+	issued := time.GoDate(2026, time.March, 20, 3, 30, 0, 0, time.LocationUTC)
 	horizon := flatHorizon(angle.Deg(7.5))
 
 	cloud := atmosphere.CloudLayer{
@@ -64,7 +64,7 @@ func TestBuilderRoundTripsEveryField(t *testing.T) {
 		AddCloud(cloud).
 		Source(source).
 		IssuedAt(issued).
-		LeadTime(90 * gotime.Minute).
+		LeadTime(90 * time.Minute).
 		Build()
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -128,7 +128,7 @@ func TestBuilderRoundTripsEveryField(t *testing.T) {
 	}
 
 	// Age is measured from the issue time, so an hour later is an hour old.
-	if got := air.Age(issued.Add(gotime.Hour)); got != gotime.Hour {
+	if got := air.Age(issued.Add(time.Hour)); got != time.Hour {
 		t.Errorf("age one hour after issue is %v, want 1h", got)
 	}
 }
@@ -195,7 +195,7 @@ func TestUnsetAtmosphereUsesItsDefaults(t *testing.T) {
 			got, atmosphere.DefaultDiffuseKappa)
 	}
 
-	if got := air.Age(gotime.Now()); got != 0 {
+	if got := air.Age(time.Now()); got != 0 {
 		t.Errorf("age with no issue time is %v, want 0", got)
 	}
 

--- a/atmosphere/dataset/cams/aod.go
+++ b/atmosphere/dataset/cams/aod.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // ErrAOD reports that an aerosol optical depth could not be resolved.
@@ -79,7 +79,7 @@ const AODVariable = "aod550"
 // must also blank-import remote/s3, which this package deliberately does not
 // — it knows nothing about S3, and pulling the AWS SDK into every build that
 // merely reads a NetCDF file would be the wrong trade.
-func AOD550(ctx context.Context, site *coord.Geodetic, when time.Time) (float64, error) {
+func AOD550(ctx context.Context, site *coord.Geodetic, when time.GoTime) (float64, error) {
 	if site == nil {
 		return 0, fmt.Errorf("%w: needs a site", ErrAOD)
 	}
@@ -128,7 +128,7 @@ func AOD550(ctx context.Context, site *coord.Geodetic, when time.Time) (float64,
 // steps from each. This takes the most recent cycle at or before the instant
 // and the step that lands on it, so any hour resolves to the freshest run
 // that covers it rather than to whichever cycle happens to be nearer.
-func AODKey(when time.Time) string {
+func AODKey(when time.GoTime) string {
 	utc := when.UTC()
 
 	cycleHour := 0
@@ -136,7 +136,7 @@ func AODKey(when time.Time) string {
 		cycleHour = 12
 	}
 
-	cycle := time.Date(utc.Year(), utc.Month(), utc.Day(), cycleHour, 0, 0, 0, time.UTC)
+	cycle := time.GoDate(utc.Year(), utc.Month(), utc.Day(), cycleHour, 0, 0, 0, time.LocationUTC)
 	step := int(utc.Sub(cycle).Hours())
 
 	stamp := cycle.Format("20060102150405")

--- a/atmosphere/dataset/cams/aod_network_test.go
+++ b/atmosphere/dataset/cams/aod_network_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere/dataset/cams"
@@ -14,11 +13,12 @@ import (
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
 	_ "github.com/TuSKan/astrogo/remote/s3"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // A date the archive is known to hold, used by every test here so they share
 // one cached file rather than fetching one each.
-var aodEpoch = gotime.Date(2023, 1, 1, 3, 0, 0, 0, gotime.UTC)
+var aodEpoch = time.GoDate(2023, 1, 1, 3, 0, 0, 0, time.LocationUTC)
 
 func siteAt(tb testing.TB, lonDeg, latDeg float64) *coord.Geodetic {
 	tb.Helper()
@@ -34,7 +34,7 @@ func siteAt(tb testing.TB, lonDeg, latDeg float64) *coord.Geodetic {
 func aodAt(tb testing.TB, lonDeg, latDeg float64) float64 {
 	tb.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	v, err := cams.AOD550(ctx, siteAt(tb, lonDeg, latDeg), aodEpoch)
@@ -160,34 +160,34 @@ func TestAODKeyPicksTheCoveringCycle(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		when gotime.Time
+		when time.GoTime
 		want string
 	}{{
 		// Exactly on the morning cycle: step zero of that cycle.
-		when: gotime.Date(2023, 1, 1, 0, 0, 0, 0, gotime.UTC),
+		when: time.GoDate(2023, 1, 1, 0, 0, 0, 0, time.LocationUTC),
 		want: "CAMS/GLOBAL/2023/01/01/z_cams_c_ecmf_20230101000000_prod_fc_sfc_000_aod550/" +
 			"z_cams_c_ecmf_20230101000000_prod_fc_sfc_000_aod550.nc",
 	}, {
 		// Three hours later: same cycle, step three.
-		when: gotime.Date(2023, 1, 1, 3, 0, 0, 0, gotime.UTC),
+		when: time.GoDate(2023, 1, 1, 3, 0, 0, 0, time.LocationUTC),
 		want: "CAMS/GLOBAL/2023/01/01/z_cams_c_ecmf_20230101000000_prod_fc_sfc_003_aod550/" +
 			"z_cams_c_ecmf_20230101000000_prod_fc_sfc_003_aod550.nc",
 	}, {
 		// Past midday: the afternoon cycle takes over, not the morning one
 		// extended.
-		when: gotime.Date(2023, 1, 1, 13, 30, 0, 0, gotime.UTC),
+		when: time.GoDate(2023, 1, 1, 13, 30, 0, 0, time.LocationUTC),
 		want: "CAMS/GLOBAL/2023/01/01/z_cams_c_ecmf_20230101120000_prod_fc_sfc_001_aod550/" +
 			"z_cams_c_ecmf_20230101120000_prod_fc_sfc_001_aod550.nc",
 	}, {
 		// A non-UTC instant resolves by its UTC time, not its wall clock.
-		when: gotime.Date(2023, 1, 1, 20, 0, 0, 0, gotime.FixedZone("UTC+7", 7*3600)),
+		when: time.GoDate(2023, 1, 1, 20, 0, 0, 0, time.FixedZone("UTC+7", 7*3600)),
 		want: "CAMS/GLOBAL/2023/01/01/z_cams_c_ecmf_20230101120000_prod_fc_sfc_001_aod550/" +
 			"z_cams_c_ecmf_20230101120000_prod_fc_sfc_001_aod550.nc",
 	}}
 
 	for _, c := range cases {
 		if got := cams.AODKey(c.when); got != c.want {
-			t.Errorf("%s\n got %s\nwant %s", c.when.Format(gotime.RFC3339), got, c.want)
+			t.Errorf("%s\n got %s\nwant %s", c.when.Format(time.RFC3339), got, c.want)
 		}
 	}
 }

--- a/atmosphere/dataset/cams/aodkey_test.go
+++ b/atmosphere/dataset/cams/aodkey_test.go
@@ -3,9 +3,9 @@ package cams_test
 import (
 	"strings"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/atmosphere/dataset/cams"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // An instant resolves to the most recent CAMS cycle at or before it, and to
@@ -29,33 +29,33 @@ func TestAODKeySelectsTheCycleAtOrBeforeTheInstant(t *testing.T) {
 
 	for _, c := range []struct {
 		name  string
-		when  gotime.Time
+		when  time.GoTime
 		cycle string
 		step  string
 	}{
 		{
 			"morning, 00Z cycle",
-			gotime.Date(2026, gotime.March, 20, 5, 0, 0, 0, gotime.UTC),
+			time.GoDate(2026, time.March, 20, 5, 0, 0, 0, time.LocationUTC),
 			"20260320000000", "005",
 		},
 		{
 			"last hour before the switch",
-			gotime.Date(2026, gotime.March, 20, 11, 59, 0, 0, gotime.UTC),
+			time.GoDate(2026, time.March, 20, 11, 59, 0, 0, time.LocationUTC),
 			"20260320000000", "011",
 		},
 		{
 			"exactly the switch",
-			gotime.Date(2026, gotime.March, 20, 12, 0, 0, 0, gotime.UTC),
+			time.GoDate(2026, time.March, 20, 12, 0, 0, 0, time.LocationUTC),
 			"20260320120000", "000",
 		},
 		{
 			"evening, 12Z cycle, part-hour truncates down",
-			gotime.Date(2026, gotime.March, 20, 18, 30, 0, 0, gotime.UTC),
+			time.GoDate(2026, time.March, 20, 18, 30, 0, 0, time.LocationUTC),
 			"20260320120000", "006",
 		},
 		{
 			"last hour of the day",
-			gotime.Date(2026, gotime.March, 20, 23, 0, 0, 0, gotime.UTC),
+			time.GoDate(2026, time.March, 20, 23, 0, 0, 0, time.LocationUTC),
 			"20260320120000", "011",
 		},
 	} {
@@ -69,7 +69,7 @@ func TestAODKeySelectsTheCycleAtOrBeforeTheInstant(t *testing.T) {
 				"_prod_fc_sfc_" + c.step + "_aod550.nc"
 
 			if got != want {
-				t.Errorf("AODKey(%s)\n got %q\nwant %q", c.when.Format(gotime.RFC3339), got, want)
+				t.Errorf("AODKey(%s)\n got %q\nwant %q", c.when.Format(time.RFC3339), got, want)
 			}
 		})
 	}
@@ -84,17 +84,17 @@ func TestAODKeySelectsTheCycleAtOrBeforeTheInstant(t *testing.T) {
 func TestAODKeyConvertsToUTC(t *testing.T) {
 	t.Parallel()
 
-	east := gotime.FixedZone("UTC+2", 2*60*60)
+	east := time.FixedZone("UTC+2", 2*60*60)
 
 	// 05:00+02:00 is 03:00 UTC, so step 3 of the 00Z cycle.
-	got := cams.AODKey(gotime.Date(2026, gotime.March, 20, 5, 0, 0, 0, east))
+	got := cams.AODKey(time.GoDate(2026, time.March, 20, 5, 0, 0, 0, east))
 
 	if !strings.Contains(got, "_prod_fc_sfc_003_") {
 		t.Errorf("AODKey for 05:00+02:00 is %q; 03:00 UTC is step 3 of the 00Z cycle", got)
 	}
 
 	// And the same instant expressed in UTC gives byte-identical output.
-	if utc := cams.AODKey(gotime.Date(2026, gotime.March, 20, 3, 0, 0, 0, gotime.UTC)); utc != got {
+	if utc := cams.AODKey(time.GoDate(2026, time.March, 20, 3, 0, 0, 0, time.LocationUTC)); utc != got {
 		t.Errorf("the same instant in two zones gave different keys:\n%q\n%q", got, utc)
 	}
 }
@@ -109,7 +109,7 @@ func TestAODKeyConvertsToUTC(t *testing.T) {
 func TestAODKeyShapeMatchesTheStoreLayout(t *testing.T) {
 	t.Parallel()
 
-	key := cams.AODKey(gotime.Date(2026, gotime.January, 2, 7, 0, 0, 0, gotime.UTC))
+	key := cams.AODKey(time.GoDate(2026, time.January, 2, 7, 0, 0, 0, time.LocationUTC))
 
 	if !strings.HasPrefix(key, "CAMS/GLOBAL/2026/01/02/") {
 		t.Errorf("key %q does not start with the zero-padded date prefix", key)

--- a/atmosphere/provenance.go
+++ b/atmosphere/provenance.go
@@ -1,6 +1,6 @@
 package atmosphere
 
-import "time"
+import "github.com/TuSKan/astrogo/time"
 
 // DatasetVersion identifies a specific, citable version of a dataset or
 // algorithm implementation — a semver string, a DOI-versioned release tag,
@@ -50,7 +50,7 @@ func (f Fidelity) String() string {
 
 // TimeRange is a closed time interval, [Start, End].
 type TimeRange struct {
-	Start, End time.Time
+	Start, End time.GoTime
 }
 
 // SourceRef records the provenance of one dataset that contributed to a
@@ -65,7 +65,7 @@ type SourceRef struct {
 	Name      string
 	Version   DatasetVersion
 	Acquired  TimeRange // the observation period the data represents
-	Retrieved time.Time
+	Retrieved time.GoTime
 	Checksum  string // "sha256:..."
 	Licence   string
 	Endpoint  string // remote.EndpointID as a string; empty for user-supplied data

--- a/catalog/example_test.go
+++ b/catalog/example_test.go
@@ -3,14 +3,13 @@ package catalog_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/catalog"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/plan"
-	astrot "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestIntegration demonstrates how to use the catalog system
@@ -39,7 +38,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// We calculate at a specific time (e.g. 2026-04-06 00:00:00 UTC)
-	obsTime := astrot.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC)
+	obsTime := time.Date(2026, 4, 6, 0, 0, 0, 0, time.LocationUTC)
 
 	// Compute target's altitude and azimuth properties from the Observatory at that time
 	ctx := coord.NewContext(obsTime, obs.Location(), atmosphere.StandardRefraction)

--- a/catalog/gaia/gaia_network_test.go
+++ b/catalog/gaia/gaia_network_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
@@ -15,6 +14,7 @@ import (
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireGaia skips the test when the default archive is unreachable - per

--- a/catalog/gaia/gaia_validation_test.go
+++ b/catalog/gaia/gaia_validation_test.go
@@ -8,13 +8,13 @@ import (
 	"net"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The two archives return the same DR3.

--- a/catalog/jpl/jpl_network_test.go
+++ b/catalog/jpl/jpl_network_test.go
@@ -5,11 +5,11 @@ package jpl
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireHorizons skips the test when the JPL Horizons API is unreachable —

--- a/catalog/mast/mast_network_test.go
+++ b/catalog/mast/mast_network_test.go
@@ -5,11 +5,11 @@ package mast
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireMast skips the test when the MAST API is unreachable — per this

--- a/catalog/norad/norad.go
+++ b/catalog/norad/norad.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/remote"
@@ -42,10 +41,10 @@ type GP struct {
 
 // EpochTime parses the GP epoch string into an astrogo Time (UTC).
 func (gp GP) EpochTime() (time.Time, error) {
-	t, err := gotime.Parse("2006-01-02T15:04:05.999999", gp.Epoch)
+	t, err := time.Parse("2006-01-02T15:04:05.999999", gp.Epoch)
 	if err != nil {
 		// Try without fractional seconds.
-		t, err = gotime.Parse("2006-01-02T15:04:05", gp.Epoch)
+		t, err = time.Parse("2006-01-02T15:04:05", gp.Epoch)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("norad: cannot parse epoch %q: %w", gp.Epoch, err)
 		}

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -15,9 +15,9 @@ import (
 	"context"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireCelestrak skips the test when the CelestTrak API endpoint is

--- a/catalog/openngc/fetch_test.go
+++ b/catalog/openngc/fetch_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/file"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 )
@@ -72,7 +72,7 @@ func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 
 	// Regression: Epoch used to never be set despite OpenNGC's RA/Dec being
 	// implicitly J2000 by the catalog's own convention.
-	if !got.Epoch.Equal(astrotime.J2000) {
+	if !got.Epoch.Equal(time.J2000) {
 		t.Errorf("Epoch = %v, want time.J2000", got.Epoch)
 	}
 

--- a/catalog/sbdb/sbdb.go
+++ b/catalog/sbdb/sbdb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // ErrAPIError indicates a SBDB API error response.
@@ -199,7 +199,7 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 		}
 
 		if hasElements {
-			t.Epoch = atime.FromJD(epochJD, atime.TDB)
+			t.Epoch = time.FromJD(epochJD, time.TDB)
 			t.SemiMajorAxis = semiMajorAxis
 			t.Eccentricity = eccentricity
 			t.Inclination = angle.Deg(incl)
@@ -554,7 +554,7 @@ func (p *Provider) queryBright(ctx context.Context, sbKind, magField string, max
 		}
 
 		if hasElements {
-			t.Epoch = atime.FromJD(epochJD, atime.TDB)
+			t.Epoch = time.FromJD(epochJD, time.TDB)
 			t.SemiMajorAxis = semiMajorAxis
 			t.Eccentricity = eccentricity
 			t.Inclination = angle.Deg(incl)

--- a/catalog/sbdb/sbdb_network_test.go
+++ b/catalog/sbdb/sbdb_network_test.go
@@ -6,11 +6,11 @@ import (
 	"context"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireSBDB skips the test when the JPL SBDB API is unreachable — per

--- a/catalog/sbdb/sbdb_test.go
+++ b/catalog/sbdb/sbdb_test.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 func TestSBDBResolver(t *testing.T) {

--- a/catalog/simbad/simbad_network_test.go
+++ b/catalog/simbad/simbad_network_test.go
@@ -5,11 +5,11 @@ package simbad
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // requireSimbad skips the test when the SIMBAD TAP endpoint is unreachable

--- a/catalog/vizier/vizier_network_test.go
+++ b/catalog/vizier/vizier_network_test.go
@@ -5,13 +5,13 @@ package vizier
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // skipOnServerUnavailable skips (never fails) the calling test after

--- a/coord/radialvelocity_fixture_test.go
+++ b/coord/radialvelocity_fixture_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -211,7 +210,7 @@ func TestRVCorrectionAgainstAstropy(t *testing.T) {
 			t.Fatalf("%s: %v", tc.Name, err)
 		}
 
-		parsed, err := gotime.Parse(gotime.RFC3339, tc.EpochUTC+"Z")
+		parsed, err := time.Parse(time.RFC3339, tc.EpochUTC+"Z")
 		if err != nil {
 			t.Fatalf("%s: parsing %q: %v", tc.Name, tc.EpochUTC, err)
 		}

--- a/coord/transform_roundtrip_test.go
+++ b/coord/transform_roundtrip_test.go
@@ -3,12 +3,11 @@ package coord_test
 import (
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // separation is the great-circle distance between two directions, in degrees,
@@ -71,14 +70,14 @@ func TestICRSGalacticRoundTrip(t *testing.T) {
 func TestICRSEclipticRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	epochs := []gotime.Time{
-		gotime.Date(2000, 1, 1, 12, 0, 0, 0, gotime.UTC),
-		gotime.Date(2026, 8, 21, 0, 0, 0, 0, gotime.UTC),
-		gotime.Date(2050, 6, 1, 18, 30, 0, 0, gotime.UTC),
+	epochs := []time.GoTime{
+		time.GoDate(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC),
+		time.GoDate(2026, 8, 21, 0, 0, 0, 0, time.LocationUTC),
+		time.GoDate(2050, 6, 1, 18, 30, 0, 0, time.LocationUTC),
 	}
 
 	for _, when := range epochs {
-		at := astrotime.FromGo(when)
+		at := time.FromGo(when)
 
 		for _, c := range sweep() {
 			start := coord.NewICRS(c.lon, c.lat)
@@ -137,7 +136,7 @@ func TestEclipticAnchors(t *testing.T) {
 
 	// J2000, where the equinox and solstice points are at their defining
 	// positions and the obliquity is 23.4393 degrees.
-	at := astrotime.FromGo(gotime.Date(2000, 1, 1, 12, 0, 0, 0, gotime.UTC))
+	at := time.FromGo(time.GoDate(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC))
 
 	const obliquity = 23.4393
 
@@ -202,7 +201,7 @@ func TestAltAzICRSRoundTrip(t *testing.T) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	at := astrotime.FromGo(gotime.Date(2026, 8, 21, 3, 0, 0, 0, gotime.UTC))
+	at := time.FromGo(time.GoDate(2026, 8, 21, 3, 0, 0, 0, time.LocationUTC))
 
 	// No refraction, so the transform is a pure geometric inverse.
 	ctx := coord.NewContext(at, site, atmosphere.Refraction{})

--- a/docs/changelog.d/75-no-stdlib-time.md
+++ b/docs/changelog.d/75-no-stdlib-time.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 75
+---
+**`astrogo/time` is now the module's only import of the standard library's
+`time`.** A guard test enforces it, and `time` gained `GoTime`, `GoDate`,
+`LocationUTC`, `Now`, the sub-second units and the timer constructors so no
+call site has to reach past it.

--- a/ephemeris/apparent_semantics_test.go
+++ b/ephemeris/apparent_semantics_test.go
@@ -3,10 +3,9 @@ package ephemeris_test
 import (
 	"math"
 	"testing"
-	gotime "time"
 
 	eph "github.com/TuSKan/astrogo/ephemeris"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
 
@@ -23,7 +22,7 @@ const lightSpeedAUPerDay = 173.144632674
 // target and nothing else. A real provider retards the observer along with it,
 // because the Earth's own barycentric position is looked up at the same epoch.
 type orbitingProvider struct {
-	epoch astrotime.Time
+	epoch time.Time
 }
 
 // earthAt and marsAt are circular coplanar orbits, which is enough: the
@@ -62,7 +61,7 @@ func marsAt(days float64) (pos, vel vector.Vec3) {
 		vector.V3(-radius*w*s, radius*w*c, 0)
 }
 
-func (p *orbitingProvider) State(_ eph.ID, t astrotime.Time) (eph.State, error) {
+func (p *orbitingProvider) State(_ eph.ID, t time.Time) (eph.State, error) {
 	d := p.days(t)
 
 	mp, mv := marsAt(d)
@@ -76,7 +75,7 @@ func (p *orbitingProvider) Close() error { return nil }
 // days is the offset from the provider's epoch, differenced through the
 // two-part Julian date so a light time of a few hundred seconds is not lost
 // to the representation.
-func (p *orbitingProvider) days(t astrotime.Time) float64 {
+func (p *orbitingProvider) days(t time.Time) float64 {
 	j1, j2 := t.JDParts()
 	b1, b2 := p.epoch.JDParts()
 
@@ -110,7 +109,7 @@ func arcsecBetween(a, b vector.Vec3) float64 {
 func TestApparentStateIsTheApparentPlaceNotTheAstrometricOne(t *testing.T) {
 	t.Parallel()
 
-	epoch := astrotime.FromGo(gotime.Date(2026, 8, 21, 0, 0, 0, 0, gotime.UTC))
+	epoch := time.FromGo(time.GoDate(2026, 8, 21, 0, 0, 0, 0, time.LocationUTC))
 	provider := &orbitingProvider{epoch: epoch}
 
 	got, err := eph.ApparentState(provider, eph.Mars, epoch)
@@ -187,7 +186,7 @@ func TestApparentStateIsTheApparentPlaceNotTheAstrometricOne(t *testing.T) {
 func TestApparentStateWithNoMotionIsGeometric(t *testing.T) {
 	t.Parallel()
 
-	epoch := astrotime.FromGo(gotime.Date(2026, 8, 21, 0, 0, 0, 0, gotime.UTC))
+	epoch := time.FromGo(time.GoDate(2026, 8, 21, 0, 0, 0, 0, time.LocationUTC))
 
 	still := &staticProvider{pos: vector.V3(3.5, -1.2, 0.4)}
 
@@ -203,7 +202,7 @@ func TestApparentStateWithNoMotionIsGeometric(t *testing.T) {
 
 type staticProvider struct{ pos vector.Vec3 }
 
-func (p *staticProvider) State(_ eph.ID, _ astrotime.Time) (eph.State, error) {
+func (p *staticProvider) State(_ eph.ID, _ time.Time) (eph.State, error) {
 	return eph.State{Pos: p.pos, Vel: vector.Zero()}, nil
 }
 

--- a/ephemeris/frame_label_test.go
+++ b/ephemeris/frame_label_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	eph "github.com/TuSKan/astrogo/ephemeris"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestProvidersLabelTheirFrame is the point of the Frame and Center fields.
@@ -23,7 +23,7 @@ import (
 func TestProvidersLabelTheirFrame(t *testing.T) {
 	t.Parallel()
 
-	when := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	st, err := eph.Default().State(eph.Mars, when)
 	if err != nil {

--- a/ephemeris/jpl/smallbody_collision_test.go
+++ b/ephemeris/jpl/smallbody_collision_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestLowNumberedAsteroidsLoad covers the bodies that used to be unreachable.
@@ -25,8 +25,8 @@ import (
 func TestLowNumberedAsteroidsLoad(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.FromJD(2460305.5, atime.TDB)
-	stop := atime.FromJD(2460355.5, atime.TDB)
+	start := time.FromJD(2460305.5, time.TDB)
+	stop := time.FromJD(2460355.5, time.TDB)
 
 	cases := []struct {
 		number      int

--- a/ephemeris/jpl/smallbody_designation_guard_test.go
+++ b/ephemeris/jpl/smallbody_designation_guard_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
 	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestBareNumberDoesNotReturnADifferentBody covers the quietest failure this
@@ -26,8 +26,8 @@ import (
 func TestBareNumberDoesNotReturnADifferentBody(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.FromJD(2460305.5, atime.TDB)
-	stop := atime.FromJD(2460355.5, atime.TDB)
+	start := time.FromJD(2460305.5, time.TDB)
+	stop := time.FromJD(2460355.5, time.TDB)
 
 	p, err := jpl.NewProvider(context.Background(), core.SmallBody, "1",
 		jpl.WithTimeInterval(start, stop))
@@ -52,8 +52,8 @@ func TestBareNumberDoesNotReturnADifferentBody(t *testing.T) {
 func TestSemicolonDesignationLoadsTheRequestedBody(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.FromJD(2460305.5, atime.TDB)
-	stop := atime.FromJD(2460355.5, atime.TDB)
+	start := time.FromJD(2460305.5, time.TDB)
+	stop := time.FromJD(2460355.5, time.TDB)
 
 	for _, designation := range []string{"1;", "433;", "433"} {
 		t.Run(designation, func(t *testing.T) {
@@ -80,8 +80,8 @@ func TestSemicolonDesignationLoadsTheRequestedBody(t *testing.T) {
 func TestHorizonsRefusalIsReported(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.FromJD(2460305.5, atime.TDB)
-	stop := atime.FromJD(2460355.5, atime.TDB)
+	start := time.FromJD(2460305.5, time.TDB)
+	stop := time.FromJD(2460355.5, time.TDB)
 
 	p, err := jpl.NewProvider(context.Background(), core.SmallBody, "101955;",
 		jpl.WithTimeInterval(start, stop))

--- a/ephemeris/jpl/smallbody_designation_test.go
+++ b/ephemeris/jpl/smallbody_designation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
 	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // A small-body provider that loaded nothing used to be indistinguishable
@@ -39,7 +39,7 @@ import (
 func TestSmallBodyDesignationFailuresAreLoud(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	for _, tc := range []struct {
 		des  string
@@ -64,7 +64,7 @@ func TestSmallBodyDesignationFailuresAreLoud(t *testing.T) {
 func TestSmallBodyDesignationsThatResolve(t *testing.T) {
 	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
 
-	start := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	for _, tc := range []struct {
 		des  string

--- a/ephemeris/jpl/validation/corpus_settled_test.go
+++ b/ephemeris/jpl/validation/corpus_settled_test.go
@@ -3,8 +3,9 @@
 package jpl_test
 
 import (
-	"github.com/TuSKan/astrogo/time"
 	"testing"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // settledMargin is how far behind the present a corpus epoch must sit.

--- a/ephemeris/jpl/validation/corpus_settled_test.go
+++ b/ephemeris/jpl/validation/corpus_settled_test.go
@@ -3,8 +3,8 @@
 package jpl_test
 
 import (
+	"github.com/TuSKan/astrogo/time"
 	"testing"
-	"time"
 )
 
 // settledMargin is how far behind the present a corpus epoch must sit.
@@ -52,7 +52,7 @@ func TestCorpusEpochsAreSettled(t *testing.T) {
 	cutoff := time.Now().UTC().Add(-settledMargin)
 
 	var (
-		latest  time.Time
+		latest  time.GoTime
 		offense string
 		count   int
 	)

--- a/ephemeris/jpl/validation/gen_corpus_test.go
+++ b/ephemeris/jpl/validation/gen_corpus_test.go
@@ -13,9 +13,9 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // updateCorpus gates every write to the checked-in corpus.
@@ -266,7 +266,7 @@ func newCorpusManifest(t *testing.T, spans []corpusSpan, sites []corpusSite) cor
 
 	return corpusManifest{
 		SchemaVersion: corpusSchemaVersion,
-		Generated:     gotime.Now().UTC().Format(gotime.RFC3339),
+		Generated:     time.Now().UTC().Format(time.RFC3339),
 		Commit:        gitCommit(t),
 		Reference:     "JPL Horizons (https://ssd.jpl.nasa.gov/api/horizons.api)",
 		ReferenceQuery: "EPHEM_TYPE=OBSERVER CENTER='coord@399' QUANTITIES='1,2,4,20' CAL_FORMAT=JD; " +

--- a/ephemeris/jpl/validation/observer_pipeline_test.go
+++ b/ephemeris/jpl/validation/observer_pipeline_test.go
@@ -6,12 +6,11 @@ import (
 	"errors"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // EOP needs no explicit load here: the time package pulls finals2000A lazily
@@ -38,7 +37,7 @@ func TestPhase1ObserverPipelineAgainstHorizons(t *testing.T) {
 	tStrStop := "2024-11-01 12:01"
 
 	// Create the AstroGo native time
-	obsTime := atime.Date(2024, 11, 1, 12, 0, 0, 0, time.UTC)
+	obsTime := time.Date(2024, 11, 1, 12, 0, 0, 0, time.LocationUTC)
 
 	// Fetch Topocentric Observer Table for Mars (NAIF ID: 499)
 	marsHorizons, err := fetchObserverTable("499", "Mars", site.Lon().Degrees(), site.Lat().Degrees(), site.Height(), tStrStart, tStrStop)

--- a/ephemeris/jpl/validation/observer_precision_test.go
+++ b/ephemeris/jpl/validation/observer_precision_test.go
@@ -22,7 +22,7 @@ import (
 	// import higher ones") is about production imports, not test fixtures,
 	// and isn't actually violated here.
 	"github.com/TuSKan/astrogo/plan"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // observerPrecisionBody is one Horizons-tracked target in the precision
@@ -191,9 +191,9 @@ func TestObserverPrecisionMatrix(t *testing.T) {
 		numEpochs = 9
 	)
 
-	epochStart := atime.Date(2026, atime.January, 5, 0, 0, 0, 0, atime.LocationUTC)
+	epochStart := time.Date(2026, time.January, 5, 0, 0, 0, 0, time.LocationUTC)
 
-	epochs := make([]atime.Time, numEpochs)
+	epochs := make([]time.Time, numEpochs)
 	for i := range numEpochs {
 		epochs[i] = epochStart.AddDays(float64(i) * 45)
 	}

--- a/ephemeris/jpl/validation/regression_test.go
+++ b/ephemeris/jpl/validation/regression_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/internal/metrology"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
 
@@ -23,12 +23,12 @@ import (
 // state at slightly earlier instants, which linear motion supplies exactly
 // enough for over the milliseconds involved.
 type mockLinearProvider struct {
-	baseTime atime.Time
+	baseTime time.Time
 	pos      vector.Vec3
 	vel      vector.Vec3
 }
 
-func (m *mockLinearProvider) State(_ eph.ID, t atime.Time) (eph.State, error) {
+func (m *mockLinearProvider) State(_ eph.ID, t time.Time) (eph.State, error) {
 	jd1Req, jd2Req := t.JDParts()
 	jd1Base, jd2Base := m.baseTime.JDParts()
 	dtDays := (jd1Req - jd1Base) + (jd2Req - jd2Base)
@@ -142,7 +142,7 @@ func TestScientificStability(t *testing.T) {
 			t.Fatalf("%s: %v", cs.Name, err)
 		}
 
-		obsTime := atime.FromJD(e.EpochJDUT, atime.UTC)
+		obsTime := time.FromJD(e.EpochJDUT, time.UTC)
 
 		mock := &mockLinearProvider{
 			baseTime: obsTime,

--- a/ephemeris/jpl/validation/smallbody_spk_test.go
+++ b/ephemeris/jpl/validation/smallbody_spk_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
 	"github.com/TuSKan/astrogo/internal/metrology"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
 
@@ -158,8 +158,8 @@ func TestSmallBodySPKAgainstHorizons(t *testing.T) {
 		marginDays = 5
 	)
 
-	start := atime.FromJD(startJD-marginDays, atime.TDB)
-	stop := atime.FromJD(startJD+days+marginDays, atime.TDB)
+	start := time.FromJD(startJD-marginDays, time.TDB)
+	stop := time.FromJD(startJD+days+marginDays, time.TDB)
 
 	for _, body := range smallBodies() {
 		t.Run(body.name, func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestSmallBodySPKAgainstHorizons(t *testing.T) {
 			for _, ref := range refs {
 				// ET is seconds past J2000.0 TDB, the same convention
 				// TestJPLStateAgainstHorizons reads.
-				when := atime.FromJD(2451545.0+ref.ET/86400.0, atime.TDB)
+				when := time.FromJD(2451545.0+ref.ET/86400.0, time.TDB)
 
 				state, serr := p.State(core.SmallBodyID(body.id), when)
 				if serr != nil {

--- a/ephemeris/kepler/kepler_test.go
+++ b/ephemeris/kepler/kepler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/ephemeris/kepler"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // wrappedDiff returns the smallest signed angular difference a-b, in
@@ -86,7 +86,7 @@ func keplerPeriodDays(a float64) float64 {
 // be a bug in the test itself, so it's reported via t.Fatal rather than
 // threaded through as a return value every call site would have to
 // check.
-func testElements(t *testing.T, epoch atime.Time, a, e float64, incl, node, argp, m0 angle.Angle) kepler.Elements {
+func testElements(t *testing.T, epoch time.Time, a, e float64, incl, node, argp, m0 angle.Angle) kepler.Elements {
 	t.Helper()
 
 	el, err := kepler.NewElements(epoch, a, e, incl, node, argp, m0)
@@ -101,7 +101,7 @@ func testElements(t *testing.T, epoch atime.Time, a, e float64, incl, node, argp
 // pass to StateAt in the first place, so there is no separate
 // StateAt-rejects-bad-elements case left to test here.
 func TestNewElements_RejectsBadInputs(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	cases := []struct {
 		name                 string
@@ -129,7 +129,7 @@ func TestNewElements_RejectsBadInputs(t *testing.T) {
 }
 
 func TestNewElements_AcceptsGoodInputs(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el, err := kepler.NewElements(epoch, 2.7, 0.15, angle.Deg(10), angle.Deg(80), angle.Deg(73), angle.Deg(20))
 	testutil.AssertNoError(t, err)
 
@@ -161,7 +161,7 @@ func TestNewElements_AcceptsGoodInputs(t *testing.T) {
 func TestElements_StateAt_KnownGeometry_Inclination0(t *testing.T) {
 	const a = 2.0
 
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, a, 0, angle.Zero(), angle.Zero(), angle.Deg(90), angle.Deg(0))
 
 	quarterPeriod := epoch.AddDays(keplerPeriodDays(a) / 4)
@@ -187,7 +187,7 @@ func TestElements_StateAt_KnownGeometry_Inclination0(t *testing.T) {
 func TestElements_StateAt_KnownGeometry_Inclination90(t *testing.T) {
 	const a = 2.0
 
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, a, 0, angle.Deg(90), angle.Zero(), angle.Zero(), angle.Deg(0))
 
 	quarterPeriod := epoch.AddDays(keplerPeriodDays(a) / 4)
@@ -203,7 +203,7 @@ func TestElements_StateAt_KnownGeometry_Inclination90(t *testing.T) {
 }
 
 func TestElements_StateAt_OnePeriodClosure(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, 2.7, 0.2, angle.Deg(12), angle.Deg(50), angle.Deg(200), angle.Deg(30))
 
 	pos0, vel0, err := el.StateAt(epoch)
@@ -224,7 +224,7 @@ func TestElements_StateAt_OnePeriodClosure(t *testing.T) {
 // v^2 = GM*(2/r - 1/a) (specific orbital energy conservation) holds at
 // several points around the orbit, in SI units.
 func TestElements_StateAt_EnergyConservation(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, 1.8, 0.35, angle.Deg(7), angle.Deg(120), angle.Deg(300), angle.Deg(10))
 
 	gm := constants.IAU.SunGravitationalParameter.Value
@@ -248,7 +248,7 @@ func TestElements_StateAt_EnergyConservation(t *testing.T) {
 // constant (equal to sqrt(GM*a*(1-e^2))) at several points around the
 // orbit, in SI units.
 func TestElements_StateAt_AngularMomentumConservation(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, 3.1, 0.5, angle.Deg(15), angle.Deg(200), angle.Deg(80), angle.Deg(-40))
 
 	gm := constants.IAU.SunGravitationalParameter.Value
@@ -274,7 +274,7 @@ func TestElements_StateAt_AngularMomentumConservation(t *testing.T) {
 // analytic velocity against a central finite difference of position, at
 // several points around the orbit.
 func TestElements_StateAt_VelocityMatchesFiniteDifference(t *testing.T) {
-	epoch := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 	el := testElements(t, epoch, 2.2, 0.4, angle.Deg(20), angle.Deg(60), angle.Deg(150), angle.Deg(90))
 
 	const h = 1e-3 // days

--- a/ephemeris/kepler/provider_test.go
+++ b/ephemeris/kepler/provider_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/kepler"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // testElementsForProvider is a small, valid osculating-elements fixture
@@ -21,7 +21,7 @@ func testElementsForProvider(t *testing.T) kepler.Elements {
 	t.Helper()
 
 	el, err := kepler.NewElements(
-		atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC),
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC),
 		2.5, 0.1, angle.Deg(5), angle.Deg(30), angle.Deg(60), angle.Deg(0),
 	)
 	testutil.AssertNoError(t, err)
@@ -45,7 +45,7 @@ func TestRegister_RejectsInvalidElements(t *testing.T) {
 	// same guard NewElements already enforces from a second angle:
 	// Register never trusts an Elements value blindly).
 	_, err := kepler.NewElements(
-		atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC),
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC),
 		2.5, 1.5, angle.Deg(5), angle.Deg(30), angle.Deg(60), angle.Deg(0), // e=1.5, hyperbolic
 	)
 	testutil.AssertErrorIs(t, err, kepler.ErrUnsupportedOrbit)
@@ -78,7 +78,7 @@ func TestProvider_State_DefaultBase_SunMoonPlanets(t *testing.T) {
 	p := kepler.New()
 	testutil.AssertNoError(t, p.Register(propagatedID, testElementsForProvider(t)))
 
-	tm := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	bodies := []struct {
 		name string
@@ -118,7 +118,7 @@ func TestProvider_State_DefaultBase_UnsupportedBody(t *testing.T) {
 	p := kepler.New()
 	testutil.AssertNoError(t, p.Register(propagatedID, testElementsForProvider(t)))
 
-	tm := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	// Pluto has no gofaext analytical source — the default sofaBase's
 	// documented gap (mirrors ephemeris's own sofaProvider).
@@ -137,7 +137,7 @@ type mockBaseProvider struct {
 
 var errMockBase = errors.New("mockBaseProvider: intentional test failure")
 
-func (m *mockBaseProvider) State(core.ID, atime.Time) (core.State, error) {
+func (m *mockBaseProvider) State(core.ID, time.Time) (core.State, error) {
 	m.called = true
 	if m.wantErr != nil {
 		return core.State{}, m.wantErr
@@ -156,7 +156,7 @@ func TestProvider_State_WithBase_Override(t *testing.T) {
 	p := kepler.New(kepler.WithBase(mock))
 	testutil.AssertNoError(t, p.Register(propagatedID, testElementsForProvider(t)))
 
-	tm := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	if _, err := p.State(core.Sun, tm); err != nil {
 		t.Fatalf("State(Sun): %v", err)
@@ -175,7 +175,7 @@ func TestProvider_State_WithBase_WrapsError(t *testing.T) {
 	p := kepler.New(kepler.WithBase(mock))
 	testutil.AssertNoError(t, p.Register(propagatedID, testElementsForProvider(t)))
 
-	tm := atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC)
+	tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	_, err := p.State(core.Sun, tm)
 	testutil.AssertErrorIs(t, err, errMockBase)
@@ -198,7 +198,7 @@ func TestProvider_MultiBody(t *testing.T) {
 	el1 := testElementsForProvider(t)
 
 	el2, err := kepler.NewElements(
-		atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC),
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC),
 		4.0, 0.2, angle.Deg(10), angle.Deg(50), angle.Deg(90), angle.Deg(180),
 	)
 	testutil.AssertNoError(t, err)

--- a/ephemeris/kepler/validation_test.go
+++ b/ephemeris/kepler/validation_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/ephemeris/kepler"
 	"github.com/TuSKan/astrogo/internal/testutil"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
 
@@ -75,7 +75,7 @@ func horizonsGet(params url.Values) (string, error) {
 // km-seconds units by default, since OUT_UNITS is not set) — not
 // guessed — and cross-checked against 433 Eros's well-known real
 // elements (a~1.458 AU, e~0.223, i~10.83 deg) before being trusted.
-func fetchHelioElements(designation string, at atime.Time) (epochJD float64, el kepler.Elements, err error) {
+func fetchHelioElements(designation string, at time.Time) (epochJD float64, el kepler.Elements, err error) {
 	params := url.Values{}
 	params.Add("format", "text")
 	params.Add("COMMAND", fmt.Sprintf("'%s'", designation))
@@ -147,7 +147,7 @@ func fetchHelioElements(designation string, at atime.Time) (epochJD float64, el 
 	const kmPerAU = 149_597_870.7
 
 	el, err = kepler.NewElements(
-		atime.FromJDParts(jdtdb, 0, atime.TDB), aKm/kmPerAU, ec,
+		time.FromJDParts(jdtdb, 0, time.TDB), aKm/kmPerAU, ec,
 		angle.Deg(incl), angle.Deg(node), angle.Deg(argp), angle.Deg(ma),
 	)
 	if err != nil {
@@ -161,7 +161,7 @@ func fetchHelioElements(designation string, at atime.Time) (epochJD float64, el 
 // position/velocity (EPHEM_TYPE=VECTORS, CENTER='@10', REF_PLANE='FRAME'
 // — the ICRF/J2000 equatorial frame [Elements.StateAt] itself returns,
 // OUT_UNITS='AU-D') at.
-func fetchHelioVector(designation string, at atime.Time) (pos, vel vector.Vec3, err error) {
+func fetchHelioVector(designation string, at time.Time) (pos, vel vector.Vec3, err error) {
 	params := url.Values{}
 	params.Add("format", "text")
 	params.Add("COMMAND", fmt.Sprintf("'%s'", designation))
@@ -241,14 +241,14 @@ func TestElements_StateAt_AgainstHorizons_433Eros(t *testing.T) {
 
 	const designation = "433"
 
-	epochJD, el, err := fetchHelioElements(designation, atime.Date(2026, atime.January, 1, 0, 0, 0, 0, atime.LocationUTC))
+	epochJD, el, err := fetchHelioElements(designation, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC))
 	testutil.AssertNoError(t, err)
 
 	if el.SemiMajorAxis() < 1.0 || el.SemiMajorAxis() > 2.0 {
 		t.Fatalf("sanity check failed: 433 Eros semi-major axis = %v AU, expected ~1.458 AU", el.SemiMajorAxis())
 	}
 
-	epoch := atime.FromJDParts(epochJD, 0, atime.TDB)
+	epoch := time.FromJDParts(epochJD, 0, time.TDB)
 
 	// 2 arcsec, chosen from real measured data, not picked in advance: a
 	// live run of this exact comparison found the two-body/perturbed

--- a/examples/18_sky_brightness/main.go
+++ b/examples/18_sky_brightness/main.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -24,6 +23,7 @@ import (
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness"
 	"github.com/TuSKan/astrogo/skybrightness/dataset"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The preset to run. GAMBONSWeb reproduces the GAMBONS web service: the five
@@ -52,7 +52,7 @@ func main() {
 
 	// A moonless night. GAMBONSWeb has no moonlight term at all, so the date
 	// matters here only through the zodiacal light's solar elongation.
-	when := time.Date(2026, 3, 20, 5, 0, 0, 0, time.UTC)
+	when := time.GoDate(2026, 3, 20, 5, 0, 0, 0, time.LocationUTC)
 
 	// Consent, granted explicitly and only for what this preset fetches.
 	// Nothing in astrogo downloads a file without it.

--- a/examples/25_sky_brightness_compare/main.go
+++ b/examples/25_sky_brightness_compare/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -25,6 +24,7 @@ import (
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness"
 	"github.com/TuSKan/astrogo/skybrightness/dataset"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -45,7 +45,7 @@ func main() {
 	// A moonless night. None of the presets used here has a moonlight term,
 	// so the date reaches the answer only through the zodiacal light's solar
 	// elongation.
-	when := time.Date(2026, 3, 20, 5, 0, 0, 0, time.UTC)
+	when := time.GoDate(2026, 3, 20, 5, 0, 0, 0, time.LocationUTC)
 
 	// Observatory reads everything the natural presets do and a solar
 	// spectrum besides, so granting for it covers the whole run.
@@ -64,7 +64,7 @@ func main() {
 // The expected result is that almost nothing happens, which is why it is
 // worth printing: the interesting fact about the transfer choice is how
 // little it buys at the zenith.
-func comparePresets(ctx context.Context, when time.Time) {
+func comparePresets(ctx context.Context, when time.GoTime) {
 	site := siteAt(heightM)
 	air := atmosphere.RuralAerosol(site.Height(), atmosphere.CleanMountainAOD550)
 
@@ -127,7 +127,7 @@ ground-emitter inventory this example does not build.
 //
 // Elevation and aerosol together, because they are not independent in
 // practice: the sites that are high are the sites that are dry.
-func compareAir(ctx context.Context, when time.Time) {
+func compareAir(ctx context.Context, when time.GoTime) {
 	// One Sky for every site here. Nothing it holds depends on the observer —
 	// the star and dust maps are all-sky, the grid and passband are spectral
 	// — so the site arrives with the scene instead.
@@ -199,7 +199,7 @@ func whatObservatoryAdds(ctx context.Context) {
 	// exists to show is exactly zero when it is not, and a column of zeros
 	// looks in every way like coverage — a mistake this module's own golden
 	// fixture made once already.
-	when := time.Date(2026, 4, 2, 5, 0, 0, 0, time.UTC)
+	when := time.GoDate(2026, 4, 2, 5, 0, 0, 0, time.LocationUTC)
 	site := siteAt(heightM)
 
 	sky, err := dataset.Open(ctx, dataset.Spec{

--- a/internal/changelog/assemble_test.go
+++ b/internal/changelog/assemble_test.go
@@ -3,11 +3,12 @@ package changelog
 import (
 	"flag"
 	"fmt"
-	"github.com/TuSKan/astrogo/time"
 	"os"
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 //nolint:gochecknoglobals // test flags must be package-level to register

--- a/internal/changelog/assemble_test.go
+++ b/internal/changelog/assemble_test.go
@@ -3,11 +3,11 @@ package changelog
 import (
 	"flag"
 	"fmt"
+	"github.com/TuSKan/astrogo/time"
 	"os"
 	"strings"
 	"testing"
 	"testing/fstest"
-	"time"
 )
 
 //nolint:gochecknoglobals // test flags must be package-level to register

--- a/internal/docsguard/stdtime_test.go
+++ b/internal/docsguard/stdtime_test.go
@@ -1,0 +1,128 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// stdTimeImport matches an import of the standard library's time package, in
+// any of the forms it is written: on its own, inside a block, and with or
+// without a local name.
+var stdTimeImport = regexp.MustCompile(`(?m)^(?:import[ 	]+|[ 	]*)(?:[a-z][a-z0-9]*[ 	]+)?"time"[ 	]*$`)
+
+// aliasedAstroTime matches an import of this module's time package under a
+// local name, in a block or on its own line.
+//
+// Spaces and tabs rather than \s, because \s matches a newline: with it, the
+// pattern could begin on the blank line above an unaliased single-line import
+// and read the `import` keyword itself as the alias. This guard reported
+// exactly that against atmosphere/provenance.go before the classes were
+// narrowed.
+var aliasedAstroTime = regexp.MustCompile(
+	`(?m)^(?:import[ 	]+|[ 	]+)[a-z][a-z0-9]*[ 	]+"github\.com/TuSKan/astrogo/time"[ 	]*$`)
+
+// TestNoStandardLibraryTimeOutsideTimePackage enforces the rule that
+// astrogo/time is the module's only door to the standard library's clock.
+//
+// # Why it is a rule and not a preference
+//
+// A package that imports both ends up with two types spelled `time.Time` and
+// a local name to tell them apart. Then the local name is what carries the
+// meaning, and a field declared `Time time.Time` says nothing on its own
+// about which one it is — the answer is at the top of the file, in an import
+// line nobody re-reads.
+//
+// That is not hypothetical here. Converting the module to this rule, an
+// intermediate version of the change swapped an import without rewriting the
+// body, and skybrightness.Scene.Time silently changed from the standard
+// library's type to this module's. The source line was character-for-character
+// identical before and after.
+//
+// astrogo/time aliases everything needed for that not to be a trade: GoTime
+// for the standard library's type, LocationUTC for the location, GoDate
+// beside Date, and the duration, month and layout constants unchanged.
+//
+// The one exception is internal/testutil, which cannot import astrogo/time
+// without closing a cycle through time/internal/iers' own tests. It uses an
+// untyped constant instead and says so.
+func TestNoStandardLibraryTimeOutsideTimePackage(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	var checked, offenders int
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		// astrogo/time is the one package allowed to import it — that is
+		// the whole point of the rule.
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unrelatable path is skipped, not fatal
+		}
+
+		if slash := filepath.ToSlash(rel); slash == "time" || strings.HasPrefix(slash, "time/") {
+			return nil
+		}
+
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // a file we cannot read is skipped, not fatal
+		}
+
+		checked++
+
+		body := string(src)
+
+		if loc := stdTimeImport.FindStringIndex(body); loc != nil {
+			offenders++
+
+			t.Errorf("%s:%d: imports the standard library's time.\n"+
+				"  Use github.com/TuSKan/astrogo/time: GoTime for the standard library's\n"+
+				"  Time, LocationUTC for its UTC location, GoDate beside Date, and the\n"+
+				"  duration, month and layout constants under their own names.",
+				filepath.ToSlash(rel), lineOf(body, loc[0]))
+		}
+
+		if loc := aliasedAstroTime.FindStringIndex(body); loc != nil {
+			offenders++
+
+			t.Errorf("%s:%d: imports astrogo/time under a local name.\n"+
+				"  With the standard library's time gone there is nothing to disambiguate,\n"+
+				"  and the alias only makes the package read differently from its neighbours.",
+				filepath.ToSlash(rel), lineOf(body, loc[0]))
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if checked == 0 {
+		t.Fatal("no Go files examined; the walk root may be wrong")
+	}
+
+	t.Logf("%d files checked, %d offenders", checked, offenders)
+}
+
+// lineOf returns the 1-indexed line containing the byte at off.
+func lineOf(s string, off int) int {
+	return 1 + strings.Count(s[:off], "\n")
+}

--- a/internal/metrology/report.go
+++ b/internal/metrology/report.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/TuSKan/astrogo/time"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +11,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // SchemaVersion is the version of the result document written by [Suite].

--- a/internal/metrology/report.go
+++ b/internal/metrology/report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/TuSKan/astrogo/time"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
-	gotime "time"
 )
 
 // SchemaVersion is the version of the result document written by [Suite].
@@ -115,7 +115,7 @@ func (s *Suite) newResult(status Status, reason string, stats Stats) Result {
 		Suite:         s.Name,
 		// UTC and RFC3339, so results from different machines sort and
 		// compare without anyone having to think about time zones.
-		Generated: gotime.Now().UTC().Format(gotime.RFC3339),
+		Generated: time.Now().UTC().Format(time.RFC3339),
 		Commit:    commit,
 		GoVersion: goVersion,
 		Platform:  platform,

--- a/internal/testutil/reachable.go
+++ b/internal/testutil/reachable.go
@@ -3,12 +3,17 @@ package testutil
 import (
 	"net"
 	"testing"
-	"time"
 )
 
 // ReachableTimeout bounds the pre-check. It is deliberately short: the point
 // is to find out whether a service is there at all, not to wait for a slow one.
-const ReachableTimeout = 5 * time.Second
+//
+// Written in nanoseconds rather than as 5 * time.Second because this package
+// is imported by nearly every test in the repository, including time's own:
+// importing astrogo/time here would close a cycle through
+// time/internal/iers. An untyped constant converts to a Duration wherever it
+// is used, so nothing at the call sites changes.
+const ReachableTimeout = 5_000_000_000
 
 // RequireReachable skips the test unless host is accepting connections.
 //

--- a/optics/detection.go
+++ b/optics/detection.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 

--- a/optics/detection_test.go
+++ b/optics/detection_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/optics"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 

--- a/plan/astropixels_test.go
+++ b/plan/astropixels_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	gotime "time"
 
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/plan"
@@ -153,7 +152,7 @@ func parseAstroPixelsPage(html string) []apPhaseEvent {
 			if isJulian {
 				tUT = time.DateJulianCal(currentYear, month, day, hour, minute, 0)
 			} else {
-				tUT = time.Date(currentYear, gotime.Month(month), day, hour, minute, 0, 0, gotime.UTC)
+				tUT = time.Date(currentYear, time.Month(month), day, hour, minute, 0, 0, time.LocationUTC)
 			}
 
 			events = append(events, apPhaseEvent{

--- a/plan/bench_test.go
+++ b/plan/bench_test.go
@@ -3,13 +3,12 @@ package plan
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // ── Visibility Detection ─────────────────────────────────────────────────────
@@ -18,12 +17,12 @@ type benchMock struct {
 	c coord.ICRS
 }
 
-func (m benchMock) ICRS(_ atime.Time) (coord.ICRS, error) {
+func (m benchMock) ICRS(_ time.Time) (coord.ICRS, error) {
 	return m.c, nil
 }
 
-func (m benchMock) Name() string                              { return "mock" }
-func (m benchMock) Position(_ atime.Time) (coord.ICRS, error) { return m.c, nil }
+func (m benchMock) Name() string                             { return "mock" }
+func (m benchMock) Position(_ time.Time) (coord.ICRS, error) { return m.c, nil }
 func (m benchMock) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }
@@ -32,7 +31,7 @@ func BenchmarkVisibleIntervals(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
 	site, _ := NewSite("Test", loc)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(0), angle.Deg(45))}
-	start := atime.FromJD(2460000.0, atime.UTC)
+	start := time.FromJD(2460000.0, time.UTC)
 	end := start.AddDays(1.0)
 
 	for b.Loop() {
@@ -44,7 +43,7 @@ func BenchmarkVisibleIntervals_1MinStep(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
 	site, _ := NewSite("Test", loc)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(0), angle.Deg(45))}
-	start := atime.FromJD(2460000.0, atime.UTC)
+	start := time.FromJD(2460000.0, time.UTC)
 	end := start.AddDays(1.0)
 
 	for b.Loop() {
@@ -58,9 +57,9 @@ func BenchmarkEventSolver_Visibility(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
 	site, _ := NewSite("Test", loc)
 	obj := NewStar("T", angle.Deg(0), angle.Deg(0))
-	start := atime.FromJD(2451545.0, atime.UTC)
-	end := start.Add(24 * atime.Hour)
-	solver := NewEventSolver(30*atime.Minute, 1*atime.Second)
+	start := time.FromJD(2451545.0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	solver := NewEventSolver(30*time.Minute, 1*time.Second)
 	spec := EventSpec{
 		Family:    EventFamilyVisibility,
 		Kind:      EventAnyVisibility,
@@ -80,12 +79,12 @@ func BenchmarkObservableWindows(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
 	site, _ := NewSite("Test", loc)
 	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
-	start := atime.FromJD(2451545.0, atime.UTC)
-	end := start.Add(12 * atime.Hour)
+	start := time.FromJD(2451545.0, time.UTC)
+	end := start.Add(12 * time.Hour)
 	constraints := []Constraint{Altitude{Threshold: angle.Deg(30)}}
 
 	for b.Loop() {
-		_, _ = ObservableWindows(obj, start, end, 5*atime.Minute, site, constraints...)
+		_, _ = ObservableWindows(obj, start, end, 5*time.Minute, site, constraints...)
 	}
 }
 
@@ -98,7 +97,7 @@ func makeBlocks(n int) []*Block {
 		blocks[i] = &Block{
 			ID:       fmt.Sprintf("B%d", i),
 			Target:   NewStar(fmt.Sprintf("T%d", i), angle.Deg(0), angle.Deg(0)),
-			Duration: 10 * atime.Minute,
+			Duration: 10 * time.Minute,
 			Priority: float64(n - i), // descending priority
 		}
 	}
@@ -115,8 +114,8 @@ func benchScheduler(b *testing.B, n int, strategy Strategy) {
 	tm := &BasicTransitionModel{BaseSetup: 0}
 	blocks := makeBlocks(n)
 
-	start := atime.ZeroTime()
-	window := Window{Start: start, End: start.Add(atime.Duration(n*15) * atime.Minute)}
+	start := time.ZeroTime()
+	window := Window{Start: start, End: start.Add(time.Duration(n*15) * time.Minute)}
 
 	for b.Loop() {
 		_, _ = strategy.Schedule(planner, window, blocks, tm)
@@ -165,7 +164,7 @@ func BenchmarkTransitEstimate(b *testing.B) {
 	loc, _ := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
 	site, _ := NewSite("Test", loc)
 	obj := benchMock{c: coord.NewICRS(angle.Deg(100), angle.Deg(20))}
-	start := atime.FromJD(2460000.0, atime.UTC)
+	start := time.FromJD(2460000.0, time.UTC)
 	end := start.AddDays(0.5)
 
 	for b.Loop() {
@@ -199,7 +198,7 @@ func BenchmarkFortnightEvents(b *testing.B) {
 	}
 
 	provider := eph.Default()
-	start := atime.Date(2026, 7, 20, 0, 0, 0, 0, tz)
+	start := time.Date(2026, 7, 20, 0, 0, 0, 0, tz)
 
 	for b.Loop() {
 		for d := range 14 {

--- a/plan/day_episode.go
+++ b/plan/day_episode.go
@@ -3,7 +3,6 @@ package plan
 import (
 	"fmt"
 	"slices"
-	stdtime "time"
 
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/time"
@@ -14,7 +13,7 @@ import (
 // there — a target that's circumpolar (never sets) or permanently below
 // the horizon (never rises). A year is comfortably longer than any real
 // periodic visibility cycle this package computes events for.
-const episodeSearchWindow = 366 * 24 * stdtime.Hour
+const episodeSearchWindow = 366 * 24 * time.Hour
 
 // initialSearchStepDays is searchEvent's first probe width. Deliberately
 // small: the overwhelmingly common case is a rise or set within hours to
@@ -42,7 +41,7 @@ const maxEpisodeSearchSteps = 10
 // do for their specific bodies; a caller wanting that runs its own solver
 // with site.SunRiseSetThreshold()/MoonRiseSetThreshold() instead.
 func visibilityEvents(target Observable, site *Site, start, end time.Time) ([]Event, error) {
-	return NewEventSolver(15*stdtime.Minute, 1*stdtime.Second).Find(EventSpec{
+	return NewEventSolver(15*time.Minute, 1*time.Second).Find(EventSpec{
 		Family:    EventFamilyVisibility,
 		Kind:      EventAnyVisibility,
 		Target:    target,
@@ -64,15 +63,15 @@ func visibilityEvents(target Observable, site *Site, start, end time.Time) ([]Ev
 // calendar day is measured in; site's location (via site.Location()) is
 // used for the geometry, and the two need not agree (a caller may
 // legitimately want "Paris's calendar day" applied to "Mauna Kea's sky").
-func DayEvents(day time.Time, loc *stdtime.Location, target Observable, site *Site) (rise, set, transit *Event, err error) {
+func DayEvents(day time.Time, loc *time.Location, target Observable, site *Site) (rise, set, transit *Event, err error) {
 	if loc == nil {
-		loc = stdtime.UTC
+		loc = time.LocationUTC
 	}
 
 	local := day.GoTime().In(loc)
 	y, m, d := local.Date()
 
-	start := time.FromGo(stdtime.Date(y, m, d, 0, 0, 0, 0, loc))
+	start := time.FromGo(time.GoDate(y, m, d, 0, 0, 0, 0, loc))
 	end := start.AddDays(1)
 
 	events, err := visibilityEvents(target, site, start, end)

--- a/plan/day_episode_test.go
+++ b/plan/day_episode_test.go
@@ -3,7 +3,6 @@ package plan
 import (
 	"errors"
 	"fmt"
-	stdtime "time"
 
 	"testing"
 
@@ -23,7 +22,7 @@ func TestDayEventsFindsSunRiseSetTransit(t *testing.T) {
 
 	day := time.FromJD(2451545.0, time.UTC) // any instant on the day in question
 
-	rise, set, transit, err := DayEvents(day, stdtime.UTC, sun, site)
+	rise, set, transit, err := DayEvents(day, time.LocationUTC, sun, site)
 	testutil.AssertNoError(t, err)
 
 	if rise == nil || set == nil || transit == nil {
@@ -47,7 +46,7 @@ func TestDayEventsUsesLocalCalendarDay(t *testing.T) {
 	// already 2000-01-01 19:30 the PREVIOUS day in a UTC-5 zone -- pick an
 	// instant where the local calendar date genuinely differs from UTC's.
 	utcMidnight30 := time.FromJD(2451544.5+0.5/24, time.UTC) // 2000-01-01 00:30 UTC
-	utcMinus5 := stdtime.FixedZone("UTC-5", -5*3600)
+	utcMinus5 := time.FixedZone("UTC-5", -5*3600)
 
 	_, _, _, err := DayEvents(utcMidnight30, utcMinus5, sun, site)
 	testutil.AssertNoError(t, err)
@@ -57,7 +56,7 @@ func TestDayEventsUsesLocalCalendarDay(t *testing.T) {
 	// function itself relies on, so this test would fail loudly if that
 	// assumption were ever wrong.
 	localDate := utcMidnight30.GoTime().In(utcMinus5)
-	utcDate := utcMidnight30.GoTime().In(stdtime.UTC)
+	utcDate := utcMidnight30.GoTime().In(time.LocationUTC)
 
 	if localDate.Day() == utcDate.Day() {
 		t.Fatal("test fixture assumption broken: local and UTC calendar days should differ at this instant")
@@ -74,7 +73,7 @@ func TestDayEventsNilLocDefaultsToUTC(t *testing.T) {
 	withNil, _, _, err := DayEvents(day, nil, sun, site)
 	testutil.AssertNoError(t, err)
 
-	withUTC, _, _, err := DayEvents(day, stdtime.UTC, sun, site)
+	withUTC, _, _, err := DayEvents(day, time.LocationUTC, sun, site)
 	testutil.AssertNoError(t, err)
 
 	if withNil == nil || withUTC == nil {
@@ -82,7 +81,7 @@ func TestDayEventsNilLocDefaultsToUTC(t *testing.T) {
 	}
 
 	if !withNil.Time.Equal(withUTC.Time) {
-		t.Errorf("nil loc should behave exactly like stdtime.UTC; got %v vs %v", withNil.Time, withUTC.Time)
+		t.Errorf("nil loc should behave exactly like time.LocationUTC; got %v vs %v", withNil.Time, withUTC.Time)
 	}
 }
 
@@ -95,7 +94,7 @@ func TestDayEventsPolarNight(t *testing.T) {
 
 	day := time.FromJD(2451727.5, time.UTC) // known midwinter date, per existing TestSunEvents_Polar
 
-	rise, set, _, err := DayEvents(day, stdtime.UTC, sun, site)
+	rise, set, _, err := DayEvents(day, time.LocationUTC, sun, site)
 	testutil.AssertNoError(t, err)
 
 	if rise != nil || set != nil {
@@ -190,7 +189,7 @@ func TestEpisodeExtendsBackwardWhenAlreadyUp(t *testing.T) {
 		t.Fatal("test setup: expected a real sunrise in the wide window")
 	}
 
-	from := realRise.Time.Add(2 * stdtime.Hour)
+	from := realRise.Time.Add(2 * time.Hour)
 	to := from.AddDays(1)
 
 	up, err := isAboveHorizon(sun, site, from)
@@ -251,8 +250,8 @@ func TestEpisodeExtendsForwardPastWindowEnd(t *testing.T) {
 
 	// End the window 1 hour before the real set, so the episode is still
 	// open at `to`.
-	from := realRise.Time.Add(1 * stdtime.Hour)
-	to := realSet.Time.Add(-1 * stdtime.Hour)
+	from := realRise.Time.Add(1 * time.Hour)
+	to := realSet.Time.Add(-1 * time.Hour)
 
 	rise, set, err := Episode(from, to, sun, site)
 	testutil.AssertNoError(t, err)
@@ -370,7 +369,7 @@ func TestDayEventsPropagatesVisibilityError(t *testing.T) {
 
 	day := time.FromJD(2451545.0, time.UTC)
 
-	_, _, _, err := DayEvents(day, stdtime.UTC, errObservable{}, site)
+	_, _, _, err := DayEvents(day, time.LocationUTC, errObservable{}, site)
 	if !errors.Is(err, errAlwaysFails) {
 		t.Fatalf("expected errAlwaysFails, got %v", err)
 	}

--- a/plan/nasa_eclipse_test.go
+++ b/plan/nasa_eclipse_test.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
@@ -141,7 +140,7 @@ func parseNASALunarEclipses(html string) []nasaEclipseRef {
 		if isJulianCal {
 			jdTD = time.DateJulianCal(year, month, day, hour, minute, sec).JD()
 		} else {
-			jdTD = time.Date(year, gotime.Month(month), day, hour, minute, sec, 0, gotime.UTC).JD()
+			jdTD = time.Date(year, time.Month(month), day, hour, minute, sec, 0, time.LocationUTC).JD()
 		}
 
 		eclipses = append(eclipses, nasaEclipseRef{
@@ -242,7 +241,7 @@ func parseNASASolarEclipses(html string) []nasaEclipseRef {
 		if isJulianCal {
 			jdTD = time.DateJulianCal(year, month, day, hour, minute, sec).JD()
 		} else {
-			jdTD = time.Date(year, gotime.Month(month), day, hour, minute, sec, 0, gotime.UTC).JD()
+			jdTD = time.Date(year, time.Month(month), day, hour, minute, sec, 0, time.LocationUTC).JD()
 		}
 
 		eclipses = append(eclipses, nasaEclipseRef{
@@ -280,7 +279,7 @@ func requireNASA(t *testing.T) {
 // finish within. Checking the remaining budget before each expensive step
 // turns a hard mid-request kill (a confusing goroutine-dump failure) into
 // a clean, explained skip.
-func nasaBudgetOK(t *testing.T, margin gotime.Duration) {
+func nasaBudgetOK(t *testing.T, margin time.Duration) {
 	t.Helper()
 
 	deadline, ok := t.Deadline()
@@ -288,7 +287,7 @@ func nasaBudgetOK(t *testing.T, margin gotime.Duration) {
 		return
 	}
 
-	if gotime.Until(deadline) < margin {
+	if time.Until(deadline) < margin {
 		t.Skip("not enough time left before the test binary's -timeout for this step — rerun with a longer -timeout (see this file's package doc) for full coverage")
 	}
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	stdtime "time"
-
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
@@ -48,8 +46,8 @@ func TestObservableWindows_Fixed(t *testing.T) {
 	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
 
 	start := time.FromJD(2451545.0, time.UTC) // J2000 Noon (Observable)
-	end := start.Add(1 * stdtime.Hour)
-	step := 10 * stdtime.Minute
+	end := start.Add(1 * time.Hour)
+	step := 10 * time.Minute
 
 	t.Run("ContinuousWindow", func(t *testing.T) {
 		// Altitude > 20 deg (It's at ~90 deg)
@@ -115,8 +113,8 @@ func TestObservableWindows_Grouping(t *testing.T) {
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()
-	step := 1 * stdtime.Minute
-	end := start.Add(5 * stdtime.Minute) // 6 samples: 0, 1, 2, 3, 4, 5
+	step := 1 * time.Minute
+	end := start.Add(5 * time.Minute) // 6 samples: 0, 1, 2, 3, 4, 5
 
 	// flipConstraint:
 	// t=0: count=1, fail
@@ -402,18 +400,18 @@ func TestObservableWindows_StepTooLarge(t *testing.T) {
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()
-	end := start.Add(6 * stdtime.Hour)
+	end := start.Add(6 * time.Hour)
 
 	// Step > 15min should return an error a caller can match via errors.Is
 	// against the documented public sentinel (R21 regression: these
 	// sentinels were declared and wrapped but never verified reachable).
-	_, err := ObservableWindows(obj, start, end, 30*stdtime.Minute, site, Altitude{Threshold: angle.Deg(30)})
+	_, err := ObservableWindows(obj, start, end, 30*time.Minute, site, Altitude{Threshold: angle.Deg(30)})
 	if !errors.Is(err, ErrStepTooLarge) {
 		t.Errorf("expected ErrStepTooLarge for step > 15 minutes, got %v", err)
 	}
 
 	// Step <= 15min should succeed.
-	_, err = ObservableWindows(obj, start, end, 15*stdtime.Minute, site, Altitude{Threshold: angle.Deg(30)})
+	_, err = ObservableWindows(obj, start, end, 15*time.Minute, site, Altitude{Threshold: angle.Deg(30)})
 	testutil.AssertNoError(t, err)
 }
 
@@ -423,14 +421,14 @@ func TestObservableWindows_StepNotPositive(t *testing.T) {
 	obj := NewStar("T", angle.Zero(), angle.Zero())
 
 	start := time.NowUTC()
-	end := start.Add(6 * stdtime.Hour)
+	end := start.Add(6 * time.Hour)
 
 	_, err := ObservableWindows(obj, start, end, 0, site, Altitude{Threshold: angle.Deg(30)})
 	if !errors.Is(err, ErrStepNotPositive) {
 		t.Errorf("expected ErrStepNotPositive for a zero step, got %v", err)
 	}
 
-	_, err = ObservableWindows(obj, start, end, -stdtime.Minute, site, Altitude{Threshold: angle.Deg(30)})
+	_, err = ObservableWindows(obj, start, end, -time.Minute, site, Altitude{Threshold: angle.Deg(30)})
 	if !errors.Is(err, ErrStepNotPositive) {
 		t.Errorf("expected ErrStepNotPositive for a negative step, got %v", err)
 	}

--- a/plan/solver_convergence_test.go
+++ b/plan/solver_convergence_test.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/plan"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // convergenceCase is a solve whose iteration budget decides the outcome.
@@ -42,11 +41,11 @@ func convergenceCases() []convergenceCase {
 func TestFindRootReportsNonConvergence(t *testing.T) {
 	t.Parallel()
 
-	t1 := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 	t2 := t1.AddDays(1)
 
 	// A straight line crossing zero 7.3 hours in.
-	eval := plan.Evaluator(func(x atime.Time) (float64, error) {
+	eval := plan.Evaluator(func(x time.Time) (float64, error) {
 		return x.JD() - (t1.JD() + 7.3/24), nil
 	})
 
@@ -54,7 +53,7 @@ func TestFindRootReportsNonConvergence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := plan.Solver{Tolerance: gotime.Second, MaxIter: tc.maxIter}
+			s := plan.Solver{Tolerance: time.Second, MaxIter: tc.maxIter}
 
 			got, val, err := s.FindRoot(eval, t1, t2)
 
@@ -93,11 +92,11 @@ func TestFindRootReportsNonConvergence(t *testing.T) {
 func TestFindExtremumReportsNonConvergence(t *testing.T) {
 	t.Parallel()
 
-	t1 := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 	t3 := t1.AddDays(1)
 
 	// A parabola with its maximum 7.3 hours in.
-	eval := plan.Evaluator(func(x atime.Time) (float64, error) {
+	eval := plan.Evaluator(func(x time.Time) (float64, error) {
 		h := (x.JD() - t1.JD()) * 24
 
 		return -(h - 7.3) * (h - 7.3), nil
@@ -107,7 +106,7 @@ func TestFindExtremumReportsNonConvergence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := plan.Solver{Tolerance: gotime.Second, MaxIter: tc.maxIter}
+			s := plan.Solver{Tolerance: time.Second, MaxIter: tc.maxIter}
 
 			got, val, err := s.FindExtremum(eval, t1, t3, true)
 
@@ -137,10 +136,10 @@ func TestFindExtremumReportsNonConvergence(t *testing.T) {
 func TestNoConvergenceNamesWhatRanOut(t *testing.T) {
 	t.Parallel()
 
-	t1 := atime.Date(2026, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 
-	s := plan.Solver{Tolerance: gotime.Second, MaxIter: 1}
-	eval := plan.Evaluator(func(x atime.Time) (float64, error) {
+	s := plan.Solver{Tolerance: time.Second, MaxIter: 1}
+	eval := plan.Evaluator(func(x time.Time) (float64, error) {
 		return x.JD() - (t1.JD() + 7.3/24), nil
 	})
 

--- a/plan/solver_domain_test.go
+++ b/plan/solver_domain_test.go
@@ -4,25 +4,24 @@ import (
 	"errors"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/plan"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // solverEpoch is an arbitrary fixed start; the algorithms do not care which.
-func solverEpoch() astrotime.Time {
-	return astrotime.FromGo(gotime.Date(2026, 8, 21, 0, 0, 0, 0, gotime.UTC))
+func solverEpoch() time.Time {
+	return time.FromGo(time.GoDate(2026, 8, 21, 0, 0, 0, 0, time.LocationUTC))
 }
 
 // atHours turns a time into hours since solverEpoch, so an evaluator can be
 // written as an ordinary function of a real variable.
-func atHours(t astrotime.Time) float64 {
-	return float64(t.Sub(solverEpoch())) / float64(astrotime.Hour)
+func atHours(t time.Time) float64 {
+	return float64(t.Sub(solverEpoch())) / float64(time.Hour)
 }
 
-func plusHours(h float64) astrotime.Time {
-	return solverEpoch().Add(astrotime.Duration(h * float64(astrotime.Hour)))
+func plusHours(h float64) time.Time {
+	return solverEpoch().Add(time.Duration(h * float64(time.Hour)))
 }
 
 // errEvaluator stands in for whatever an ephemeris lookup can fail with.
@@ -52,7 +51,7 @@ func TestFindRootRefusesAnUnbracketedInterval(t *testing.T) {
 	} {
 		// A straight line through the two endpoint values, so the evaluator
 		// genuinely has those signs everywhere between them.
-		eval := func(at astrotime.Time) (float64, error) {
+		eval := func(at time.Time) (float64, error) {
 			h := atHours(at)
 
 			return c.fa + (c.fb-c.fa)*(h/6), nil
@@ -73,7 +72,7 @@ func TestFindRootRefusesAnUnbracketedInterval(t *testing.T) {
 		{"root at the start", 0, 5},
 		{"root at the end", -5, 0},
 	} {
-		eval := func(at astrotime.Time) (float64, error) {
+		eval := func(at time.Time) (float64, error) {
 			h := atHours(at)
 
 			return c.fa + (c.fb-c.fa)*(h/6), nil
@@ -91,7 +90,7 @@ func TestFindRootRefusesAnUnbracketedInterval(t *testing.T) {
 func TestFindRootLandsOnKnownRoots(t *testing.T) {
 	t.Parallel()
 
-	solver := plan.Solver{Tolerance: astrotime.Second / 1000, MaxIter: 200}
+	solver := plan.Solver{Tolerance: time.Second / 1000, MaxIter: 200}
 
 	for _, c := range []struct {
 		name string
@@ -105,7 +104,7 @@ func TestFindRootLandsOnKnownRoots(t *testing.T) {
 		{"root at the very start", 0, func(h float64) float64 { return h }},
 		{"root at the very end", 12, func(h float64) float64 { return h - 12 }},
 	} {
-		eval := func(at astrotime.Time) (float64, error) { return c.f(atHours(at)), nil }
+		eval := func(at time.Time) (float64, error) { return c.f(atHours(at)), nil }
 
 		got, value, err := solver.FindRoot(eval, solverEpoch(), plusHours(12))
 		if err != nil {
@@ -131,7 +130,7 @@ func TestFindRootPropagatesFailure(t *testing.T) {
 
 	// Failing at the very first evaluation.
 	_, _, err := solver.FindRoot(
-		func(astrotime.Time) (float64, error) { return 0, errEvaluator },
+		func(time.Time) (float64, error) { return 0, errEvaluator },
 		solverEpoch(), plusHours(6))
 	if !errors.Is(err, errEvaluator) {
 		t.Errorf("a failing evaluator gave err = %v, want the evaluator's own error", err)
@@ -142,7 +141,7 @@ func TestFindRootPropagatesFailure(t *testing.T) {
 	// NaN passes convergence tests that a real value would not.
 	for _, bad := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
 		calls := 0
-		eval := func(at astrotime.Time) (float64, error) {
+		eval := func(at time.Time) (float64, error) {
 			calls++
 			if calls > 2 {
 				return bad, nil
@@ -162,7 +161,7 @@ func TestFindRootPropagatesFailure(t *testing.T) {
 func TestFindExtremumLandsOnKnownExtrema(t *testing.T) {
 	t.Parallel()
 
-	solver := plan.Solver{Tolerance: astrotime.Second / 1000, MaxIter: 200}
+	solver := plan.Solver{Tolerance: time.Second / 1000, MaxIter: 200}
 
 	for _, c := range []struct {
 		name  string
@@ -188,7 +187,7 @@ func TestFindExtremumLandsOnKnownExtrema(t *testing.T) {
 			func(h float64) float64 { return 1 - math.Pow(h-4, 4)/100 },
 		},
 	} {
-		eval := func(at astrotime.Time) (float64, error) { return c.f(atHours(at)), nil }
+		eval := func(at time.Time) (float64, error) { return c.f(atHours(at)), nil }
 
 		got, value, err := solver.FindExtremum(eval, solverEpoch(), plusHours(12), c.isMax)
 		if err != nil {

--- a/plan/visibility.go
+++ b/plan/visibility.go
@@ -2,7 +2,6 @@ package plan
 
 import (
 	"fmt"
-	stdtime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
@@ -109,14 +108,14 @@ func VisibleIntervals(
 	obj coord.Object,
 	site *Site,
 	start, end time.Time,
-	step stdtime.Duration,
+	step time.Duration,
 	minAlt angle.Angle,
 ) ([]Interval, error) {
 	if step <= 0 {
-		step = 5 * stdtime.Minute
+		step = 5 * time.Minute
 	}
 
-	if step > 15*stdtime.Minute {
+	if step > 15*time.Minute {
 		return nil, fmt.Errorf("%w: %v", ErrStepTooLarge, step)
 	}
 
@@ -187,7 +186,7 @@ func VisibleIntervals(
 //  1. Coarse 10-min grid scan to bracket the maximum.
 //  2. Brent's minimization (via Solver) within the bracket for sub-second precision.
 func TransitEstimate(obj coord.Object, site *Site, start, end time.Time) (time.Time, angle.Angle, error) {
-	const coarseStep = 10 * stdtime.Minute
+	const coarseStep = 10 * time.Minute
 
 	// Stage 1: coarse scan to locate the bracket [tLeft, tRight] around the peak.
 	type sample struct {
@@ -286,13 +285,13 @@ func Find(
 	site *Site,
 	constraints []Constraint,
 	start, end time.Time,
-	step stdtime.Duration,
+	step time.Duration,
 ) ([]Interval, error) {
 	if step <= 0 {
-		step = 5 * stdtime.Minute
+		step = 5 * time.Minute
 	}
 
-	if step > 15*stdtime.Minute {
+	if step > 15*time.Minute {
 		return nil, fmt.Errorf("%w: %v", ErrStepTooLarge, step)
 	}
 

--- a/plan/visibility_test.go
+++ b/plan/visibility_test.go
@@ -3,7 +3,6 @@ package plan
 import (
 	"errors"
 	"testing"
-	stdtime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
@@ -64,7 +63,7 @@ func TestVisibleIntervals(t *testing.T) {
 	// Circumpolar-like object (very high dec)
 	obj := mockObject{pos: coord.NewICRS(angle.Deg(0), angle.Deg(89))}
 
-	intervals, err := VisibleIntervals(obj, site, start, end, 15*stdtime.Minute, angle.Deg(10))
+	intervals, err := VisibleIntervals(obj, site, start, end, 15*time.Minute, angle.Deg(10))
 	testutil.AssertNoError(t, err)
 
 	if len(intervals) == 0 {
@@ -83,7 +82,7 @@ func TestVisibleIntervals_StepTooLarge(t *testing.T) {
 
 	// A caller must be able to match this via errors.Is against the
 	// documented public sentinel (R21 regression).
-	_, err := VisibleIntervals(obj, site, start, end, 20*stdtime.Minute, angle.Deg(10))
+	_, err := VisibleIntervals(obj, site, start, end, 20*time.Minute, angle.Deg(10))
 	if !errors.Is(err, ErrStepTooLarge) {
 		t.Errorf("expected ErrStepTooLarge for step > 15 minutes, got %v", err)
 	}
@@ -99,7 +98,7 @@ func TestNeverVisible(t *testing.T) {
 	// Object far below horizon (antipode)
 	obj := mockObject{pos: coord.NewICRS(angle.Deg(0), angle.Deg(-89))}
 
-	intervals, err := VisibleIntervals(obj, site, start, end, 15*stdtime.Minute, angle.Deg(0))
+	intervals, err := VisibleIntervals(obj, site, start, end, 15*time.Minute, angle.Deg(0))
 	testutil.AssertNoError(t, err)
 
 	if len(intervals) > 0 {
@@ -139,7 +138,7 @@ func TestFind(t *testing.T) {
 	end := start.AddDays(1)
 	obj := mockObject{pos: coord.NewICRS(angle.Deg(100), angle.Deg(20))}
 
-	intervals, err := Find(obj, site, nil, start, end, 15*stdtime.Minute)
+	intervals, err := Find(obj, site, nil, start, end, 15*time.Minute)
 	testutil.AssertNoError(t, err)
 
 	if len(intervals) == 0 {
@@ -158,7 +157,7 @@ func TestDuration(t *testing.T) {
 	win := Window{Start: start, End: end}
 
 	dur := win.Duration()
-	if dur != 24*stdtime.Hour {
+	if dur != 24*time.Hour {
 		t.Errorf("expected 24h, got %v", dur)
 	}
 }

--- a/plan/window_algebra_test.go
+++ b/plan/window_algebra_test.go
@@ -3,15 +3,14 @@ package plan_test
 import (
 	"math/rand/v2"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/plan"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // base is an arbitrary fixed epoch; the algebra does not care which.
-func base() astrotime.Time {
-	return astrotime.FromGo(gotime.Date(2026, 8, 21, 0, 0, 0, 0, gotime.UTC))
+func base() time.Time {
+	return time.FromGo(time.GoDate(2026, 8, 21, 0, 0, 0, 0, time.LocationUTC))
 }
 
 // win builds a window from two hour offsets.
@@ -19,8 +18,8 @@ func win(fromHours, toHours float64) plan.Window {
 	b := base()
 
 	return plan.Window{
-		Start: b.Add(astrotime.Duration(fromHours * float64(astrotime.Hour))),
-		End:   b.Add(astrotime.Duration(toHours * float64(astrotime.Hour))),
+		Start: b.Add(time.Duration(fromHours * float64(time.Hour))),
+		End:   b.Add(time.Duration(toHours * float64(time.Hour))),
 	}
 }
 
@@ -49,7 +48,7 @@ func randomSet(r *rand.Rand, n int) []plan.Window {
 
 // total is TotalDuration in hours, for readable failure messages.
 func totalHours(ws []plan.Window) float64 {
-	return float64(plan.TotalDuration(ws)) / float64(astrotime.Hour)
+	return float64(plan.TotalDuration(ws)) / float64(time.Hour)
 }
 
 // Union must produce a normalized set: sorted, pairwise disjoint, covering

--- a/plan/window_test.go
+++ b/plan/window_test.go
@@ -1,8 +1,6 @@
 package plan
 
 import (
-	stdtime "time"
-
 	"testing"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
@@ -17,8 +15,8 @@ var t0 = time.FromJD(2451545.0, time.UTC) //nolint:gochecknoglobals // test fixt
 // h builds a Window [t0+startH, t0+endH] hours from the fixture base.
 func h(startH, endH float64) Window {
 	return Window{
-		Start: t0.Add(stdtime.Duration(startH * float64(stdtime.Hour))),
-		End:   t0.Add(stdtime.Duration(endH * float64(stdtime.Hour))),
+		Start: t0.Add(time.Duration(startH * float64(time.Hour))),
+		End:   t0.Add(time.Duration(endH * float64(time.Hour))),
 	}
 }
 
@@ -350,21 +348,21 @@ func TestTotalDuration(t *testing.T) {
 
 	t.Run("single window", func(t *testing.T) {
 		got := TotalDuration([]Window{h(0, 2)})
-		if got != 2*stdtime.Hour {
+		if got != 2*time.Hour {
 			t.Errorf("got %v, want 2h", got)
 		}
 	})
 
 	t.Run("disjoint windows sum", func(t *testing.T) {
 		got := TotalDuration([]Window{h(0, 1), h(2, 4)})
-		if got != 3*stdtime.Hour {
+		if got != 3*time.Hour {
 			t.Errorf("got %v, want 3h", got)
 		}
 	})
 
 	t.Run("overlapping windows are not double-counted", func(t *testing.T) {
 		got := TotalDuration([]Window{h(0, 2), h(1, 3)})
-		if got != 3*stdtime.Hour {
+		if got != 3*time.Hour {
 			t.Errorf("got %v, want 3h (union, not 4h)", got)
 		}
 	})
@@ -398,7 +396,7 @@ func TestSubtractIntersectPartitionUnion(t *testing.T) {
 			remaining := TotalDuration(Subtract(c.a, c.b))
 
 			testutil.AssertNear(t, "removed+remaining vs total",
-				float64(removed+remaining), float64(total), float64(stdtime.Microsecond))
+				float64(removed+remaining), float64(total), float64(time.Microsecond))
 		})
 	}
 }

--- a/remote/api/client.go
+++ b/remote/api/client.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/url"
 	"sync"
-	"time"
 
 	"resty.dev/v3"
 
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // DefaultTimeout applies to an endpoint whose registered Timeout is zero.
@@ -107,7 +107,7 @@ type Client struct {
 	// minimum interval was asked for, so an ordinary client pays nothing.
 	minInterval time.Duration
 	mu          sync.Mutex
-	last        time.Time
+	last        time.GoTime
 }
 
 // NewClient builds a client configured from endpoint id: its registered

--- a/remote/api/client_test.go
+++ b/remote/api/client_test.go
@@ -10,10 +10,10 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // redirect points an endpoint at a test server for one test. Every method

--- a/remote/api/pace_test.go
+++ b/remote/api/pace_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // A paced client must actually wait, and must not let concurrent callers
@@ -22,7 +22,7 @@ import (
 func TestMinIntervalPacesAndSerialises(t *testing.T) {
 	var (
 		mu     sync.Mutex
-		starts []time.Time
+		starts []time.GoTime
 	)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/remote/endpoint.go
+++ b/remote/endpoint.go
@@ -1,8 +1,8 @@
 package remote
 
 import (
+	"github.com/TuSKan/astrogo/time"
 	"os"
-	"time"
 )
 
 // EndpointID names a remote service astrogo can contact. The set below is

--- a/remote/endpoint.go
+++ b/remote/endpoint.go
@@ -1,8 +1,9 @@
 package remote
 
 import (
-	"github.com/TuSKan/astrogo/time"
 	"os"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // EndpointID names a remote service astrogo can contact. The set below is

--- a/remote/eop.go
+++ b/remote/eop.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // eopLoader supplies IERS finals2000A data to astrogo/time.
@@ -26,29 +26,29 @@ type eopLoader struct{}
 // which a hand-pre-seeded file never has. Reading the cache object
 // directly is what finds a file copied in by hand for an offline or
 // air-gapped deployment.
-func (eopLoader) Cached(ctx context.Context) (atime.EOPData, error) {
+func (eopLoader) Cached(ctx context.Context) (time.EOPData, error) {
 	bucket, prefix, err := CacheDir(ctx, IERSFinals2000A)
 	if err != nil {
-		return atime.EOPData{}, atime.ErrNoEOPData
+		return time.EOPData{}, time.ErrNoEOPData
 	}
 
 	key := prefix + eopCacheName
 
 	attrs, err := bucket.Attributes(ctx, key)
 	if err != nil {
-		return atime.EOPData{}, atime.ErrNoEOPData
+		return time.EOPData{}, time.ErrNoEOPData
 	}
 
 	raw, err := bucket.ReadAll(ctx, key)
 	if err != nil {
-		return atime.EOPData{}, atime.ErrNoEOPData
+		return time.EOPData{}, time.ErrNoEOPData
 	}
 
-	return atime.EOPData{Raw: raw, ModTime: attrs.ModTime}, nil
+	return time.EOPData{Raw: raw, ModTime: attrs.ModTime}, nil
 }
 
 // Fetch downloads finals2000A.all, subject to download consent.
-func (eopLoader) Fetch(ctx context.Context) (atime.EOPData, error) {
+func (eopLoader) Fetch(ctx context.Context) (time.EOPData, error) {
 	// GetFile reuses the cache untouched when the source's current ETag
 	// shows the IERS bulletin has not changed since it was last
 	// downloaded — a content check rather than a wall-clock expiry, since
@@ -58,26 +58,26 @@ func (eopLoader) Fetch(ctx context.Context) (atime.EOPData, error) {
 	bucket, key, err := GetFile(ctx, IERSFinals2000A, "finals2000A.all",
 		WithCacheName(eopCacheName),
 		WithValidate(func(r io.Reader) error {
-			if _, perr := atime.ParseFinals2000A(r); perr != nil {
+			if _, perr := time.ParseFinals2000A(r); perr != nil {
 				return fmt.Errorf("remote: EOP data does not parse: %w", perr)
 			}
 
 			return nil
 		}))
 	if err != nil {
-		return atime.EOPData{}, fmt.Errorf("remote: fetch EOP data: %w", err)
+		return time.EOPData{}, fmt.Errorf("remote: fetch EOP data: %w", err)
 	}
 
 	raw, err := bucket.ReadAll(ctx, key)
 	if err != nil {
-		return atime.EOPData{}, fmt.Errorf("remote: read EOP data: %w", err)
+		return time.EOPData{}, fmt.Errorf("remote: read EOP data: %w", err)
 	}
 
-	return atime.EOPData{Raw: raw}, nil
+	return time.EOPData{Raw: raw}, nil
 }
 
 // eopCacheName is the name finals2000A.all is cached under.
 const eopCacheName = "finals2000A.data"
 
 //nolint:gochecknoinits // the registration this package exists to provide
-func init() { atime.RegisterEOPLoader(eopLoader{}) }
+func init() { time.RegisterEOPLoader(eopLoader{}) }

--- a/remote/eop_test.go
+++ b/remote/eop_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote/file"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // sampleFinals2000A mimics finals2000A.all format for two consecutive
@@ -56,7 +56,7 @@ func scratchCache(t *testing.T) {
 	t.Cleanup(func() {
 		SetDataDir("")
 		Reset()
-		atime.ResetEOP()
+		time.ResetEOP()
 	})
 }
 
@@ -70,7 +70,7 @@ func TestEOPLoaderFetchesAndParses(t *testing.T) {
 		t.Fatalf("Fetch: %v", err)
 	}
 
-	if _, err := atime.ParseFinals2000A(bytes.NewReader(data.Raw)); err != nil {
+	if _, err := time.ParseFinals2000A(bytes.NewReader(data.Raw)); err != nil {
 		t.Fatalf("fetched bytes do not parse as finals2000A: %v", err)
 	}
 }
@@ -159,8 +159,8 @@ func TestEOPLoaderRejectsCorruptDownload(t *testing.T) {
 		t.Error("a corrupt download must not be cached")
 	}
 
-	if _, ok := atime.GetModel().(atime.ZeroModel); !ok {
-		t.Errorf("model must be unchanged after a rejected download, got %T", atime.GetModel())
+	if _, ok := time.GetModel().(time.ZeroModel); !ok {
+		t.Errorf("model must be unchanged after a rejected download, got %T", time.GetModel())
 	}
 }
 
@@ -199,7 +199,7 @@ func TestEOPLoaderCachedReportsNoDataWhenEmpty(t *testing.T) {
 	scratchCache(t)
 
 	_, err := eopLoader{}.Cached(context.Background())
-	if !errors.Is(err, atime.ErrNoEOPData) {
+	if !errors.Is(err, time.ErrNoEOPData) {
 		t.Fatalf("Cached with an empty cache = %v, want ErrNoEOPData", err)
 	}
 }
@@ -248,9 +248,9 @@ func TestInitRegistersTheLoader(t *testing.T) {
 	// Nothing here registers a loader: if init did not, this reports
 	// ErrNoEOPLoader instead of finding the file above.
 	// MJD 41684 as a JD, on the UTC scale.
-	atime.FromJD(41684+2400000.5, atime.UTC).EOP()
+	time.FromJD(41684+2400000.5, time.UTC).EOP()
 
-	if got := atime.EOPSource(); got != "cache" {
+	if got := time.EOPSource(); got != "cache" {
 		t.Errorf("EOPSource = %q, want %q", got, "cache")
 	}
 }

--- a/remote/fetch.go
+++ b/remote/fetch.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"time"
 
 	"gocloud.dev/gcerrors"
 
 	"github.com/TuSKan/astrogo/remote/file"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // readConfig carries per-GetFile options.

--- a/remote/file/readerat_test.go
+++ b/remote/file/readerat_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/TuSKan/astrogo/time"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // payload is deterministic and longer than several chunks at the sizes the

--- a/remote/file/readerat_test.go
+++ b/remote/file/readerat_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/TuSKan/astrogo/time"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 // payload is deterministic and longer than several chunks at the sizes the
@@ -158,7 +158,7 @@ func TestReaderAtOverHTTPBucket(t *testing.T) {
 	data := payload(1000)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeContent(w, r, "obj", time.Time{}, bytes.NewReader(data))
+		http.ServeContent(w, r, "obj", time.GoTime{}, bytes.NewReader(data))
 	}))
 	defer srv.Close()
 

--- a/remote/httpsource_test.go
+++ b/remote/httpsource_test.go
@@ -10,9 +10,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
 )
 
 var errRejectEverything = errors.New("rejected by test validator")

--- a/remote/lock_resume.go
+++ b/remote/lock_resume.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"time"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 
 	"github.com/TuSKan/astrogo/remote/file"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // sourceETagKey is the blob metadata entry recording the source ETag a

--- a/remote/lock_test.go
+++ b/remote/lock_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/remote/file"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestGetFileConcurrentSameDestNoCorruption is a regression test for a real

--- a/remote/singlekey_test.go
+++ b/remote/singlekey_test.go
@@ -3,12 +3,13 @@ package remote
 import (
 	"bytes"
 	"context"
-	"github.com/TuSKan/astrogo/time"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // A KindFile endpoint's URL is a bucket root, and the caller's name

--- a/remote/singlekey_test.go
+++ b/remote/singlekey_test.go
@@ -3,12 +3,12 @@ package remote
 import (
 	"bytes"
 	"context"
+	"github.com/TuSKan/astrogo/time"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 )
 
 // A KindFile endpoint's URL is a bucket root, and the caller's name

--- a/skybrightness/artificial_component.go
+++ b/skybrightness/artificial_component.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -91,7 +91,7 @@ func WithEscapeElevation(e angle.Angle) ArtificialOption {
 // but not on the viewing direction.
 type artificialGeometry struct {
 	observer *coord.Geodetic
-	at       time.Time
+	at       time.GoTime
 	grid     unit.SpectralGrid
 
 	sources []artificialSource

--- a/skybrightness/artificial_component_test.go
+++ b/skybrightness/artificial_component_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -66,7 +66,7 @@ func artificialScene(t *testing.T) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 3, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 3, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 	}
 }
@@ -457,7 +457,7 @@ func BenchmarkArtificialSkyglow(b *testing.B) {
 
 	scene := &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 3, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 3, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 	}
 
@@ -509,7 +509,7 @@ func TestArtificialSkyglowPhaseWeighting(t *testing.T) {
 
 	scene := &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 3, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 3, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 	}
 

--- a/skybrightness/bench_test.go
+++ b/skybrightness/bench_test.go
@@ -3,7 +3,6 @@ package skybrightness_test
 import (
 	"context"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/atmosphere"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/optics"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -211,7 +211,7 @@ func BenchmarkInstrumentProjection(b *testing.B) {
 
 // benchTime and benchAtmosphere keep the benchmark scene fixed, so the
 // numbers compare across runs.
-var benchTime = gotime.Date(2026, 8, 14, 3, 0, 0, 0, gotime.UTC)
+var benchTime = time.GoDate(2026, 8, 14, 3, 0, 0, 0, time.LocationUTC)
 
 func benchAtmosphere(heightM float64) *atmosphere.Atmosphere {
 	return atmosphere.StandardDefault(heightM)

--- a/skybrightness/cloudy_test.go
+++ b/skybrightness/cloudy_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -65,7 +65,7 @@ func cloudyScene(tb testing.TB, baseM, albedo float64) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   observer,
-		Time:       gotime.Date(2026, 3, 20, 3, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 20, 3, 0, 0, 0, time.LocationUTC),
 		Atmosphere: air,
 	}
 }

--- a/skybrightness/cloudy_validation_test.go
+++ b/skybrightness/cloudy_validation_test.go
@@ -5,12 +5,12 @@ package skybrightness_test
 import (
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -102,7 +102,7 @@ func zilinaScene(tb testing.TB, cover float64) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   observer,
-		Time:       gotime.Date(2026, 3, 20, 3, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 20, 3, 0, 0, 0, time.LocationUTC),
 		Atmosphere: air,
 	}
 }

--- a/skybrightness/component_audit_test.go
+++ b/skybrightness/component_audit_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -35,7 +35,7 @@ func auditScene(t *testing.T) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 20, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 20, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 		Ephemeris:  eph.Default(),
 	}

--- a/skybrightness/dataset/aerosol.go
+++ b/skybrightness/dataset/aerosol.go
@@ -3,11 +3,11 @@ package dataset
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/atmosphere/dataset/cams"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // AerosolPreset is one of [atmosphere]'s OPAC-sourced aerosol constructors —
@@ -57,7 +57,7 @@ type AerosolPreset func(heightM, aod550 float64) *atmosphere.Builder
 func LiveAerosol(
 	ctx context.Context,
 	site *coord.Geodetic,
-	when time.Time,
+	when time.GoTime,
 	preset AerosolPreset,
 ) (*atmosphere.Builder, error) {
 	if site == nil {

--- a/skybrightness/dataset/airglow/airglow_network_test.go
+++ b/skybrightness/dataset/airglow/airglow_network_test.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The whole provider, against the real service.

--- a/skybrightness/dataset/airglow/almanac.go
+++ b/skybrightness/dataset/airglow/almanac.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Almanac is what SkyCalc's almanac knows about an instant that an airglow
@@ -79,7 +79,7 @@ type Almanac struct {
 // One small JSON call against a service this package already talks to, and
 // the answer for a past month never changes — but a caller assembling one
 // scene makes this call once, so there is nothing here worth the cache key.
-func AlmanacAt(ctx context.Context, when time.Time, obs Observatory) (Almanac, error) {
+func AlmanacAt(ctx context.Context, when time.GoTime, obs Observatory) (Almanac, error) {
 	if obs == "" {
 		obs = Paranal
 	}

--- a/skybrightness/dataset/airglow/almanac_network_test.go
+++ b/skybrightness/dataset/airglow/almanac_network_test.go
@@ -5,10 +5,10 @@ package airglow_test
 import (
 	"context"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The almanac's solar flux tracks the real solar cycle.
@@ -29,13 +29,13 @@ func TestAlmanacFluxFollowsTheSolarCycle(t *testing.T) {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 
 	quiet, err := airglow.AlmanacAt(context.Background(),
-		gotime.Date(2020, gotime.June, 15, 2, 0, 0, 0, gotime.UTC), airglow.Paranal)
+		time.GoDate(2020, time.June, 15, 2, 0, 0, 0, time.LocationUTC), airglow.Paranal)
 	if err != nil {
 		t.Fatalf("AlmanacAt at solar minimum: %v", err)
 	}
 
 	active, err := airglow.AlmanacAt(context.Background(),
-		gotime.Date(2014, gotime.March, 10, 2, 0, 0, 0, gotime.UTC), airglow.Paranal)
+		time.GoDate(2014, time.March, 10, 2, 0, 0, 0, time.LocationUTC), airglow.Paranal)
 	if err != nil {
 		t.Fatalf("AlmanacAt at solar maximum: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestAlmanacFluxFollowsTheSolarCycle(t *testing.T) {
 func TestAlmanacReportsAnUnpublishedMonthAsUnset(t *testing.T) {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 
-	got, err := airglow.AlmanacAt(context.Background(), gotime.Now().UTC(), airglow.Paranal)
+	got, err := airglow.AlmanacAt(context.Background(), time.Now().UTC(), airglow.Paranal)
 	if err != nil {
 		t.Fatalf("AlmanacAt for the current month: %v", err)
 	}

--- a/skybrightness/dataset/airglow/almanac_test.go
+++ b/skybrightness/dataset/airglow/almanac_test.go
@@ -2,10 +2,10 @@ package airglow
 
 import (
 	"errors"
+	"github.com/TuSKan/astrogo/time"
 	"math"
 	"strings"
 	"testing"
-	gotime "time"
 )
 
 // The almanac's own "no data" sentinel becomes this package's "unset".
@@ -117,6 +117,6 @@ func TestAlmanacAtRefusesAnUnknownObservatory(t *testing.T) {
 
 // timeFixture is any instant; the refusal under test happens before the date
 // is used.
-func timeFixture() gotime.Time {
-	return gotime.Date(2020, gotime.June, 15, 2, 0, 0, 0, gotime.UTC)
+func timeFixture() time.GoTime {
+	return time.GoDate(2020, time.June, 15, 2, 0, 0, 0, time.LocationUTC)
 }

--- a/skybrightness/dataset/airglow/almanac_test.go
+++ b/skybrightness/dataset/airglow/almanac_test.go
@@ -2,10 +2,11 @@ package airglow
 
 import (
 	"errors"
-	"github.com/TuSKan/astrogo/time"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The almanac's own "no data" sentinel becomes this package's "unset".

--- a/skybrightness/dataset/crosssection/ozone_network_test.go
+++ b/skybrightness/dataset/crosssection/ozone_network_test.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/crosssection"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 

--- a/skybrightness/dataset/dust/dust.go
+++ b/skybrightness/dataset/dust/dust.go
@@ -33,12 +33,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
 	"github.com/TuSKan/astrogo/remote/file"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Sentinel errors for the dust provider.

--- a/skybrightness/dataset/dust/network_test.go
+++ b/skybrightness/dataset/dust/network_test.go
@@ -5,11 +5,11 @@ package dust_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The real service, checked against two numbers that are properties of the

--- a/skybrightness/dataset/dust/sfd_validation_test.go
+++ b/skybrightness/dataset/dust/sfd_validation_test.go
@@ -8,12 +8,12 @@ import (
 	"math"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The local all-sky map reproduces what IRSA answers for the same directions.

--- a/skybrightness/dataset/sky.go
+++ b/skybrightness/dataset/sky.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -13,6 +12,7 @@ import (
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -169,7 +169,7 @@ func consentAdvice(p skybrightness.Preset, err error) error {
 // named call the caller makes is better than either, and
 // SurfaceAtAltitude(site.Height()) is not the kind of line anyone gets wrong.
 func (s *Sky) Scene(
-	site *coord.Geodetic, when time.Time, air *atmosphere.Builder,
+	site *coord.Geodetic, when time.GoTime, air *atmosphere.Builder,
 ) (*skybrightness.Scene, error) {
 	if site == nil {
 		return nil, fmt.Errorf("%w: a scene needs a site", ErrSpec)

--- a/skybrightness/dataset/sky_test.go
+++ b/skybrightness/dataset/sky_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -14,6 +13,7 @@ import (
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness"
 	"github.com/TuSKan/astrogo/skybrightness/dataset"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -66,7 +66,7 @@ func TestLiveAerosolRefusesAnIncompleteRequest(t *testing.T) {
 			t.Parallel()
 
 			_, err := dataset.LiveAerosol(context.Background(), c.site,
-				gotime.Date(2023, 1, 1, 3, 0, 0, 0, gotime.UTC), c.preset)
+				time.GoDate(2023, 1, 1, 3, 0, 0, 0, time.LocationUTC), c.preset)
 			if !errors.Is(err, dataset.ErrSpec) {
 				t.Errorf("got %v, want ErrSpec — this must fail on the request rather "+
 					"than by reaching a service", err)
@@ -239,7 +239,7 @@ func TestOneSkyServesManySites(t *testing.T) {
 		t.Fatalf("NewSky: %v", err)
 	}
 
-	when := gotime.Date(2026, 4, 2, 5, 0, 0, 0, gotime.UTC)
+	when := time.GoDate(2026, 4, 2, 5, 0, 0, 0, time.LocationUTC)
 
 	// The same coordinates at two elevations, so the sky above them is
 	// identical and the air between is the only thing that differs.

--- a/skybrightness/dataset/solar/network_test.go
+++ b/skybrightness/dataset/solar/network_test.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/solar"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // reachable skips when STScI is down rather than failing CI for someone

--- a/skybrightness/dataset/starlight/async.go
+++ b/skybrightness/dataset/starlight/async.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // ErrAsyncJob reports that an asynchronous TAP job did not produce a result.

--- a/skybrightness/dataset/starlight/brightfetch.go
+++ b/skybrightness/dataset/starlight/brightfetch.go
@@ -9,12 +9,12 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Defaults for [FetchBrightStars], measured rather than chosen.

--- a/skybrightness/dataset/starlight/gaia.go
+++ b/skybrightness/dataset/starlight/gaia.go
@@ -9,12 +9,12 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/api"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Sentinel errors for the Gaia builder.

--- a/skybrightness/dataset/starlight/gaia_network_test.go
+++ b/skybrightness/dataset/starlight/gaia_network_test.go
@@ -8,13 +8,13 @@ import (
 	"math"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The one test that catches a malformed query.

--- a/skybrightness/dataset/starlight/validation_test.go
+++ b/skybrightness/dataset/starlight/validation_test.go
@@ -6,13 +6,13 @@ import (
 	"context"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The absolute scale of the map, bounded by numbers nobody in this repository

--- a/skybrightness/ebl_test.go
+++ b/skybrightness/ebl_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -31,7 +31,7 @@ func eblScene(t *testing.T) *Scene {
 
 	return &Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 8, 20, 23, 16, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 8, 20, 23, 16, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 	}
 }

--- a/skybrightness/fullsky_test.go
+++ b/skybrightness/fullsky_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -23,7 +23,7 @@ func (u uniformDust) IntensityAt(_, _ angle.Angle) (float64, error) { return flo
 // assembleSky builds a Model holding every component the module has, over a
 // scene at Paranal. It is the thing the engine exists to do, and until this
 // existed the components had never been run together.
-func assembleSky(t *testing.T, when gotime.Time) (*skybrightness.Model, *skybrightness.Scene, unit.SpectralGrid) {
+func assembleSky(t *testing.T, when time.GoTime) (*skybrightness.Model, *skybrightness.Scene, unit.SpectralGrid) {
 	t.Helper()
 
 	grid := skybrightness.DefaultOpticalGrid()
@@ -148,7 +148,7 @@ func TestFullSkyAssembles(t *testing.T) {
 	// A new Moon epoch, so the sky is genuinely dark and the natural terms
 	// dominate.
 	when, phase := nearFullMoonUp(t)
-	dark := when.Add(14 * 24 * gotime.Hour)
+	dark := when.Add(14 * 24 * time.Hour)
 
 	model, scene, grid := assembleSky(t, dark)
 
@@ -217,7 +217,7 @@ func TestFullSkyComponentShares(t *testing.T) {
 	t.Parallel()
 
 	when, _ := nearFullMoonUp(t)
-	model, scene, grid := assembleSky(t, when.Add(14*24*gotime.Hour))
+	model, scene, grid := assembleSky(t, when.Add(14*24*time.Hour))
 
 	est, err := model.Estimate(context.Background(), skybrightness.Query{
 		Scene:     scene,
@@ -310,7 +310,7 @@ func TestFullSkyBrightensTowardTheHorizon(t *testing.T) {
 	t.Parallel()
 
 	when, _ := nearFullMoonUp(t)
-	model, scene, grid := assembleSky(t, when.Add(14*24*gotime.Hour))
+	model, scene, grid := assembleSky(t, when.Add(14*24*time.Hour))
 
 	idx := gridIndex(t, grid, 554)
 
@@ -402,7 +402,7 @@ func TestFullSkyProvenance(t *testing.T) {
 func BenchmarkFullSkyEstimate(b *testing.B) {
 	t := &testing.T{}
 
-	when := gotime.Date(2026, 3, 3, 5, 0, 0, 0, gotime.UTC)
+	when := time.GoDate(2026, 3, 3, 5, 0, 0, 0, time.LocationUTC)
 	model, scene, grid := assembleSky(t, when)
 
 	if t.Failed() {

--- a/skybrightness/gambons_allsky_test.go
+++ b/skybrightness/gambons_allsky_test.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"sort"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -21,7 +20,7 @@ import (
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -199,7 +198,7 @@ func runAllSky(t *testing.T) allSkyRun {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 	testutil.RequireReachable(t, "github.com:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 90*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Minute)
 	defer cancel()
 
 	enableStarMapDownload(t)
@@ -226,7 +225,7 @@ func runAllSky(t *testing.T) allSkyRun {
 		galactic coord.Galactic
 	}
 
-	cc := coord.NewContext(astrotime.FromGo(scene.Time), scene.Observer,
+	cc := coord.NewContext(time.FromGo(scene.Time), scene.Observer,
 		scene.Atmosphere.Refraction())
 
 	var samples []sample
@@ -258,7 +257,7 @@ func runAllSky(t *testing.T) allSkyRun {
 		dirs = append(dirs, dust.Direction{L: s.galactic.L(), B: s.galactic.B()})
 	}
 
-	fetchStart := gotime.Now()
+	fetchStart := time.Now()
 
 	dustMap := dust.NewMap()
 
@@ -270,14 +269,14 @@ func runAllSky(t *testing.T) allSkyRun {
 			// being asked the remaining several hundred times, and a partial
 			// sky would silently bias every band it did not finish.
 			t.Skipf("IRSA stopped answering after %d of %d sightlines in %v: %v",
-				dustMap.Len(), len(dirs), gotime.Since(fetchStart).Round(gotime.Second), err)
+				dustMap.Len(), len(dirs), time.Since(fetchStart).Round(time.Second), err)
 		}
 
 		t.Logf("  dust: %d of %d sightlines (%v)", end, len(dirs),
-			gotime.Since(fetchStart).Round(gotime.Second))
+			time.Since(fetchStart).Round(time.Second))
 	}
 
-	t.Logf("fetched %d dust cells in %v", dustMap.Len(), gotime.Since(fetchStart).Round(gotime.Second))
+	t.Logf("fetched %d dust cells in %v", dustMap.Len(), time.Since(fetchStart).Round(time.Second))
 
 	// Built from the preset rather than assembled here.
 	//
@@ -304,7 +303,7 @@ func runAllSky(t *testing.T) allSkyRun {
 	// differ by airglow alone, rather than by anything a second model build
 	// might also have changed.
 	results := make([]allSkySample, 0, len(samples))
-	evalStart := gotime.Now()
+	evalStart := time.Now()
 
 	componentShare := make(map[skybrightness.ComponentID]float64)
 
@@ -361,7 +360,7 @@ func runAllSky(t *testing.T) allSkyRun {
 		}
 	}
 
-	t.Logf("evaluated %d directions in %v", len(results), gotime.Since(evalStart).Round(gotime.Second))
+	t.Logf("evaluated %d directions in %v", len(results), time.Since(evalStart).Round(time.Second))
 
 	return allSkyRun{
 		results:        results,

--- a/skybrightness/gambons_bands_test.go
+++ b/skybrightness/gambons_bands_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -16,6 +15,7 @@ import (
 	"github.com/TuSKan/astrogo/skybrightness"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/passband"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Table 2 across all five Johnson-Cousins bands, on the one ratio that can be
@@ -50,7 +50,7 @@ func TestAgainstGAMBONSTable2AcrossBands(t *testing.T) {
 	testutil.RequireReachable(t, "svo2.cab.inta-csic.es:443")
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 	defer cancel()
 
 	grid := skybrightness.DefaultOpticalGrid()

--- a/skybrightness/gambons_decompose_test.go
+++ b/skybrightness/gambons_decompose_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -17,7 +16,7 @@ import (
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -35,7 +34,7 @@ func TestGAMBONSGapDecomposition(t *testing.T) {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 	testutil.RequireReachable(t, "github.com:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
 	enableStarMapDownload(t)
@@ -46,7 +45,7 @@ func TestGAMBONSGapDecomposition(t *testing.T) {
 	zenith := coord.NewAltAz(angle.Deg(89.9), angle.Deg(0))
 
 	// ── where the zenith is pointing ────────────────────────────────────────
-	cc := coord.NewContext(astrotime.FromGo(scene.Time), scene.Observer,
+	cc := coord.NewContext(time.FromGo(scene.Time), scene.Observer,
 		scene.Atmosphere.Refraction())
 
 	icrs, err := cc.AltAzToICRS(zenith)
@@ -55,7 +54,7 @@ func TestGAMBONSGapDecomposition(t *testing.T) {
 	}
 
 	gal := coord.ICRSToGalactic(icrs)
-	ecl := coord.ICRSToEcliptic(icrs, astrotime.FromGo(scene.Time))
+	ecl := coord.ICRSToEcliptic(icrs, time.FromGo(scene.Time))
 
 	t.Logf("zenith: RA %.2f Dec %+.2f | galactic l %.2f b %+.2f | ecliptic lon %.2f lat %+.2f",
 		icrs.RA().Degrees(), icrs.Dec().Degrees(),

--- a/skybrightness/gambons_eq11_test.go
+++ b/skybrightness/gambons_eq11_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -15,6 +14,7 @@ import (
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/skybrightness"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -54,7 +54,7 @@ import (
 func TestEq11AgainstTheTable2Ratio(t *testing.T) {
 	testutil.RequireReachable(t, "github.com:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 40*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Minute)
 	defer cancel()
 
 	enableStarMapDownload(t)

--- a/skybrightness/gambons_table2_test.go
+++ b/skybrightness/gambons_table2_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -18,7 +17,7 @@ import (
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -107,7 +106,7 @@ func TestAgainstGAMBONSTable2(t *testing.T) {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 	testutil.RequireReachable(t, "github.com:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
 	defer cancel()
 
 	enableStarMapDownload(t)
@@ -149,7 +148,7 @@ func TestAgainstGAMBONSTable2(t *testing.T) {
 	dirs := make([]dust.Direction, 0, len(capDirs)*len(epochs))
 
 	for _, when := range epochs {
-		cc := coord.NewContext(astrotime.FromGo(when), site, atm.Refraction())
+		cc := coord.NewContext(time.FromGo(when), site, atm.Refraction())
 
 		for _, d := range capDirs {
 			icrs, err := cc.AltAzToICRS(d)
@@ -314,28 +313,28 @@ func table2Epochs(
 	site *coord.Geodetic,
 	provider eph.Provider,
 	atm *atmosphere.Atmosphere,
-) []gotime.Time {
+) []time.GoTime {
 	t.Helper()
 
-	var out []gotime.Time
+	var out []time.GoTime
 
 	for month := range table2Months {
 		// The fifteenth of each month, which is close enough to the middle for
 		// a yearly mean of something that varies smoothly with solar longitude.
-		day := gotime.Date(2026, gotime.Month(month+1), 15, 0, 0, 0, 0, gotime.UTC)
+		day := time.GoDate(2026, time.Month(month+1), 15, 0, 0, 0, 0, time.LocationUTC)
 
 		var found int
 
 		// Walk the night in half-hour steps and keep the hours that are dark,
 		// spread across the window rather than clustered at its start.
-		var dark []gotime.Time
+		var dark []time.GoTime
 
 		for step := range 48 {
-			when := day.Add(gotime.Duration(step*30) * gotime.Minute) //nolint:durationcheck // step*30 is a count of minutes, not a duration
+			when := day.Add(time.Duration(step*30) * time.Minute) //nolint:durationcheck // step*30 is a count of minutes, not a duration
 
-			cc := coord.NewContext(astrotime.FromGo(when), site, atm.Refraction())
+			cc := coord.NewContext(time.FromGo(when), site, atm.Refraction())
 
-			sun, err := eph.Position(provider, eph.Sun, astrotime.FromGo(when))
+			sun, err := eph.Position(provider, eph.Sun, time.FromGo(when))
 			if err != nil {
 				continue
 			}

--- a/skybrightness/gambons_table2_test.go
+++ b/skybrightness/gambons_table2_test.go
@@ -330,7 +330,9 @@ func table2Epochs(
 		var dark []time.GoTime
 
 		for step := range 48 {
-			when := day.Add(time.Duration(step*30) * time.Minute) //nolint:durationcheck // step*30 is a count of minutes, not a duration
+			// step*30 is a count of minutes, not a duration, so the
+			// multiplication is a scaling and not a duration times a duration.
+			when := day.Add(time.Duration(step*30) * time.Minute)
 
 			cc := coord.NewContext(time.FromGo(when), site, atm.Refraction())
 

--- a/skybrightness/gambons_validation_test.go
+++ b/skybrightness/gambons_validation_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -19,7 +18,7 @@ import (
 	"github.com/TuSKan/astrogo/skybrightness/dataset/airglow"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/dust"
 	"github.com/TuSKan/astrogo/skybrightness/dataset/starlight"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -56,8 +55,8 @@ func enableStarMapDownload(tb testing.TB) {
 	remote.EnableDownloads(endpoint.ApproxSize, remote.GaiaStarMap)
 }
 
-func gambonsEpoch() gotime.Time {
-	return gotime.Date(2026, 8, 20, 23, 16, 0, 0, gotime.UTC)
+func gambonsEpoch() time.GoTime {
+	return time.GoDate(2026, 8, 20, 23, 16, 0, 0, time.LocationUTC)
 }
 
 // johnsonVTophat approximates the Johnson V response.
@@ -136,7 +135,7 @@ func TestAgainstGAMBONS(t *testing.T) {
 	testutil.RequireReachable(t, "etimecalret-002.eso.org:443")
 	testutil.RequireReachable(t, "github.com:443")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*gotime.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
 	enableStarMapDownload(t)
@@ -378,7 +377,7 @@ func zenithCap(capDeg float64, samples int) []coord.AltAz {
 func capDustDirections(t *testing.T, scene *skybrightness.Scene, capDeg float64, samples int) []dust.Direction {
 	t.Helper()
 
-	cc := coord.NewContext(astrotime.FromGo(scene.Time), scene.Observer,
+	cc := coord.NewContext(time.FromGo(scene.Time), scene.Observer,
 		scene.Atmosphere.Refraction())
 
 	dirs := zenithCap(capDeg, samples)

--- a/skybrightness/model_test.go
+++ b/skybrightness/model_test.go
@@ -6,13 +6,13 @@ import (
 	"math"
 	"sync"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -79,7 +79,7 @@ func testScene(t *testing.T) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 8, 14, 3, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 8, 14, 3, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atmosphere.StandardDefault(2635),
 	}
 }
@@ -415,7 +415,7 @@ func TestNumericalStabilityAcrossGeometry(t *testing.T) {
 			est, err := m.Estimate(context.Background(), skybrightness.Query{
 				Scene: &skybrightness.Scene{
 					Observer:   loc,
-					Time:       gotime.Date(2026, 8, 14, 3, 0, 0, 0, gotime.UTC),
+					Time:       time.GoDate(2026, 8, 14, 3, 0, 0, 0, time.LocationUTC),
 					Atmosphere: atmosphere.StandardDefault(s.heightM),
 				},
 				Direction: coord.NewAltAz(angle.Deg(d.alt), angle.Deg(d.az)),

--- a/skybrightness/moonlight.go
+++ b/skybrightness/moonlight.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -14,7 +13,7 @@ import (
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 	"github.com/TuSKan/astrogo/vector"
 )
@@ -80,7 +79,7 @@ type moonScratch struct {
 // viewing direction.
 type moonGeometry struct {
 	observer *coord.Geodetic
-	at       time.Time
+	at       time.GoTime
 
 	direction  coord.AltAz
 	airmass    float64
@@ -318,7 +317,7 @@ func (m *ScatteredMoonlight) computeGeometry(scene *Scene) (*moonGeometry, error
 		return nil, ErrNoEphemeris
 	}
 
-	at := astrotime.FromGo(scene.Time)
+	at := time.FromGo(scene.Time)
 
 	moon, err := scene.Ephemeris.State(eph.Moon, at)
 	if err != nil {

--- a/skybrightness/moonlight_test.go
+++ b/skybrightness/moonlight_test.go
@@ -99,7 +99,9 @@ func nearFullMoonUp(t *testing.T) (time.GoTime, angle.Angle) {
 	)
 
 	for step := range 30 * 24 {
-		when := start.Add(time.Hour * time.Duration(step)) //nolint:durationcheck // step is a count of hours, not a duration
+		// step is a count of hours, not a duration, so the multiplication is
+		// a scaling and not a duration times a duration.
+		when := start.Add(time.Hour * time.Duration(step))
 		at := time.FromGo(when)
 
 		phase, err := magnitude.PhaseAngle(provider, eph.Moon, at)

--- a/skybrightness/moonlight_test.go
+++ b/skybrightness/moonlight_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"sync"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -14,7 +13,7 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/skybrightness"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -55,7 +54,7 @@ func solarSpectrumFixture(tb testing.TB) []float64 {
 
 // moonlightScene builds a Paranal scene at t with a clear standard
 // atmosphere and the offline SOFA ephemeris.
-func moonlightScene(t *testing.T, when gotime.Time) *skybrightness.Scene {
+func moonlightScene(t *testing.T, when time.GoTime) *skybrightness.Scene {
 	t.Helper()
 
 	loc, err := coord.NewGeodetic(angle.Deg(-70.4), angle.Deg(-24.6), 2635)
@@ -82,7 +81,7 @@ func moonlightScene(t *testing.T, when gotime.Time) *skybrightness.Scene {
 // nearFullMoonUp scans a lunation for the moment the Moon is closest to full
 // while well above the horizon at Paranal, so the absolute check below runs
 // in the geometry it is calibrated against. Deterministic and offline.
-func nearFullMoonUp(t *testing.T) (gotime.Time, angle.Angle) {
+func nearFullMoonUp(t *testing.T) (time.GoTime, angle.Angle) {
 	t.Helper()
 
 	provider := eph.Default()
@@ -92,16 +91,16 @@ func nearFullMoonUp(t *testing.T) (gotime.Time, angle.Angle) {
 		t.Fatalf("NewGeodetic: %v", err)
 	}
 
-	start := gotime.Date(2026, 3, 1, 0, 0, 0, 0, gotime.UTC)
+	start := time.GoDate(2026, 3, 1, 0, 0, 0, 0, time.LocationUTC)
 
 	var (
-		best      gotime.Time
+		best      time.GoTime
 		bestPhase = angle.Deg(360)
 	)
 
 	for step := range 30 * 24 {
-		when := start.Add(gotime.Hour * gotime.Duration(step)) //nolint:durationcheck // step is a count of hours, not a duration
-		at := astrotime.FromGo(when)
+		when := start.Add(time.Hour * time.Duration(step)) //nolint:durationcheck // step is a count of hours, not a duration
+		at := time.FromGo(when)
 
 		phase, err := magnitude.PhaseAngle(provider, eph.Moon, at)
 		if err != nil {
@@ -256,7 +255,7 @@ func TestScatteredMoonlightBelowHorizon(t *testing.T) {
 	when, _ := nearFullMoonUp(t)
 
 	// Half a day later the near-full Moon is on the other side of the Earth.
-	scene := moonlightScene(t, when.Add(12*gotime.Hour))
+	scene := moonlightScene(t, when.Add(12*time.Hour))
 
 	component, err := skybrightness.NewScatteredMoonlight(solarSpectrumFixture(t))
 	if err != nil {
@@ -346,7 +345,7 @@ func TestScatteredMoonlightCacheRespectsScene(t *testing.T) {
 	}
 
 	full := at(moonlightScene(t, when))
-	later := at(moonlightScene(t, when.Add(6*gotime.Hour)))
+	later := at(moonlightScene(t, when.Add(6*time.Hour)))
 	backAgain := at(moonlightScene(t, when))
 
 	if full == later {
@@ -495,7 +494,7 @@ func TestScatteredMoonlightProvenance(t *testing.T) {
 func moonDirection(t *testing.T, scene *skybrightness.Scene) coord.AltAz {
 	t.Helper()
 
-	at := astrotime.FromGo(scene.Time)
+	at := time.FromGo(scene.Time)
 
 	moon, err := scene.Ephemeris.State(eph.Moon, at)
 	if err != nil {
@@ -528,7 +527,7 @@ func BenchmarkScatteredMoonlight(b *testing.B) {
 
 	scene := &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 3, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 3, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 		Ephemeris:  eph.Default(),
 	}

--- a/skybrightness/natural.go
+++ b/skybrightness/natural.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -32,7 +31,7 @@ var ErrNoDustMap = errors.New("skybrightness: diffuse galactic light needs a 100
 // and rebuilds it only when the scene changes.
 type sceneFrame struct {
 	observer *coord.Geodetic
-	at       time.Time
+	at       time.GoTime
 
 	// refraction is part of the cache key, because ctx was built with it.
 	refraction atmosphere.Refraction
@@ -95,7 +94,7 @@ func newSceneFrame(scene *Scene, needSun bool) (*sceneFrame, error) {
 		return nil, err
 	}
 
-	at := astrotime.FromGo(scene.Time)
+	at := time.FromGo(scene.Time)
 
 	frame := &sceneFrame{
 		observer:   scene.Observer,
@@ -450,7 +449,7 @@ func (z *ZodiacalLight) AddRadiance(
 		return 0, fmt.Errorf("skybrightness: zodiacal: direction: %w", err)
 	}
 
-	ecliptic := coord.ICRSToEcliptic(icrs, astrotime.FromGo(scene.Time))
+	ecliptic := coord.ICRSToEcliptic(icrs, time.FromGo(scene.Time))
 
 	geom := ZodiacalGeometry{
 		DifferentialLongitude: ecliptic.Lon() - frame.sunEcliptic.Lon(),

--- a/skybrightness/plan/imaging.go
+++ b/skybrightness/plan/imaging.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -42,7 +41,7 @@ type Spec struct {
 	Instrument optics.Instrument
 
 	// Exposure is one integration.
-	Exposure gotime.Duration
+	Exposure time.Duration
 
 	// AperturePixels is how many pixels the measurement sums over — the
 	// photometric aperture, not the whole sensor.

--- a/skybrightness/plan/imaging_network_test.go
+++ b/skybrightness/plan/imaging_network_test.go
@@ -5,7 +5,6 @@ package plan_test
 import (
 	"context"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -74,7 +73,7 @@ func TestImagingDepthAgainstARealSky(t *testing.T) {
 		Site:           site,
 		Air:            atmosphere.RuralAerosol(site.Height(), atmosphere.CleanMountainAOD550),
 		Instrument:     inst,
-		Exposure:       300 * gotime.Second,
+		Exposure:       300 * time.Second,
 		AperturePixels: 9,
 		SNR:            5,
 	})
@@ -82,7 +81,7 @@ func TestImagingDepthAgainstARealSky(t *testing.T) {
 		t.Fatalf("NewImaging: %v", err)
 	}
 
-	when := time.Date(2026, gotime.March, 20, 5, 0, 0, 0, time.LocationUTC)
+	when := time.Date(2026, time.March, 20, 5, 0, 0, 0, time.LocationUTC)
 
 	zenith, err := depth.LimitingMagnitudeAt(when, angle.Deg(90), angle.Deg(0))
 	if err != nil {
@@ -149,7 +148,7 @@ func TestImagingSatisfiesThePlanningConstraint(t *testing.T) {
 
 	depth, err := sbplan.NewImaging(sbplan.Spec{
 		Sky: sky, Site: site, Instrument: inst,
-		Exposure: 300 * gotime.Second, AperturePixels: 9, SNR: 5,
+		Exposure: 300 * time.Second, AperturePixels: 9, SNR: 5,
 	})
 	if err != nil {
 		t.Fatalf("NewImaging: %v", err)
@@ -160,7 +159,7 @@ func TestImagingSatisfiesThePlanningConstraint(t *testing.T) {
 		t.Fatalf("NewSite: %v", err)
 	}
 
-	when := time.Date(2026, gotime.March, 20, 5, 0, 0, 0, time.LocationUTC)
+	when := time.Date(2026, time.March, 20, 5, 0, 0, 0, time.LocationUTC)
 
 	// A bright star, which any such instrument reaches, and an absurdly faint
 	// one, which none does. Both are above the horizon at this instant.

--- a/skybrightness/plan/imaging_test.go
+++ b/skybrightness/plan/imaging_test.go
@@ -5,12 +5,12 @@ import (
 	"math"
 	"strings"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/optics"
 	sbplan "github.com/TuSKan/astrogo/skybrightness/plan"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // The sky calibrates itself: a source producing exactly the sky's per-pixel
@@ -111,7 +111,7 @@ func TestNewImagingRefusesAnUnusableSpec(t *testing.T) {
 	base := sbplan.Spec{
 		Site:           site,
 		Instrument:     inst,
-		Exposure:       300 * gotime.Second,
+		Exposure:       300 * time.Second,
 		AperturePixels: 9,
 		SNR:            5,
 	}
@@ -129,7 +129,7 @@ func TestNewImagingRefusesAnUnusableSpec(t *testing.T) {
 		{"no sky", "dataset.Sky", func(*sbplan.Spec) {}},
 		{"no site", "site", func(s *sbplan.Spec) { s.Site = nil }},
 		{"zero exposure", "exposure", func(s *sbplan.Spec) { s.Exposure = 0 }},
-		{"negative exposure", "exposure", func(s *sbplan.Spec) { s.Exposure = -gotime.Second }},
+		{"negative exposure", "exposure", func(s *sbplan.Spec) { s.Exposure = -time.Second }},
 		{"zero aperture", "aperture", func(s *sbplan.Spec) { s.AperturePixels = 0 }},
 		{"zero threshold", "threshold", func(s *sbplan.Spec) { s.SNR = 0 }},
 		{"infinite threshold", "threshold", func(s *sbplan.Spec) { s.SNR = math.Inf(1) }},

--- a/skybrightness/preset_golden_test.go
+++ b/skybrightness/preset_golden_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -12,6 +11,7 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // goldenTol is how far a preset's output may move before this test calls it a
@@ -81,7 +81,7 @@ func presetGoldenScene(tb testing.TB, p skybrightness.Preset) *skybrightness.Sce
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 4, 2, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 4, 2, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 		Ephemeris:  eph.Default(),
 	}

--- a/skybrightness/preset_test.go
+++ b/skybrightness/preset_test.go
@@ -5,14 +5,13 @@ import (
 	"math"
 	"testing"
 
-	gotime "time"
-
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -734,7 +733,7 @@ func TestMultipleScatteringBrightensOnlyTheScatteredTerm(t *testing.T) {
 		est, err := model.WithoutPreset().Estimate(t.Context(), skybrightness.Query{
 			Scene: &skybrightness.Scene{
 				Observer:   loc,
-				Time:       gotime.Date(2026, 3, 20, 5, 0, 0, 0, gotime.UTC),
+				Time:       time.GoDate(2026, 3, 20, 5, 0, 0, 0, time.LocationUTC),
 				Atmosphere: atm,
 				Ephemeris:  eph.Default(),
 			},

--- a/skybrightness/provenance.go
+++ b/skybrightness/provenance.go
@@ -2,8 +2,9 @@ package skybrightness
 
 import (
 	"fmt"
-	"github.com/TuSKan/astrogo/time"
 	"strings"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Provenance records the science behind one component: what model, from

--- a/skybrightness/provenance.go
+++ b/skybrightness/provenance.go
@@ -2,8 +2,8 @@ package skybrightness
 
 import (
 	"fmt"
+	"github.com/TuSKan/astrogo/time"
 	"strings"
-	"time"
 )
 
 // Provenance records the science behind one component: what model, from
@@ -116,7 +116,7 @@ type Reproducibility struct {
 	// AtmosphereTime is the timestamp of that atmospheric state, which may
 	// differ from the observation time when a forecast or an analysis is
 	// used.
-	AtmosphereTime time.Time
+	AtmosphereTime time.GoTime
 
 	// Datasets are every data product involved, with versions.
 	Datasets []DatasetRef

--- a/skybrightness/scene.go
+++ b/skybrightness/scene.go
@@ -3,11 +3,11 @@ package skybrightness
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Sentinel errors for scene construction. Match with errors.Is.
@@ -42,7 +42,7 @@ type Scene struct {
 	Observer *coord.Geodetic
 
 	// Time is the instant of the observation.
-	Time time.Time
+	Time time.GoTime
 
 	// Atmosphere is the atmospheric state: surface conditions, aerosol,
 	// clouds, ozone, precipitable water, vertical profile, horizon and

--- a/skybrightness/scene_cache_test.go
+++ b/skybrightness/scene_cache_test.go
@@ -2,13 +2,13 @@ package skybrightness_test
 
 import (
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/skybrightness"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // sceneWithPressure builds two scenes that differ only in surface conditions.
@@ -29,7 +29,7 @@ func sceneWithPressure(t *testing.T, loc *coord.Geodetic, hPa, kelvin float64) *
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2026, 3, 20, 5, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2026, 3, 20, 5, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 		Ephemeris:  eph.Default(),
 	}

--- a/skybrightness/starlight_component_test.go
+++ b/skybrightness/starlight_component_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"math"
 	"testing"
-	gotime "time"
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
@@ -13,7 +12,7 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/skybrightness"
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/unit"
 )
 
@@ -68,7 +67,7 @@ func starlightScene(t *testing.T) *skybrightness.Scene {
 
 	return &skybrightness.Scene{
 		Observer:   loc,
-		Time:       gotime.Date(2024, 6, 21, 4, 0, 0, 0, gotime.UTC),
+		Time:       time.GoDate(2024, 6, 21, 4, 0, 0, 0, time.LocationUTC),
 		Atmosphere: atm,
 		Ephemeris:  eph.Default(),
 	}
@@ -336,7 +335,7 @@ func TestIntegratedStarlightHonoursTheMapFrame(t *testing.T) {
 	}
 
 	frame := coord.NewContext(
-		astrotime.FromGo(scene.Time), scene.Observer, scene.Atmosphere.Refraction())
+		time.FromGo(scene.Time), scene.Observer, scene.Atmosphere.Refraction())
 
 	icrs, err := frame.AltAzToICRS(dir)
 	if err != nil {

--- a/time/time.go
+++ b/time/time.go
@@ -9,6 +9,9 @@ import (
 	"github.com/TuSKan/astrogo/internal/gofaext"
 )
 
+// GoTime is an alias for the standard library's time.Time.
+type GoTime = time.Time
+
 // Duration is the interface that represents a duration.
 type Duration = time.Duration
 
@@ -67,6 +70,12 @@ const (
 	Minute time.Duration = time.Minute //nolint:revive,nolintlint // Public time unit constant; unit name is intentional.
 	// Hour is one hour.
 	Hour time.Duration = time.Hour //nolint:revive,nolintlint // Public time unit constant; unit name is intentional.
+	// Nanosecond is one nanosecond, the unit Duration counts in.
+	Nanosecond time.Duration = time.Nanosecond //nolint:revive,nolintlint // Public time unit constant; unit name is intentional.
+	// Microsecond is one microsecond.
+	Microsecond time.Duration = time.Microsecond //nolint:revive,nolintlint // Public time unit constant; unit name is intentional.
+	// Millisecond is one millisecond.
+	Millisecond time.Duration = time.Millisecond //nolint:revive,nolintlint // Public time unit constant; unit name is intentional.
 )
 
 // Month constants re-exported from the standard library.
@@ -100,6 +109,16 @@ const (
 // LoadLocation loads a location from the standard library.
 var LoadLocation = time.LoadLocation
 
+// Parse parses a formatted time string, as the standard library does.
+var Parse = time.Parse
+
+// ParseInLocation is Parse with a default location for a layout that carries
+// no zone.
+var ParseInLocation = time.ParseInLocation
+
+// Since returns the duration since the given time.
+var Since = time.Since
+
 // MustLocation loads a location from the standard library, panicking if the
 // location cannot be loaded.
 var MustLocation = func(name string) *time.Location {
@@ -112,7 +131,49 @@ var MustLocation = func(name string) *time.Location {
 }
 
 // LocationUTC is the UTC location.
+//
+// Named for the location rather than aliased as UTC, because [UTC] is this
+// package's coordinated-universal *scale* and the two are different things.
 var LocationUTC = time.UTC
+
+// FixedZone returns a location with a fixed offset from UTC.
+var FixedZone = time.FixedZone
+
+// Unix converts a Unix timestamp to a [GoTime].
+var Unix = time.Unix
+
+// GoDate builds a [GoTime] from calendar fields.
+//
+// Named apart from [Date], which builds this package's own [Time]. Both are
+// needed: astronomy wants the scale-aware type, while ordinary calendar work
+// — a cache key, a filename stamp — wants the standard library's.
+var GoDate = time.Date
+
+// Now returns the current wall-clock instant as a [GoTime].
+//
+// Distinct from [NowUTC], which returns this package's own [Time] on the UTC
+// scale. Reach for NowUTC for anything astronomical; Now is for the ordinary
+// clock work — a cache timestamp, a rate limiter, a generated-at field —
+// that would otherwise be a reason to import the standard library's time
+// package alongside this one.
+var Now = time.Now
+
+// Until returns the duration until the given [GoTime].
+var Until = time.Until
+
+// Sleep pauses the calling goroutine.
+var Sleep = time.Sleep
+
+// After returns a channel that receives after the given duration.
+//
+// Not to be confused with [Time.After], which compares two instants.
+var After = time.After
+
+// NewTimer returns a timer that fires after the given duration.
+var NewTimer = time.NewTimer
+
+// NewTicker returns a ticker that fires repeatedly.
+var NewTicker = time.NewTicker
 
 // J2000 is the standard epoch J2000.0 (JD 2451545.0 TT) — the reference
 // epoch most star catalogs (Gaia excepted, at J2016.0) and orbital-element
@@ -124,6 +185,14 @@ var (
 	RFC1123 = time.RFC1123
 	// RFC3339 is a time format that conforms to RFC 3339.
 	RFC3339 = time.RFC3339
+	// RFC3339Nano is RFC 3339 with nanosecond precision.
+	RFC3339Nano = time.RFC3339Nano
+	// DateOnly is the year-month-day layout.
+	DateOnly = time.DateOnly
+	// DateTime is the year-month-day hour:minute:second layout.
+	DateTime = time.DateTime
+	// TimeOnly is the hour:minute:second layout.
+	TimeOnly = time.TimeOnly
 )
 
 // Scale represents an astronomical time scale.


### PR DESCRIPTION
## What

The standard library's `time` is no longer imported anywhere outside the `time` package. 107 files change; a test enforces the rule from here on.

## Why

A package that imports both ends up with two types spelled `time.Time` and a local name to tell them apart — `stdtime`, `gotime`, `astrot`, all three appeared in the tree. Once a local name is what carries the meaning, a field declared `Time time.Time` says nothing on its own about which type it is: the answer is at the top of the file, in an import line nobody re-reads.

That is not a hypothetical. Converting the module, an intermediate version of the change swapped an import without rewriting the body, and `skybrightness.Scene.Time` silently changed from the standard library's type to this module's. **The source line was character-for-character identical before and after.** Nothing in a review of that diff would have shown it.

## What makes it not a trade

`time` already aliased most of what was needed. This adds the rest, so no call site has to reach past it:

| need | before | now |
| :--- | :--- | :--- |
| the standard library's `Time` | `stdtime.Time` | `time.GoTime` |
| its UTC location | `stdtime.UTC` | `time.LocationUTC` |
| building one from fields | `stdtime.Date(…)` | `time.GoDate(…)` |
| the clock | `stdtime.Now()` | `time.Now()` |
| sub-second units, `RFC3339Nano`, `DateOnly`, timers, tickers | — | added |

`GoDate` is named apart from `Date` because both exist and build different types; `Now` sits beside `NowUTC` for the same reason, and both say so in their doc comments.

## The one exception

`internal/testutil` cannot import `astrogo/time` without closing a cycle through `time/internal/iers`' own tests. Its single timeout becomes an untyped constant in nanoseconds, with a comment saying why it is not written as `5 * time.Second`.

## The guard

`internal/docsguard/stdtime_test.go` walks every `.go` file, skips `time/`, and fails on either an import of the standard library's `time` or an *aliased* import of this module's — with the standard library gone there is nothing left to disambiguate, so an alias only makes a package read differently from its neighbours.

Two regexp details are load-bearing and are commented in place: `[ \t]` rather than `\s`, because `\s` matches a newline and let a pattern start on the blank line above an unaliased single-line import and read the `import` keyword itself as the alias; and `import[ \t]+` as an alternative to the in-block form, so a single-line import is caught too.

## Verification

- `gofmt -l .` clean, `go build ./...`, `go vet` untagged and with `integration,network,validation`
- `go test ./...` passes
- `golangci-lint run` and `golangci-lint run --build-tags="integration,network,validation"` both at **0 issues**
- The guard passes on the whole tree

Two `//nolint:durationcheck` directives went dead in the conversion — with the constants coming from `astrogo/time`, `durationcheck` no longer reads `time.Hour * time.Duration(step)` as a duration times a duration, and `nolintlint` flags the leftover. The reasoning was worth keeping, so it stays as an ordinary comment.