### PR TITLE
Require a changelog fragment, and add the two that were missed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,57 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: false
 
+  # CONTRIBUTING.md's pull request process asks for a changelog fragment, and
+  # docs/PULL_REQUESTS.md section 4 explains why one file per entry rather than
+  # editing CHANGELOG.md. Nothing enforced it, so #80 and #81 both merged
+  # without one and would have been absent from the release they belong to —
+  # discovered by hand, weeks after the fact, which is exactly the drift
+  # internal/docsguard exists to prevent everywhere else.
+  #
+  # `go test ./internal/changelog/` already validates that a fragment parses
+  # and names a real section. It cannot know which pull request is running, so
+  # the existence check has to live here, where the number is.
+  #
+  # Label a pull request `no-changelog` when it genuinely warrants no entry —
+  # pure test coverage for shipped behaviour, or a change to CI that no user
+  # can observe. The label is deliberate and reviewable; silence was not.
+  changelog-fragment:
+    name: Changelog Fragment
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Require a changelog fragment naming this pull request
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if [[ ",${PR_LABELS}," == *",no-changelog,"* ]]; then
+            echo "Labelled no-changelog — skipping."
+            exit 0
+          fi
+
+          shopt -s nullglob
+          found=(docs/changelog.d/"${PR_NUMBER}"-*.md)
+
+          if (( ${#found[@]} )); then
+            printf 'Found %d fragment(s):
+' "${#found[@]}"
+            printf '  %s
+' "${found[@]}"
+            exit 0
+          fi
+
+          echo "::error::No changelog fragment for pull request #${PR_NUMBER}."
+          echo "Add docs/changelog.d/${PR_NUMBER}-<short-slug>.md — see docs/changelog.d/README.md"
+          echo "and docs/PULL_REQUESTS.md section 4. If this change warrants no entry,"
+          echo "label the pull request 'no-changelog'."
+          exit 1
+
   race-detection:
     name: Race Detection
     runs-on: ubuntu-latest

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -104,6 +104,18 @@ reordering. A file per entry cannot collide, and carries its own section.
 malformed one fails the pull request that added it rather than the release weeks
 later.
 
+**A missing one fails too.** CI's `changelog-fragment` job requires
+`docs/changelog.d/<this PR number>-*.md` to exist. That check had to live in the
+workflow rather than in `internal/changelog`, because a Go test cannot know
+which pull request is running — and its absence was not hypothetical: #80 and
+#81 both merged without a fragment while this very section asked for one, and
+would have been missing from the release they belong to.
+
+If a change genuinely warrants no entry — pure test coverage for behaviour
+already shipped, or a CI change no user can observe — label the pull request
+`no-changelog`. The label is deliberate and shows up in review; silence did
+not.
+
 Deep forensic detail — root cause, before-and-after numbers, what you refuted —
 belongs in the pull request body or the code's own doc comment. **The changelog
 is an index, not the record.**

--- a/docs/changelog.d/80-known-limitations.md
+++ b/docs/changelog.d/80-known-limitations.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 80
+---
+**The six known scientific limitations are gathered into one checklist** in
+`docs/ROADMAP.md`, with what each blocks and what would unblock it. They were
+spread across `VALIDATION.md`, `skybrightness.md` §16 and a roadmap checkbox,
+so answering "what is still open" meant reading three documents.

--- a/docs/changelog.d/81-rv-multiplicative.md
+++ b/docs/changelog.d/81-rv-multiplicative.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 81
+---
+**Radial velocities composed by adding a correction instead of multiplying
+redshifts.** `coord.Context.BarycentricRadialVelocity` is the correct
+conversion and `ObservedRadialVelocity` is now its exact inverse; the dropped
+`rv*corr/c` term reached 4.66 m/s at a target velocity of 46.6 km/s and 30 m/s
+for a halo star.

--- a/docs/changelog.d/82-require-changelog-fragment.md
+++ b/docs/changelog.d/82-require-changelog-fragment.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 82
+---
+**CI now requires a changelog fragment naming the pull request.** Both
+`CONTRIBUTING.md` and `docs/PULL_REQUESTS.md` asked for one and nothing checked,
+so #80 and #81 merged without and would have been missing from their release.
+Label a pull request `no-changelog` when it genuinely warrants no entry.


### PR DESCRIPTION
`CONTRIBUTING.md`'s pull request process asks for a changelog fragment. `docs/PULL_REQUESTS.md` §4 spends a section explaining why one file per entry rather than editing `CHANGELOG.md`. **Nothing enforced it.**

So #80 and #81 both merged without one — while that section sat in the same repository asking for it. They would have been absent from the release they belong to, and the way that gets noticed is someone reading the assembled `CHANGELOG.md` weeks later and wondering where a change went.

## What this does

**Adds the two missing fragments.** `80-known-limitations.md` and `81-rv-multiplicative.md`.

**Adds a `changelog-fragment` CI job** that requires `docs/changelog.d/<PR number>-*.md` to exist on every pull request.

It is a workflow job rather than a Go test because **a Go test cannot know which pull request is running.** `go test ./internal/changelog/` already validates that a fragment parses and names a real Keep a Changelog section — what was missing was *existence*, and the number only exists in the workflow context.

**Escape hatch:** label a pull request `no-changelog` when it genuinely warrants no entry — pure test coverage for behaviour already shipped (#77 was one), or a CI change no user can observe. A label is deliberate and shows up in review; silence did not.

**Documents both in `PULL_REQUESTS.md` §4**, so the instruction and the thing enforcing it cannot drift apart — which is the same failure mode `internal/docsguard` exists to prevent everywhere else in this repository.

## The job's shell, exercised before pushing

| input | result |
| :--- | :--- |
| #80, no labels | PASS — `80-known-limitations.md` |
| #81, no labels | PASS — `81-rv-multiplicative.md` |
| #79, `enhancement` | PASS — 2 fragments |
| #999, no labels | **FAIL** |
| #999, `no-changelog` | SKIP |
| #999, `bug,no-changelog,docs` | SKIP |

The label match is `,${labels},` against `*,no-changelog,*`, so it cannot half-match a label like `no-changelog-needed`.

## Verification

The complete gate from `PULL_REQUESTS.md` §5, this time including the two steps I had been skipping — `go mod tidy` (go.mod/go.sum unchanged) and `go test -race -short -count=1 ./...` (clean):

`gofmt -l .` · `go build ./...` · `go vet ./...` · `go mod tidy` · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · `golangci-lint run --build-tags="integration,network,validation"` **0 issues** · `go vet` tagged · `internal/docsguard` · `internal/changelog`