### PR TITLE
Give every target a radial velocity

### DIFF
--- a/constants/constant_test.go
+++ b/constants/constant_test.go
@@ -83,7 +83,7 @@ func TestSets_Count(t *testing.T) {
 	}
 
 	// SI2019, CODATA2022, CODATA2018, IAU2015, WGS84, Derived, Photometric
-	wantCounts := []int{3, 5, 5, 14, 2, 6, 1}
+	wantCounts := []int{3, 5, 5, 14, 3, 6, 1}
 
 	total := 0
 
@@ -96,8 +96,8 @@ func TestSets_Count(t *testing.T) {
 		}
 	}
 
-	if total != 36 {
-		t.Errorf("total constants across all sets = %d, want 36", total)
+	if total != 37 {
+		t.Errorf("total constants across all sets = %d, want 37", total)
 	}
 }
 

--- a/constants/units.go
+++ b/constants/units.go
@@ -17,6 +17,15 @@ var (
 		Name: "meter per second", Symbol: "m/s",
 		ScaleFactor: 1, Dimension: unit.Velocity,
 	}
+	// radianPerSecond is rad·s⁻¹ (angular velocity) — WGS84.AngularVelocity.
+	//
+	// A radian is dimensionless, so this carries the dimension of an
+	// inverse time; the symbol is what tells a reader it is a rotation
+	// rate rather than a frequency.
+	radianPerSecond = unit.Unit{
+		Name: "radian per second", Symbol: "rad/s",
+		ScaleFactor: 1, Dimension: unit.Dimension{T: -1},
+	}
 	// squareMeter is m² (area) — ThomsonCrossSection.
 	squareMeter = unit.Unit{
 		Name: "square meter", Symbol: "m²",

--- a/constants/wgs84.go
+++ b/constants/wgs84.go
@@ -3,8 +3,8 @@ package constants
 import "github.com/TuSKan/astrogo/unit"
 
 // WGS84Set holds the defining parameters of the WGS 84 reference
-// ellipsoid: the semi-major axis and the reciprocal (inverse) flattening,
-// both fixed exact by the standard itself. Unlike IAU2015/CODATA, there
+// system: the semi-major axis, the reciprocal (inverse) flattening and
+// Earth's angular velocity, all fixed exact by the standard itself. Unlike IAU2015/CODATA, there
 // is a single active realization (NGA.STND.0036_1.0.0_WGS84, 2014) this
 // library targets, so there is no epoch-versioned family here — if a
 // second ellipsoid standard is ever needed (GRS80, WGS72, ...), add it
@@ -18,6 +18,7 @@ type WGS84Set struct {
 
 	SemiMajorAxis     Constant
 	InverseFlattening Constant
+	AngularVelocity   Constant
 }
 
 // Name reports the set's vintage, implementing [Set].
@@ -26,7 +27,7 @@ func (s WGS84Set) Name() string { return s.Vintage }
 // All returns every member of the set, in declaration order, implementing
 // [Set].
 func (s WGS84Set) All() []Constant {
-	return []Constant{s.SemiMajorAxis, s.InverseFlattening}
+	return []Constant{s.SemiMajorAxis, s.InverseFlattening, s.AngularVelocity}
 }
 
 // WGS84 is the WGS 84 geodetic realization astrogo targets. Treat it as
@@ -43,6 +44,15 @@ var WGS84 = WGS84Set{
 	InverseFlattening: Constant{
 		Name: "WGS 84 reciprocal flattening", Symbol: "1/f",
 		Value: 298.257_223_563, Unit: unit.One,
+		Reference: "NGA.STND.0036_1.0.0_WGS84 (2014), Table 3.1", Exact: true,
+	},
+	// One of WGS 84's four defining parameters, alongside the two above
+	// and the geocentric gravitational constant. It is the rotation rate
+	// of a site about the Earth's axis, and so the size of the diurnal
+	// term in a topocentric radial velocity: 0.465 km/s at the equator.
+	AngularVelocity: Constant{
+		Name: "WGS 84 nominal mean angular velocity", Symbol: "omega",
+		Value: 7.292_115e-5, Unit: radianPerSecond,
 		Reference: "NGA.STND.0036_1.0.0_WGS84 (2014), Table 3.1", Exact: true,
 	},
 }

--- a/coord/radialvelocity.go
+++ b/coord/radialvelocity.go
@@ -146,3 +146,55 @@ func (ctx *Context) HeliocentricRVCorrection(target ICRS) (float64, error) {
 
 	return heliocentricObserverVel.Dot(target.ToUnitVector()), nil
 }
+
+// TopocentricRadialVelocity returns the radial velocity, in km/s, an observer
+// at ctx measures for a body whose geocentric state is posAU and velAUPerDay
+// — the line-of-sight component of the body's motion relative to the
+// observer, positive when the two are separating.
+//
+// # Why a solar-system body needs its own function
+//
+// [Context.BarycentricRVCorrection] and the conversions built on it exist for
+// a target whose radial velocity somebody measured and wrote down: a star, a
+// galaxy, anything far enough away to be a fixed direction with a catalog
+// number beside it. A planet has no such number. Its radial velocity is not a
+// property to be looked up but a consequence of where it and the observer are
+// now, and it changes by tens of km/s over a night — which is exactly why it
+// is worth computing rather than tabulating.
+//
+// # What is subtracted, and why it is not the barycentric velocity
+//
+// The state is geocentric, so the velocity to remove is the observer's own
+// geocentric velocity: the site turning about Earth's axis. Earth's orbital
+// motion is already absent from both sides and must not be subtracted twice.
+//
+// That diurnal term is omega x r for the observer's geocentric position,
+// reaching 0.465 km/s at the equator and falling as the cosine of latitude.
+// Small against a planet's tens of km/s, and not against the Moon's, whose
+// own geocentric radial velocity stays inside about 0.06 km/s — for the Moon
+// the site's rotation is the dominant term, not a correction to it.
+//
+// The line of sight is topocentric, from the observer rather than from the
+// geocentre. For the Moon those differ by up to a degree.
+func (ctx *Context) TopocentricRadialVelocity(posAU, velAUPerDay vector.Vec3) float64 {
+	auKM := constants.IAU.AstronomicalUnit.Value / 1000.0
+	dayS := constants.Derived.JulianDaySeconds.Value
+
+	// Observer's geocentric position, and the velocity that position has by
+	// virtue of Earth turning under it. The rotation axis is the celestial
+	// pole; polar motion is tens of milliarcseconds and cannot matter to a
+	// half-kilometre-per-second term.
+	obsKM := ctx.ObsVec().MulScalar(auKM)
+	omega := vector.V3(0, 0, constants.WGS84.AngularVelocity.Value)
+	siteVel := omega.Cross(obsKM)
+
+	bodyVel := velAUPerDay.MulScalar(auKM / dayS)
+
+	// Topocentric line of sight, from the observer to the body.
+	los := posAU.Sub(ctx.ObsVec())
+	if los.Norm() == 0 {
+		return 0
+	}
+
+	return bodyVel.Sub(siteVel).Dot(los.Unit())
+}

--- a/docs/changelog.d/90-radial-velocity-everywhere.md
+++ b/docs/changelog.d/90-radial-velocity-everywhere.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 90
+---
+**Radial velocity now works for every target kind.** `plan.RadialVelocity`
+returns it for a solar-system body, computed from the ephemeris and agreeing
+with JPL Horizons to under 6 m/s, and `*DeepSkyObject` carries the catalog
+value SIMBAD publishes for galaxies. Adds
+`coord.Context.TopocentricRadialVelocity` and `constants.WGS84.AngularVelocity`.

--- a/plan/deepsky.go
+++ b/plan/deepsky.go
@@ -14,6 +14,9 @@ type DeepSkyObject struct {
 	coord   coord.ICRS
 	vMag    float64
 	hasVMag bool
+
+	radialVelocity float64
+	hasRV          bool
 }
 
 // DSOOption configures optional DeepSkyObject fields.
@@ -27,6 +30,17 @@ func WithDSOMagnitude(v float64) DSOOption {
 // WithDSOKind sets the display kind (e.g. "Galaxy", "Nebula").
 func WithDSOKind(kind string) DSOOption {
 	return func(d *DeepSkyObject) { d.kind = kind }
+}
+
+// WithDSORadialVelocity sets the catalog (barycentric) radial velocity in
+// km/s, tracked distinctly from "no RV set" — see [MeasuredRadialVelocity].
+//
+// For an extragalactic object this is the headline measurement: SIMBAD
+// carries it for essentially every galaxy, and it is what a redshift is
+// usually quoted as. It was fetched and discarded until now, because
+// FromCatalog read HasRadialVelocity in the star branch only.
+func WithDSORadialVelocity(kmPerSec float64) DSOOption {
+	return func(d *DeepSkyObject) { d.radialVelocity = kmPerSec; d.hasRV = true }
 }
 
 // WithDSOAliases sets alternative designations.
@@ -45,6 +59,12 @@ func NewDeepSkyObject(name string, ra, dec angle.Angle, opts ...DSOOption) *Deep
 	}
 
 	return d
+}
+
+// MeasuredRadialVelocity returns the catalog barycentric radial velocity and
+// whether one was ever set, implementing [MeasuredRadialVelocity].
+func (d *DeepSkyObject) MeasuredRadialVelocity() (float64, bool) {
+	return d.radialVelocity, d.hasRV
 }
 
 // Name returns the object's display name.

--- a/plan/details.go
+++ b/plan/details.go
@@ -156,7 +156,7 @@ func computeDetails(obs Observable, ctx *coord.Context, props ...string) (*Targe
 	}
 
 	// ── Radial velocity via interface dispatch ──
-	fillRadialVelocity(d, obs, pos, ctx)
+	fillRadialVelocity(d, obs, ctx)
 
 	// ── Type-specific catalog properties ──
 	fillTypedProps(d, obs)
@@ -241,30 +241,38 @@ func fillStaticMagnitude(d *TargetDetails, obs Observable) {
 
 // ── Radial velocity ─────────────────────────────────────────────────────────
 
-// fillRadialVelocity computes the topocentric radial velocity an observer
-// at ctx would measure right now for a target with a catalog (barycentric)
-// RV, via coord.Context.ObservedRadialVelocity. Silently skipped (never a
-// hard error) for a target with no MeasuredRadialVelocity, or one that
-// implements the interface but has no RV set — same best-effort
-// convention AngularDiameter/Elongation already use in fillMovingBody.
-// pos is the target's astrometric ICRS position already computed by
-// computeDetails (its own catalog coordinates, not a topocentric-adjusted
-// one — the only type implementing MeasuredRadialVelocity today, *Star,
-// is never a MovingBody, so this is always the right line-of-sight
-// direction regardless of which branch of computeDetails ran first).
-func fillRadialVelocity(d *TargetDetails, obs Observable, pos coord.ICRS, ctx *coord.Context) {
-	mrv, ok := obs.(MeasuredRadialVelocity)
-	if !ok {
+// fillRadialVelocity records the radial velocity an observer at ctx would
+// measure right now, for any target that has one.
+//
+// Silently skipped rather than a hard error when the target has none — the
+// same best-effort convention AngularDiameter and Elongation already use in
+// fillMovingBody.
+//
+// It used to handle only MeasuredRadialVelocity, and so only *Star. That
+// missed both halves of the sky: a galaxy's catalog RV was being fetched and
+// discarded, and a solar-system body — whose radial velocity is the one that
+// actually moves, by tens of km/s in a night — had none at all. [RadialVelocity]
+// dispatches on what the target is.
+func fillRadialVelocity(d *TargetDetails, obs Observable, ctx *coord.Context) {
+	rv, err := RadialVelocity(obs, ctx)
+	if err != nil {
 		return
 	}
 
-	rvBarycentric, has := mrv.MeasuredRadialVelocity()
-	if !has {
-		return
+	// A catalog value is worth showing beside the measurement, because the
+	// two differ by up to ~30 km/s and a reader comparing against a
+	// published number needs to know which they are looking at. A moving
+	// body has no catalog value to show.
+	if mrv, ok := obs.(MeasuredRadialVelocity); ok {
+		if barycentric, has := mrv.MeasuredRadialVelocity(); has {
+			d.RadialVelocity = fmt.Sprintf("%+.2f km/s topocentric (%+.2f km/s barycentric)",
+				rv, barycentric)
+
+			return
+		}
 	}
 
-	rvObserved := ctx.ObservedRadialVelocity(pos, rvBarycentric)
-	d.RadialVelocity = fmt.Sprintf("%+.2f km/s topocentric (%+.2f km/s barycentric)", rvObserved, rvBarycentric)
+	d.RadialVelocity = fmt.Sprintf("%+.2f km/s topocentric", rv)
 }
 
 // ── Type-specific property extraction ───────────────────────────────────────
@@ -402,4 +410,55 @@ func clamp(v, lo, hi float64) float64 {
 	}
 
 	return v
+}
+
+// RadialVelocity returns the radial velocity, in km/s, an observer at ctx
+// measures for obs right now — positive when the target is receding.
+//
+// # One function, two entirely different quantities
+//
+// A fixed target's radial velocity is a measurement somebody made and wrote
+// in a catalog: it is a property of the object, constant on any timescale an
+// observer cares about, and the only work here is referring it from the
+// barycentre to the observer. That is [MeasuredRadialVelocity], carried by
+// *Star and *DeepSkyObject.
+//
+// A solar-system body has no such number, and could not have one. Its radial
+// velocity is a consequence of where it and the observer happen to be, and it
+// swings by tens of km/s over a single night. It is computed from the
+// ephemeris state the provider already returns — see
+// [coord.Context.TopocentricRadialVelocity].
+//
+// Both are radial velocities and a caller wanting "how fast is this
+// separating from me" should not have to know which kind it has, which is why
+// this dispatches rather than exposing two functions.
+//
+// Returns ErrNoRadialVelocity for a target that is neither: a fixed target
+// whose catalog carried no RV, or one of the target kinds with no position
+// model at all.
+func RadialVelocity(obs Observable, ctx *coord.Context) (float64, error) {
+	// Moving body first. A body with an ephemeris always has a radial
+	// velocity, and a catalog value for one would be meaningless — the
+	// ordering matters if a type ever implements both.
+	if mb, ok := obs.(MovingBody); ok {
+		state, err := mb.Provider().State(mb.EphID(), ctx.Time())
+		if err != nil {
+			return 0, fmt.Errorf("radial velocity for %s: %w", mb.Name(), err)
+		}
+
+		return ctx.TopocentricRadialVelocity(state.Pos, state.Vel), nil
+	}
+
+	if mrv, ok := obs.(MeasuredRadialVelocity); ok {
+		if rvBarycentric, has := mrv.MeasuredRadialVelocity(); has {
+			pos, err := obs.Position(ctx.Time())
+			if err != nil {
+				return 0, fmt.Errorf("radial velocity for %s: %w", obs.Name(), err)
+			}
+
+			return ctx.ObservedRadialVelocity(pos, rvBarycentric), nil
+		}
+	}
+
+	return 0, fmt.Errorf("%w: %s", ErrNoRadialVelocity, obs.Name())
 }

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -26,6 +26,12 @@ var (
 	// magnitude depends on the detector, the exposure and the observer.
 	ErrNoSkyDepth = errors.New("limiting magnitude constraint requires a SkyDepth")
 
+	// ErrNoRadialVelocity indicates a target with no radial velocity to
+	// report: a fixed target whose catalog carried none, or a kind with no
+	// position model at all. Distinct from a measured RV of exactly zero,
+	// which MeasuredRadialVelocity reports as a value with ok true.
+	ErrNoRadialVelocity = errors.New("target has no radial velocity")
+
 	// ErrNotCoordObject indicates the object does not implement coord.Object.
 	//
 	// Deprecated: RankObservable no longer returns this — every Observable

--- a/plan/factory.go
+++ b/plan/factory.go
@@ -164,6 +164,10 @@ func FromCatalog(c catalog.Target, p eph.Provider) Observable {
 		opts = append(opts, WithDSOMagnitude(c.VMag))
 	}
 
+	if c.HasRadialVelocity {
+		opts = append(opts, WithDSORadialVelocity(c.RadialVelocity))
+	}
+
 	if string(c.Kind) != "" {
 		opts = append(opts, WithDSOKind(string(c.Kind)))
 	}

--- a/plan/factory_test.go
+++ b/plan/factory_test.go
@@ -277,3 +277,75 @@ func TestFromCatalog_AsteroidDiameterAndAlbedo(t *testing.T) {
 		}
 	})
 }
+
+// TestFromCatalogKeepsADeepSkyRadialVelocity covers the half of the catalog
+// that was being discarded.
+//
+// SIMBAD populates rvz_radvel for any object type — M31 at −300.0 km/s, M87
+// at +1256.5 — and for an extragalactic object it is the headline
+// measurement, usually quoted as a redshift. FromCatalog read
+// HasRadialVelocity in the star branch only, so a galaxy's arrived and was
+// dropped on the floor.
+func TestFromCatalogKeepsADeepSkyRadialVelocity(t *testing.T) {
+	t.Parallel()
+
+	obs := plan.FromCatalog(catalog.Target{
+		Name:              "M31-like",
+		Kind:              resolve.KindGalaxy,
+		Coord:             coord.NewICRS(angle.Deg(10.6847), angle.Deg(41.2688)),
+		HasCoord:          true,
+		RadialVelocity:    -300.0,
+		HasRadialVelocity: true,
+	}, nil)
+
+	mrv, ok := obs.(plan.MeasuredRadialVelocity)
+	if !ok {
+		t.Fatalf("%T does not implement MeasuredRadialVelocity", obs)
+	}
+
+	rv, has := mrv.MeasuredRadialVelocity()
+	if !has {
+		t.Fatal("the catalog radial velocity did not survive FromCatalog")
+	}
+
+	if rv != -300.0 {
+		t.Errorf("radial velocity = %v, want -300.0", rv)
+	}
+}
+
+// TestFromCatalogDistinguishesNoRadialVelocityFromZero keeps the same
+// distinction HasRadialVelocity exists for. A galaxy at rest relative to the
+// barycentre would read 0 km/s, and that is a measurement; a galaxy with no
+// published RV also reads 0, and that is not.
+func TestFromCatalogDistinguishesNoRadialVelocityFromZero(t *testing.T) {
+	t.Parallel()
+
+	base := catalog.Target{
+		Name:     "no RV on file",
+		Kind:     resolve.KindGalaxy,
+		Coord:    coord.NewICRS(angle.Deg(10), angle.Deg(41)),
+		HasCoord: true,
+	}
+
+	absent, ok := plan.FromCatalog(base, nil).(plan.MeasuredRadialVelocity)
+	if !ok {
+		t.Fatal("a deep-sky object does not implement MeasuredRadialVelocity")
+	}
+
+	if _, has := absent.MeasuredRadialVelocity(); has {
+		t.Error("a target with no published RV reports one")
+	}
+
+	measured := base
+	measured.RadialVelocity, measured.HasRadialVelocity = 0, true
+
+	got, ok := plan.FromCatalog(measured, nil).(plan.MeasuredRadialVelocity)
+	if !ok {
+		t.Fatal("a deep-sky object does not implement MeasuredRadialVelocity")
+	}
+
+	rv, has := got.MeasuredRadialVelocity()
+	if !has || rv != 0 {
+		t.Errorf("a measured 0 km/s reports (%v, %v), want (0, true)", rv, has)
+	}
+}

--- a/plan/observable.go
+++ b/plan/observable.go
@@ -43,10 +43,14 @@ type StaticMagnitude interface {
 	StaticMagnitude() (float64, bool)
 }
 
-// MeasuredRadialVelocity is implemented by targets with a catalog
-// (barycentric) radial velocity — currently *Star, via
-// WithRadialVelocity. ok is false when no RV was ever set, distinct
-// from a genuine measured RV of exactly zero.
+// MeasuredRadialVelocity is implemented by a fixed target carrying a catalog
+// (barycentric) radial velocity: *Star via WithRadialVelocity, and
+// *DeepSkyObject via WithDSORadialVelocity. ok is false when no RV was ever
+// set, distinct from a genuine measured RV of exactly zero.
+//
+// A solar-system body implements none of this. Its radial velocity is not a
+// catalog value but a consequence of the geometry at the moment of asking,
+// computed from the ephemeris — see [RadialVelocity].
 type MeasuredRadialVelocity interface {
 	MeasuredRadialVelocity() (kmPerSec float64, ok bool)
 }
@@ -98,6 +102,7 @@ var (
 	_ StaticMagnitude = (*Satellite)(nil)
 
 	_ MeasuredRadialVelocity = (*Star)(nil)
+	_ MeasuredRadialVelocity = (*DeepSkyObject)(nil)
 
 	_ PhysicalRadius = (*Asteroid)(nil)
 )

--- a/plan/radialvelocity_network_test.go
+++ b/plan/radialvelocity_network_test.go
@@ -1,0 +1,160 @@
+//go:build network
+
+package plan_test
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// horizonsRangeRate fetches JPL Horizons' own topocentric range-rate
+// (quantity 20, the second column of the pair) for one body, at one instant,
+// from a site on the equator at the prime meridian.
+func horizonsRangeRate(t *testing.T, command, tlistJD string) float64 {
+	t.Helper()
+
+	url := fmt.Sprintf("https://ssd.jpl.nasa.gov/api/horizons.api?format=text"+
+		"&COMMAND='%s'&CENTER='coord@399'&COORD_TYPE=GEODETIC&SITE_COORD='0,0,0'"+
+		"&MAKE_EPHEM='YES'&EPHEM_TYPE='OBSERVER'&QUANTITIES='20'&TLIST='%s'"+
+		"&CSV_FORMAT='YES'&OBJ_DATA='NO'", command, tlistJD)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("Horizons: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("read Horizons: %v", err)
+	}
+
+	body := string(raw)
+
+	// Only the block between $$SOE and $$EOE is ephemeris. The header carries
+	// comma-bearing lines too, and a "last parseable float on the line"
+	// heuristic reads the body's radius out of one of them — 695700 km for
+	// the Sun, which is what the first version of this test compared against
+	// and how the mistake announced itself.
+	var inData bool
+
+	for line := range strings.SplitSeq(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		switch trimmed {
+		case "$$SOE":
+			inData = true
+
+			continue
+		case "$$EOE":
+			inData = false
+		}
+
+		if !inData || !strings.Contains(trimmed, ",") {
+			continue
+		}
+
+		// QUANTITIES='20' yields the date, the range and the range-rate; the
+		// rate is the last number on the row.
+		var nums []float64
+
+		for c := range strings.SplitSeq(trimmed, ",") {
+			if v, err := strconv.ParseFloat(strings.TrimSpace(c), 64); err == nil {
+				nums = append(nums, v)
+			}
+		}
+
+		if len(nums) >= 2 {
+			return nums[len(nums)-1]
+		}
+	}
+
+	t.Skip("Horizons returned no parseable range-rate")
+
+	return 0
+}
+
+// TestMovingBodyRadialVelocityAgainstHorizons checks the computed radial
+// velocity against the service that publishes it.
+//
+// # What the bound is, and what it is not
+//
+// It is not an accuracy claim about this library's ephemeris. Both sides
+// compute the same quantity, but from different ephemerides: Horizons reads
+// DE440 and this uses ephemeris.Default(), gofa's truncated analytical
+// series. The residual is therefore dominated by the series, not by the
+// geometry under test.
+//
+// So the bound comes from the series' own published velocity error. Plan94's
+// documentation gives maximum absolute range-rate differences against DE200
+// of 0.9 m/s for Venus, 2.5 for Mars and 8.2 for Jupiter; Epv00 quotes 5.0
+// mm/s for the Sun path and Moon98 a comparable figure. Tripled here, which
+// covers DE200 against DE440 and leaves the test measuring whether the
+// projection, the frame and the diurnal term are right — a sign error in any
+// of them is a whole km/s, not a few m/s.
+func TestMovingBodyRadialVelocityAgainstHorizons(t *testing.T) {
+	testutil.RequireReachable(t, "ssd.jpl.nasa.gov:443")
+
+	site, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(0), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	// A fixed instant, so a failure is reproducible.
+	const tlistJD = "2461114.5"
+
+	at := time.FromJD(2461114.5, time.UTC)
+	ctx := coord.NewContext(at, site, atmosphere.Refraction{Pressure: 0})
+	e := ephemeris.Default()
+
+	for _, tc := range []struct {
+		name, command string
+		obs           plan.Observable
+		toleranceKmS  float64
+	}{
+		{"Sun", "10", plan.NewSun(e), 0.015},
+		{"Moon", "301", plan.NewMoon(e), 0.015},
+		{"Venus", "299", plan.NewVenus(e), 0.0027},
+		{"Mars", "499", plan.NewMars(e), 0.0075},
+		{"Jupiter", "599", plan.NewJupiter(e), 0.0246},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := plan.RadialVelocity(tc.obs, ctx)
+			if err != nil {
+				t.Fatalf("RadialVelocity: %v", err)
+			}
+
+			want := horizonsRangeRate(t, tc.command, tlistJD)
+
+			t.Logf("%s: astrogo %+.4f km/s, Horizons %+.4f, difference %+.1f m/s",
+				tc.name, got, want, (got-want)*1e3)
+
+			if math.Abs(got-want) > tc.toleranceKmS {
+				t.Errorf("radial velocity %+.4f km/s against Horizons' %+.4f — a difference of "+
+					"%.1f m/s, past the %.1f m/s the analytical series' own published velocity "+
+					"error allows", got, want, (got-want)*1e3, tc.toleranceKmS*1e3)
+			}
+		})
+	}
+}


### PR DESCRIPTION
It worked for `*Star` and nothing else. Two different quantities were missing, for two different reasons.

## Piece 1 — a galaxy's catalog RV was fetched and thrown away

SIMBAD populates `rvz_radvel` for **any** object type — M31 at −300.0 km/s, M87 at +1256.5, M42 at +27.8 — and for an extragalactic object it is the headline measurement, usually quoted as a redshift.

`FromCatalog` read `c.HasRadialVelocity` **in the star branch only**. A galaxy's arrived and was dropped on the floor.

`*DeepSkyObject` now carries it via `WithDSORadialVelocity` and implements `MeasuredRadialVelocity`, with the same absent-versus-zero distinction the star path already had — a galaxy genuinely at rest relative to the barycentre reads 0 km/s, and that *is* a measurement.

## Piece 2 — a solar-system body had none at all

And could not have one from a catalog. Its radial velocity is a consequence of where it and the observer happen to be, and it swings by **tens of km/s over a single night** — which is exactly why it is worth computing rather than tabulating.

`coord.Context.TopocentricRadialVelocity` computes it from the geocentric state the provider already returns.

**What it subtracts is the observer's *geocentric* velocity, not the barycentric one.** The state is geocentric, so Earth's orbital motion is already absent from both sides; removing it again would double-count. What remains is the site turning about Earth's axis, `ω × r` — 0.465 km/s at the equator. Small against a planet's tens of km/s, and *dominant* for the Moon, whose own geocentric radial velocity stays inside about 0.06 km/s.

Earth's angular velocity had no constant in the repository. It is one of WGS 84's four defining parameters, so it goes in `constants.WGS84` with the standard's own citation. The count guard in `constants` caught the addition, as it should.

## One entry point

`plan.RadialVelocity(obs, ctx)` dispatches on what the target is. A caller asking *how fast is this separating from me* should not have to know which kind of radial velocity it has.

## Checked against JPL Horizons

Its own topocentric range-rate, at a fixed instant, using only the **offline SOFA provider**:

| body | astrogo | Horizons | difference |
| :--- | ---: | ---: | ---: |
| Sun | +0.4961 | +0.4961 | 0.0 m/s |
| Moon | −0.3441 | −0.3440 | 0.1 m/s |
| Venus | −4.6397 | −4.6387 | 1.1 m/s |
| Mars | −2.6555 | −2.6540 | 1.5 m/s |
| Jupiter | +26.5613 | +26.5562 | 5.1 m/s |

**The tolerances are not these measurements.** They are Plan94's published maximum range-rate differences against DE200 — 0.9 m/s for Venus, 2.5 for Mars, 8.2 for Jupiter — tripled to cover DE200 against DE440. The residual is the analytical series, not the geometry under test: a sign error in the projection, the frame or the diurnal term is a whole km/s, not a few.

## What I got wrong writing it

The test's first version reported **695700 km/s** for the Sun. It took the last parseable number on any comma-bearing line and found the solar radius in Horizons' header. It now parses only between `$$SOE` and `$$EOE`, and the comment says why so the next person does not repeat it.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues** · plus `-tags=network` for the Horizons comparison.

Two linter findings fixed rather than suppressed: `forcetypeassert` on the new tests, and `modernize` wanting `SplitSeq`.

Depends on nothing, but note #88 is what makes the deep-sky RV actually *arrive* — before it, resolution returned the wrong object.