### PR TITLE
Skip the JPL tests when the kernel cannot be fetched

### DIFF
--- a/docs/changelog.d/95-jpl-tests-skip-on-upstream.md
+++ b/docs/changelog.d/95-jpl-tests-skip-on-upstream.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 95
+---
+**A slow NAIF turned into a red build.** `ephemeris/jpl`'s untagged tests fetch
+a 32 MB kernel and treated a download timeout as a test failure — four of them
+sat at 120 s each and took the package past its limit. An upstream failure now
+skips, as this repository's policy says it must.

--- a/ephemeris/jpl/jpl_test.go
+++ b/ephemeris/jpl/jpl_test.go
@@ -87,10 +87,7 @@ func TestCheby(t *testing.T) {
 }
 
 func TestJPLUnitsAreAUAndAUPerDay(t *testing.T) {
-	p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("failed to initialize provider: %v", err)
-	}
+	p := mustPlanetProvider(t)
 
 	t.Cleanup(func() {
 		err := p.Close()
@@ -111,10 +108,7 @@ func TestJPLUnitsAreAUAndAUPerDay(t *testing.T) {
 }
 
 func TestJPLUnsupportedBody(t *testing.T) {
-	p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("setup failed: %v", err)
-	}
+	p := mustPlanetProvider(t)
 
 	t.Cleanup(func() {
 		err := p.Close()
@@ -123,17 +117,14 @@ func TestJPLUnsupportedBody(t *testing.T) {
 		}
 	})
 
-	_, err = p.State(core.ID(255), time.NowUTC())
+	_, err := p.State(core.ID(255), time.NowUTC())
 	if err == nil {
 		t.Error("Expected error for unsupported body")
 	}
 }
 
 func TestJPLOutOfCoverageEpoch(t *testing.T) {
-	p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("setup failed: %v", err)
-	}
+	p := mustPlanetProvider(t)
 
 	t.Cleanup(func() {
 		err := p.Close()
@@ -145,17 +136,14 @@ func TestJPLOutOfCoverageEpoch(t *testing.T) {
 	// Year 5000
 	tm := time.FromJD(3545000.0, time.UTC)
 
-	_, err = p.State(core.Sun, tm)
+	_, err := p.State(core.Sun, tm)
 	if err == nil {
 		t.Error("Expected error for out-of-coverage epoch")
 	}
 }
 
 func TestJPLDeterministicRepeatedCalls(t *testing.T) {
-	p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("setup failed: %v", err)
-	}
+	p := mustPlanetProvider(t)
 
 	t.Cleanup(func() {
 		err := p.Close()
@@ -183,10 +171,7 @@ func TestJPLDeterministicRepeatedCalls(t *testing.T) {
 
 func TestSourceSelection(t *testing.T) {
 	t.Run("Planets", func(t *testing.T) {
-		p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-		if err != nil {
-			t.Fatalf("Planets source failed: %v", err)
-		}
+		p := mustPlanetProvider(t)
 
 		if p == nil {
 			t.Fatal("Planets source returned nil provider")
@@ -331,10 +316,7 @@ func TestSmallBodyMultiMatch(t *testing.T) {
 // in this sandbox), but it does exercise the exact interleaving under real
 // CI, and confirms nothing panics or deadlocks under contention.
 func TestProvider_ConcurrentAddKernelAndState(t *testing.T) {
-	p, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("setup failed: %v", err)
-	}
+	p := mustPlanetProvider(t)
 
 	t.Cleanup(func() {
 		if err := p.Close(); err != nil {

--- a/ephemeris/jpl/lifecycle_test.go
+++ b/ephemeris/jpl/lifecycle_test.go
@@ -47,10 +47,7 @@ func TestNewProvider_ColdCacheDownloadsDisabled(t *testing.T) {
 // from the cache bucket with zero network involvement, proving the offline
 // path works independently of NewProvider.
 func TestKernelLifecycle(t *testing.T) {
-	seed, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
-	if err != nil {
-		t.Fatalf("seed provider: %v", err)
-	}
+	seed := mustPlanetProvider(t)
 
 	kernels := seed.LoadedKernels()
 	if len(kernels) != 1 || kernels[0].Key == "" {

--- a/ephemeris/jpl/main_test.go
+++ b/ephemeris/jpl/main_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
 )
 
@@ -22,4 +25,44 @@ func TestMain(m *testing.M) {
 	remote.EnableDownloads(0, remote.JPLHorizonsSPK)
 
 	os.Exit(m.Run())
+}
+
+// mustPlanetProvider builds a planetary-kernel provider, skipping the test
+// when the kernel cannot
+// be obtained rather than failing it.
+//
+// # Why a download failure is not a test failure
+//
+// These tests are untagged, so they run in the ordinary `go test ./...` — and
+// a provider needs a kernel, which on a machine without one cached means
+// fetching 32 MB from NAIF. When that is slow the tests do not fail quickly:
+// four of them sat at 120 seconds each and took the package past its 600
+// second limit, turning a bad minute at NAIF into a red main branch.
+//
+// This repository's policy is that an external service must never fail a
+// build. It is written for the network-tagged suites and applies here for the
+// same reason, so an upstream failure — a timeout, a 5xx, a rate limit —
+// skips. Anything else still fails, because a kernel that arrives and cannot
+// be opened is a real defect.
+//
+// The deeper question this does not settle: CLAUDE.md says the default suite
+// is "fast, deterministic, offline", and a 32 MB download is none of those.
+// Whether these belong behind the network tag is a call worth making
+// deliberately rather than inside a build fix.
+// testKernel is the planetary kernel every test in this package uses: the
+// small DE440 variant, 32 MB against de440's 115, covering 1849-2150. Every
+// case here works well inside that span, so the larger file would only make
+// the fetch slower.
+const testKernel = "de440s"
+
+func mustPlanetProvider(t *testing.T) *jpl.Provider {
+	t.Helper()
+
+	p, err := jpl.NewProvider(t.Context(), core.Planets, testKernel)
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("NewProvider(planets, %q): %v", testKernel, err)
+	}
+
+	return p
 }


### PR DESCRIPTION
`main`'s **Race Detection** job is failing. Four `ephemeris/jpl` tests each sat at **120 seconds** and the package hit its 600 second limit:

```
--- FAIL: TestJPLUnitsAreAUAndAUPerDay        (120.60s)
--- FAIL: TestJPLUnsupportedBody              (120.58s)
--- FAIL: TestJPLOutOfCoverageEpoch           (120.52s)
--- FAIL: TestJPLDeterministicRepeatedCalls   (120.37s)
FAIL github.com/TuSKan/astrogo/ephemeris/jpl  600.044s
```

None of it is a defect in the code under test.

## Why it happens

These tests are **untagged**, so they run in the ordinary `go test ./...`, and a provider needs a kernel — 32 MB from NAIF on any machine without one cached. When the fetch is slow they do not fail fast; they hang, then fail, and a bad minute at NAIF becomes a red `main`.

NAIF answers a range request in **0.75 s** from here, so this is the runner's network rather than an outage — which is exactly the case the policy exists for.

## The fix

This repository already states, for its network-tagged suites, that an external service must never fail a build. It applies here for the same reason. Provider construction goes through `mustPlanetProvider`, which skips on an upstream failure — timeout, 5xx, rate limit — via the existing `testutil.SkipOnUpstreamFailure`, and **still fails on anything else**, because a kernel that arrives and cannot be opened is a real defect.

## The helper lost its parameters one at a time

`unparam` flagged each in turn, and each deletion was right: every caller passed `core.Planets`, then `"de440s"`, then no options. What is left says plainly that this package tests one planetary kernel, with `testKernel` naming which and why — the small DE440 variant, 32 MB against `de440`'s 115, covering 1849–2150, which every case here sits well inside.

Fixed rather than suppressed, three times.

## What this does not settle

`CLAUDE.md` describes the default suite as *"fast, deterministic, offline"*, and a 32 MB download is **none of those**. Whether these tests belong behind the `network` tag is a real decision — it would make the default suite honest, and it would drop them from ordinary CI and from coverage.

I have not made that call inside a build fix, and the helper's doc comment says so, so the next reader meets the question rather than assuming it was settled.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues** · `go vet` tagged.