### PR TITLE
Resolve a satellite by identity, not by arrival order

### DIFF
--- a/catalog/norad/norad.go
+++ b/catalog/norad/norad.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -273,14 +274,111 @@ func (p *Provider) Capabilities() []resolve.Capability {
 	return []resolve.Capability{resolve.CapObjectResolution}
 }
 
-// Resolve attempts to find a single satellite by name or catalog number.
+// Resolve finds the satellite a name or catalog number refers to.
+//
+// # Why this is not Search's first result
+//
+// It was, and CelesTrak's NAME query is a substring match. Asking for "ISS"
+// returns eighteen objects — UME (ISS), UME-2 (ISS-B), SWISSCUBE, AISSAT 1
+// and the five real station modules among them — with the Japanese
+// Ionosphere Sounding Satellite first and ISS (ZARYA) third. Taking the first
+// row meant tracking the wrong satellite, silently, for the single most
+// common query this provider will ever receive.
+//
+// A catalog number now goes to CelesTrak's CATNR parameter, which is exact:
+// "25544" used to find nothing at all, because the number was being sent as
+// a name.
+//
+// A name is ranked rather than taken in arrival order — see [rankByName].
 func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.Search(ctx, query)
-	if len(targets) > 0 {
-		return targets[0], true
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return resolve.Target{}, false
 	}
 
-	return resolve.Target{}, false
+	// A bare catalog number is an exact identifier; nothing to rank.
+	if isCatalogNumber(q) {
+		gps, err := p.Fetch(ctx, QueryCatNr, q)
+		if err != nil || len(gps) == 0 {
+			return resolve.Target{}, false
+		}
+
+		return gpToTarget(gps[0]), true
+	}
+
+	targets := p.Search(ctx, q)
+	if len(targets) == 0 {
+		return resolve.Target{}, false
+	}
+
+	return targets[0], true
+}
+
+// isCatalogNumber reports whether the query is a bare NORAD catalog number.
+// CelesTrak documents CATNR as 1-9 digits.
+func isCatalogNumber(q string) bool {
+	if len(q) == 0 || len(q) > 9 {
+		return false
+	}
+
+	for _, r := range q {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// rankByName orders a substring match so the satellite actually asked for
+// comes first.
+//
+// CelesTrak matches anywhere in the name, so a short query pulls in
+// unrelated craft: "ISS" reaches SWISSCUBE and AISSAT 1 through the middle of
+// a word. The ordering is, in turn:
+//
+//   - an exact name match, which settles it outright;
+//   - a name whose first word is the query — "ISS (ZARYA)" for "ISS" —
+//     because a designation in parentheses is a component of the thing named
+//     before it;
+//   - a name beginning with the query;
+//   - everything else, which is a mid-word match and almost never meant.
+//
+// Within a tier, the lower catalog number wins. For the station that is
+// ISS (ZARYA), 25544 — the first module launched and the one every ephemeris
+// means by "the ISS".
+func rankByName(query string, targets []resolve.Target) {
+	tier := func(name string) int {
+		upper := strings.ToUpper(strings.TrimSpace(name))
+		q := strings.ToUpper(strings.TrimSpace(query))
+
+		switch {
+		case upper == q:
+			return 0
+		case strings.HasPrefix(upper, q+" ("):
+			return 1
+		case strings.HasPrefix(upper, q):
+			return 2
+		default:
+			return 3
+		}
+	}
+
+	sort.SliceStable(targets, func(i, j int) bool {
+		ti, tj := tier(targets[i].Name), tier(targets[j].Name)
+		if ti != tj {
+			return ti < tj
+		}
+
+		ni, erri := strconv.Atoi(targets[i].ID)
+		nj, errj := strconv.Atoi(targets[j].ID)
+
+		if erri == nil && errj == nil {
+			return ni < nj
+		}
+
+		return targets[i].Name < targets[j].Name
+	})
 }
 
 // Search returns satellites matching the query string.
@@ -296,6 +394,8 @@ func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 	for _, gp := range gps {
 		targets = append(targets, gpToTarget(gp))
 	}
+
+	rankByName(query, targets)
 
 	return targets
 }

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -149,3 +149,29 @@ func TestResolve_Live(t *testing.T) {
 		t.Errorf("Catalog = %q, want %q", target.Catalog, "norad")
 	}
 }
+
+// TestResolveISSIsTheStation is the end-to-end guard on the defect.
+//
+// The README's satellite showcase is "predict ISS passes over your location",
+// and Resolve("ISS") returned UME (ISS) — NORAD 8709, a Japanese ionosphere
+// satellite launched in 1976. Every pass, elevation and ground track computed
+// from it was for the wrong spacecraft, and nothing said so.
+func TestResolveISSIsTheStation(t *testing.T) {
+	testutil.RequireReachable(t, "celestrak.org:443")
+
+	p := New()
+
+	for _, q := range []string{"ISS", "25544", "ISS (ZARYA)"} {
+		t.Run(q, func(t *testing.T) {
+			tgt, ok := p.Resolve(context.Background(), q)
+			if !ok {
+				t.Fatalf("Resolve(%q) found nothing", q)
+			}
+
+			if tgt.ID != "25544" {
+				t.Errorf("Resolve(%q) = %q (NORAD %s), want NORAD 25544 ISS (ZARYA)",
+					q, tgt.Name, tgt.ID)
+			}
+		})
+	}
+}

--- a/catalog/norad/norad_test.go
+++ b/catalog/norad/norad_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/TuSKan/astrogo/ephemeris/satellite"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
 )
 
 // issFixture is a representative ISS GP element set in CelestTrak JSON format.
@@ -270,5 +272,92 @@ func TestParseMultiGP(t *testing.T) {
 
 	if gps[1].ObjectName != "CSS (TIANHE)" {
 		t.Errorf("Second object = %q, want CSS", gps[1].ObjectName)
+	}
+}
+
+// TestRankByNamePutsTheSatelliteAskedForFirst covers the ordering Resolve
+// depends on, without a network call.
+//
+// CelesTrak's NAME query is a substring match anywhere in the name, so "ISS"
+// returns eighteen objects. The list below is the real response, in the real
+// order CelesTrak returns it: the Japanese Ionosphere Sounding Satellite
+// first, the station third, and two craft that match through the middle of a
+// word. Taking the first row — which Resolve used to do — tracked UME.
+func TestRankByNamePutsTheSatelliteAskedForFirst(t *testing.T) {
+	t.Parallel()
+
+	// CelesTrak's actual NAME=ISS response order, trimmed to the interesting
+	// rows.
+	targets := []resolve.Target{
+		{ID: "8709", Name: "UME (ISS)"},
+		{ID: "10674", Name: "UME-2 (ISS-B)"},
+		{ID: "25544", Name: "ISS (ZARYA)"},
+		{ID: "25575", Name: "ISS (UNITY)"},
+		{ID: "26400", Name: "ISS (ZVEZDA)"},
+		{ID: "35932", Name: "SWISSCUBE"},
+		{ID: "36797", Name: "AISSAT 1"},
+	}
+
+	rankByName("ISS", targets)
+
+	if got := targets[0].Name; got != "ISS (ZARYA)" {
+		t.Errorf("first result is %q (id %s), want ISS (ZARYA) — the station, not a "+
+			"satellite whose name merely contains ISS", got, targets[0].ID)
+	}
+
+	// The module ordering matters too: ZARYA is the first module launched and
+	// what every ephemeris means by "the ISS". The tie-break is the catalog
+	// number, so UNITY and ZVEZDA must follow it rather than precede it.
+	if targets[1].Name != "ISS (UNITY)" {
+		t.Errorf("second result is %q, want ISS (UNITY) by catalog number", targets[1].Name)
+	}
+
+	// A mid-word match is last, always.
+	last := targets[len(targets)-1].Name
+	if last != "SWISSCUBE" && last != "AISSAT 1" {
+		t.Errorf("last result is %q, want one of the mid-word matches", last)
+	}
+}
+
+// TestRankByNamePrefersAnExactMatch keeps the strongest signal strongest: a
+// name that is exactly the query beats one that merely starts with it.
+func TestRankByNamePrefersAnExactMatch(t *testing.T) {
+	t.Parallel()
+
+	targets := []resolve.Target{
+		{ID: "64562", Name: "HUBBLE 6"},
+		{ID: "20580", Name: "HST"},
+	}
+
+	rankByName("HST", targets)
+
+	if targets[0].Name != "HST" {
+		t.Errorf("first result is %q, want the exact match HST", targets[0].Name)
+	}
+}
+
+// TestIsCatalogNumber pins what routes to CelesTrak's exact CATNR parameter
+// rather than its substring NAME one. "25544" used to find nothing, because
+// the number was sent as a name.
+func TestIsCatalogNumber(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"25544", true},
+		{"1", true},
+		{"123456789", true},   // CelesTrak documents 1-9 digits
+		{"1234567890", false}, // ten is past it
+		{"ISS", false},
+		{"ISS (ZARYA)", false},
+		{"", false},
+		{"2554a", false},
+		{"-1", false},
+	} {
+		if got := isCatalogNumber(tc.in); got != tc.want {
+			t.Errorf("isCatalogNumber(%q) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }

--- a/docs/changelog.d/89-norad-satellite-resolution.md
+++ b/docs/changelog.d/89-norad-satellite-resolution.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 89
+---
+**`Resolve("ISS")` returned the wrong satellite.** CelesTrak's NAME query is a
+substring match, so it gave UME (ISS) — NORAD 8709 — instead of the station,
+and a bare catalog number like `25544` found nothing because it was sent as a
+name. Numbers now use CATNR, and name matches are ranked.


### PR DESCRIPTION
Found while checking whether other providers shared #85's defect. **NORAD does.**

`Resolve("ISS")` returned **UME (ISS)** — NORAD 8709, a Japanese ionosphere sounding satellite launched in 1976. The README's satellite showcase is *"predict ISS passes over your location"*, so every pass, elevation and ground track it produced was for the wrong spacecraft.

## Measured

CelesTrak's `NAME` parameter matches anywhere in the name. `NAME=ISS` returns 18 objects:

```
  8709  UME (ISS)          <- Resolve took this
 10674  UME-2 (ISS-B)
 25544  ISS (ZARYA)        <- the station
 25575  ISS (UNITY)
 26400  ISS (ZVEZDA)
 35932  SWISSCUBE          <- matched mid-word
 36797  AISSAT 1           <- matched mid-word
```

And `25544` — the station's own catalog number — **found nothing**, because the number was sent as a name and no satellite is called that. CelesTrak's `CATNR=25544` works perfectly and was never used.

| query | before | after |
| :--- | :--- | :--- |
| `ISS` | `UME (ISS)` (8709) | `ISS (ZARYA)` (25544) ✓ |
| `25544` | **not found** | `ISS (ZARYA)` ✓ |
| `ISS (ZARYA)` | `UME (ISS)` | `ISS (ZARYA)` ✓ |
| `20580` | not found | `HST` ✓ |

## The fix

**A bare catalog number goes to `CATNR`**, which is exact. `QueryCatNr` already existed in this package; `Search` simply never used it.

**A name is ranked** rather than taken in arrival order: exact match, then the query as the whole first word — `ISS (ZARYA)` over `SWISSCUBE`, a parenthesised designation being a component of the thing named before it — then a prefix, then everything else. Within a tier the lower catalog number wins, which for the station is ZARYA, 25544: the first module launched and what every ephemeris means by "the ISS".

## The cross-provider audit that found it

Same objects through every provider:

| provider | verdict |
| :--- | :--- |
| SIMBAD | had the defect — fixed in #88 |
| **NORAD** | **had the defect — this PR** |
| MAST | correct (M31, M87, NGC 5128, Sirius all resolve to the right positions) |
| OpenNGC | correct — but silently returns *not found* when its download is not consented to, which is indistinguishable from "no such object" |
| Gaia, VizieR | return not-found for a plain name; no wrong object |

The OpenNGC failure mode is worth its own look and is not touched here.

## Tests

The offline ranking test uses **CelesTrak's real response in its real order**, so it fails the way the bug did rather than the way a synthetic fixture would. Plus an end-to-end test that `ISS`, `25544` and `ISS (ZARYA)` all reach NORAD 25544.

`Resolve("HUBBLE")` returns `HUBBLE 6`, and that is correct — CelesTrak has no object named HUBBLE, the telescope is `HST`, and `20580` resolves it. Verified against the live service rather than assumed.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues** · plus `-tags=integration` for the live CelesTrak test.