### PR TITLE
Compile the build-tagged files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,25 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         run: go test -v ./...
 
+      # The default `go test ./...` never compiles a file behind a build
+      # tag, and neither does golangci-lint below, which runs untagged. So
+      # 59 test files — 34 network, 17 validation, 8 integration — are only
+      # ever built by the weekly Validation workflow — off the pull-request
+      # path by design, because those suites query other people's services.
+      #
+      # The consequence is that a tagged file that does not compile reaches
+      # main green. It has happened: #75 rewrote an import in
+      # ephemeris/kepler/validation_test.go and left two references to the old
+      # alias behind, so `go vet -tags=network` did not build that package on
+      # main until #78 rebased onto it and noticed.
+      #
+      # vet type-checks those files without running any of them, so this costs
+      # seconds and makes no external request. It is the compile check, not a
+      # substitute for running the suites.
+      - name: Vet build-tagged files
+        if: matrix.os == 'ubuntu-latest'
+        run: go vet -tags="integration,network,validation" ./...
+
       - name: Run golangci-lint
         if: matrix.os == 'ubuntu-latest'
         uses: golangci/golangci-lint-action@v9

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The best way to see whether a library's numbers are trustworthy is to point it a
 | [**Equinox & Solstice Almanac**](docs/EQUINOX.md) | A decade of seasons, eclipses, and apsides computed from first principles — no lookup tables, no curve fits, just JPL DE442 and root-finding. | [`examples/17_equinox_prediction/`](examples/17_equinox_prediction/) |
 | **Satellite Tracking** | Predict ISS passes over your location from live NORAD/CelestTrak data — AOS, max elevation, LOS, ground track. | [`examples/12_satellite_tracking/`](examples/12_satellite_tracking/) |
 | **What's Visible Tonight** | What can I actually see in the sky tonight brighter than magnitude X — stars, deep-sky objects, planets, the Moon, even asteroids and comets, all in one query? | [`examples/20_whats_visible_tonight/`](examples/20_whats_visible_tonight/) |
-| **Kepler Propagation, No Kernel** | Six orbital elements and an epoch — no SPK kernel, no network — is enough to place 1 Ceres in the sky and feed it straight into rise/transit/set, exactly like any catalog-resolved target. | [`examples/22_kepler_propagator/`](examples/22_kepler_propagator/) |
+| **Kepler Propagation, No Kernel** | Six orbital elements and an epoch — no SPK kernel, no network — is enough to place 1 Ceres in the sky and feed it straight into rise/transit/set, exactly like any catalog-resolved target. Measured against a Horizons kernel it holds **1–4″ over a month** either side of the elements' epoch ([what you give up](#what-you-give-up-by-staying-offline)). | [`examples/22_kepler_propagator/`](examples/22_kepler_propagator/) |
 | **Radial-Velocity Correction** | Sirius's measured RV swings by ~±25 km/s across the year purely from Earth's own orbital motion — barycentric/heliocentric correction removes it. | [`examples/23_radial_velocity_correction/`](examples/23_radial_velocity_correction/) |
 | **Telescope & Eyepiece Optics** | An 8" f/10 SCT with a wide-field and a planetary eyepiece, a 2x Barlow, and a CMOS sensor — magnification, true field of view, exit pupil, and plate scale, no astrometry involved at all. | [`examples/24_optics/`](examples/24_optics/) |
 
@@ -778,8 +778,11 @@ photometric aperture placement, or anything that must land inside a slit.
 it is two-body propagation of Standish elements. At 3′ it gives you the constellation,
 not the object.
 
-Small bodies propagated from published osculating elements hold roughly 1–4″ over a
-month either side of the elements' epoch, degrading as t² beyond that.
+**The offline path for asteroids and comets is `ephemeris/kepler`** — `NewMovingBodyProvider`
+plus six elements from `catalog/sbdb`, which is what `plan.NewAsteroid` uses when no kernel is
+available. Measured against Horizons-generated SPK kernels, it holds roughly **1–4″ over a
+month** either side of the elements' epoch of osculation, degrading as t² beyond that. That is
+good enough to find the object in a finder and not good enough to measure it.
 
 Every figure above is generated from the `ephemeris.sofa.*` and `ephemeris.kepler.*`
 suites — see [docs/VALIDATION.md](docs/VALIDATION.md) for the full distributions, the

--- a/docs/changelog.d/79-time-aliases-in-time-package.md
+++ b/docs/changelog.d/79-time-aliases-in-time-package.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 79
+---
+**The `time` package's own tests no longer alias it.** Five external test
+files carried `atime`, `astrotime` and `gotime` — the package that exists to
+end the two-spellings-of-time problem was the last place still having it. The
+guard now applies its alias rule inside `time/` too.

--- a/docs/changelog.d/79-vet-build-tags.md
+++ b/docs/changelog.d/79-vet-build-tags.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 79
+---
+**CI never compiled the build-tagged test files.** 59 of them — network,
+validation and integration — were built only by the weekly Validation
+workflow, so a tagged file that did not compile reached `main` green, and one
+did. `go vet` with all three tags now runs on every pull request.

--- a/internal/docsguard/stdtime_test.go
+++ b/internal/docsguard/stdtime_test.go
@@ -70,16 +70,21 @@ func TestNoStandardLibraryTimeOutsideTimePackage(t *testing.T) {
 			return nil
 		}
 
-		// astrogo/time is the one package allowed to import it — that is
-		// the whole point of the rule.
 		rel, rerr := filepath.Rel(root, path)
 		if rerr != nil {
 			return nil //nolint:nilerr // an unrelatable path is skipped, not fatal
 		}
 
-		if slash := filepath.ToSlash(rel); slash == "time" || strings.HasPrefix(slash, "time/") {
-			return nil
-		}
+		// astrogo/time is the one package allowed to import the standard
+		// library's time — that is the whole point of the rule. It gets no
+		// exemption from the *alias* rule below, though: its own external
+		// tests are `package time_test` and can import it unaliased like
+		// anyone else, and five of them did not. Four carried `atime` and one
+		// carried `astrotime` beside a `gotime`, so the package that exists
+		// to end the two-spellings-of-time problem was the last place still
+		// having it.
+		slash := filepath.ToSlash(rel)
+		inTimePackage := slash == "time" || strings.HasPrefix(slash, "time/")
 
 		src, rerr := os.ReadFile(path)
 		if rerr != nil {
@@ -90,7 +95,7 @@ func TestNoStandardLibraryTimeOutsideTimePackage(t *testing.T) {
 
 		body := string(src)
 
-		if loc := stdTimeImport.FindStringIndex(body); loc != nil {
+		if loc := stdTimeImport.FindStringIndex(body); loc != nil && !inTimePackage {
 			offenders++
 
 			t.Errorf("%s:%d: imports the standard library's time.\n"+

--- a/time/eop_test.go
+++ b/time/eop_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/file"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 )
@@ -49,27 +49,27 @@ func fakeIERSSourceForGateway(t *testing.T, content string) {
 // ResetEOP is what returns to "zero" afterward, not another
 // RegisterModel(ZeroModel{}) call.
 func TestEOPSourceGateway(t *testing.T) {
-	t.Cleanup(atime.ResetEOP)
+	t.Cleanup(time.ResetEOP)
 
-	if got := atime.EOPSource(); got != "zero" {
+	if got := time.EOPSource(); got != "zero" {
 		t.Errorf(`EOPSource() = %q before any RegisterModel call, want "zero"`, got)
 	}
 
-	atime.RegisterModel(atime.ZeroModel{})
+	time.RegisterModel(time.ZeroModel{})
 
-	if got := atime.EOPSource(); got != "explicit" {
+	if got := time.EOPSource(); got != "explicit" {
 		t.Errorf(`EOPSource() = %q after RegisterModel, want "explicit"`, got)
 	}
 
-	atime.ResetEOP()
+	time.ResetEOP()
 
-	if got := atime.EOPSource(); got != "zero" {
+	if got := time.EOPSource(); got != "zero" {
 		t.Errorf(`EOPSource() = %q after ResetEOP, want "zero"`, got)
 	}
 }
 
 func TestParseFinals2000AGateway(t *testing.T) {
-	table, err := atime.ParseFinals2000A(strings.NewReader(sampleFinals2000AForGateway))
+	table, err := time.ParseFinals2000A(strings.NewReader(sampleFinals2000AForGateway))
 	if err != nil {
 		t.Fatalf("ParseFinals2000A: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestParseFinals2000AGateway(t *testing.T) {
 // httptest server below) zero network access.
 func TestEOPLazyLoadFindsPreSeededCacheWithoutConsent(t *testing.T) {
 	t.Cleanup(func() {
-		atime.ResetEOP()
+		time.ResetEOP()
 		remote.Reset()
 	})
 
@@ -108,14 +108,14 @@ func TestEOPLazyLoadFindsPreSeededCacheWithoutConsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tm := atime.FromJD(2441684.5, atime.UTC) // MJD 41684
+	tm := time.FromJD(2441684.5, time.UTC) // MJD 41684
 
 	eop := tm.EOP()
-	if eop == (atime.EOP{}) {
+	if eop == (time.EOP{}) {
 		t.Error("expected non-zero EOP from the pre-seeded cache file")
 	}
 
-	lo, hi, ok := atime.Coverage()
+	lo, hi, ok := time.Coverage()
 	if !ok {
 		t.Fatal("expected a coverage-reporting model after the lazy load")
 	}
@@ -131,15 +131,15 @@ func TestEOPLazyLoadFindsPreSeededCacheWithoutConsent(t *testing.T) {
 // FetchIfStale call needed.
 func TestEOPLazyLoadFetchesWithConsent(t *testing.T) {
 	t.Cleanup(func() {
-		atime.ResetEOP()
+		time.ResetEOP()
 		remote.Reset()
-		atime.SetRetryCooldown(5 * atime.Minute)
+		time.SetRetryCooldown(5 * time.Minute)
 	})
 
 	// Another test in this binary may have made a recent lazy-load attempt
 	// (success or failure); disable the cooldown so this test's own
 	// attempt isn't throttled by that unrelated prior attempt.
-	atime.SetRetryCooldown(0)
+	time.SetRetryCooldown(0)
 
 	fakeIERSSourceForGateway(t, sampleFinals2000AForGateway)
 
@@ -147,14 +147,14 @@ func TestEOPLazyLoadFetchesWithConsent(t *testing.T) {
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	t.Cleanup(func() { remote.SetDataDir("") })
 
-	tm := atime.FromJD(2441684.5, atime.UTC) // MJD 41684
+	tm := time.FromJD(2441684.5, time.UTC) // MJD 41684
 
 	eop := tm.EOP()
-	if eop == (atime.EOP{}) {
+	if eop == (time.EOP{}) {
 		t.Error("expected non-zero EOP after the automatic network fetch")
 	}
 
-	if _, _, ok := atime.Coverage(); !ok {
+	if _, _, ok := time.Coverage(); !ok {
 		t.Error("expected a coverage-reporting model after the lazy fetch")
 	}
 }
@@ -165,16 +165,16 @@ func TestEOPLazyLoadFetchesWithConsent(t *testing.T) {
 // erroring.
 func TestEOPLazyLoadDegradesToZeroWithoutCacheOrConsent(t *testing.T) {
 	t.Cleanup(func() {
-		atime.ResetEOP()
+		time.ResetEOP()
 		remote.Reset()
 	})
 
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	t.Cleanup(func() { remote.SetDataDir("") })
 
-	tm := atime.FromJD(2441684.5, atime.UTC) // MJD 41684
+	tm := time.FromJD(2441684.5, time.UTC) // MJD 41684
 
-	if eop := tm.EOP(); eop != (atime.EOP{}) {
+	if eop := tm.EOP(); eop != (time.EOP{}) {
 		t.Errorf("expected zero EOP with no cache and no consent, got %+v", eop)
 	}
 }
@@ -182,6 +182,6 @@ func TestEOPLazyLoadDegradesToZeroWithoutCacheOrConsent(t *testing.T) {
 func TestSetRetryCooldownGateway(_ *testing.T) {
 	// Exercises the gateway wrapper only; time/internal/iers's own tests
 	// cover the throttling behavior itself.
-	atime.SetRetryCooldown(0)
-	atime.SetRetryCooldown(5 * atime.Minute) // restore the default
+	time.SetRetryCooldown(0)
+	time.SetRetryCooldown(5 * time.Minute) // restore the default
 }

--- a/time/epoch_test.go
+++ b/time/epoch_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 func TestTimeMJD(t *testing.T) {
 	// J2000.0 = JD 2451545.0 = MJD 51544.5.
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 	testutil.AssertNear(t, "MJD at J2000.0", tm.MJD(), 51544.5, 1e-9)
 }
 
@@ -18,7 +18,7 @@ func TestTimeGASTMatchesKnownValue(t *testing.T) {
 	// Known GAST at J2000.0 ~280.46deg +-0.5deg (same reference value
 	// plan.Site.LocalSiderealTime's own test validates against, since LST
 	// at longitude 0 is exactly GAST).
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 
 	gast, err := tm.GAST()
 	if err != nil {
@@ -29,15 +29,15 @@ func TestTimeGASTMatchesKnownValue(t *testing.T) {
 }
 
 func TestTimeJulianEpochYear(t *testing.T) {
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 	testutil.AssertNear(t, "JulianEpochYear at J2000.0", tm.JulianEpochYear(), 2000.0, 1e-9)
 }
 
 func TestTimeDayOfYear(t *testing.T) {
-	jan1 := atime.Date(2025, 1, 1, 0, 0, 0, 0, atime.LocationUTC)
+	jan1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.LocationUTC)
 	testutil.AssertNear(t, "DayOfYear on Jan 1", jan1.DayOfYear(), 1.0, 1e-9)
 
-	dec31 := atime.Date(2025, 12, 31, 0, 0, 0, 0, atime.LocationUTC)
+	dec31 := time.Date(2025, 12, 31, 0, 0, 0, 0, time.LocationUTC)
 	testutil.AssertNear(t, "DayOfYear on Dec 31 (non-leap year)", dec31.DayOfYear(), 365.0, 1e-9)
 }
 
@@ -47,11 +47,11 @@ func TestTimeGASTFallsBackToUTCOnUT1Error(t *testing.T) {
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	t.Cleanup(func() { remote.SetDataDir("") })
 
-	atime.RegisterModel(errorEOP{})
+	time.RegisterModel(errorEOP{})
 
-	defer atime.ResetEOP()
+	defer time.ResetEOP()
 
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 
 	gast, err := tm.GAST()
 	if err == nil {
@@ -69,14 +69,14 @@ func TestTimeEOPDegradesToZeroWithWarning(t *testing.T) {
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	t.Cleanup(func() { remote.SetDataDir("") })
 
-	atime.RegisterModel(errorEOP{})
+	time.RegisterModel(errorEOP{})
 
-	defer atime.ResetEOP()
+	defer time.ResetEOP()
 
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 
 	eop := tm.EOP()
-	if eop != (atime.EOP{}) {
+	if eop != (time.EOP{}) {
 		t.Errorf("expected zero EOP on lookup failure, got %+v", eop)
 	}
 }
@@ -87,14 +87,14 @@ func TestTimeUTCFromUT1FallsBackOnEOPError(t *testing.T) {
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	t.Cleanup(func() { remote.SetDataDir("") })
 
-	atime.RegisterModel(errorEOP{})
+	time.RegisterModel(errorEOP{})
 
-	defer atime.ResetEOP()
+	defer time.ResetEOP()
 
 	// A UT1-scale Time converting to UTC hits dut1OrFallback, which
 	// substitutes DUT1=0 (UT1≈UTC) and logs a one-time warning on lookup
 	// failure, rather than propagating the error like Time.UT1() does.
-	ut1 := atime.FromJD(2451545.0, atime.UT1)
+	ut1 := time.FromJD(2451545.0, time.UT1)
 
 	utc := ut1.UTC()
 	testutil.AssertNear(t, "UTC fallback (DUT1=0) at J2000", utc.JD(), 2451545.0, 1e-9)

--- a/time/scale_matrix_test.go
+++ b/time/scale_matrix_test.go
@@ -5,23 +5,23 @@ import (
 	"testing"
 
 	"github.com/TuSKan/astrogo/internal/metrology"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // scaleName pairs a scale with its converter, so the matrix below can be
 // written as a loop rather than as twenty-five hand-written cases.
 type scaleName struct {
 	name string
-	to   func(atime.Time) atime.Time
+	to   func(time.Time) time.Time
 }
 
 func allScales() []scaleName {
 	return []scaleName{
-		{"UTC", atime.Time.UTC},
-		{"TAI", atime.Time.TAI},
-		{"TT", atime.Time.TT},
-		{"TDB", atime.Time.TDB},
-		{"UT1", func(t atime.Time) atime.Time {
+		{"UTC", time.Time.UTC},
+		{"TAI", time.Time.TAI},
+		{"TT", time.Time.TT},
+		{"TDB", time.Time.TDB},
+		{"UT1", func(t time.Time) time.Time {
 			// UT1 needs Earth-orientation data and reports when it cannot
 			// get it; the fallback is what every other caller in the module
 			// gets, so the matrix uses it too rather than skipping the scale.
@@ -39,7 +39,7 @@ func allScales() []scaleName {
 // is in the list.
 type matrixEpoch struct {
 	name string
-	t    atime.Time
+	t    time.Time
 	why  string
 
 	// preUTC marks an epoch before 1972, where UTC is not related to atomic
@@ -56,29 +56,29 @@ type matrixEpoch struct {
 // everywhere between them and wrong at every one.
 func matrixEpochs() []matrixEpoch {
 	return []matrixEpoch{
-		{"2017 leap second, before", atime.Date(2016, 12, 31, 23, 59, 0, 0, atime.LocationUTC),
+		{"2017 leap second, before", time.Date(2016, 12, 31, 23, 59, 0, 0, time.LocationUTC),
 			"the last leap second inserted, and the one ephemeris/jpl/lsk silently dropped", false},
-		{"2017 leap second, after", atime.Date(2017, 1, 1, 0, 1, 0, 0, atime.LocationUTC),
+		{"2017 leap second, after", time.Date(2017, 1, 1, 0, 1, 0, 0, time.LocationUTC),
 			"the other side of the same insertion", false},
-		{"2015 leap second", atime.Date(2015, 7, 1, 0, 0, 30, 0, atime.LocationUTC),
+		{"2015 leap second", time.Date(2015, 7, 1, 0, 0, 30, 0, time.LocationUTC),
 			"an earlier insertion, so the table is exercised at more than its last row", false},
-		{"1972 UTC epoch", atime.Date(1972, 1, 1, 0, 0, 1, 0, atime.LocationUTC),
+		{"1972 UTC epoch", time.Date(1972, 1, 1, 0, 0, 1, 0, time.LocationUTC),
 			"leap seconds begin here; the Delta-T path hands over to Delta-AT", true},
-		{"1971, drift era", atime.Date(1971, 6, 15, 12, 0, 0, 0, atime.LocationUTC),
+		{"1971, drift era", time.Date(1971, 6, 15, 12, 0, 0, 0, time.LocationUTC),
 			"UTC ran at a rubber rate before 1972, so Delta-AT is not integral", true},
-		{"1960, pre-Delta-AT", atime.Date(1960, 1, 1, 0, 0, 0, 0, atime.LocationUTC),
+		{"1960, pre-Delta-AT", time.Date(1960, 1, 1, 0, 0, 0, 0, time.LocationUTC),
 			"SOFA's Dat begins here; before it there is no Delta-AT at all", true},
-		{"J2000", atime.FromJD(2451545.0, atime.TDB),
+		{"J2000", time.FromJD(2451545.0, time.TDB),
 			"the origin every reduction in the library is expressed against", false},
-		{"1900", atime.Date(1900, 1, 1, 0, 0, 0, 0, atime.LocationUTC),
+		{"1900", time.Date(1900, 1, 1, 0, 0, 0, 0, time.LocationUTC),
 			"a century before J2000, well inside the Delta-T polynomial", true},
-		{"1600", atime.Date(1600, 6, 15, 12, 0, 0, 0, atime.LocationUTC),
+		{"1600", time.Date(1600, 6, 15, 12, 0, 0, 0, time.LocationUTC),
 			"historical; Delta-T is about two minutes and the two directions used to disagree by all of it", true},
-		{"AD 33", atime.Date(33, 4, 3, 15, 0, 0, 0, atime.LocationUTC),
+		{"AD 33", time.Date(33, 4, 3, 15, 0, 0, 0, time.LocationUTC),
 			"the era the historical showcases compute in, where Delta-T is hours", true},
-		{"present era", atime.Date(2026, 8, 29, 6, 30, 0, 0, atime.LocationUTC),
+		{"present era", time.Date(2026, 8, 29, 6, 30, 0, 0, time.LocationUTC),
 			"an ordinary modern date with no special property", false},
-		{"2100", atime.Date(2100, 1, 1, 0, 0, 0, 0, atime.LocationUTC),
+		{"2100", time.Date(2100, 1, 1, 0, 0, 0, 0, time.LocationUTC),
 			"past the end of measured Earth-orientation data", false},
 	}
 }
@@ -243,8 +243,8 @@ func TestToGoIsOneInstantWhateverTheScale(t *testing.T) {
 func TestApplyDeltaTReturnsTT(t *testing.T) {
 	t.Parallel()
 
-	got := atime.Date(1600, 6, 15, 12, 0, 0, 0, atime.LocationUTC).ApplyDeltaT()
-	if got.Scale() != atime.TT {
+	got := time.Date(1600, 6, 15, 12, 0, 0, 0, time.LocationUTC).ApplyDeltaT()
+	if got.Scale() != time.TT {
 		t.Errorf("ApplyDeltaT().Scale() = %v, want TT — which is what its own doc comment says",
 			got.Scale())
 	}

--- a/time/scale_roundtrip_test.go
+++ b/time/scale_roundtrip_test.go
@@ -3,22 +3,21 @@ package time_test
 import (
 	"math"
 	"testing"
-	gotime "time"
 
-	astrotime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // epochs spans the range a catalogue or an ephemeris is likely to be asked
 // about, including a leap-second boundary and both sides of J2000.
-func epochs() []gotime.Time {
-	return []gotime.Time{
-		gotime.Date(1972, 1, 1, 0, 0, 0, 0, gotime.UTC), // TAI-UTC becomes 10s
-		gotime.Date(1999, 12, 31, 23, 59, 59, 0, gotime.UTC),
-		gotime.Date(2000, 1, 1, 12, 0, 0, 0, gotime.UTC),     // J2000.0
-		gotime.Date(2016, 12, 31, 23, 59, 59, 0, gotime.UTC), // last leap second so far
-		gotime.Date(2017, 1, 1, 0, 0, 1, 0, gotime.UTC),
-		gotime.Date(2026, 8, 21, 3, 14, 15, 0, gotime.UTC),
-		gotime.Date(2050, 6, 1, 18, 30, 0, 0, gotime.UTC),
+func epochs() []time.GoTime {
+	return []time.GoTime{
+		time.GoDate(1972, 1, 1, 0, 0, 0, 0, time.LocationUTC), // TAI-UTC becomes 10s
+		time.GoDate(1999, 12, 31, 23, 59, 59, 0, time.LocationUTC),
+		time.GoDate(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC),     // J2000.0
+		time.GoDate(2016, 12, 31, 23, 59, 59, 0, time.LocationUTC), // last leap second so far
+		time.GoDate(2017, 1, 1, 0, 0, 1, 0, time.LocationUTC),
+		time.GoDate(2026, 8, 21, 3, 14, 15, 0, time.LocationUTC),
+		time.GoDate(2050, 6, 1, 18, 30, 0, 0, time.LocationUTC),
 	}
 }
 
@@ -37,16 +36,16 @@ func TestScaleConversionsAreReversible(t *testing.T) {
 	// checked separately below.
 	scales := []struct {
 		name string
-		to   func(astrotime.Time) astrotime.Time
+		to   func(time.Time) time.Time
 	}{
-		{"UTC", astrotime.Time.UTC},
-		{"TAI", astrotime.Time.TAI},
-		{"TT", astrotime.Time.TT},
-		{"TDB", astrotime.Time.TDB},
+		{"UTC", time.Time.UTC},
+		{"TAI", time.Time.TAI},
+		{"TT", time.Time.TT},
+		{"TDB", time.Time.TDB},
 	}
 
 	for _, when := range epochs() {
-		start := astrotime.FromGo(when)
+		start := time.FromGo(when)
 
 		for _, out := range scales {
 			for _, back := range scales {
@@ -58,7 +57,7 @@ func TestScaleConversionsAreReversible(t *testing.T) {
 				// exact to well below a microsecond.
 				if d := math.Abs(home.JD()-there.JD()) * 86400; d > 1e-6 {
 					t.Errorf("%s: %s -> %s -> %s moved the instant by %.3g seconds",
-						when.Format(gotime.RFC3339), out.name, back.name, out.name, d)
+						when.Format(time.RFC3339), out.name, back.name, out.name, d)
 				}
 			}
 		}
@@ -72,7 +71,7 @@ func TestScaleConversionsAreReversible(t *testing.T) {
 func TestScaleConversionsActuallyShiftTheInstant(t *testing.T) {
 	t.Parallel()
 
-	when := astrotime.FromGo(gotime.Date(2026, 8, 21, 3, 0, 0, 0, gotime.UTC))
+	when := time.FromGo(time.GoDate(2026, 8, 21, 3, 0, 0, 0, time.LocationUTC))
 
 	utc := when.UTC()
 	tai := when.TAI()
@@ -89,7 +88,7 @@ func TestScaleConversionsActuallyShiftTheInstant(t *testing.T) {
 	}
 
 	// And the labels have to agree with the arithmetic.
-	if utc.Scale() != astrotime.UTC || tai.Scale() != astrotime.TAI || tt.Scale() != astrotime.TT {
+	if utc.Scale() != time.UTC || tai.Scale() != time.TAI || tt.Scale() != time.TT {
 		t.Errorf("scales mislabelled: %v %v %v", utc.Scale(), tai.Scale(), tt.Scale())
 	}
 }
@@ -99,25 +98,25 @@ func TestJulianDateCalendarRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	for _, when := range epochs() {
-		start := astrotime.FromGo(when)
+		start := time.FromGo(when)
 
-		back := astrotime.FromJD(start.JD(), start.Scale())
+		back := time.FromJD(start.JD(), start.Scale())
 		if d := math.Abs(back.JD()-start.JD()) * 86400; d > 1e-6 {
-			t.Errorf("%s: JD round trip moved by %.3g seconds", when.Format(gotime.RFC3339), d)
+			t.Errorf("%s: JD round trip moved by %.3g seconds", when.Format(time.RFC3339), d)
 		}
 
 		// The two-part form exists to keep precision that one float loses; it
 		// must be at least as good as the single value.
 		jd1, jd2 := start.JDParts()
 
-		parts := astrotime.FromJDParts(jd1, jd2, start.Scale())
+		parts := time.FromJDParts(jd1, jd2, start.Scale())
 		if d := math.Abs(parts.JD()-start.JD()) * 86400; d > 1e-6 {
-			t.Errorf("%s: JDParts round trip moved by %.3g seconds", when.Format(gotime.RFC3339), d)
+			t.Errorf("%s: JDParts round trip moved by %.3g seconds", when.Format(time.RFC3339), d)
 		}
 
 		// And the Go round trip, which is what most callers use.
-		if d := start.ToGo().Sub(when).Abs(); d > gotime.Microsecond {
-			t.Errorf("%s: FromGo/ToGo moved by %v", when.Format(gotime.RFC3339), d)
+		if d := start.ToGo().Sub(when).Abs(); d > time.Microsecond {
+			t.Errorf("%s: FromGo/ToGo moved by %v", when.Format(time.RFC3339), d)
 		}
 	}
 }
@@ -127,20 +126,20 @@ func TestCalendarAccessorsAgree(t *testing.T) {
 	t.Parallel()
 
 	for _, when := range epochs() {
-		start := astrotime.FromGo(when)
+		start := time.FromGo(when)
 
 		y, m, d, _ := start.Calendar()
 
 		if y != start.Year() || m != int(start.Month()) || d != start.Day() {
 			t.Errorf("%s: Calendar gave (%d, %d, %d) but the accessors gave (%d, %d, %d)",
-				when.Format(gotime.RFC3339), y, m, d, start.Year(), int(start.Month()), start.Day())
+				when.Format(time.RFC3339), y, m, d, start.Year(), int(start.Month()), start.Day())
 		}
 
 		// Against Go's own calendar, which is independent of this package.
 		gy, gm, gd := when.Date()
 		if y != gy || m != int(gm) || d != gd {
 			t.Errorf("%s: Calendar gave (%d, %d, %d), Go says (%d, %d, %d)",
-				when.Format(gotime.RFC3339), y, m, d, gy, int(gm), gd)
+				when.Format(time.RFC3339), y, m, d, gy, int(gm), gd)
 		}
 	}
 }
@@ -151,15 +150,15 @@ func TestAddIsReversible(t *testing.T) {
 	t.Parallel()
 
 	for _, when := range epochs() {
-		start := astrotime.FromGo(when)
+		start := time.FromGo(when)
 
-		for _, d := range []gotime.Duration{
-			gotime.Second, gotime.Minute, gotime.Hour, 24 * gotime.Hour, 365 * 24 * gotime.Hour,
+		for _, d := range []time.Duration{
+			time.Second, time.Minute, time.Hour, 24 * time.Hour, 365 * 24 * time.Hour,
 		} {
 			back := start.Add(d).Add(-d)
 			if moved := math.Abs(back.JD()-start.JD()) * 86400; moved > 1e-6 {
 				t.Errorf("%s: +%v then -%v moved the instant by %.3g seconds",
-					when.Format(gotime.RFC3339), d, d, moved)
+					when.Format(time.RFC3339), d, d, moved)
 			}
 		}
 
@@ -167,7 +166,7 @@ func TestAddIsReversible(t *testing.T) {
 			back := start.AddDays(days).AddDays(-days)
 			if moved := math.Abs(back.JD()-start.JD()) * 86400; moved > 1e-6 {
 				t.Errorf("%s: +%v days then back moved by %.3g seconds",
-					when.Format(gotime.RFC3339), days, moved)
+					when.Format(time.RFC3339), days, moved)
 			}
 		}
 	}
@@ -181,7 +180,7 @@ func TestAddIsReversible(t *testing.T) {
 // is the representation, not the conversion, and JDParts exists precisely so a
 // caller does not have to lose it — the integer day and the fraction are kept
 // apart, and differencing them term by term keeps the fraction's own precision.
-func secondsBetween(a, b astrotime.Time) float64 {
+func secondsBetween(a, b time.Time) float64 {
 	a1, a2 := a.JDParts()
 	b1, b2 := b.JDParts()
 

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -3,20 +3,19 @@ package time_test
 import (
 	"math"
 	"testing"
-	"time"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
-	atime "github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/time/internal/iers"
 )
 
 func TestFromJD(t *testing.T) {
 	jd := 2460000.5
-	tm := atime.FromJD(jd, atime.UTC)
+	tm := time.FromJD(jd, time.UTC)
 
 	testutil.AssertNear(t, "JD value", tm.JD(), jd, 1e-15)
-	testutil.AssertEqual(t, "Scale", tm.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "Scale", tm.Scale(), time.UTC)
 
 	jd1, jd2 := tm.JDParts()
 	if jd1+jd2 != jd {
@@ -26,12 +25,12 @@ func TestFromJD(t *testing.T) {
 
 func TestFromJDParts(t *testing.T) {
 	// 2460000.5 + 0.1
-	tm := atime.FromJDParts(2460000.5, 0.1, atime.TAI)
+	tm := time.FromJDParts(2460000.5, 0.1, time.TAI)
 	testutil.AssertNear(t, "Total JD", tm.JD(), 2460000.6, 1e-15)
-	testutil.AssertEqual(t, "Scale", tm.Scale(), atime.TAI)
+	testutil.AssertEqual(t, "Scale", tm.Scale(), time.TAI)
 
 	// Normalization check: FromJDParts(2460000.5, 1.1)
-	tm2 := atime.FromJDParts(2460000.5, 1.1, atime.UTC)
+	tm2 := time.FromJDParts(2460000.5, 1.1, time.UTC)
 	j1, j2 := tm2.JDParts()
 	// Total JD = 2460001.6. Normalization moves everything to jd2 except the integer part.
 	testutil.AssertNear(t, "jd1 after norm", j1, 2460001.0, 1e-15)
@@ -40,29 +39,29 @@ func TestFromJDParts(t *testing.T) {
 
 func TestFromGo(t *testing.T) {
 	// 2000-01-01 12:00:00 UTC is exactly JD 2451545.0
-	goTime := time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC)
-	tm := atime.FromGo(goTime)
+	goTime := time.GoDate(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC)
+	tm := time.FromGo(goTime)
 
 	testutil.AssertNear(t, "JD for 2000-01-01 12:00", tm.JD(), 2451545.0, 1e-9)
-	testutil.AssertEqual(t, "Scale", tm.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "Scale", tm.Scale(), time.UTC)
 }
 
 func TestNowUTC(t *testing.T) {
-	tm := atime.NowUTC()
+	tm := time.NowUTC()
 	if tm.JD() < 2460000 {
 		t.Errorf("NowUTC JD seems too small: %v", tm.JD())
 	}
 
-	testutil.AssertEqual(t, "Scale", tm.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "Scale", tm.Scale(), time.UTC)
 }
 
 func TestArithmetic(t *testing.T) {
-	tm := atime.FromJD(2450000.0, atime.TT)
+	tm := time.FromJD(2450000.0, time.TT)
 
 	// AddDays
 	tm2 := tm.AddDays(1.5)
 	testutil.AssertNear(t, "Add 1.5 days", tm2.JD(), 2450001.5, 1e-15)
-	testutil.AssertEqual(t, "Scale preserved", tm2.Scale(), atime.TT)
+	testutil.AssertEqual(t, "Scale preserved", tm2.Scale(), time.TT)
 
 	// SubDays
 	diff := tm2.SubDays(tm)
@@ -70,12 +69,12 @@ func TestArithmetic(t *testing.T) {
 }
 
 func TestScaleString(t *testing.T) {
-	testutil.AssertEqual(t, "UTC string", atime.UTC.String(), "UTC")
-	testutil.AssertEqual(t, "TAI string", atime.TAI.String(), "TAI")
+	testutil.AssertEqual(t, "UTC string", time.UTC.String(), "UTC")
+	testutil.AssertEqual(t, "TAI string", time.TAI.String(), "TAI")
 }
 
 func TestString(t *testing.T) {
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 
 	s := tm.String()
 	if !math.IsNaN(tm.JD()) && (s == "" || s == "UNKNOWN") {
@@ -85,20 +84,20 @@ func TestString(t *testing.T) {
 
 func TestScaleConversions(t *testing.T) {
 	// J2000.0 UTC -> JD 2451545.0
-	tm := atime.FromJD(2451545.0, atime.UTC)
+	tm := time.FromJD(2451545.0, time.UTC)
 
 	// In 2000, ΔAT = 32s
 	// TT = UTC + 32s + 32.184s = UTC + 64.184s
 	// TT_JD = 2451545.0 + 64.184 / 86400 = 2451545.0007428704
 
 	tt := tm.TT()
-	testutil.AssertEqual(t, "TT scale", tt.Scale(), atime.TT)
+	testutil.AssertEqual(t, "TT scale", tt.Scale(), time.TT)
 	testutil.AssertNear(t, "TT JD", tt.JD(), 2451545.0007428704, 1e-12)
 
 	// TDB uses Fairhead & Bretagnon correction.
 	// At J2000 (T=0): g = 357.5277233°, TDB−TT ≈ −71.5 μs
 	tdb := tm.TDB()
-	testutil.AssertEqual(t, "TDB scale", tdb.Scale(), atime.TDB)
+	testutil.AssertEqual(t, "TDB scale", tdb.Scale(), time.TDB)
 
 	// Compute TDB−TT correction in seconds via two-part JD differencing.
 	tt1, tt2 := tt.JDParts()
@@ -118,9 +117,9 @@ func TestScaleConversions(t *testing.T) {
 }
 
 func TestTimeComparisons(t *testing.T) {
-	t1 := atime.FromJD(2450000.0, atime.UTC)
-	t2 := atime.FromJD(2450001.0, atime.UTC)
-	t3 := atime.FromJD(2450000.0, atime.UTC)
+	t1 := time.FromJD(2450000.0, time.UTC)
+	t2 := time.FromJD(2450001.0, time.UTC)
+	t3 := time.FromJD(2450000.0, time.UTC)
 
 	if !t1.Before(t2) {
 		t.Errorf("Expected t1 before t2")
@@ -138,7 +137,7 @@ func TestTimeComparisons(t *testing.T) {
 		t.Errorf("Expected t1 not equal to t2")
 	}
 
-	zero := atime.Time{}
+	zero := time.Time{}
 	if !zero.IsZero() {
 		t.Errorf("Expected zero time to be zero")
 	}
@@ -149,14 +148,14 @@ func TestTimeComparisons(t *testing.T) {
 }
 
 func TestTimeStdInterop(t *testing.T) {
-	t1 := atime.FromJD(2451545.0, atime.UTC) // J2000
+	t1 := time.FromJD(2451545.0, time.UTC) // J2000
 
 	gt := t1.ToGo()
 	if gt.Year() != 2000 || gt.Month() != 1 || gt.Day() != 1 || gt.Hour() != 12 {
 		t.Errorf("ToGo conversion failed, got %v", gt)
 	}
 
-	t2 := atime.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC)
 	if !t1.Equal(t2) {
 		t.Errorf("Date constructor failed, expected %v got %v", t1.JD(), t2.JD())
 	}
@@ -178,19 +177,19 @@ func TestTimeStdInterop(t *testing.T) {
 func TestTimeFloatPrecisionRoundTrip(t *testing.T) {
 	// Let's test a broad spectrum of "dirty" hours and dates
 	// to ensure floating-point precision truncation never regresses again.
-	datesToTest := []time.Time{
-		time.Date(2026, 4, 6, 22, 0, 0, 0, time.UTC),                       // JD = 2461137.41666667 (The original issue)
-		time.Date(2026, 4, 6, 19, 0, 0, 0, time.FixedZone("BRT", -3*3600)), // São Paulo Timezone directly
-		time.Date(1999, 12, 31, 23, 59, 59, 0, time.UTC),                   // One second before Y2K
-		time.Date(2038, 1, 19, 3, 14, 7, 0, time.UTC),                      // Year 2038 problem epoch
-		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),                       // Exact .5 JD boundary
-		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),                        // Unix Epoch Origin
-		time.Date(2050, 7, 4, 18, 30, 45, 123456000, time.UTC),             // Mixed sub-seconds
+	datesToTest := []time.GoTime{
+		time.GoDate(2026, 4, 6, 22, 0, 0, 0, time.LocationUTC),               // JD = 2461137.41666667 (The original issue)
+		time.GoDate(2026, 4, 6, 19, 0, 0, 0, time.FixedZone("BRT", -3*3600)), // São Paulo Timezone directly
+		time.GoDate(1999, 12, 31, 23, 59, 59, 0, time.LocationUTC),           // One second before Y2K
+		time.GoDate(2038, 1, 19, 3, 14, 7, 0, time.LocationUTC),              // Year 2038 problem epoch
+		time.GoDate(2000, 1, 1, 12, 0, 0, 0, time.LocationUTC),               // Exact .5 JD boundary
+		time.GoDate(1970, 1, 1, 0, 0, 0, 0, time.LocationUTC),                // Unix Epoch Origin
+		time.GoDate(2050, 7, 4, 18, 30, 45, 123456000, time.LocationUTC),     // Mixed sub-seconds
 	}
 
 	for _, dt := range datesToTest {
 		// Go -> AstroGo Time
-		astroTime := atime.FromGo(dt)
+		astroTime := time.FromGo(dt)
 
 		// AstroGo Time -> Go
 		roundTripped := astroTime.ToGo()
@@ -221,14 +220,14 @@ func TestTime_UT1(t *testing.T) {
 	iers.RegisterModel(mockEOP{})
 	t.Cleanup(iers.Reset)
 
-	utc := atime.FromJD(2451545.0, atime.UTC) // J2000 UTC
+	utc := time.FromJD(2451545.0, time.UTC) // J2000 UTC
 
 	ut1, err := utc.UT1()
 	if err != nil {
 		t.Fatalf("UT1() returned error: %v", err)
 	}
 
-	testutil.AssertEqual(t, "UT1 scale", ut1.Scale(), atime.UT1)
+	testutil.AssertEqual(t, "UT1 scale", ut1.Scale(), time.UT1)
 
 	expectedJD := 2451545.0 + (1.5 / 86400.0)
 	testutil.AssertNear(t, "UT1 JD offset", ut1.JD(), expectedJD, 1e-12)
@@ -239,7 +238,7 @@ func TestTime_UT1(t *testing.T) {
 		t.Fatalf("UT1() on UT1 time returned error: %v", err)
 	}
 
-	testutil.AssertEqual(t, "Idempotent UT1 scale", ut1b.Scale(), atime.UT1)
+	testutil.AssertEqual(t, "Idempotent UT1 scale", ut1b.Scale(), time.UT1)
 	testutil.AssertNear(t, "Idempotent UT1 JD", ut1b.JD(), ut1.JD(), 1e-15)
 }
 
@@ -247,8 +246,8 @@ func TestTime_LocationPreservation(t *testing.T) {
 	brt := time.FixedZone("BRT", -3*3600)
 
 	// FromGo preserves the original location
-	goTime := time.Date(2026, 4, 14, 22, 0, 0, 0, brt)
-	tm := atime.FromGo(goTime)
+	goTime := time.GoDate(2026, 4, 14, 22, 0, 0, 0, brt)
+	tm := time.FromGo(goTime)
 
 	if tm.Location().String() != "BRT" {
 		t.Errorf("expected BRT location, got %s", tm.Location())
@@ -265,7 +264,7 @@ func TestTime_LocationPreservation(t *testing.T) {
 	}
 
 	// Date preserves the location
-	tm2 := atime.Date(2026, 4, 14, 22, 0, 0, 0, brt)
+	tm2 := time.Date(2026, 4, 14, 22, 0, 0, 0, brt)
 	if tm2.Location().String() != "BRT" {
 		t.Errorf("expected BRT from Date, got %s", tm2.Location())
 	}
@@ -278,10 +277,10 @@ func TestTime_LocationPreservation(t *testing.T) {
 }
 
 func TestTime_In(t *testing.T) {
-	tm := atime.FromJD(2451545.0, atime.UTC) // J2000 at UTC
+	tm := time.FromJD(2451545.0, time.UTC) // J2000 at UTC
 
 	// Default location is UTC
-	if tm.Location() != time.UTC {
+	if tm.Location() != time.LocationUTC {
 		t.Errorf("expected UTC default, got %s", tm.Location())
 	}
 
@@ -310,7 +309,7 @@ func TestTime_LocationPropagation(t *testing.T) {
 	t.Cleanup(iers.Reset)
 
 	brt := time.FixedZone("BRT", -3*3600)
-	tm := atime.Date(2026, 4, 14, 22, 0, 0, 0, brt)
+	tm := time.Date(2026, 4, 14, 22, 0, 0, 0, brt)
 
 	// AddDays preserves location
 	tm2 := tm.AddDays(1)
@@ -362,17 +361,17 @@ func TestTime_LocationPropagation(t *testing.T) {
 
 func TestTAI_Conversion(t *testing.T) {
 	// J2000.0 UTC: ΔAT = 32 leap seconds
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 
 	tai := utc.TAI()
-	testutil.AssertEqual(t, "TAI scale", tai.Scale(), atime.TAI)
+	testutil.AssertEqual(t, "TAI scale", tai.Scale(), time.TAI)
 	// TAI = UTC + 32s
 	expectedTAI := 2451545.0 + 32.0/86400.0
 	testutil.AssertNear(t, "TAI JD", tai.JD(), expectedTAI, 1e-12)
 
 	// TAI → TT should add 32.184s
 	tt := tai.TT()
-	testutil.AssertEqual(t, "TT from TAI scale", tt.Scale(), atime.TT)
+	testutil.AssertEqual(t, "TT from TAI scale", tt.Scale(), time.TT)
 
 	expectedTT := expectedTAI + 32.184/86400.0
 	testutil.AssertNear(t, "TT from TAI JD", tt.JD(), expectedTT, 1e-12)
@@ -383,24 +382,24 @@ func TestTAI_Conversion(t *testing.T) {
 }
 
 func TestUTC_Inverse(t *testing.T) {
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 
 	// UTC → TT → UTC round-trip
 	tt := utc.TT()
 	utcBack := tt.UTC()
-	testutil.AssertEqual(t, "UTC round-trip scale", utcBack.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "UTC round-trip scale", utcBack.Scale(), time.UTC)
 	testutil.AssertNear(t, "UTC→TT→UTC", utcBack.JD(), utc.JD(), 1e-12)
 
 	// UTC → TAI → UTC round-trip
 	tai := utc.TAI()
 	utcBack2 := tai.UTC()
-	testutil.AssertEqual(t, "UTC→TAI→UTC scale", utcBack2.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "UTC→TAI→UTC scale", utcBack2.Scale(), time.UTC)
 	testutil.AssertNear(t, "UTC→TAI→UTC", utcBack2.JD(), utc.JD(), 1e-12)
 
 	// UTC → TDB → UTC round-trip
 	tdb := utc.TDB()
 	utcBack3 := tdb.UTC()
-	testutil.AssertEqual(t, "UTC→TDB→UTC scale", utcBack3.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "UTC→TDB→UTC scale", utcBack3.Scale(), time.UTC)
 	testutil.AssertNear(t, "UTC→TDB→UTC", utcBack3.JD(), utc.JD(), 1e-10)
 
 	// Idempotent
@@ -416,7 +415,7 @@ func TestConversionRoundTrips(t *testing.T) {
 	t.Cleanup(iers.Reset)
 
 	// Full chain: UTC → TAI → TT → TDB → TT → TAI → UTC
-	utc := atime.FromJD(2460000.5, atime.UTC)
+	utc := time.FromJD(2460000.5, time.UTC)
 
 	tai := utc.TAI()
 	tt := tai.TT()
@@ -425,7 +424,7 @@ func TestConversionRoundTrips(t *testing.T) {
 	taiBack := ttBack.TAI()
 	utcBack := taiBack.UTC()
 
-	testutil.AssertEqual(t, "Full round-trip scale", utcBack.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "Full round-trip scale", utcBack.Scale(), time.UTC)
 	// Allow 1e-10 JD tolerance for TDB→TT round-trip (FB is not exactly invertible)
 	testutil.AssertNear(t, "Full round-trip JD", utcBack.JD(), utc.JD(), 1e-10)
 
@@ -438,7 +437,7 @@ func TestConversionRoundTrips(t *testing.T) {
 	}
 
 	utcFromUT1 := ut1.UTC()
-	testutil.AssertEqual(t, "UT1→UTC scale", utcFromUT1.Scale(), atime.UTC)
+	testutil.AssertEqual(t, "UT1→UTC scale", utcFromUT1.Scale(), time.UTC)
 	// DUT1=1.5s: UTC→UT1→UTC should recover within ~1e-12 JD
 	testutil.AssertNear(t, "UTC→UT1→UTC", utcFromUT1.JD(), utc.JD(), 1e-12)
 }
@@ -461,7 +460,7 @@ func TestTDB_XJSE2000(t *testing.T) {
 
 	for _, ep := range epochs {
 		t.Run(ep.name, func(t *testing.T) {
-			utc := atime.FromJD(ep.jd, atime.UTC)
+			utc := time.FromJD(ep.jd, time.UTC)
 			tt := utc.TT()
 			tdb := utc.TDB()
 
@@ -494,7 +493,7 @@ func TestTDB_XJSE2000(t *testing.T) {
 
 func TestCrossScaleComparison(t *testing.T) {
 	// Create the same instant in different scales
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 	tt := utc.TT()
 	tai := utc.TAI()
 	tdb := utc.TDB()
@@ -541,8 +540,8 @@ func TestCrossScaleComparison(t *testing.T) {
 
 func TestCrossScaleSub(t *testing.T) {
 	// Verify Sub handles same-scale fast path correctly
-	a := atime.FromJD(2451545.0, atime.TT)
-	b := atime.FromJD(2451546.0, atime.TT)
+	a := time.FromJD(2451545.0, time.TT)
+	b := time.FromJD(2451546.0, time.TT)
 
 	dur := b.Sub(a)
 	if dur != 24*time.Hour {
@@ -550,7 +549,7 @@ func TestCrossScaleSub(t *testing.T) {
 	}
 
 	// Cross-scale Sub
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 	tt := utc.TT()
 
 	dur2 := utc.Sub(tt)
@@ -580,7 +579,7 @@ func TestUT1_Error(t *testing.T) {
 
 	defer iers.Reset() // restore
 
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 
 	_, err := utc.UT1()
 	if err == nil {
@@ -600,7 +599,7 @@ func TestTT_FromAllScales(t *testing.T) {
 
 	defer iers.Reset()
 
-	utc := atime.FromJD(2451545.0, atime.UTC)
+	utc := time.FromJD(2451545.0, time.UTC)
 	expectedTT := utc.TT()
 
 	// TAI → TT
@@ -635,11 +634,11 @@ func TestTT_FromAllScales(t *testing.T) {
 // *formula* matches the code's documented design intent, not to demonstrate a
 // large numerical discrepancy.
 func TestTT_Pre1972UsesDeltaTNotLeapSeconds(t *testing.T) {
-	utc := atime.FromGo(time.Date(1965, 6, 15, 0, 0, 0, 0, time.UTC))
+	utc := time.FromGo(time.GoDate(1965, 6, 15, 0, 0, 0, 0, time.LocationUTC))
 	tt := utc.TT()
 
 	offsetSeconds := (tt.JD() - utc.JD()) * 86400.0
-	expectedDT := atime.DeltaT(utc.DecimalYear())
+	expectedDT := time.DeltaT(utc.DecimalYear())
 
 	// 1e-4s tolerance absorbs float64 noise from JD() collapsing the
 	// two-part representation, while still being tighter than the ~0.09s
@@ -647,7 +646,7 @@ func TestTT_Pre1972UsesDeltaTNotLeapSeconds(t *testing.T) {
 	testutil.AssertNear(t, "TT-UTC offset (ΔT-based)", offsetSeconds, expectedDT, 1e-4)
 
 	// The true 1972-01-01 boundary itself must still use the leap-second path.
-	boundary := atime.FromGo(time.Date(1972, 1, 1, 0, 0, 0, 0, time.UTC))
+	boundary := time.FromGo(time.GoDate(1972, 1, 1, 0, 0, 0, 0, time.LocationUTC))
 	ttBoundary := boundary.TT()
 	boundaryOffset := (ttBoundary.JD() - boundary.JD()) * 86400.0
 	testutil.AssertNear(t, "TT-UTC offset at 1972-01-01 (leap-second based)", boundaryOffset, 10+32.184, 1e-4)


### PR DESCRIPTION
CI never built a tagged file on the pull-request path.

`go test ./...` skips them, `golangci-lint` runs untagged, and the `integration` job is `continue-on-error: true` so it cannot fail a build. **59 test files — 34 `network`, 17 `validation`, 8 `integration` — were only ever compiled by the weekly `Validation` workflow**, which is deliberately off the PR path because those suites query JPL, USNO, NASA, ESO and VizieR.

The consequence is that a tagged file which does not compile reaches `main` green. It has happened: #75 rewrote an import in `ephemeris/kepler/validation_test.go` and left two references to the old alias behind, so `go vet -tags=network` did not build that package on `main` until #78 rebased onto it a day later and noticed.

## The fix

One step, ubuntu only:

```yaml
- name: Vet build-tagged files
  if: matrix.os == 'ubuntu-latest'
  run: go vet -tags="integration,network,validation" ./...
```

`vet` type-checks those files without running any of them, so this costs seconds and makes **no external request**. It is the compile check, not a substitute for running the suites — the weekly workflow still does that.

## Verified against the bug it exists for

Reintroduced the exact `atime` reference and ran all three:

| | result |
| :--- | :--- |
| `go vet ./...` | clean — the bug is invisible |
| `golangci-lint run` | `0 issues` |
| **`go vet -tags="integration,network,validation" ./...`** | **`undefined: atime`** |

## Also here: the README's Kepler entry

Two halves of the README were written apart and never joined. The feature table sells *"Kepler Propagation, No Kernel — six orbital elements and an epoch, no SPK kernel, no network"* with **no accuracy figure at all**, while the offline-accuracy section added in #78 quantified that same capability without naming it.

- The feature row now carries the measured **1–4″ over a month** and links to the section.
- The section names `ephemeris/kepler` and `NewMovingBodyProvider` as the path `plan.NewAsteroid` takes when no kernel is available, and says plainly that it is good enough to find the object and not to measure it.

## Verification

`gofmt -l .` clean, `go build ./...`, `go test ./...`, `go vet` untagged and tagged, `golangci-lint run` at **0 issues**.