### PR TITLE
Make every cited test exist, and guard it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Quick local checks
 go test ./...                       # all packages, default (unit) tests
 go test ./coord/...                 # single package
-go test -run TestApparentPlace ./coord/...   # single test by name
+go test -run TestApparentToObserved ./coord/...  # single test by name
 go test -race -short -count=1 ./... # race detector (CI runs this)
 
 # Build-tagged test suites (see "Build tags" below)

--- a/docs/changelog.d/83-fix-test-citations.md
+++ b/docs/changelog.d/83-fix-test-citations.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 83
+---
+**Ten doc comments and documents named tests that do not exist**, including
+`scatterKernel`'s claim that a named test held its rearrangement to the
+functions it rearranges — there was no test of the kernel at all. That test and
+`TestCharonNeedsTheSystemParameter` are written here, the rest repointed, and
+`internal/docsguard` now fails on a citation that resolves to nothing.

--- a/docs/skybrightness.md
+++ b/docs/skybrightness.md
@@ -294,9 +294,9 @@ imagery.
 
 | Paper | Content | Go function | Validation test |
 | :--- | :--- | :--- | :--- |
-| Eq. 1 | Total scattering phase function `P(g,Θ) = [P_a(g_a,Θ)·ϖ_a·k_a + P_R(Θ)·k_R] / (k_a + k_R)` | `atmosphere.CombinedPhaseFunction` | `TestCombinedPhaseFunctionWeighting`, `TestRayleighPhaseFunctionNormalisation` |
+| Eq. 1 | Total scattering phase function `P(g,Θ) = [P_a(g_a,Θ)·ϖ_a·k_a + P_R(Θ)·k_R] / (k_a + k_R)` | `atmosphere.CombinedPhaseFunction` | `TestCombinedPhaseFunction`, `TestRayleighPhaseFunctionNormalisation` |
 | Eq. 2 | All-sky radiance `L(z,A)` from `L_S`, `P(g,Θ)`, `(1−g)²/(1+g)`, `M(z)`, `M_S`, `t` | `AllSkyRadiance` | `TestKocifaj2022Eq2HorizonLimit`, `…FallsWithDistance`, `…BrightensTowardTheHorizon`, `…SingularityIsSmooth`, `…NearHorizonTurnover` |
-| Eq. 3 | `t = (τ_a/H_a + τ_R/H_R)·D / M_S` for an exponential atmosphere | `OpticalParameterT` | `TestKocifaj2022Eq3ExponentialAtmosphere` |
+| Eq. 3 | `t = (τ_a/H_a + τ_R/H_R)·D / M_S` for an exponential atmosphere | `OpticalParameterT` | `TestKocifaj2022Eq3Structure` |
 | Eq. 4 | `g = c₀ + c₁·g_a + c₂·g_a²` | `AsymmetryParameter` | `TestKocifaj2022Eq4CleanAtmosphereAsymptote`, `…Monotonic` |
 | Eq. 5 | `c₀ = 0.33 + 0.15τ_a`, `c₁ = 0.9τ_a^0.51`, `c₂ = 1.3τ_a^1.85` | `AsymmetryParameter` | `TestKocifaj2022Eq5Coefficients`, `…LeavesPhysicalRange` |
 
@@ -705,7 +705,7 @@ validation.
 | — | `ρ = 0.0148`, giving `(1+3ρ)/(1−ρ) = 1.06` | `atmosphere.RayleighDepolarisation` | `TestRayleighDepolarisationMatchesKS91Coefficient` |
 | Winkler Eq. 10 | `p_M(Θ) = (1−g²)/(4π(1+g²−2g·cosΘ)^{3/2})` (Henyey & Greenstein 1941) | `atmosphere.HenyeyGreensteinPhaseFunction` | `TestHenyeyGreensteinNormalisation`, `…Limits` |
 | Winkler Eq. 12 | `p(Θ) = (τ_R/τ_s)·p_R + (τ_M/τ_s)·p_M` | `atmosphere.CombinedPhaseFunction` | `TestCombinedPhaseFunction` (normalisation plus both pure limits) |
-| Ångström | `τ_a(λ) = τ_a(λ₀)·(λ/λ₀)^−α` | `atmosphere.AerosolOpticalDepth` | `TestAerosolOpticalDepthAngstrom` |
+| Ångström | `τ_a(λ) = τ_a(λ₀)·(λ/λ₀)^−α` | `atmosphere.Aerosol.TauAt` | `TestAerosolTauAtFollowsTheAngstromLaw` |
 
 The `ρ = 0.0148` value is worth noting: it is the depolarisation for which Bucholtz's
 theoretical phase function reproduces the `1.06 + cos²Θ` coefficient Krisciunas & Schaefer
@@ -862,8 +862,9 @@ package read it as V − G and negated it, so the query applied 10^(0.4(V−G)) 
 
 The error is invisible to every internal check. It leaves the map positive, smooth and
 monotonic plane-to-cap; it survived a ±1 mag absolute comparison because it is only 0.53
-mag at solar colour; and the one test that covered the sign, `TestGaiaJohnsonVBrightensRedStars`,
-asserted the inversion as its premise — *"a red star is fainter in G than in V"*, which is
+mag at solar colour; and the one test that covered the sign asserted the inversion as its premise
+(`TestGaiaJohnsonVBrightensRedStars`, since deleted — `TestGaiaGToJohnsonV` now
+covers the same ground with the sign the right way round) — *"a red star is fainter in G than in V"*, which is
 backwards. Gaia's G spans 330–1050 nm against Johnson V's ~500–600 nm, so a star is always
 brighter in G, G − V is negative, and a red star must **lose** flux in V. Because the error
 scales with colour it is worst exactly where the map is brightest: 1.6× at BP−RP = 1.1,

--- a/ephemeris/kepler/centralbody_test.go
+++ b/ephemeris/kepler/centralbody_test.go
@@ -599,3 +599,84 @@ func TestSatelliteFailureNamesItsParent(t *testing.T) {
 		t.Errorf("error %q names neither the role nor the parent body", msg)
 	}
 }
+
+// TestCharonNeedsTheSystemParameter is the counter-case
+// [TestCentralBodyForReturnsTheBodyParameter] points at, and the reason this
+// package documents a choice rather than a rule.
+//
+// # Why it exists
+//
+// Because the repository shipped the opposite claim twice. #71 and #72 both
+// stated that the system mass parameter is "wrong by 12% at Pluto" for a
+// satellite orbit. That is backwards. Two-body relative motion is governed by
+// G(M_primary + M_satellite), and Charon is 12% of Pluto — so for Charon the
+// system value, which adds the satellites back, is very nearly exact, and the
+// body value is the one that is wrong.
+//
+// #74 corrected the prose in kepler and constants and cited a test by this
+// name. The test was never written, so the corrected claim sat in three doc
+// comments with nothing checking it — which is how it came to be stated
+// backwards twice in the first place.
+//
+// # What it measures
+//
+// Charon's published sidereal period, 6.3872 days, against the period a
+// two-body propagation gives under each parameter. The two published values
+// bracket it, which is the whole point: neither is "the" right one, and which
+// is closer depends on how heavy the satellite is.
+func TestCharonNeedsTheSystemParameter(t *testing.T) {
+	// Charon's orbit about Pluto: a = 19,595.764 km, and the mutual orbit is
+	// very nearly circular. JPL satellite mean elements, plu058.
+	const (
+		charonAxisKM       = 19_595.764
+		charonPeriodDays   = 6.3872
+		secondsPerDay      = 86_400.0
+		charonEccentricity = 0.0002
+	)
+
+	period := func(gm float64) float64 {
+		a := charonAxisKM * 1e3
+
+		return 2 * math.Pi * math.Sqrt(a*a*a/gm) / secondsPerDay
+	}
+
+	system := period(constants.Ephemeris.PlutoSystemGravitationalParameter.Value)
+	body := period(constants.Ephemeris.PlutoGravitationalParameter.Value)
+
+	t.Logf("Charon at a = %.0f km: system parameter gives %.4f d, body parameter %.4f d, "+
+		"published %.4f d", charonAxisKM, system, body, charonPeriodDays)
+
+	// The system parameter is the one that reproduces the published period.
+	// A tenth of a per cent is far tighter than the gap to the body value and
+	// far looser than the elements' own precision, so this fails on a swapped
+	// constant and not on a refit.
+	if rel := math.Abs(system-charonPeriodDays) / charonPeriodDays; rel > 1e-3 {
+		t.Errorf("the system parameter gives %.4f d against a published %.4f, a relative %.2e; "+
+			"it should reproduce it closely", system, charonPeriodDays, rel)
+	}
+
+	// And the body parameter is not merely less good, it is wrong by a margin
+	// no observer would accept: about 5%, close to nine hours per revolution.
+	relBody := math.Abs(body-charonPeriodDays) / charonPeriodDays
+	if relBody < 0.03 {
+		t.Errorf("the body parameter gives %.4f d, only a relative %.2e from the published "+
+			"%.4f — the two parameters are supposed to bracket it by a wide margin here",
+			body, relBody, charonPeriodDays)
+	}
+
+	// The direction is the claim #71 and #72 got backwards: for Charon the
+	// system value wins. Asserting the ordering, not just the two bounds,
+	// is what makes this test the counter-case it is cited as.
+	if math.Abs(system-charonPeriodDays) >= math.Abs(body-charonPeriodDays) {
+		t.Errorf("the body parameter is at least as close as the system one "+
+			"(%.4f vs %.4f against %.4f); the documented Charon case no longer holds",
+			body, system, charonPeriodDays)
+	}
+
+	// Guard the fixture itself: an eccentricity this small is what lets a
+	// circular-orbit period formula stand in for the real one.
+	if charonEccentricity > 0.01 {
+		t.Fatalf("Charon's eccentricity is quoted as %v; the circular period formula "+
+			"used here needs it near zero", charonEccentricity)
+	}
+}

--- a/internal/docsguard/citation_test.go
+++ b/internal/docsguard/citation_test.go
@@ -1,0 +1,192 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// testDecl matches a test function's declaration, in any file, under any
+// build tag — the files are read as text rather than compiled, so a
+// network-tagged test counts as declared just like an ordinary one.
+var testDecl = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]+)\s*\(`)
+
+// testCitation matches a name that reads as a reference to a test.
+//
+// The five-character tail keeps it from firing on `TestMain` or on a bare
+// `Test`, and requiring an upper-case letter after `Test` keeps it from
+// matching prose like "Tests".
+var testCitation = regexp.MustCompile(`\b(Test[A-Z][A-Za-z0-9_]{4,})`)
+
+// historicalMention marks a line that names a test in the past tense.
+//
+// Some of the most useful prose in this repository is about a test that no
+// longer exists: docs/skybrightness.md explains a sign inversion by pointing
+// at the test whose premise was the bug, which was deleted precisely because
+// it was wrong. Requiring that name to resolve would force the history out of
+// the document, which is worse than the drift this guard prevents.
+//
+// The escape hatch is a word on the same line, so it is visible where it is
+// used rather than hidden in a list here.
+var historicalMention = regexp.MustCompile(`(?i)\b(since deleted|since removed|since renamed|no longer exists|was deleted|was removed)\b`)
+
+// TestCitedTestsExist checks that every test named in a comment or a document
+// is a test that exists.
+//
+// # Why
+//
+// Because a name is how a reader checks whether a claim is guarded, and a
+// name that resolves to nothing ends the check with the wrong answer. The
+// worst case found when this guard was written was skybrightness's
+// scatterKernel: a rearrangement of the model's innermost loop whose doc
+// comment said it "is not allowed to drift from the functions it rearranges"
+// and named the test holding it to that. There was no such test — and no test
+// of the kernel at all. A reader following the citation would have concluded
+// the opposite of the truth.
+//
+// It found nine more. Three equation-to-test maps in docs/skybrightness.md
+// naming tests that had been renamed; a CLAUDE.md command line offering
+// `-run TestApparentPlace` (no longer exists) to run "a single test by name";
+// and TestCharonNeedsTheSystemParameter, cited by a neighbouring test as the
+// counter-case establishing a scientific claim this repository had previously
+// shipped backwards twice — and never written.
+//
+// That first line is itself exempt, by the marker sitting on it. The marker
+// has to share the line with the name, which is the whole reason it reads as
+// an aside rather than a footnote: a reader meets the caveat where they meet
+// the name.
+//
+// # What is exempt
+//
+// CHANGELOG.md, because it is forward-only by policy: an entry describes the
+// release it shipped in, and the tests it named were real then. Rewriting a
+// released entry to track a rename would falsify the record to satisfy a
+// guard.
+//
+// A line marked as historical — see [historicalMention].
+//
+// A citation that is a prefix of a real test also passes, since
+// `TestAstroPixels` is a fair way to refer to the `TestAstroPixels_*` family.
+func TestCitedTestsExist(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	goFiles, docFiles := collectSources(t, root)
+
+	declared := make(map[string]bool)
+
+	for _, path := range goFiles {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		for _, m := range testDecl.FindAllStringSubmatch(string(src), -1) {
+			declared[m[1]] = true
+		}
+	}
+
+	if len(declared) < 100 {
+		t.Fatalf("only %d test declarations found; the walk root is probably wrong", len(declared))
+	}
+
+	// A citation resolves if it names a test outright, or names the common
+	// prefix of a family of them.
+	resolves := func(name string) bool {
+		if declared[name] {
+			return true
+		}
+
+		for d := range declared {
+			if strings.HasPrefix(d, name) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	var checked, offenders int
+
+	for _, path := range append(goFiles, docFiles...) {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			continue
+		}
+
+		slash := filepath.ToSlash(rel)
+		if slash == "CHANGELOG.md" {
+			continue
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		isGo := strings.HasSuffix(slash, ".go")
+		checked++
+
+		for n, line := range strings.Split(string(src), "\n") {
+			// In Go, only comments are prose; a bare identifier in code is
+			// checked by the compiler already.
+			if isGo && !strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+
+			if historicalMention.MatchString(line) {
+				continue
+			}
+
+			for _, m := range testCitation.FindAllStringSubmatch(line, -1) {
+				if resolves(m[1]) {
+					continue
+				}
+
+				offenders++
+
+				t.Errorf("%s:%d: cites %s, which no test declares.\n"+
+					"  Point at the test that covers this now, or write it. If the name is "+
+					"deliberately historical, say so on the same line — \"since deleted\", "+
+					"\"since renamed\".", slash, n+1, m[1])
+			}
+		}
+	}
+
+	t.Logf("%d files checked, %d test declarations, %d unresolved citations",
+		checked, len(declared), offenders)
+}
+
+// collectSources returns every Go and Markdown file under root.
+func collectSources(t *testing.T, root string) (goFiles, docFiles []string) {
+	t.Helper()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		switch {
+		case strings.HasSuffix(path, ".go"):
+			goFiles = append(goFiles, path)
+		case strings.HasSuffix(path, ".md"):
+			docFiles = append(docFiles, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	return goFiles, docFiles
+}

--- a/skybrightness/kernel_test.go
+++ b/skybrightness/kernel_test.go
@@ -1,0 +1,224 @@
+package skybrightness
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/unit"
+)
+
+// kernelScene is the scene the equivalence below is measured against.
+//
+// Internal to this file rather than shared with the external tests, because
+// scatterKernel is unexported and this has to be an in-package test.
+func kernelScene(t *testing.T) *Scene {
+	t.Helper()
+
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4), angle.Deg(-24.6), 2635) // Paranal
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	return &Scene{
+		Observer:   loc,
+		Time:       time.GoDate(2026, 8, 14, 3, 0, 0, 0, time.LocationUTC),
+		Atmosphere: atmosphere.StandardDefault(2635),
+	}
+}
+
+// TestScatterKernelMatchesTheReferenceFunctions is the test scatterKernel's
+// doc comment has cited since the type was written.
+//
+// # Why it is worth having
+//
+// scatterKernel is a rearrangement of atmosphere.SingleScatteredRadiance and
+// atmosphere.CombinedPhaseFunction, hoisting everything that does not vary
+// around a ring of the hemispheric quadrature out of the innermost loop. The
+// doc comment states plainly that this "is a rearrangement, not an
+// approximation, and it is not allowed to drift from the functions it
+// rearranges", and names this test as what holds it to that.
+//
+// The test did not exist. The rearranged form — the innermost loop of the
+// whole sky-brightness model, and the only place in it where a transcendental
+// was traded for a table lookup — had no test of any kind, while its comment
+// said otherwise. That is worse than an untested optimisation, because a
+// reader checking whether the claim is guarded finds a name and stops.
+//
+// # What equivalence means here
+//
+// Exactly, not approximately. Both forms compute
+//
+//	L = source * phase * (tau_sca/tau_ext) * M_v * P(tau, M_s, M_v)
+//
+// from the same inputs in a different order, so they may differ only by
+// floating-point reassociation. The tolerance is relative and set at 1e-12 —
+// a few ulp of headroom over the handful of operations reordered, and many
+// orders below any physical effect. An approximation would blow through it.
+func TestScatterKernelMatchesTheReferenceFunctions(t *testing.T) {
+	t.Parallel()
+
+	scene := kernelScene(t)
+	grid := DefaultOpticalGrid()
+
+	k, err := newScatterKernel(scene, grid)
+	if err != nil {
+		t.Fatalf("newScatterKernel: %v", err)
+	}
+
+	aerosol := scene.Atmosphere.Aerosol()
+	pressure, _ := scene.Atmosphere.Surface()
+
+	// A spread of geometries and optical depths, as the doc comment promises:
+	// both airmasses near the zenith, both near the horizon, the source above
+	// the view and below it, and the degenerate case where they coincide —
+	// which is the branch the path integral special-cases.
+	geometries := []struct {
+		name                       string
+		airmassSource, airmassView float64
+		thetaDeg                   float64
+	}{
+		{"both near zenith", 1.0, 1.0, 30},
+		{"source below view", 1.2, 3.5, 90},
+		{"view below source", 4.0, 1.1, 150},
+		{"both near horizon", 5.5, 6.0, 5},
+		{"airmasses coincide", 2.5, 2.5, 60},
+		{"forward scattering", 1.5, 2.0, 0.5},
+		{"back scattering", 1.5, 2.0, 179.5},
+	}
+
+	const (
+		dOmega       = 0.017 // a plausible quadrature cell, sr
+		relTolerance = 1e-12
+	)
+
+	for _, g := range geometries {
+		t.Run(g.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Per subtest, not hoisted: these run in parallel, and sharing
+			// the scratch slices across them is a data race. Hoisting them
+			// was the first version of this test, and it failed by reporting
+			// a zero where another subtest had just cleared the buffer —
+			// which reads exactly like the kernel drifting.
+			path := make([]float64, grid.Len())
+			dst := make([]float64, grid.Len())
+
+			theta := g.thetaDeg * math.Pi / 180
+
+			phaseRayleigh, phaseAerosol, perr := k.phaseAt(theta)
+			if perr != nil {
+				t.Fatalf("phaseAt: %v", perr)
+			}
+
+			k.pathFactor(path, g.airmassSource, g.airmassView)
+
+			// A source spectrum that is neither flat nor zero, so a
+			// wavelength-indexing slip cannot pass by symmetry.
+			source := make([]float64, grid.Len())
+			for i := range source {
+				source[i] = 1e-9 * (1 + float64(i%7))
+			}
+
+			k.accumulate(dst, source, path, dOmega, phaseRayleigh, phaseAerosol)
+
+			for i := range dst {
+				lambda := grid.At(i)
+
+				rayleigh, rerr := atmosphere.RayleighOpticalDepth(lambda, float64(pressure))
+				if rerr != nil {
+					t.Fatalf("RayleighOpticalDepth: %v", rerr)
+				}
+
+				aer := unit.OpticalDepth(aerosol.TauAt(lambda))
+				ext := rayleigh + aer
+				sca := rayleigh + unit.OpticalDepth(
+					float64(aer)*float64(aerosol.SingleScatteringAlbedo))
+
+				// The reference phase function, combined by the same weights
+				// the kernel splits apart.
+				phase, perr := atmosphere.CombinedPhaseFunction(
+					theta, rayleigh, aer, k.asymmetry, k.depolarisation)
+				if perr != nil {
+					t.Fatalf("CombinedPhaseFunction: %v", perr)
+				}
+
+				want, werr := atmosphere.SingleScatteredRadiance(
+					source[i], phase, sca, ext, g.airmassSource, g.airmassView)
+				if werr != nil {
+					t.Fatalf("SingleScatteredRadiance: %v", werr)
+				}
+
+				want *= dOmega
+
+				if rel := relativeDiff(dst[i], want); rel > relTolerance {
+					t.Fatalf("at %v nm the kernel gives %.17g and the reference functions %.17g, "+
+						"a relative %.3e — the rearrangement has drifted from what it rearranges",
+						lambda, dst[i], want, rel)
+				}
+			}
+		})
+	}
+}
+
+// TestScatterKernelSkipsZeroSourceWithoutChangingTheAnswer covers the one
+// shortcut accumulate takes that is not pure arithmetic: it skips a
+// wavelength whose source radiance is zero.
+//
+// That is only sound if the contribution would have been zero anyway, which
+// it is — every remaining factor is finite. Worth a test because the branch
+// exists for speed and a future edit could make it skip something that
+// matters.
+func TestScatterKernelSkipsZeroSourceWithoutChangingTheAnswer(t *testing.T) {
+	t.Parallel()
+
+	scene := kernelScene(t)
+	grid := DefaultOpticalGrid()
+
+	k, err := newScatterKernel(scene, grid)
+	if err != nil {
+		t.Fatalf("newScatterKernel: %v", err)
+	}
+
+	phaseRayleigh, phaseAerosol, err := k.phaseAt(math.Pi / 3)
+	if err != nil {
+		t.Fatalf("phaseAt: %v", err)
+	}
+
+	path := make([]float64, grid.Len())
+	k.pathFactor(path, 1.4, 2.2)
+
+	// Every other wavelength carries no light.
+	sparse := make([]float64, grid.Len())
+	for i := range sparse {
+		if i%2 == 0 {
+			sparse[i] = 3e-9
+		}
+	}
+
+	got := make([]float64, grid.Len())
+	k.accumulate(got, sparse, path, 0.02, phaseRayleigh, phaseAerosol)
+
+	for i := range got {
+		if i%2 == 1 && got[i] != 0 {
+			t.Errorf("wavelength %d had no source but accumulated %g", i, got[i])
+		}
+
+		if i%2 == 0 && got[i] == 0 {
+			t.Errorf("wavelength %d had a source and accumulated nothing", i)
+		}
+	}
+}
+
+// relativeDiff compares two values that should agree to within reassociation,
+// falling back to an absolute comparison when both are effectively zero.
+func relativeDiff(got, want float64) float64 {
+	if want == 0 {
+		return math.Abs(got)
+	}
+
+	return math.Abs(got-want) / math.Abs(want)
+}


### PR DESCRIPTION
Ten names across doc comments and documents referred to tests that no test declares. A name is how a reader checks whether a claim is guarded — a name resolving to nothing ends that check with the **wrong** answer.

## Two were missing tests, not stale citations

### `scatterKernel` had no test at all

`skybrightness/kernel.go` rearranges `SingleScatteredRadiance` and `CombinedPhaseFunction` to hoist work out of the model's innermost loop. Its doc comment says:

> This is a rearrangement, not an approximation, and it is not allowed to drift from the functions it rearranges: `TestScatterKernelMatchesTheReferenceFunctions` evaluates both forms…

**There was no such test, and no test of the kernel at all.** A reader following that citation would have concluded the opposite of the truth about the most performance-critical code in the module.

It exists now, and checks both forms agree to **1e-12 relative** across seven geometries: both airmasses at the zenith, both at the horizon, either side of the degenerate case the path integral special-cases, and forward/back scattering. They do — it is an exact rearrangement. A second test covers the one shortcut `accumulate` takes that is not pure arithmetic.

*What I got wrong writing it:* the first version hoisted the scratch slices above subtests that call `t.Parallel()`, and failed by reporting a zero where a sibling had just cleared the buffer — which reads exactly like the kernel drifting. Per-subtest now, with a comment saying why.

### `TestCharonNeedsTheSystemParameter` was cited but never written

#71 and #72 both shipped the claim that the system mass parameter is "wrong by 12% at Pluto". That is backwards — two-body motion is governed by `G(M_primary + M_satellite)` and Charon is 12% of Pluto. #74 corrected the prose in three places and **cited this test by name without writing it**, so the corrected claim sat in three doc comments with nothing checking it. Which is how it came to be stated backwards twice.

Measured, at a = 19,595.764 km against a published 6.3872 d:

| parameter | period |
| :--- | ---: |
| Pluto **system** | **6.3870 d** |
| Pluto **body** | 6.7647 d |

The test asserts the ordering, not just the bounds — that is what makes it the counter-case it is cited as.

## The rest were renames

| cited | actually |
| :--- | :--- |
| `TestAerosolOpticalDepthAngstrom` | `TestAerosolTauAtFollowsTheAngstromLaw` |
| `TestCombinedPhaseFunctionWeighting` | `TestCombinedPhaseFunction` |
| `TestKocifaj2022Eq3ExponentialAtmosphere` | `TestKocifaj2022Eq3Structure` |
| `TestApparentPlace` (CLAUDE.md) | `TestApparentToObserved` |

One row in `docs/skybrightness.md` had a stale **function** name too: `atmosphere.AerosolOpticalDepth` has been `Aerosol.TauAt` for some time. A guard over the function column would be a larger piece of work and is not attempted here.

## The guard

`internal/docsguard` walks every Go comment and Markdown file and requires each cited name to resolve. **672 files, 1795 declarations, 0 unresolved.** Verified to catch a fresh break by introducing one.

Two exemptions, both deliberate:

- **`CHANGELOG.md`** — forward-only by policy. Rewriting a released entry to track a rename would falsify the record to satisfy a guard.
- **A same-line marker** (`since deleted`, `no longer exists`, …). `docs/skybrightness.md` explains a sign inversion by pointing at the test whose *premise was the bug*, deleted precisely because it was wrong. Requiring that name to resolve would force real history out of the document.

A citation that is a prefix of a real test passes, so `TestAstroPixels` may stand for the `TestAstroPixels_*` family.

The marker must share the line with the name, and **the guard's own doc comment failed against that rule before it passed** — the paragraph describing the bad names tripped on one. The mechanism working.

## Verification

The complete `PULL_REQUESTS.md` §5 gate: `gofmt -l .` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · with `--build-tags="integration,network,validation"` **0 issues** · `go vet` tagged. The new kernel tests also pass under `-race` specifically.