### PR TITLE
Compose radial velocities by multiplying redshifts, not adding velocities

### DIFF
--- a/coord/radialvelocity.go
+++ b/coord/radialvelocity.go
@@ -19,10 +19,25 @@ import (
 // this is BarycentricVelocity() dotted with the unit vector FROM the
 // observer TO target. If the observer is moving toward target, that dot
 // product is positive, the observer's own motion blueshifts the
-// measured line (makes RV_measured read too low), and adding this
-// correction brings it back up to the true barycentric value:
+// measured line (makes RV_measured read too low), and this correction
+// brings it back up to the true barycentric value.
 //
-//	rvBarycentric = rvMeasured + ctx.BarycentricRVCorrection(target)
+// # Do not add this to a radial velocity
+//
+// Use [Context.BarycentricRadialVelocity], which composes the two
+// correctly. This comment used to say
+//
+//	rvBarycentric = rvMeasured + ctx.BarycentricRVCorrection(target)  // WRONG
+//
+// and that is first-order only: redshifts multiply, so the exact form
+// carries a third term rvMeasured·corr/c. Dropping it costs 4.66 m/s at
+// a target velocity of 46.6 km/s and 30 m/s at 300 — larger, for such a
+// target, than every relativistic term listed below put together.
+//
+// This function remains exported because the raw projection is a real
+// quantity with real uses (its annual sinusoid, its diurnal amplitude,
+// comparing against another implementation's correction). It is the
+// composition that needed fixing, not the value.
 //
 // Accuracy: about 1 m/s, no better. gofaext.Epv00/Apco13's underlying
 // ephemeris is itself accurate to a few cm/s, but this is a classical
@@ -35,19 +50,62 @@ func (ctx *Context) BarycentricRVCorrection(target ICRS) float64 {
 	return ctx.BarycentricVelocity().Dot(target.ToUnitVector())
 }
 
+// lightSpeedKmPerSec is c in the units every radial velocity here is
+// expressed in.
+var lightSpeedKmPerSec = constants.SI2019.SpeedOfLight.Value / 1000.0
+
+// BarycentricRadialVelocity refers a measured (topocentric) radial
+// velocity of target to the solar system barycenter, in km/s.
+//
+// # Why this is not rvObserved plus the correction
+//
+// Because a radial velocity is a redshift, and redshifts compose by
+// multiplication rather than addition. Two successive Doppler shifts
+// give (1+z) = (1+z₁)(1+z₂), so in velocities:
+//
+//	rvBarycentric = rvObserved + corr + rvObserved·corr/c
+//
+// The third term is what adding drops. It is not a refinement: at a
+// correction of 30 km/s it reaches 4.66 m/s — the size of every
+// relativistic term this package documents itself as omitting, combined —
+// once the target's own velocity passes 46.6 km/s, and 30 m/s for a halo
+// star at 300 km/s. For the Sun-like targets most catalogs hold it is
+// well under a metre per second, which is why it can sit unnoticed.
+//
+// It sat unnoticed here. [Context.BarycentricRVCorrection]'s own doc
+// comment gave the additive form as the way to use it, and the 175-case
+// Astropy fixture that validates this file could not see the error,
+// because every target in it has no radial velocity at all — the term
+// vanishes identically when rvObserved is zero. Astropy documents the
+// same three-term formula for the same reason.
+//
+// The correction itself is unchanged and still classical: this fixes how
+// it composes, not what it contains. See [Context.BarycentricRVCorrection]
+// for the terms that remain unimplemented.
+func (ctx *Context) BarycentricRadialVelocity(target ICRS, rvObserved float64) float64 {
+	corr := ctx.BarycentricRVCorrection(target)
+
+	return rvObserved + corr + rvObserved*corr/lightSpeedKmPerSec
+}
+
 // ObservedRadialVelocity returns the topocentric radial velocity, in
 // km/s, an observer at ctx would measure right now for a target whose
-// barycentric RV is rvBarycentric — the inverse of
-// BarycentricRVCorrection, and the direction almost every real use
-// needs: published catalog RVs (SIMBAD's rvz_radvel, for one) are
-// already barycentric, so applying BarycentricRVCorrection to one
-// directly double-corrects by up to ~60 km/s peak-to-peak. Derived
-// directly from BarycentricRVCorrection's own documented sign
-// convention (rvBarycentric = rvMeasured + correction):
+// barycentric RV is rvBarycentric — the exact inverse of
+// [Context.BarycentricRadialVelocity], and the direction almost every
+// real use needs: published catalog RVs (SIMBAD's rvz_radvel, for one)
+// are already barycentric, so applying BarycentricRVCorrection to one
+// directly double-corrects by up to ~60 km/s peak-to-peak.
 //
-//	rvObserved = rvBarycentric - ctx.BarycentricRVCorrection(target)
+// Inverting rvBarycentric = rvObserved·(1 + corr/c) + corr:
+//
+//	rvObserved = (rvBarycentric - corr) / (1 + corr/c)
+//
+// which is exact rather than a series, so the round trip closes to
+// floating-point precision at any radial velocity.
 func (ctx *Context) ObservedRadialVelocity(target ICRS, rvBarycentric float64) float64 {
-	return rvBarycentric - ctx.BarycentricRVCorrection(target)
+	corr := ctx.BarycentricRVCorrection(target)
+
+	return (rvBarycentric - corr) / (1 + corr/lightSpeedKmPerSec)
 }
 
 // HeliocentricRVCorrection is [Context.BarycentricRVCorrection], but

--- a/coord/radialvelocity_test.go
+++ b/coord/radialvelocity_test.go
@@ -281,11 +281,118 @@ func TestObservedRadialVelocity_RoundTripsWithBarycentricRVCorrection(t *testing
 		for _, target := range targets {
 			rvObserved := ctx.ObservedRadialVelocity(target, rvBarycentric)
 
-			// The defining relation BarycentricRVCorrection documents:
-			// rvBarycentric = rvMeasured + ctx.BarycentricRVCorrection(target).
-			roundTripped := rvObserved + ctx.BarycentricRVCorrection(target)
+			// The two conversions are exact inverses, so this closes to
+			// floating point rather than to a series truncation.
+			roundTripped := ctx.BarycentricRadialVelocity(target, rvObserved)
 
-			testutil.AssertNear(t, "round-tripped barycentric RV", roundTripped, rvBarycentric, 1e-9)
+			testutil.AssertNear(t, "round-tripped barycentric RV", roundTripped, rvBarycentric, 1e-12)
 		}
+	}
+}
+
+// TestBarycentricRadialVelocity_ComposesRedshiftsMultiplicatively checks the
+// conversion against the relation it is derived from, rather than against a
+// restatement of its own arithmetic.
+//
+// A radial velocity is a redshift, and two successive Doppler shifts compose
+// as (1+z) = (1+z1)(1+z2). Writing z = rv/c, the barycentric velocity is
+// therefore c[(1 + rvObserved/c)(1 + corr/c) - 1] exactly. Building the
+// expected value that way — from the product, not from the expanded
+// three-term form the implementation uses — means a sign slip or a dropped
+// term in either expression fails the test.
+//
+// The tolerance is 1e-9 km/s, a micrometre per second, and it is set by the
+// *reference* expression rather than by the code under test. Both velocities
+// are of order 1e-4 c, so the bracket (1+a)(1+b)-1 subtracts two numbers that
+// agree to fifteen digits and c multiplies what survives back up: the product
+// form is good to about 3e-11 km/s and no better. The implementation's
+// expanded form does not perform that subtraction at all, which makes it the
+// more accurate of the two as well as the cheaper. That is why it is written
+// out rather than expressed as the product it comes from.
+func TestBarycentricRadialVelocity_ComposesRedshiftsMultiplicatively(t *testing.T) {
+	site := equatorSite(t)
+	ctx := coord.NewContext(
+		time.Date(2026, time.January, 4, 0, 0, 0, 0, time.LocationUTC), site, noRefraction)
+
+	// Speed of light in km/s, spelled out here so the test does not import
+	// the same constant the implementation does.
+	const c = 299792.458
+
+	targets := []coord.ICRS{
+		coord.NewICRS(angle.Zero(), angle.Zero()),
+		coord.NewICRS(angle.Deg(90), angle.Deg(30)),
+		coord.NewICRS(angle.Deg(200), angle.Deg(-45)),
+	}
+
+	// Spanning a Sun-like star, a thick-disc star and a halo star.
+	for _, rvObserved := range []float64{0, -5.5, 20, 100, -300} {
+		for _, target := range targets {
+			corr := ctx.BarycentricRVCorrection(target)
+			want := c * ((1+rvObserved/c)*(1+corr/c) - 1)
+
+			got := ctx.BarycentricRadialVelocity(target, rvObserved)
+
+			testutil.AssertNear(t, "barycentric RV from the redshift product", got, want, 1e-9)
+		}
+	}
+}
+
+// TestBarycentricRadialVelocity_ExceedsTheAdditiveFormByTheDocumentedAmount
+// measures what the old additive form dropped, because the doc comments now
+// quote those figures and a quoted figure nobody checks is a comment.
+//
+// The gap is rvObserved*corr/c, so it grows with the target's own velocity
+// and vanishes entirely at zero — which is why the 175-case Astropy fixture,
+// whose every target has no radial velocity, could not see this.
+func TestBarycentricRadialVelocity_ExceedsTheAdditiveFormByTheDocumentedAmount(t *testing.T) {
+	site := equatorSite(t)
+
+	// Early January, when Earth is near perihelion and moving fastest, and a
+	// target on the ecliptic at RA 0 — the geometry that maximises the
+	// correction and so the term that scales with it.
+	ctx := coord.NewContext(
+		time.Date(2026, time.January, 4, 0, 0, 0, 0, time.LocationUTC), site, noRefraction)
+	target := coord.NewICRS(angle.Zero(), angle.Zero())
+
+	corr := ctx.BarycentricRVCorrection(target)
+	if math.Abs(corr) < 25 {
+		t.Fatalf("correction is %.3f km/s, expected about 30 near perihelion on the ecliptic; "+
+			"the geometry this test relies on has changed", corr)
+	}
+
+	const c = 299792.458
+
+	cases := []struct {
+		rvObserved float64
+		what       string
+	}{
+		{0, "no radial velocity — the term vanishes, which is the fixture's blind spot"},
+		{-5.5, "Sirius"},
+		{20, "a typical thick-disc star"},
+		{300, "a halo star"},
+	}
+
+	for _, tc := range cases {
+		additive := tc.rvObserved + corr
+		exact := ctx.BarycentricRadialVelocity(target, tc.rvObserved)
+
+		gapMPerS := (exact - additive) * 1e3
+		wantMPerS := tc.rvObserved * corr / c * 1e3
+
+		t.Logf("rv %+7.1f km/s (%s): additive form is off by %+8.2f m/s",
+			tc.rvObserved, tc.what, gapMPerS)
+
+		testutil.AssertNear(t, "gap against the additive form", gapMPerS, wantMPerS, 1e-9)
+	}
+
+	// The claim the doc comments make: at 46.6 km/s the dropped term equals
+	// the 4.66 m/s of relativistic physics this package omits, so beyond it
+	// the composition error dominates the modelling error.
+	const crossover = 46.6
+
+	dropped := math.Abs(crossover*corr/c) * 1e3
+	if dropped < 4.0 || dropped > 5.4 {
+		t.Errorf("at %.1f km/s the dropped term is %.2f m/s; the doc comments claim it reaches "+
+			"the 4.66 m/s of omitted relativistic terms there", crossover, dropped)
 	}
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -399,7 +399,7 @@ implementing `MeasuredRadialVelocity` (currently `*Star`).
 - [x] `plan.TargetDetails.RadialVelocity` — a `MeasuredRadialVelocity` capability
       interface (mirroring `StaticMagnitude`) on `*Star`, wired into `computeDetails`
       alongside the magnitude dispatch block; `Context.ObservedRadialVelocity` is the
-      inverse of `BarycentricRVCorrection`, tested to round-trip exactly
+      exact inverse of `BarycentricRadialVelocity`, tested to round-trip exactly
 - [x] `resolve.Target.HasRadialVelocity` — distinguishes a true-zero measured RV from
       "no RV on file", which a zero `RadialVelocity` cannot. Set by `catalog/simbad`,
       preserved through the multi-provider merge in `catalog`, and consumed by
@@ -412,6 +412,13 @@ implementing `MeasuredRadialVelocity` (currently `*Star`).
       needs no Python. Compared like for like against the classical projection, since
       Astropy's barycentric value is relativistic; the 4.66 m/s gap between the two is
       asserted against the 4.649 predicted from the terms astrogo omits
+- [x] `coord.Context.BarycentricRadialVelocity` — composes the correction with the
+      target's own velocity by multiplying redshifts rather than adding velocities,
+      which is the first Wright & Eastman point and the one that was costing the most.
+      The dropped cross-term `rv*corr/c` reaches 4.66 m/s at a target velocity of
+      46.6 km/s — the size of every relativistic term still omitted, combined — and
+      30 m/s for a halo star. It was invisible to the 175-case Astropy fixture because
+      every target in it has no radial velocity
 - [ ] Full Wright & Eastman (2014) treatment for sub-1-m/s precision-RV work
       (gravitational redshift, light-travel-time to barycenter, target proper
       motion/parallax effects on the projection geometry) — the current classical

--- a/examples/23_radial_velocity_correction/main.go
+++ b/examples/23_radial_velocity_correction/main.go
@@ -80,7 +80,10 @@ func main() {
 	}
 
 	fmt.Println()
-	fmt.Println("  rvBarycentric = rvMeasured + BarycentricRVCorrection(target)")
+	fmt.Println("  rvBarycentric = ctx.BarycentricRadialVelocity(target, rvMeasured)")
+	fmt.Println("  Not rvMeasured + the correction: redshifts compose by multiplying,")
+	fmt.Println("  so the exact form carries a third term rvMeasured*corr/c. For Sirius")
+	fmt.Println("  that is 0.55 m/s; for a halo star at 300 km/s it is 30 m/s.")
 	fmt.Println("  This is a classical (non-relativistic) velocity projection, accurate")
 	fmt.Println("  to ~1 m/s — it does not implement gravitational redshift, light-time")
 	fmt.Println("  to the barycenter, or a target's own proper-motion/parallax effects")


### PR DESCRIPTION
**Limitation A** of the six in #80.

The Wright & Eastman treatment is usually described as three missing physical terms — gravitational redshift, light-travel time, proper-motion geometry — worth 4.66 m/s together. It opens with a fourth point that is not a term at all, and that one was costing more than the other three.

## The defect

A radial velocity is a redshift, and redshifts compose as `(1+z) = (1+z₁)(1+z₂)`. In velocities:

```
rvBarycentric = rvObserved + corr + rvObserved·corr/c
```

This package documented the first two and dropped the third. `BarycentricRVCorrection`'s own doc comment gave the additive form as the way to use it:

```go
rvBarycentric = rvMeasured + ctx.BarycentricRVCorrection(target)  // first-order only
```

## What it cost — measured, not derived

The dropped term scales with the target's own velocity, so it is nothing for the Sun-like stars most catalogs hold and large elsewhere. `TestBarycentricRadialVelocity_ExceedsTheAdditiveFormByTheDocumentedAmount` prints all of these:

| target RV | additive form is off by |
| ---: | ---: |
| 0 | 0.00 m/s |
| −5.5 km/s (Sirius) | 0.55 m/s |
| 20 km/s | 2.00 m/s |
| **46.6 km/s** | **4.66 m/s** — equal to every relativistic term still omitted, *combined* |
| 300 km/s (halo star) | 29.93 m/s |

## Why nothing caught it

**Every target in the 175-case Astropy fixture has no radial velocity**, and the term vanishes identically at zero. The fixture reports the same `4.6611 m/s` relativistic gap before and after this change, because the correction itself is untouched — what changed is how it composes. Astropy documents the same three-term formula, for the same reason.

## The change

- **`Context.BarycentricRadialVelocity(target, rvObserved)`** — the conversion, composed correctly.
- **`Context.ObservedRadialVelocity`** becomes the *exact* inverse, `(rvBary − corr)/(1 + corr/c)`, rather than a subtraction — so the round trip closes at any velocity instead of only near zero. Its test tolerance tightens from 1e-9 to 1e-12.
- **`Context.BarycentricRVCorrection` stays exported.** The raw projection is a real quantity with real uses — its annual sinusoid, its diurnal amplitude, comparison against another implementation. The composition was the defect, not the value. Its doc comment now carries the wrong form struck through and the reason.
- `plan.TargetDetails` picks the fix up unchanged, since it already went through `ObservedRadialVelocity`.
- `examples/23_radial_velocity_correction` was **printing the wrong formula to users** and now prints the right one, with the Sirius and halo-star figures.

## A note on the test's tolerance

`TestBarycentricRadialVelocity_ComposesRedshiftsMultiplicatively` builds its expected value from the product `c[(1+a)(1+b)−1]` — the definition — rather than from the expanded form the implementation uses, so a sign slip or dropped term in either expression fails.

Its tolerance of 1e-9 km/s is set by the **reference expression, not the code**. Both velocities are ~1e-4 c, so that bracket subtracts two numbers agreeing to fifteen digits and c multiplies what survives back up: the product form is good to ~3e-11 km/s and no better. The implementation never performs that subtraction, which makes the expanded form the more accurate of the two as well as the cheaper — that is why it is written out rather than as the product it comes from.

## Not the whole of limitation A

The box stays unchecked. The three relativistic terms — second-order Doppler, solar and Earth gravitational redshift — remain unimplemented and are still documented as such. Worth noting for whoever takes them: they are largely *constant* offsets, so they matter for absolute radial velocity and mostly cancel in the differential work precision-RV actually does.

## Verification

`gofmt -l .` clean, `go build ./...`, `go test ./...`, `go vet` untagged and with `integration,network,validation`, `golangci-lint run` at **0 issues**, `internal/docsguard`, and `go test -tags=validation ./coord/` — the Astropy fixture passes unchanged at 4.6611 m/s.