### PR TITLE
Resolve SIMBAD names by identity, not by substring

### DIFF
--- a/catalog/simbad/request.go
+++ b/catalog/simbad/request.go
@@ -3,29 +3,108 @@ package simbad
 import (
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
 )
 
-// BuildResolveQuery constructs an ADQL query to resolve an object by name
-// from SIMBAD's TAP service. It joins the `basic` and `ident` tables.
+// identifierVariants returns the spellings SIMBAD might store for a
+// user-typed identifier.
+//
+// SIMBAD right-justifies a catalogue number in a fixed-width field, so the
+// Andromeda Galaxy is stored as "M  31" and its Henry Draper number as
+// "HD   3969" — two and three spaces, chosen by the width of the field and
+// the number, not by any rule a caller can be expected to follow. Nobody
+// types those. A user types "M31", "M 31" or "m31".
+//
+// SIMBAD's ADQL cannot normalise: REPLACE, LOWER, ILIKE and ivo_nocasematch
+// are all rejected by its parser, verified against the live service. So the
+// normalisation has to happen here, by generating the handful of spellings
+// the padding can produce and matching all of them exactly.
+//
+// Four spaces is past every field width SIMBAD uses for the catalogues in
+// common use, and an over-generated variant simply matches nothing.
+//
+// The "NAME " prefix is how SIMBAD stores common names — "NAME Andromeda
+// Galaxy", "NAME Centaurus A" — so prepending it makes a plain-English name
+// resolve without a second service.
+func identifierVariants(query string) []string {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil
+	}
+
+	seen := map[string]bool{q: true, "NAME " + q: true}
+
+	// Split a leading catalogue acronym from the number that follows it, so
+	// the padding can be varied between them.
+	if i := strings.IndexFunc(q, func(r rune) bool { return r >= '0' && r <= '9' }); i > 0 {
+		prefix := strings.TrimRight(q[:i], " ")
+		number := q[i:]
+
+		for pad := range maxIdentifierPadding + 1 {
+			seen[prefix+strings.Repeat(" ", pad)+number] = true
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for v := range seen {
+		out = append(out, v)
+	}
+
+	sort.Strings(out) // deterministic, so the query is reproducible and cacheable
+
+	return out
+}
+
+// maxIdentifierPadding is the widest gap [identifierVariants] will try
+// between a catalogue acronym and its number.
+const maxIdentifierPadding = 4
+
+// quoteADQL renders values as a comma-separated ADQL string list.
+func quoteADQL(values []string) string {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = "'" + strings.ReplaceAll(v, "'", "''") + "'"
+	}
+
+	return strings.Join(quoted, ", ")
+}
+
+// BuildResolveQuery constructs an ADQL query that identifies exactly one
+// object by name.
+//
+// # Why this is not a LIKE
+//
+// It was. `WHERE ident.id LIKE '%<query>%'` matched any object carrying the
+// query as a substring of any of its identifiers, and returned TOP N of them
+// with no ORDER BY. For "M31" that is 15,843 rows — every CXOM31 J… Chandra
+// source in the galaxy — and the ten fetched did not include M31 itself. The
+// provider's own scoring then ranked ten wrong answers and returned the best,
+// which is how Resolve("M87") came back with an object 70 degrees away in
+// Cassiopeia while Resolve("M42") came back with no coordinates at all.
+//
+// Matching exactly against [identifierVariants] costs one query, returns one
+// object, and returns nothing at all when the name is unknown — which is the
+// answer a caller can act on.
+//
+// The subquery is what keeps the alias list: filtering the joined `ident`
+// directly would return only the identifier that matched, so the object's
+// other names would vanish. Selecting the oid first and joining afterwards
+// leaves the fan-out intact.
 func BuildResolveQuery(req resolve.ObjectRequest) string {
-	// A naive query that looks up the object in the ident table
-	// and fetches core properties from the basic table.
 	limit := req.Limit
 	if limit <= 0 {
 		limit = 10
 	}
 
-	// ADQL and postgres handle text, but SIMBAD enforces case-sensitivity on LIKE.
-	// Preserving original casing.
-	q := req.Query
+	variants := identifierVariants(req.Query)
+	if len(variants) == 0 {
+		return ""
+	}
 
-	// Ensure we handle single quotes safely
-	safeQ := strings.ReplaceAll(q, "'", "''")
-
-	query := fmt.Sprintf(`SELECT TOP %d 
+	return fmt.Sprintf(`SELECT TOP %d
 		basic.oid,
 		basic.main_id,
 		basic.ra,
@@ -37,12 +116,50 @@ func BuildResolveQuery(req resolve.ObjectRequest) string {
 		basic.rvz_radvel,
 		ident.id,
 		allfluxes.V
-	FROM basic 
+	FROM basic
 	JOIN ident ON basic.oid = ident.oidref
 	LEFT JOIN allfluxes ON basic.oid = allfluxes.oidref
-	WHERE ident.id LIKE '%%%s%%'`, limit, safeQ)
+	WHERE basic.oid IN (SELECT oidref FROM ident WHERE id IN (%s))`,
+		limit, quoteADQL(variants))
+}
 
-	return query
+// BuildSearchQuery constructs an ADQL query for a freeform search, where
+// several answers are the point rather than a failure.
+//
+// Still a LIKE, because that is what a search is — but anchored at the start
+// rather than wrapped in wildcards on both sides, and ordered, so that the
+// rows returned are the ones a person would recognise and are the same rows
+// on every run. The unordered TOP N it replaces was not reproducible: two
+// identical calls for "M42" returned different objects.
+//
+// Brightest first, since between two objects whose identifiers both begin
+// with the query, the brighter is overwhelmingly the one meant. Nulls sort
+// last so an object with no V magnitude never displaces one that has it.
+func BuildSearchQuery(req resolve.ObjectRequest) string {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+
+	safeQ := strings.ReplaceAll(strings.TrimSpace(req.Query), "'", "''")
+
+	return fmt.Sprintf(`SELECT TOP %d
+		basic.oid,
+		basic.main_id,
+		basic.ra,
+		basic.dec,
+		basic.otype,
+		basic.pmra,
+		basic.pmdec,
+		basic.plx_value,
+		basic.rvz_radvel,
+		ident.id,
+		allfluxes.V AS vmag
+	FROM basic
+	JOIN ident ON basic.oid = ident.oidref
+	LEFT JOIN allfluxes ON basic.oid = allfluxes.oidref
+	WHERE ident.id LIKE '%s%%'
+	ORDER BY vmag ASC, basic.main_id ASC`, limit, safeQ)
 }
 
 // BuildBrightQuery constructs an ADQL query enumerating every object

--- a/catalog/simbad/resolution_network_test.go
+++ b/catalog/simbad/resolution_network_test.go
@@ -1,0 +1,84 @@
+//go:build network
+
+package simbad
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+)
+
+// simbadTAPHost is the reachability pre-check target, per this repository's
+// policy that an unreachable external service skips rather than fails.
+const simbadTAPHost = "simbad.cds.unistra.fr:80"
+
+// TestResolveReturnsTheObjectAsked is the test that would have caught the
+// substring-matching defect, and the reason it asserts positions.
+//
+// A name check alone passes on the wrong object: resolving "M87" returned
+// `[AKM87] 23`, whose name plainly contains the query, while sitting 70
+// degrees away in Cassiopeia. Only the coordinate says which object it is.
+//
+// The tolerance is a degree, which is enormous by this repository's standards
+// and deliberately so: this is an identity check, not an astrometric one. The
+// failures it exists to catch were 61 and 70 degrees, and an object 0.3
+// degrees away — a catalogued source *inside* the galaxy asked for — is also
+// the wrong object and also fails.
+func TestResolveReturnsTheObjectAsked(t *testing.T) {
+	testutil.RequireReachable(t, simbadTAPHost)
+
+	const toleranceDeg = 1.0
+
+	for _, tc := range []struct {
+		query, wantID string
+		raDeg, decDeg float64
+		why           string
+	}{
+		{"M31", "M  31", 10.6847, 41.2688, "returned a nova inside the galaxy"},
+		{"M87", "M  87", 187.7059, 12.3911, "returned a 2MASS source 70 degrees away"},
+		{"M42", "M  42", 83.8201, -5.3876, "returned an object with no coordinates at all"},
+		{"M13", "M  13", 250.4235, 36.4613, "returned an object 61 degrees away"},
+		{"NGC 5128", "NAME Centaurus A", 201.3651, -43.0191, "returned a companion source"},
+		{"Sirius", "Sirius", 101.2872, -16.7161, "the one name that always worked"},
+		{"Andromeda Galaxy", "M  31", 10.6847, 41.2688, "a common name, via SIMBAD's NAME prefix"},
+		{"m31", "M  31", 10.6847, 41.2688, "lower case"},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			p := New()
+
+			tgt, ok := p.Resolve(context.Background(), tc.query)
+			if !ok {
+				t.Fatalf("Resolve(%q) found nothing (%s)", tc.query, tc.why)
+			}
+
+			if !tgt.HasCoord {
+				t.Fatalf("Resolve(%q) returned %q with no coordinates", tc.query, tgt.Name)
+			}
+
+			dRA := math.Abs(tgt.Coord.RA().Degrees()-tc.raDeg) * math.Cos(tc.decDeg*math.Pi/180)
+			dDec := math.Abs(tgt.Coord.Dec().Degrees() - tc.decDeg)
+
+			if sep := math.Hypot(dRA, dDec); sep > toleranceDeg {
+				t.Errorf("Resolve(%q) returned %q at (%.4f, %+.4f), %.2f degrees from %q at "+
+					"(%.4f, %+.4f) — %s",
+					tc.query, tgt.Name, tgt.Coord.RA().Degrees(), tgt.Coord.Dec().Degrees(),
+					sep, tc.wantID, tc.raDeg, tc.decDeg, tc.why)
+			}
+		})
+	}
+}
+
+// TestResolveFindsNothingRatherThanSomethingWrong pins the other half of the
+// contract: an unknown name is an answer a caller can act on, and the least
+// wrong of ten wrong objects is not.
+func TestResolveFindsNothingRatherThanSomethingWrong(t *testing.T) {
+	testutil.RequireReachable(t, simbadTAPHost)
+
+	p := New()
+
+	if tgt, ok := p.Resolve(context.Background(), "NoSuchObjectXYZ123"); ok {
+		t.Errorf("Resolve of a nonexistent name returned %q", tgt.Name)
+	}
+}

--- a/catalog/simbad/response.go
+++ b/catalog/simbad/response.go
@@ -17,6 +17,11 @@ import (
 // ErrMissingColumn indicates a required column is missing from the SIMBAD response.
 var ErrMissingColumn = errors.New("simbad: missing expected column")
 
+// ErrEmptyQuery marks a resolve request with nothing to match on. An empty
+// name cannot identify an object, and matching it against everything is how
+// the substring query this replaced returned an arbitrary one.
+var ErrEmptyQuery = errors.New("simbad: empty query")
+
 // ParseCSV parses SIMBAD's TAP output in CSV format into resolve.Targets.
 // The expected order from BuildResolveQuery is:
 // oid, main_id, ra, dec, otype, id (matched alias)

--- a/catalog/simbad/simbad.go
+++ b/catalog/simbad/simbad.go
@@ -42,55 +42,87 @@ func (p *Provider) Capabilities() []resolve.Capability {
 	return []resolve.Capability{resolve.CapObjectResolution, resolve.CapMagnitudeBrowse}
 }
 
-// Resolve matches a single object by returning the most relevant hit.
-// Adheres strictly to resolve.Provider and utilizes AstroGo scoring for precision.
+// Resolve identifies the single object a name refers to.
+//
+// # Identity, not the best of a search
+//
+// This used to be Search's first result after client-side scoring, and the
+// scoring could not save it: the underlying query matched any object holding
+// the name as a substring of any identifier, so for "M31" the ten rows
+// fetched out of 15,843 were Chandra sources inside the galaxy and M31 itself
+// was not among them. Scoring ranks what it is given.
+//
+// It now matches identifiers exactly, against the spellings SIMBAD is known
+// to store — see [identifierVariants]. An unknown name returns false rather
+// than the least-wrong of ten wrong answers, because a caller can act on
+// "not found" and cannot act on a plausible object 70 degrees from the one
+// they asked for.
+//
+// Aliases fan out across rows, so several rows may arrive for one object;
+// they are merged by oid upstream in ResolveObject and the first target is
+// the object.
 func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.Search(ctx, query)
+	targets := p.ResolveObjects(ctx, resolve.ObjectRequest{Query: query, Limit: 10})
 	if len(targets) == 0 {
 		return resolve.Target{}, false
 	}
 
-	bestIdx := 0
-	bestScore := -1.0
-
-	for i, t := range targets {
-		s := resolve.Score(query, t.Name)
-		if idScore := resolve.Score(query, t.ID); idScore > s {
-			s = idScore
-		}
-
-		for _, a := range t.Aliases {
-			if aScore := resolve.Score(query, a); aScore > s {
-				s = aScore
-			}
-		}
-
-		if s > bestScore {
-			bestScore = s
-			bestIdx = i
-		}
-	}
-
-	return targets[bestIdx], true
+	return targets[0], true
 }
 
-// Search matches all objects closely matching a freeform query.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
-	req := resolve.ObjectRequest{Query: query, Limit: 10}
-
-	iter := p.ResolveObject(ctx, req)
+// ResolveObjects drains ResolveObject into a slice, dropping errors after
+// logging them — the shape both Resolve and Search need.
+func (p *Provider) ResolveObjects(ctx context.Context, req resolve.ObjectRequest) []resolve.Target {
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
 
 	var targets []resolve.Target
 
-	iter(func(t resolve.Target, err error) bool {
+	p.ResolveObject(ctx, req)(func(t resolve.Target, err error) bool {
 		if err != nil {
 			log.Printf("SIMBAD ERR: %v", err)
+
 			return false
 		}
 
 		targets = append(targets, t)
-		// Try to read up to 10
-		return len(targets) < 10
+
+		return len(targets) < limit
+	})
+
+	return targets
+}
+
+// Search matches objects whose identifiers begin with a freeform query.
+//
+// Distinct from [Provider.Resolve], and deliberately: several answers are
+// this method's purpose, where for Resolve they are a failure. Anchored at
+// the start rather than wrapped in wildcards, and ordered brightest-first,
+// so the rows are ones a person would recognise and are the same rows on
+// every call — the query this replaces had no ORDER BY, and two identical
+// searches for "M42" returned different objects.
+func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+	if strings.TrimSpace(query) == "" {
+		return nil
+	}
+
+	req := resolve.ObjectRequest{Query: query, Limit: 10}
+	adql := BuildSearchQuery(req)
+
+	var targets []resolve.Target
+
+	p.stream(ctx, "search:"+query, adql)(func(tgt resolve.Target, err error) bool {
+		if err != nil {
+			log.Printf("SIMBAD ERR: %v", err)
+
+			return false
+		}
+
+		targets = append(targets, tgt)
+
+		return len(targets) < req.Limit
 	})
 
 	return targets
@@ -155,6 +187,19 @@ func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest)
 	}
 
 	adql := BuildResolveQuery(req)
+	if adql == "" {
+		return func(yield func(resolve.Target, error) bool) {
+			yield(resolve.Target{}, ErrEmptyQuery)
+		}
+	}
+
+	return p.stream(ctx, cacheKey, adql)
+}
+
+// stream runs one ADQL query and yields its rows, caching a successful
+// fetch. Shared by the identity and search paths, which differ only in the
+// query they hand it.
+func (p *Provider) stream(ctx context.Context, cacheKey, adql string) resolve.SeqIterator[resolve.Target] {
 	v := TAPRequest(adql)
 
 	return func(yield func(resolve.Target, error) bool) {

--- a/catalog/simbad/simbad_test.go
+++ b/catalog/simbad/simbad_test.go
@@ -441,3 +441,99 @@ func redirect(t *testing.T, id remote.EndpointID, url string) {
 		t.Fatalf("SetURL(%s): %v", id, err)
 	}
 }
+
+// TestIdentifierVariantsCoversSIMBADPadding pins the spellings the exact
+// match depends on, without a network call.
+//
+// SIMBAD right-justifies a catalogue number in a fixed-width field — "M  31",
+// "HD   3969" — and its ADQL cannot normalise (REPLACE, LOWER, ILIKE and
+// ivo_nocasematch are all rejected by the live parser). So these variants are
+// the whole mechanism: if the padded forms stop being generated, resolution
+// silently reverts to matching only what the user typed.
+func TestIdentifierVariantsCoversSIMBADPadding(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		query string
+		want  []string
+	}{
+		{"M31", []string{"M31", "M 31", "M  31", "M   31", "M    31", "NAME M31"}},
+		{"NGC5128", []string{"NGC5128", "NGC 5128", "NGC  5128", "NAME NGC5128"}},
+		{"Sirius", []string{"Sirius", "NAME Sirius"}},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+
+			got := identifierVariants(tc.query)
+
+			have := make(map[string]bool, len(got))
+			for _, g := range got {
+				have[g] = true
+			}
+
+			for _, w := range tc.want {
+				if !have[w] {
+					t.Errorf("variants(%q) is missing %q; got %q", tc.query, w, got)
+				}
+			}
+		})
+	}
+
+	if v := identifierVariants("   "); v != nil {
+		t.Errorf("a blank query produced %q; it must match nothing rather than everything", v)
+	}
+}
+
+// TestBuildResolveQueryIsExactNotSubstring is the guard on the defect itself.
+//
+// The query this replaced was `WHERE ident.id LIKE '%<query>%'`, which for
+// "M31" matched 15,843 rows and returned an unordered ten of them — none of
+// which was M31. A LIKE reappearing in the identity query would restore that
+// silently, since the failure looks like a plausible object rather than an
+// error.
+func TestBuildResolveQueryIsExactNotSubstring(t *testing.T) {
+	t.Parallel()
+
+	q := BuildResolveQuery(resolve.ObjectRequest{Query: "M31", Limit: 10})
+
+	if strings.Contains(q, "LIKE") {
+		t.Errorf("the identity query uses LIKE:\n%s", q)
+	}
+
+	if !strings.Contains(q, "'M  31'") {
+		t.Errorf("the identity query does not offer SIMBAD's own padded spelling:\n%s", q)
+	}
+
+	// The subquery is what preserves the alias fan-out: filtering the joined
+	// ident directly would return only the identifier that matched.
+	if !strings.Contains(q, "SELECT oidref FROM ident WHERE id IN") {
+		t.Errorf("the identity query does not select by oid, so aliases would be lost:\n%s", q)
+	}
+
+	if BuildResolveQuery(resolve.ObjectRequest{Query: "  "}) != "" {
+		t.Error("a blank query produced a query; it must produce none")
+	}
+}
+
+// TestBuildSearchQueryIsAnchoredAndOrdered keeps the fuzzy path honest.
+//
+// Search is allowed to be fuzzy — that is its purpose — but not unbounded and
+// not unordered. Two identical searches for "M42" used to return different
+// objects, because TOP N without ORDER BY is whatever the planner produces.
+func TestBuildSearchQueryIsAnchoredAndOrdered(t *testing.T) {
+	t.Parallel()
+
+	q := BuildSearchQuery(resolve.ObjectRequest{Query: "M42", Limit: 10})
+
+	if strings.Contains(q, "'%M42%'") {
+		t.Errorf("search is still wrapped in wildcards on both sides:\n%s", q)
+	}
+
+	if !strings.Contains(q, "LIKE 'M42%'") {
+		t.Errorf("search is not anchored at the start of the identifier:\n%s", q)
+	}
+
+	if !strings.Contains(q, "ORDER BY") {
+		t.Errorf("search has no ORDER BY, so its results are not reproducible:\n%s", q)
+	}
+}

--- a/docs/changelog.d/88-simbad-identity-resolution.md
+++ b/docs/changelog.d/88-simbad-identity-resolution.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 88
+---
+**SIMBAD name resolution returned the wrong object for most deep-sky names.**
+`Resolve("M87")` gave a source 70° away in Cassiopeia, `Resolve("M31")` a nova
+inside the galaxy. The substring `LIKE '%name%'` is now an exact match against
+the spellings SIMBAD stores, and an unknown name returns not-found rather than
+the least-wrong of ten.


### PR DESCRIPTION
Closes #85.

`Resolve` returned an object that merely *contained* the query somewhere in one of its identifiers, picked arbitrarily.

## Before and after, measured against the live service

| query | before | after |
| :--- | :--- | :--- |
| `M87` | `[AKM87] 23` — **70° away**, in Cassiopeia | `M  87` at 187.706°, +12.391° ✓ |
| `M13` | `[YEE2006] 22` — **61° away** | `M  13` at 250.424°, +36.461° ✓ |
| `M31` | `M31N 2011-10a` — a nova *inside* the galaxy | `M  31` at 10.685°, +41.269° ✓ |
| `M42` | `vdWG M42 B` — **no coordinates at all** | `M  42` at 83.820°, −5.388° ✓ |
| `NGC 5128` | `[ZHG90b] NGC 5128 2` — a companion source | `NAME Centaurus A` ✓ |
| `Andromeda Galaxy` | — | `M  31` ✓ |
| `NoSuchObjectXYZ` | an arbitrary wrong object | **not found** ✓ |

## Why the scorer did not save it

`WHERE ident.id LIKE '%M31%'` matches **15,843 rows** — every `CXOM31 J…` Chandra source in Andromeda — and `TOP 10` had **no `ORDER BY`**. The ten rows fetched did not include M31. `Provider.Resolve` then scored ten wrong answers and returned the best.

Scoring ranks what it is given. The defect was in candidate selection, and no improvement to `resolve.Score` could have reached it.

The missing `ORDER BY` also made it unreproducible: two identical calls for `M42` returned different objects.

## Why the fix is client-side normalisation

Exact matching needs normalisation, and **SIMBAD's ADQL cannot do it** — `REPLACE`, `LOWER`, `ILIKE` and `ivo_nocasematch` are each rejected by its parser, all four verified against the live service. SIMBAD also right-justifies catalogue numbers in a fixed-width field, storing `M  31` and `HD   3969` while users type `M31`.

So `identifierVariants` generates the spellings that padding can produce, plus SIMBAD's `NAME ` prefix for common names, and the query matches them exactly.

**One round trip, no second endpoint.** I had proposed a two-step `sim-id` → TAP design; testing showed a single query with generated variants does the same job without the extra service or latency. A subquery selects the oid *before* joining `ident`, which keeps the alias fan-out that filtering the join directly would have discarded.

Verified at the edges too: `m31` (lower case) works, and `HD3969` correctly resolves to M31 — that is its Henry Draper number.

## `Resolve` and `Search` are now different operations

- **`Resolve`** is identity. An unknown name returns not-found, because a caller can act on that and cannot act on a plausible object 70° away.
- **`Search`** stays fuzzy — several answers are its purpose — but anchored at the start rather than wrapped in wildcards, and ordered brightest-first so its results are reproducible.

## The test asserts positions, not names

A name check passes on the wrong object: `[AKM87] 23` plainly contains `M87`. Only the coordinate says which object it is.

The one-degree tolerance is an identity check, not an astrometric one. The failures it exists to catch were 61° and 70°; the 0.3° ones — a catalogued source *inside* the galaxy asked for — are equally wrong objects and equally caught.

Three offline guards come with it, so the mechanism is covered without the network: the padded variants are generated, the identity query contains no `LIKE`, and the search query is anchored and ordered.

## Side effect worth noting

Every deep-sky object now arrives **with its radial velocity**, which SIMBAD had all along — M31 −300.0, M87 +1256.5, M42 +27.8 km/s. That was the blocker on extending `MeasuredRadialVelocity` to `DeepSkyObject`; it is now unblocked.

## Verification

Full `PULL_REQUESTS.md` §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · with `--build-tags="integration,network,validation"` **0 issues** · `go vet` tagged · plus `go test -tags=network ./catalog/simbad/` — all 8 resolution cases pass.

Stacked on nothing: independent of #87, which fixes what `plan` did with a coordinate-less target once one was returned.