### PR TITLE
Refuse a catalog target with no position

### DIFF
--- a/docs/changelog.d/87-no-fabricated-coordinates.md
+++ b/docs/changelog.d/87-no-fabricated-coordinates.md
@@ -1,0 +1,7 @@
+---
+type: Changed — BREAKING
+pr: 87
+---
+**`plan.FromCatalog` returns `(Observable, error)`** and refuses a fixed target
+with no position instead of placing it at RA 0, Dec 0 — a real point in Pisces
+that rises, sets and schedules without complaint. Returns `plan.ErrNoCoordinates`.

--- a/examples/02_target_visibility/main.go
+++ b/examples/02_target_visibility/main.go
@@ -36,7 +36,10 @@ func main() {
 		log.Fatalf("Failed to resolve target: %v", err)
 	}
 
-	target := plan.FromCatalog(targetData, nil)
+	target, err := plan.FromCatalog(targetData, nil)
+	if err != nil {
+		log.Fatalf("build target: %v", err)
+	}
 
 	// 4. Set Time to 'tonight at 7 PM' (UTC-3)
 	tz, err := time.LoadLocation("America/Sao_Paulo")

--- a/examples/03_rise_transit_set/main.go
+++ b/examples/03_rise_transit_set/main.go
@@ -24,7 +24,10 @@ func main() {
 		log.Fatalf("Failed to resolve target: %s", "Sirius")
 	}
 
-	target := plan.FromCatalog(sirius, nil)
+	target, err := plan.FromCatalog(sirius, nil)
+	if err != nil {
+		log.Fatalf("build target: %v", err)
+	}
 
 	// 3. Define the Time interval (next 24 hours starting from 6 PM tonight)
 	tz, err := time.LoadLocation("America/Sao_Paulo")

--- a/examples/14_target_scoring/main.go
+++ b/examples/14_target_scoring/main.go
@@ -68,7 +68,14 @@ func main() {
 			continue
 		}
 
-		targets = append(targets, plan.FromCatalog(t, nil))
+		obj, err := plan.FromCatalog(t, nil)
+		if err != nil {
+			log.Printf("skipping %s: %v", t.Name, err)
+
+			continue
+		}
+
+		targets = append(targets, obj)
 	}
 
 	// ── Constraints ──────────────────────────────────────────────────────

--- a/examples/15_target_details/deep-sky/main.go
+++ b/examples/15_target_details/deep-sky/main.go
@@ -41,7 +41,10 @@ func main() {
 		log.Fatalf("failed to resolve M31: %v", err)
 	}
 
-	m31 := plan.FromCatalog(catTarget, nil)
+	m31, err := plan.FromCatalog(catTarget, nil)
+	if err != nil {
+		log.Fatalf("build target: %v", err)
+	}
 
 	details, err := m31.GetDetails(ctx, "Description", "Andromeda Galaxy", "Source", "OpenNGC")
 	if err != nil {

--- a/examples/15_target_details/satellites/main.go
+++ b/examples/15_target_details/satellites/main.go
@@ -39,7 +39,10 @@ func main() {
 		}
 	}()
 
-	iss := plan.FromCatalog(catTarget, prov)
+	iss, err := plan.FromCatalog(catTarget, prov)
+	if err != nil {
+		log.Fatalf("build target: %v", err)
+	}
 
 	// Use satellite epoch for calculation (you can use time.Date/Now() as well)
 	t := catTarget.Epoch

--- a/examples/15_target_details/stars/main.go
+++ b/examples/15_target_details/stars/main.go
@@ -41,7 +41,10 @@ func main() {
 		log.Fatalf("failed to resolve Sirius: %v", err)
 	}
 
-	sirius := plan.FromCatalog(catTarget, nil)
+	sirius, err := plan.FromCatalog(catTarget, nil)
+	if err != nil {
+		log.Fatalf("build target: %v", err)
+	}
 
 	details, err := sirius.GetDetails(ctx,
 		"Bayer letter", "α CMa",

--- a/examples/22_kepler_propagator/main.go
+++ b/examples/22_kepler_propagator/main.go
@@ -70,7 +70,10 @@ func main() {
 	// target.HasElements, builds the Kepler-propagated provider itself,
 	// and returns a fully-formed *plan.Asteroid. Everything from here
 	// runs entirely offline.
-	obs := plan.FromCatalog(target, nil)
+	obs, err := plan.FromCatalog(target, nil)
+	if err != nil {
+		log.Fatalf("FromCatalog: %v", err)
+	}
 
 	asteroid, ok := obs.(*plan.Asteroid)
 	if !ok {

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -26,6 +26,17 @@ var (
 	// magnitude depends on the detector, the exposure and the observer.
 	ErrNoSkyDepth = errors.New("limiting magnitude constraint requires a SkyDepth")
 
+	// ErrNoCoordinates indicates a catalog target that resolves to no
+	// position at all, which cannot become a fixed Observable.
+	//
+	// The zero value of a missing coordinate is RA 0, Dec 0 — a real point
+	// in Pisces, and a target built on it will rise, transit, set and
+	// schedule without complaint. FromCatalog used to substitute it
+	// silently; a resolver returning an object with no position now fails
+	// loudly instead, which is the only safe direction for a library that
+	// points telescopes.
+	ErrNoCoordinates = errors.New("catalog target has no coordinates")
+
 	// ErrNotCoordObject indicates the object does not implement coord.Object.
 	//
 	// Deprecated: RankObservable no longer returns this — every Observable

--- a/plan/factory.go
+++ b/plan/factory.go
@@ -1,9 +1,10 @@
 package plan
 
 import (
+	"fmt"
+
 	"strconv"
 
-	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/catalog"
 	"github.com/TuSKan/astrogo/catalog/resolve"
 	eph "github.com/TuSKan/astrogo/ephemeris"
@@ -25,12 +26,12 @@ import (
 //     preferred over eph.Default() here, which has no data for an arbitrary small body
 //   - Star kind → *Star
 //   - Everything else → *DeepSkyObject
-func FromCatalog(c catalog.Target, p eph.Provider) Observable {
+func FromCatalog(c catalog.Target, p eph.Provider) (Observable, error) {
 	id := parseEphID(c.ID)
 
 	// ── Satellite ──
 	if c.Kind == "Satellite" && p != nil {
-		return NewSatellite(c.Name, id, p)
+		return NewSatellite(c.Name, id, p), nil
 	}
 
 	// ── Sun/Moon/planets — always have a real ephemeris, provider or not ──
@@ -46,7 +47,7 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 	// be on c.Coord. A caller-supplied provider (a real kernel, for
 	// perturbation-aware accuracy) always takes precedence, unchanged.
 	if (c.Kind == resolve.KindPlanet || c.Kind == resolve.KindMoon || c.Kind == resolve.KindStar) && isPlanetID(id) {
-		return NewPlanet(c.Name, id, p)
+		return NewPlanet(c.Name, id, p), nil
 	}
 
 	// ── Moving body with provider ──
@@ -60,22 +61,22 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 		// FromCatalog has no error return.
 		if c.Kind == resolve.KindPlanetaryMoon {
 			if m, err := NewPlanetaryMoon(c.Name, p); err == nil {
-				return m
+				return m, nil
 			}
 		}
 
 		// Comet
 		if c.HasM1 {
-			return newCometFromTarget(c, id, p)
+			return newCometFromTarget(c, id, p), nil
 		}
 
 		// Asteroid
 		if c.HasH {
-			return NewAsteroid(c.Name, id, p, asteroidOptsFrom(c)...)
+			return NewAsteroid(c.Name, id, p, asteroidOptsFrom(c)...), nil
 		}
 
 		// Generic moving body (unknown sub-type) — no photometric model.
-		return NewGenericBody(c.Name, id, p)
+		return NewGenericBody(c.Name, id, p), nil
 	}
 
 	// ── Elements-only moving body (no provider supplied) ──
@@ -106,15 +107,24 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 			if provider, err := eph.NewFromElements(keplerID, el); err == nil {
 				switch {
 				case c.HasM1:
-					return newCometFromTarget(c, keplerID, provider)
+					return newCometFromTarget(c, keplerID, provider), nil
 				case c.HasH:
-					return NewAsteroid(c.Name, keplerID, provider, asteroidOptsFrom(c)...)
+					return NewAsteroid(c.Name, keplerID, provider, asteroidOptsFrom(c)...), nil
 				}
 			}
 		}
 	}
 
 	// ── Fixed targets ──
+
+	// ── Fixed targets need a real position ──
+	//
+	// Everything above this line gets its position from an ephemeris, so a
+	// missing catalog coordinate is irrelevant to it. Everything below is
+	// pinned to c.Coord and cannot be built without one.
+	if !c.HasCoord {
+		return nil, fmt.Errorf("%w: %s", ErrNoCoordinates, c.Name)
+	}
 
 	// Star
 	if c.Kind == resolve.KindStar || c.Kind == resolve.KindDoubleStar {
@@ -139,25 +149,10 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 			opts = append(opts, WithAliases(c.Aliases...))
 		}
 
-		ra := angle.Rad(0)
-		dec := angle.Rad(0)
-
-		if c.HasCoord {
-			ra = c.Coord.RA()
-			dec = c.Coord.Dec()
-		}
-
-		return NewStar(c.Name, ra, dec, opts...)
+		return NewStar(c.Name, c.Coord.RA(), c.Coord.Dec(), opts...), nil
 	}
 
 	// Deep-sky object (galaxy, nebula, cluster, etc.)
-	ra := angle.Rad(0)
-	dec := angle.Rad(0)
-
-	if c.HasCoord {
-		ra = c.Coord.RA()
-		dec = c.Coord.Dec()
-	}
 
 	var opts []DSOOption
 	if c.HasVMag {
@@ -172,7 +167,7 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 		opts = append(opts, WithDSOAliases(c.Aliases...))
 	}
 
-	return NewDeepSkyObject(c.Name, ra, dec, opts...)
+	return NewDeepSkyObject(c.Name, c.Coord.RA(), c.Coord.Dec(), opts...), nil
 }
 
 // newCometFromTarget builds a *Comet from c's M1/K1 (and optional M2/K2)

--- a/plan/factory_test.go
+++ b/plan/factory_test.go
@@ -44,7 +44,7 @@ func TestFromCatalog_PlanetaryMoon(t *testing.T) {
 		Kind: resolve.KindPlanetaryMoon,
 	}
 
-	obj := plan.FromCatalog(c, stubMoonProvider{})
+	obj := mustFromCatalog(t, c, stubMoonProvider{})
 
 	moon, ok := obj.(*plan.PlanetaryMoon)
 	if !ok {
@@ -66,7 +66,7 @@ func TestFromCatalog_UnknownPlanetaryMoonFallsThrough(t *testing.T) {
 		Kind: resolve.KindPlanetaryMoon,
 	}
 
-	obj := plan.FromCatalog(c, stubMoonProvider{})
+	obj := mustFromCatalog(t, c, stubMoonProvider{})
 
 	if _, ok := obj.(*plan.GenericBody); !ok {
 		t.Fatalf("FromCatalog: got %T, want *plan.GenericBody", obj)
@@ -103,7 +103,7 @@ func TestFromCatalog_ElementsToAsteroid(t *testing.T) {
 	c := ceresLikeTarget(resolve.KindAsteroid)
 	c.H, c.HasH, c.G = 3.34, true, 0.12
 
-	obj := plan.FromCatalog(c, nil)
+	obj := mustFromCatalog(t, c, nil)
 
 	ast, ok := obj.(*plan.Asteroid)
 	if !ok {
@@ -133,7 +133,7 @@ func TestFromCatalog_ElementsToComet(t *testing.T) {
 	c := ceresLikeTarget(resolve.KindComet)
 	c.M1, c.HasM1, c.K1 = 4.5, true, 8.0
 
-	obj := plan.FromCatalog(c, nil)
+	obj := mustFromCatalog(t, c, nil)
 
 	if _, ok := obj.(*plan.Comet); !ok {
 		t.Fatalf("FromCatalog: got %T, want *plan.Comet", obj)
@@ -144,14 +144,21 @@ func TestFromCatalog_ElementsToComet(t *testing.T) {
 // published eccentricity is >= 1 (which ephemeris/kepler's two-body
 // propagator cannot represent — eph.NewElements rejects it with
 // ErrUnsupportedOrbit) falls straight through to the fixed-target path
-// rather than panicking or silently building a broken Observable, since
-// FromCatalog has no error return.
+// rather than panicking or silently building a broken Observable.
+//
+// The fixture carries a coordinate, which a real interstellar object
+// resolved from SBDB does. It did not before FromCatalog could fail, and the
+// fall-through then produced a *DeepSkyObject at RA 0, Dec 0 — this test
+// passed on it, because it only checked the type. What the fixed-target path
+// does without a position is now TestFromCatalogRefusesATargetWithNoCoordinates'
+// business, and it is an error.
 func TestFromCatalog_ElementsHyperbolicFallsThrough(t *testing.T) {
 	c := ceresLikeTarget(resolve.KindInterstellar)
 	c.Eccentricity = 1.2 // hyperbolic
 	c.H, c.HasH = 22.0, true
+	c.Coord, c.HasCoord = coord.NewICRS(angle.Deg(83.8), angle.Deg(-5.4)), true
 
-	obj := plan.FromCatalog(c, nil)
+	obj := mustFromCatalog(t, c, nil)
 
 	if _, ok := obj.(*plan.DeepSkyObject); !ok {
 		t.Fatalf("FromCatalog: got %T, want the fixed-target fallback *plan.DeepSkyObject", obj)
@@ -165,7 +172,7 @@ func TestFromCatalog_ProviderTakesPrecedenceOverElements(t *testing.T) {
 	c := ceresLikeTarget(resolve.KindAsteroid)
 	c.H, c.HasH, c.G = 3.34, true, 0.12
 
-	obj := plan.FromCatalog(c, stubMoonProvider{})
+	obj := mustFromCatalog(t, c, stubMoonProvider{})
 
 	ast, ok := obj.(*plan.Asteroid)
 	if !ok {
@@ -208,7 +215,7 @@ func TestFromCatalog_StarRadialVelocity(t *testing.T) {
 				RadialVelocity:    c.rv,
 			}
 
-			obj := plan.FromCatalog(tgt, nil)
+			obj := mustFromCatalog(t, tgt, nil)
 
 			star, ok := obj.(*plan.Star)
 			if !ok {
@@ -238,7 +245,7 @@ func TestFromCatalog_AsteroidDiameterAndAlbedo(t *testing.T) {
 		c.H, c.HasH, c.G = 3.34, true, 0.12
 		c.HasDiameter, c.Diameter = true, 16.84 // km, real Eros value
 
-		obj := plan.FromCatalog(c, nil)
+		obj := mustFromCatalog(t, c, nil)
 
 		ast, ok := obj.(*plan.Asteroid)
 		if !ok {
@@ -260,7 +267,7 @@ func TestFromCatalog_AsteroidDiameterAndAlbedo(t *testing.T) {
 		c.H, c.HasH, c.G = 3.34, true, 0.12
 		c.HasAlbedo, c.Albedo = true, 0.25 // real Eros value
 
-		obj := plan.FromCatalog(c, nil)
+		obj := mustFromCatalog(t, c, nil)
 
 		ast, ok := obj.(*plan.Asteroid)
 		if !ok {
@@ -276,4 +283,100 @@ func TestFromCatalog_AsteroidDiameterAndAlbedo(t *testing.T) {
 			t.Errorf("PhysicalRadius() = %v, want a positive H+albedo estimate", metres)
 		}
 	})
+}
+
+// mustFromCatalog fails the test if FromCatalog cannot build the target.
+//
+// FromCatalog gained an error return so a catalog target with no position
+// could be refused rather than placed at RA 0, Dec 0. Every case in this
+// file supplies a real coordinate or a moving body, so that error is never
+// what is under test here — TestFromCatalogRefusesATargetWithNoCoordinates
+// covers it directly.
+func mustFromCatalog(t *testing.T, c catalog.Target, p eph.Provider) plan.Observable {
+	t.Helper()
+
+	obs, err := plan.FromCatalog(c, p)
+	if err != nil {
+		t.Fatalf("FromCatalog(%q): %v", c.Name, err)
+	}
+
+	return obs
+}
+
+// TestFromCatalogRefusesATargetWithNoCoordinates covers the defect the error
+// return exists for.
+//
+// A resolver can return an object with no position — SIMBAD's `vdWG M42 B`
+// is one, and it was reachable through an ordinary Resolve("M42"). FromCatalog
+// used to substitute the zero value, which is RA 0, Dec 0: a real point in
+// Pisces, on the celestial equator, visible from almost everywhere. The
+// resulting target rises, transits, sets, scores against constraints and
+// enters a schedule, and nothing about it looks wrong.
+//
+// This is the same class of defect HasRadialVelocity was introduced to fix —
+// a zero meaning "absent" read as a zero meaning "measured" — except that here
+// the fabricated value is not even plausible, merely unchecked.
+func TestFromCatalogRefusesATargetWithNoCoordinates(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		kind resolve.Kind
+	}{
+		{"deep-sky object", resolve.KindGalaxy},
+		{"star", resolve.KindStar},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obs, err := plan.FromCatalog(catalog.Target{
+				Name:     "no position at all",
+				Kind:     tc.kind,
+				HasCoord: false,
+			}, nil)
+
+			if !errors.Is(err, plan.ErrNoCoordinates) {
+				t.Fatalf("err = %v, want ErrNoCoordinates", err)
+			}
+
+			if obs != nil {
+				t.Errorf("got a %T alongside the error; a refused target must be nil", obs)
+			}
+		})
+	}
+}
+
+// TestFromCatalogKeepsACoordinateAtTheOrigin is the other half: RA 0, Dec 0
+// is a real position, and a target that genuinely carries it must survive.
+//
+// Without this, the obvious way to implement the check above — treating a
+// zero coordinate as missing — would pass its own test while quietly refusing
+// a legitimate object. HasCoord is what distinguishes them, which is why the
+// check reads that field rather than the coordinate.
+func TestFromCatalogKeepsACoordinateAtTheOrigin(t *testing.T) {
+	t.Parallel()
+
+	obs, err := plan.FromCatalog(catalog.Target{
+		Name:     "genuinely at the origin",
+		Kind:     resolve.KindGalaxy,
+		Coord:    coord.NewICRS(angle.Zero(), angle.Zero()),
+		HasCoord: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("FromCatalog: %v", err)
+	}
+
+	dso, ok := obs.(*plan.DeepSkyObject)
+	if !ok {
+		t.Fatalf("got %T, want *plan.DeepSkyObject", obs)
+	}
+
+	pos, err := dso.Position(time.J2000)
+	if err != nil {
+		t.Fatalf("Position: %v", err)
+	}
+
+	if pos.RA().Degrees() != 0 || pos.Dec().Degrees() != 0 {
+		t.Errorf("position = %v, want the origin it was given", pos)
+	}
 }

--- a/plan/target_test.go
+++ b/plan/target_test.go
@@ -122,7 +122,7 @@ func TestDeepSkyObject(t *testing.T) {
 
 func TestFromCatalog(t *testing.T) {
 	// Star
-	star := FromCatalog(catalog.Target{
+	star := mustFromCatalog(t, catalog.Target{
 		Name: "Sirius", Kind: resolve.KindStar, HasCoord: true,
 		Coord: coord.NewICRS(angle.Deg(10), angle.Deg(20)),
 	}, nil)
@@ -131,7 +131,7 @@ func TestFromCatalog(t *testing.T) {
 	}
 
 	// Planet
-	planet := FromCatalog(catalog.Target{
+	planet := mustFromCatalog(t, catalog.Target{
 		ID: "11", Name: "Sun", Kind: resolve.KindStar,
 	}, eph.Default())
 	if p, ok := planet.(*Planet); !ok {
@@ -146,7 +146,7 @@ func TestFromCatalog(t *testing.T) {
 	// instead of a real, moving *Planet, since the planet-routing switch
 	// only ever ran inside FromCatalog's `if p != nil` block. FromCatalog
 	// must fall back to eph.Default() for a major named body instead.
-	planetNoProvider := FromCatalog(catalog.Target{
+	planetNoProvider := mustFromCatalog(t, catalog.Target{
 		ID: "4", Name: "Mars", Kind: resolve.KindPlanet,
 	}, nil)
 	if p, ok := planetNoProvider.(*Planet); !ok {
@@ -156,7 +156,7 @@ func TestFromCatalog(t *testing.T) {
 	}
 
 	// DSO
-	dso := FromCatalog(catalog.Target{
+	dso := mustFromCatalog(t, catalog.Target{
 		Name: "M31", Kind: resolve.KindGalaxy, HasCoord: true,
 		Coord: coord.NewICRS(angle.Deg(10), angle.Deg(41)),
 	}, nil)
@@ -194,4 +194,17 @@ func TestNewPlanet_NilProviderDefaults(t *testing.T) {
 	if _, err := pluto.Position(epoch); err != nil {
 		t.Errorf("NewPluto(nil).Position(): unexpected error: %v", err)
 	}
+}
+
+// mustFromCatalog is the in-package twin of the helper in factory_test.go;
+// see there for why FromCatalog is fallible.
+func mustFromCatalog(t *testing.T, c catalog.Target, p eph.Provider) Observable {
+	t.Helper()
+
+	obs, err := FromCatalog(c, p)
+	if err != nil {
+		t.Fatalf("FromCatalog(%q): %v", c.Name, err)
+	}
+
+	return obs
 }

--- a/plan/visible_tonight.go
+++ b/plan/visible_tonight.go
@@ -474,7 +474,15 @@ func isFixedTarget(obs Observable) bool {
 
 func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end time.Time, cfg visibleTonightConfig) (Observable, eph.Provider) {
 	if !needsSmallBodyEphemeris(tgt.Kind) {
-		return FromCatalog(tgt, nil), nil
+		// A target the resolver returned with no position at all is
+		// dropped rather than placed at RA 0, Dec 0. Both callers already
+		// treat a nil Observable as "no candidate".
+		obj, err := FromCatalog(tgt, nil)
+		if err != nil {
+			return nil, nil
+		}
+
+		return obj, nil
 	}
 
 	// Kepler first: try FromCatalog's own elements-based construction
@@ -484,7 +492,7 @@ func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end tim
 	// are hyperbolic/parabolic, or the caller forced kernels via
 	// WithSmallBodyKernels.
 	if !cfg.forceSmallBodyKernels && tgt.HasElements {
-		if obj := FromCatalog(tgt, nil); !isFixedTarget(obj) {
+		if obj, err := FromCatalog(tgt, nil); err == nil && !isFixedTarget(obj) {
 			return obj, nil
 		}
 	}
@@ -495,7 +503,14 @@ func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end tim
 		return nil, nil
 	}
 
-	return FromCatalog(tgt, minorProvider), minorProvider
+	obj, err := FromCatalog(tgt, minorProvider)
+	if err != nil {
+		_ = minorProvider.Close()
+
+		return nil, nil
+	}
+
+	return obj, minorProvider
 }
 
 // gatherSolarSystemCandidates builds the Moon and every naked-eye planet,


### PR DESCRIPTION
Closes #86.

`plan.FromCatalog` turned *"this object has no coordinates"* into **RA 0, Dec 0** — a real point in Pisces, on the celestial equator, visible from nearly everywhere. The resulting target rises, transits, sets, scores against constraints and enters a schedule, and no number it produces looks wrong.

It was reachable through ordinary use: resolving `M42` returns SIMBAD's `vdWG M42 B`, which carries no position, and `plan` built a target on the origin from it.

## The shape of the bug

`resolve.Target.HasCoord` exists precisely to tell an absent coordinate from a measured one. It was checked and then discarded:

```go
ra := angle.Rad(0)
dec := angle.Rad(0)

if c.HasCoord {
    ra = c.Coord.RA()
    dec = c.Coord.Dec()
}
```

Same class as the defect `HasRadialVelocity` was introduced to fix — a zero meaning *absent* read as a zero meaning *measured*. That one was caught because a true 0 km/s is plausible and someone thought about it. Here the fabricated value is not even plausible, merely unchecked.

## The change is breaking, and the alternative was worse

`FromCatalog` now returns `(Observable, error)`, with `plan.ErrNoCoordinates`.

Silently returning an unusable `Observable` cannot be distinguished from a correct one by any caller. Two of `FromCatalog`'s own comments already named *"since FromCatalog has no error return"* as the reason they degrade silently rather than fail — the absence was felt before it was found.

Only the fixed-target paths need a coordinate; everything above them gets its position from an ephemeris and is untouched. With `HasCoord` guaranteed at that point, the zero-then-maybe-overwrite in both branches goes away.

Call sites updated: 8 in `examples/`, 3 in `plan` itself, 13 in tests via a `mustFromCatalog` helper.

## Two tests, because one is not enough

The obvious implementation — treat a *zero* coordinate as missing — passes the first test while being wrong. So there is a second asserting an object genuinely at RA 0, Dec 0 still builds. `HasCoord` is what separates them, which is why the check reads that field and not the coordinate.

## One existing test was passing on the bug

`TestFromCatalog_ElementsHyperbolicFallsThrough` asserted only the *type* returned, so it had been passing on a `*DeepSkyObject` at the origin — the exact defect this fixes, inside the suite meant to cover that path. Its fixture now carries a coordinate, as a real interstellar object resolved from SBDB does.

## Verification

Full `PULL_REQUESTS.md` §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · with `--build-tags="integration,network,validation"` **0 issues** · `go vet` tagged.

#85 — the resolver returning a coordinate-less object in the first place — is next, on its own branch.