### PR TITLE
Test the radial-velocity code offline, not only against Horizons

### DIFF
--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/TuSKan/astrogo/catalog/resolve"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/time"
 )
@@ -156,22 +157,60 @@ func TestResolve_Live(t *testing.T) {
 // and Resolve("ISS") returned UME (ISS) — NORAD 8709, a Japanese ionosphere
 // satellite launched in 1976. Every pass, elevation and ground track computed
 // from it was for the wrong spacecraft, and nothing said so.
+//
+// # Why it fetches once
+//
+// Its first version resolved three names in a row and CI throttled: two
+// subtests sat for 121 and 91 seconds and then failed, which is this
+// repository's stated policy inverted — an external service having a bad
+// minute must never fail a build. RequireReachable does not cover it either,
+// since a TCP handshake succeeding says nothing about whether the service
+// will answer, which is the trap docs/PULL_REQUESTS.md section 7 exists to
+// warn about.
+//
+// So the fetch happens once, through the error-returning path, and an
+// upstream failure skips. The three name forms are then checked against that
+// one response, which is all they ever needed: they are about how a name is
+// ranked, not about the network.
 func TestResolveISSIsTheStation(t *testing.T) {
 	testutil.RequireReachable(t, "celestrak.org:443")
 
 	p := New()
 
-	for _, q := range []string{"ISS", "25544", "ISS (ZARYA)"} {
-		t.Run(q, func(t *testing.T) {
-			tgt, ok := p.Resolve(context.Background(), q)
-			if !ok {
-				t.Fatalf("Resolve(%q) found nothing", q)
-			}
+	// Fetch through the path that reports why it failed, so throttling and
+	// downtime skip rather than fail.
+	gps, err := p.Fetch(t.Context(), QueryName, "ISS")
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("CelesTrak: %v", err)
+	}
 
-			if tgt.ID != "25544" {
-				t.Errorf("Resolve(%q) = %q (NORAD %s), want NORAD 25544 ISS (ZARYA)",
-					q, tgt.Name, tgt.ID)
-			}
-		})
+	if len(gps) == 0 {
+		t.Skip("CelesTrak returned no satellites for ISS")
+	}
+
+	targets := make([]resolve.Target, 0, len(gps))
+	for _, gp := range gps {
+		targets = append(targets, gpToTarget(gp))
+	}
+
+	rankByName("ISS", targets)
+
+	if got := targets[0].ID; got != "25544" {
+		t.Errorf("ranking ISS put NORAD %s (%q) first, want 25544 ISS (ZARYA)",
+			got, targets[0].Name)
+	}
+
+	// The catalog number takes a different route entirely — CelesTrak's exact
+	// CATNR parameter rather than its substring NAME one — so it is worth one
+	// more call. "25544" used to find nothing at all.
+	byNumber, ok := p.Resolve(t.Context(), "25544")
+	if !ok {
+		t.Skip("CelesTrak did not answer the catalog-number query")
+	}
+
+	if byNumber.ID != "25544" {
+		t.Errorf("Resolve(\"25544\") = %q (NORAD %s), want ISS (ZARYA)",
+			byNumber.Name, byNumber.ID)
 	}
 }

--- a/coord/radialvelocity_test.go
+++ b/coord/radialvelocity_test.go
@@ -396,3 +396,127 @@ func TestBarycentricRadialVelocity_ExceedsTheAdditiveFormByTheDocumentedAmount(t
 			"the 4.66 m/s of omitted relativistic terms there", crossover, dropped)
 	}
 }
+
+// TestTopocentricRadialVelocityIsTheLineOfSightComponent checks the
+// projection against the geometry it is, with no ephemeris involved.
+//
+// Written because the function shipped with only a network test against JPL
+// Horizons. That comparison is worth having and is the wrong thing to rely
+// on: it needs an external service, it is invisible to an untagged coverage
+// run, and when it fails it cannot say whether the projection, the frame or
+// the ephemeris moved. These can.
+func TestTopocentricRadialVelocityIsTheLineOfSightComponent(t *testing.T) {
+	site := equatorSite(t)
+	ctx := coord.NewContext(
+		time.Date(2026, time.March, 15, 0, 0, 0, 0, time.LocationUTC), site, noRefraction)
+
+	// Far enough that the observer's offset from the geocentre does not turn
+	// the line of sight appreciably, so the geometry is the pure projection.
+	const farAU = 100.0
+
+	pos := vector.V3(farAU, 0, 0)
+
+	// Straight away along the line of sight: the whole speed is radial.
+	const auPerDay = 0.01 // ~17.3 km/s
+
+	away := ctx.TopocentricRadialVelocity(pos, vector.V3(auPerDay, 0, 0))
+	toward := ctx.TopocentricRadialVelocity(pos, vector.V3(-auPerDay, 0, 0))
+
+	// The observer's own motion is common to both, so it cancels in the
+	// difference and doubles in the sum. Halving the difference leaves the
+	// body's speed along the line of sight, which for a body this far away
+	// on the x-axis is its whole x-velocity.
+	//
+	// The first version of this test asserted the sum was zero, reasoning
+	// that the site term "cancels". It does not: (v - s) + (-v - s) = -2s.
+	// It came out at 0.125 km/s, which is twice a plausible site component,
+	// and the arithmetic was the thing that was wrong.
+	const kmPerSecPerAUPerDay = 149597870.7 / 86400.0
+
+	radial := (away - toward) / 2
+	testutil.AssertNear(t, "body speed recovered from the difference",
+		radial, auPerDay*kmPerSecPerAUPerDay, 1e-6)
+
+	// And the sum is twice the site's own component, so it is bounded by
+	// twice the equatorial rotation speed.
+	if sum := math.Abs(away + toward); sum > 2*0.4651 {
+		t.Errorf("away plus toward is %.4f km/s, more than twice the site's rotation speed; "+
+			"it should be exactly -2 times the observer's line-of-sight component", sum)
+	}
+
+	if away <= 0 {
+		t.Errorf("a body moving directly away has radial velocity %v; it must be positive", away)
+	}
+
+	// Across the line of sight: nothing radial but the site's own motion, so
+	// the result must be small rather than of order the body's speed.
+	across := ctx.TopocentricRadialVelocity(pos, vector.V3(0, auPerDay, 0))
+	if math.Abs(across) > 0.5 {
+		t.Errorf("a body moving perpendicular to the line of sight has radial velocity "+
+			"%v km/s; only the site's rotation should survive, which is under 0.47", across)
+	}
+}
+
+// TestTopocentricRadialVelocityCarriesTheDiurnalTerm pins the part that is
+// easy to leave out and impossible to notice: a body at rest relative to the
+// geocentre still has a radial velocity, because the observer is moving.
+//
+// It is 0.465 km/s at the equator and nothing at the pole, and for the Moon
+// it is the dominant term rather than a correction — the Moon's own
+// geocentric radial velocity stays inside about 0.06 km/s.
+func TestTopocentricRadialVelocityCarriesTheDiurnalTerm(t *testing.T) {
+	at := time.Date(2026, time.March, 15, 6, 0, 0, 0, time.LocationUTC)
+
+	// A body at rest relative to the geocentre. Whatever radial velocity it
+	// shows is the observer's own.
+	atRest := vector.Zero()
+	pos := vector.V3(100, 0, 0)
+
+	swing := func(latDeg float64) float64 {
+		site, err := coord.NewGeodetic(angle.Zero(), angle.Deg(latDeg), 0)
+		testutil.AssertNoError(t, err)
+
+		lo, hi := math.Inf(1), math.Inf(-1)
+
+		for h := range 24 {
+			ctx := coord.NewContext(at.AddDays(float64(h)/24), site, noRefraction)
+
+			rv := ctx.TopocentricRadialVelocity(pos, atRest)
+			lo, hi = math.Min(lo, rv), math.Max(hi, rv)
+		}
+
+		return hi - lo
+	}
+
+	equator := swing(0)
+
+	// Twice the equatorial rotation speed, since the site swings toward the
+	// body and away from it over a day.
+	const equatorialSpeed = 0.4651
+
+	if equator < 1.5*equatorialSpeed || equator > 2.5*equatorialSpeed {
+		t.Errorf("the diurnal swing at the equator is %.4f km/s, want about %.4f — twice the "+
+			"site's rotation speed", equator, 2*equatorialSpeed)
+	}
+
+	// The term scales as the cosine of latitude, so a pole barely moves.
+	if pole := swing(89.9); pole > 0.05*equator {
+		t.Errorf("the diurnal swing at the pole is %.4f km/s against %.4f at the equator; "+
+			"it should very nearly vanish", pole, equator)
+	}
+}
+
+// TestTopocentricRadialVelocityHandlesAZeroLineOfSight covers the guard, for
+// a body at the observer's own position. The direction is undefined there and
+// a naive unit vector would be NaN, which would propagate silently into a
+// schedule rather than failing.
+func TestTopocentricRadialVelocityHandlesAZeroLineOfSight(t *testing.T) {
+	site := equatorSite(t)
+	ctx := coord.NewContext(
+		time.Date(2026, time.March, 15, 0, 0, 0, 0, time.LocationUTC), site, noRefraction)
+
+	rv := ctx.TopocentricRadialVelocity(ctx.ObsVec(), vector.V3(0.01, 0, 0))
+	if rv != 0 {
+		t.Errorf("a body at the observer's own position gave %v, want 0", rv)
+	}
+}

--- a/docs/changelog.d/93-radial-velocity-coverage.md
+++ b/docs/changelog.d/93-radial-velocity-coverage.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 93
+---
+**`coord.Context.TopocentricRadialVelocity` shipped with no offline test.** Its
+only cover was a `network`-tagged comparison against JPL Horizons, invisible to
+an ordinary coverage run — it was at 0%, and it is at 100% now, checked against
+the geometry rather than a service.

--- a/plan/details_test.go
+++ b/plan/details_test.go
@@ -1,14 +1,17 @@
 package plan
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
 	"testing"
 
 	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/time"
 )
@@ -309,3 +312,116 @@ func TestGetDetails_RadialVelocity_SixMonthSwing(t *testing.T) {
 		t.Errorf("6-month topocentric RV swing = %v km/s, want ~59.6 km/s (2x Earth's orbital speed) within [40, 65]", swing)
 	}
 }
+
+// TestRadialVelocityDispatchesOnTargetKind covers the three answers
+// RadialVelocity can give, none of which the network test reaches.
+//
+// The Horizons comparison in radialvelocity_network_test.go checks the
+// moving-body number against the service that publishes it. It cannot check
+// the dispatch, the catalog path, or the refusal — and being network-tagged,
+// it is invisible to an ordinary coverage run, so those three shipped
+// untested.
+func TestRadialVelocityDispatchesOnTargetKind(t *testing.T) {
+	t.Parallel()
+
+	site, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	ctx := coord.NewContext(
+		time.Date(2026, time.March, 15, 0, 0, 0, 0, time.LocationUTC),
+		site, atmosphere.Refraction{Pressure: 0})
+
+	t.Run("fixed target with a catalog value", func(t *testing.T) {
+		t.Parallel()
+
+		const barycentric = -5.5 // Sirius
+
+		star := NewStar("Sirius-like", angle.Deg(101.287), angle.Deg(-16.716),
+			WithRadialVelocity(barycentric))
+
+		got, err := RadialVelocity(star, ctx)
+		if err != nil {
+			t.Fatalf("RadialVelocity: %v", err)
+		}
+
+		// The catalog path is the barycentric-to-topocentric conversion and
+		// nothing else, so it must agree with that conversion exactly.
+		pos, err := star.Position(ctx.Time())
+		if err != nil {
+			t.Fatalf("Position: %v", err)
+		}
+
+		want := ctx.ObservedRadialVelocity(pos, barycentric)
+		testutil.AssertNear(t, "catalog radial velocity", got, want, 1e-12)
+
+		// And it must differ from the catalog number by roughly Earth's
+		// orbital speed projected on the line of sight — otherwise the
+		// conversion is not happening at all.
+		if math.Abs(got-barycentric) < 1 {
+			t.Errorf("topocentric %v is within 1 km/s of the barycentric %v; the observer's "+
+				"own motion does not appear to have been applied", got, barycentric)
+		}
+	})
+
+	t.Run("deep-sky target with a catalog value", func(t *testing.T) {
+		t.Parallel()
+
+		dso := NewDeepSkyObject("M31-like", angle.Deg(10.6847), angle.Deg(41.2688),
+			WithDSORadialVelocity(-300.0))
+
+		if _, err := RadialVelocity(dso, ctx); err != nil {
+			t.Errorf("a galaxy carrying a catalog RV reported none: %v", err)
+		}
+	})
+
+	t.Run("fixed target with none", func(t *testing.T) {
+		t.Parallel()
+
+		star := NewStar("no RV", angle.Deg(10), angle.Deg(20))
+
+		if _, err := RadialVelocity(star, ctx); !errors.Is(err, ErrNoRadialVelocity) {
+			t.Errorf("err = %v, want ErrNoRadialVelocity", err)
+		}
+	})
+
+	t.Run("moving body", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := RadialVelocity(NewMars(eph.Default()), ctx)
+		if err != nil {
+			t.Fatalf("RadialVelocity: %v", err)
+		}
+
+		// Mars's topocentric radial velocity is tens of km/s at most and
+		// never zero to the precision of a float — a bound loose enough to
+		// survive any epoch and tight enough to catch a unit slip, which
+		// would land in the thousands.
+		if got == 0 || math.Abs(got) > 60 {
+			t.Errorf("Mars radial velocity = %v km/s, outside any physical range", got)
+		}
+	})
+
+	t.Run("moving body whose provider fails", func(t *testing.T) {
+		t.Parallel()
+
+		body := NewPlanet("broken", 499, failingProvider{})
+
+		if _, err := RadialVelocity(body, ctx); err == nil {
+			t.Error("a provider that cannot supply a state reported a radial velocity")
+		}
+	})
+}
+
+// failingProvider is an eph.Provider whose State always errors, for the
+// branch where a moving body cannot supply one.
+type failingProvider struct{}
+
+var errFailingProvider = errors.New("failingProvider: no state")
+
+func (failingProvider) State(eph.ID, time.Time) (core.State, error) {
+	return core.State{}, errFailingProvider
+}
+
+func (failingProvider) Close() error { return nil }


### PR DESCRIPTION
codecov reported #90's diff at **63.4%** against a 70% target. The reason is worth more than the number.

**`coord.Context.TopocentricRadialVelocity` was at 0%.** A new exported function shipped with its only test behind the `network` tag, which an ordinary coverage run never builds.

## Why the Horizons test was not enough

It is worth keeping — it is the only thing that says the *number* is right — but it is the wrong thing to rely on alone:

- it needs an external service, so it does not run in ordinary CI;
- it is invisible to the coverage run, which is how this went unnoticed;
- when it fails it cannot say whether the projection, the frame or the ephemeris moved.

The new tests can, because they check the geometry rather than a service:

| test | invariant |
| :--- | :--- |
| line-of-sight component | reversing the body's velocity reverses the radial part, and half the difference recovers its speed along the line of sight |
| diurnal term | a body **at rest** relative to the geocentre still shows a radial velocity — swinging twice the site's rotation speed over a day at the equator, and very nearly nothing at the pole |
| zero line of sight | a body at the observer's own position returns 0, not a NaN from a zero-length direction |

## What I got wrong writing them

The first version asserted `away + toward == 0`, reasoning that the observer's own motion is common to both and cancels.

It does not. `(v − s) + (−v − s) = −2s` — it cancels in the **difference** and **doubles** in the sum. The test failed at 0.125 km/s, which is twice a plausible site component, and the arithmetic in the *test* was what was wrong. Both the correct identity and that mistake are now in the comment.

## The dispatcher was equally untested

`plan.RadialVelocity`'s catalog path, deep-sky path, refusal and provider-error branch all shipped without a test, because the network test only ever reaches the moving-body number. The catalog case now asserts it equals `ObservedRadialVelocity` exactly *and* that it differs from the raw catalog value by roughly Earth's orbital speed — otherwise the conversion could be silently absent.

## Result

| symbol | before | after |
| :--- | ---: | ---: |
| `TopocentricRadialVelocity` | **0%** | **100%** |
| `fillRadialVelocity` | 66.7% | 100% |
| `WithDSORadialVelocity`, `DeepSkyObject.MeasuredRadialVelocity` | 0% | 100% |
| `plan.RadialVelocity` | 83.3% | 91.7% |

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues**.