### PR TITLE
Modernize benchmark loops to b.Loop()

### DIFF
--- a/atmosphere/transfer_test.go
+++ b/atmosphere/transfer_test.go
@@ -222,9 +222,8 @@ func TestSingleScatteredRadianceRejectsBadInput(t *testing.T) {
 
 func BenchmarkSingleScatteredRadiance(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := atmosphere.SingleScatteredRadiance(1, 0.1, 0.2, 0.4, 2, 1.5); err != nil {
 			b.Fatal(err)
 		}

--- a/coord/healpix_test.go
+++ b/coord/healpix_test.go
@@ -212,9 +212,8 @@ func BenchmarkHEALPixPixelOf(b *testing.B) {
 	lon, lat := angle.Deg(123.4), angle.Deg(-42.1)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		_ = h.PixelOf(lon, lat)
 	}
 }

--- a/docs/changelog.d/76-bench-loop.md
+++ b/docs/changelog.d/76-bench-loop.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 76
+---
+**Benchmarks use `testing.B.Loop` instead of `b.N`.** 19 loops across 15
+files, and the 20 now-dead `b.ResetTimer()` calls that preceded them —
+`b.Loop` resets the timer on its first call.

--- a/magnitude/rolo_test.go
+++ b/magnitude/rolo_test.go
@@ -443,9 +443,8 @@ func BenchmarkROLOReflectance(b *testing.B) {
 	geom := magnitude.ROLOGeometry{PhaseAngle: angle.Deg(30), SolarLongitude: angle.Deg(-30)}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if err := magnitude.ROLOReflectance(dst, geom); err != nil {
 			b.Fatal(err)
 		}

--- a/remote/file/readerat_bench_test.go
+++ b/remote/file/readerat_bench_test.go
@@ -63,9 +63,7 @@ func benchPattern(b *testing.B, sizeMB int, read func(off int64) error, n int) {
 	size := int64(sizeMB) << 20
 	offs := spkLikeOffsets(size, n)
 
-	b.ResetTimer()
-
-	for range b.N {
+	for b.Loop() {
 		for _, off := range offs {
 			if err := read(off); err != nil {
 				b.Fatalf("read at %d: %v", off, err)

--- a/skybrightness/airglow_test.go
+++ b/skybrightness/airglow_test.go
@@ -281,9 +281,8 @@ func BenchmarkAirglow(b *testing.B) {
 	dst := skybrightness.NewSpectralRadiance(grid)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := skybrightness.AirglowRadiance(dst, grid, zenith, angle.Deg(45), 0); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/artificial_component_test.go
+++ b/skybrightness/artificial_component_test.go
@@ -471,9 +471,8 @@ func BenchmarkArtificialSkyglow(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := component.AddRadiance(context.Background(), dst, grid, dir, scene); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/artificial_test.go
+++ b/skybrightness/artificial_test.go
@@ -489,9 +489,8 @@ func TestKocifaj2022Eq2RejectsBadInput(t *testing.T) {
 
 func BenchmarkAllSkyRadiance(b *testing.B) {
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := skybrightness.AllSkyRadiance(1e-3, 0.1, 0.6, 12, 3, 0.25); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/bench_test.go
+++ b/skybrightness/bench_test.go
@@ -73,9 +73,8 @@ func BenchmarkEstimateSingleDirection(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := m.Estimate(context.Background(), q); err != nil {
 			b.Fatalf("Estimate: %v", err)
 		}
@@ -87,9 +86,8 @@ func BenchmarkEstimate100Directions(b *testing.B) {
 	scene := benchScene(b)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		for d := range 100 {
 			q := skybrightness.Query{
 				Scene:     scene,
@@ -108,9 +106,8 @@ func BenchmarkSkyMapFullSky(b *testing.B) {
 	q := skybrightness.Query{Scene: benchScene(b)}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := m.SkyMap(context.Background(), q, 18); err != nil {
 			b.Fatalf("SkyMap: %v", err)
 		}
@@ -144,9 +141,8 @@ func BenchmarkEstimateSpectralResolution(b *testing.B) {
 			}
 
 			b.ReportAllocs()
-			b.ResetTimer()
 
-			for range b.N {
+			for b.Loop() {
 				if _, err := m.Estimate(context.Background(), q); err != nil {
 					b.Fatalf("Estimate: %v", err)
 				}
@@ -188,9 +184,8 @@ func BenchmarkInstrumentProjection(b *testing.B) {
 
 	b.Run("surface-brightness", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for range b.N {
+		for b.Loop() {
 			if _, err := est.SurfaceBrightness(band, magnitude.AB); err != nil {
 				b.Fatalf("SurfaceBrightness: %v", err)
 			}
@@ -199,9 +194,8 @@ func BenchmarkInstrumentProjection(b *testing.B) {
 
 	b.Run("electron-rate", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for range b.N {
+		for b.Loop() {
 			if _, err := est.ElectronRate(inst); err != nil {
 				b.Fatalf("ElectronRate: %v", err)
 			}

--- a/skybrightness/cloudy_bench_test.go
+++ b/skybrightness/cloudy_bench_test.go
@@ -22,9 +22,8 @@ func benchCloudy(b *testing.B, c skybrightness.Component, scene *skybrightness.S
 	dir := coord.NewAltAz(angle.Deg(60), angle.Deg(0))
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		clear(dst)
 
 		if _, err := c.AddRadiance(b.Context(), dst, grid, dir, scene); err != nil {

--- a/skybrightness/dataset/starlight/starlight_test.go
+++ b/skybrightness/dataset/starlight/starlight_test.go
@@ -284,9 +284,8 @@ func BenchmarkRadianceAt(b *testing.B) {
 	lon, lat := angle.Deg(123.4), angle.Deg(-42.1)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := m.RadianceAt("V", lon, lat); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/dgl_test.go
+++ b/skybrightness/dgl_test.go
@@ -296,9 +296,8 @@ func BenchmarkDiffuseGalacticLight(b *testing.B) {
 	dst := skybrightness.NewSpectralRadiance(grid)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := skybrightness.DiffuseGalacticRadiance(dst, grid, 5); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/fullsky_test.go
+++ b/skybrightness/fullsky_test.go
@@ -418,9 +418,8 @@ func BenchmarkFullSkyEstimate(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := model.Estimate(context.Background(), q); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/moonlight_test.go
+++ b/skybrightness/moonlight_test.go
@@ -554,9 +554,8 @@ func BenchmarkScatteredMoonlight(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := component.AddRadiance(context.Background(), dst, grid, dir, scene); err != nil {
 			b.Fatal(err)
 		}

--- a/skybrightness/preset_bench_test.go
+++ b/skybrightness/preset_bench_test.go
@@ -62,7 +62,6 @@ func BenchmarkPresetSkyMap(b *testing.B) {
 			}
 
 			b.ReportMetric(float64(len(points)), "directions")
-			b.ResetTimer()
 
 			for b.Loop() {
 				if _, err := model.SkyMap(b.Context(), q, rings); err != nil {

--- a/skybrightness/zodiacal_test.go
+++ b/skybrightness/zodiacal_test.go
@@ -408,9 +408,8 @@ func BenchmarkZodiacalLight(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		if _, err := skybrightness.ZodiacalRadiance(dst, grid, geom); err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Fixes the `modernize` finding *"b.N can be modernized using b.Loop()"* everywhere it appears: **19 loops across 15 files**.

## What changes

```diff
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
```

That is the whole change, 19 times. No benchmark body is touched.

## Why the `b.ResetTimer()` goes too

`b.Loop()` resets the timer on its first call, so a `ResetTimer` immediately above the loop does nothing. All **20** of them (19 here plus one in `preset_bench_test.go`, which had already been converted by hand) are removed.

`nolintlint` would not have caught these — they are not directives — but they are the same kind of debt: a line that reads as doing something and does not.

## The one thing worth checking

Two benchmarks read `b.N` *after* their loop, to divide a total by the iteration count:

| | metric |
| :--- | :--- |
| `BenchmarkReadAtStrategies` | `float64(calls.Load()) / float64(b.N)` → `rangereads/op` |
| `BenchmarkPresetSkyMap` | `b.Elapsed() / float64(b.N) / len(points)` → `ms/direction`, `s/whole-sky` |

This is still correct: `b.N` holds the final iteration count once the loop ends. `preset_bench_test.go` was already written this way before this PR, so the pattern is already the repository's own — the change just makes `readerat_bench_test.go` match it.

Measured rather than assumed:

```
BenchmarkReadAtStrategies/plain-NewRangeReader-per-ReadAt-16   2000 rangereads/op
BenchmarkPresetSkyMap/gambons-web-16      0.07257 ms/direction   1.497 s/whole-sky
BenchmarkPresetSkyMap/gambons-full-16      0.8115 ms/direction   16.74 s/whole-sky
```

`2000` is exactly the per-iteration read count the benchmark issues, so the division is landing on the right denominator.

## Verification

- Every converted benchmark **run**, not merely built: `go test -run=^$ -bench=. -benchtime=10x -benchmem` across `atmosphere`, `coord`, `magnitude`, `remote/file`, `skybrightness` and `skybrightness/dataset/starlight` — all report.
- `gofmt -l .` clean, `go build ./...`, `go vet` untagged and with `integration,network,validation`
- `go test ./...` passes
- `golangci-lint run` and `golangci-lint run --build-tags="integration,network,validation"` both at **0 issues**

Removing the `ResetTimer` left `b.ReportAllocs()` cuddled against the `for`, which `wsl_v5` rejects; the blank line is restored at all 19 sites.