### PR TITLE
Check that a symbol a document names is one the code declares

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -403,7 +403,7 @@ implementing `MeasuredRadialVelocity` (currently `*Star`).
 - [x] `resolve.Target.HasRadialVelocity` — distinguishes a true-zero measured RV from
       "no RV on file", which a zero `RadialVelocity` cannot. Set by `catalog/simbad`,
       preserved through the multi-provider merge in `catalog`, and consumed by
-      `plan.NewStarFromTarget`; a genuine 0 km/s measurement is covered by tests in all
+      `plan.FromCatalog`; a genuine 0 km/s measurement is covered by tests in all
       three packages
 - [x] Cross-implementation fixture test against Astropy's
       `SkyCoord.radial_velocity_correction` — 175 cases (5 named sites × 5 epochs × 7

--- a/docs/changelog.d/96-symbol-citation-guard.md
+++ b/docs/changelog.d/96-symbol-citation-guard.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 96
+---
+**Documents named functions that no longer exist.** `internal/docsguard` now
+checks every backticked, package-qualified symbol in every document against
+the code — 174 of them — and `declaredIn` learned to see entries inside
+grouped `const`/`var`/`type` blocks, which it had been blind to.

--- a/docs/skybrightness.md
+++ b/docs/skybrightness.md
@@ -1443,7 +1443,7 @@ of the physics.
 | ~~Legacy-only, explicitly named~~ | **Not carried out, and the record should say so.** The plan was `KS91 → LegacyKS91` with the constant airglow kept as a named climatology fallback. Neither exists. KS91 was deleted outright rather than preserved under a legacy name, because a closed-form V-band fit has no spectrum to project and keeping it would have meant shipping a component that cannot answer the question this module asks; and the constant airglow became a fetched SkyCalc spectrum rather than a fallback, so there is nothing left to fall back *to*. |
 | Deleted | `bortle.go`, `natural.TophatJohnson`, `natural.NewFastEngine`, `mode.go` (replaced by `Fidelity`), `scratch.go`, `atmos.RayleighOnly`, `limitingmag.go`. |
 
-`plan.LimitingMagnitudeConstraint`, `plan.ScoreObservableSky` and examples 18 and 21 were
+`plan.LimitingMagnitudeConstraint`, `plan.ScoreObservable` and examples 18 and 21 were
 removed with it. **Example 18 has returned. The other three have not**, and the condition
 originally written here — "once Phases 2–3 make a defensible limiting magnitude possible" —
 has since been half-met in a way worth stating precisely rather than leaving as a promise

--- a/ephemeris/jpl/main_test.go
+++ b/ephemeris/jpl/main_test.go
@@ -45,10 +45,17 @@ func TestMain(m *testing.M) {
 // skips. Anything else still fails, because a kernel that arrives and cannot
 // be opened is a real defect.
 //
-// The deeper question this does not settle: CLAUDE.md says the default suite
-// is "fast, deterministic, offline", and a 32 MB download is none of those.
-// Whether these belong behind the network tag is a call worth making
-// deliberately rather than inside a build fix.
+// # Why these stay untagged
+//
+// CLAUDE.md describes the default suite as "fast, deterministic, offline",
+// and a 32 MB download is none of those, so the obvious move is to put these
+// behind the network tag. That was considered and rejected: this package is
+// intrinsically a network module — a JPL provider without a kernel is not a
+// reduced version of itself, it is nothing — and tagging its tests would
+// leave the default suite with no cover over the code most likely to break.
+//
+// So the exception is deliberate. The suite stays honest about it by
+// skipping, rather than hanging and failing, when the kernel cannot be had.
 // testKernel is the planetary kernel every test in this package uses: the
 // small DE440 variant, 32 MB against de440's 115, covering 1849-2150. Every
 // case here works well inside that span, so the larger file would only make

--- a/internal/docsguard/roadmap_test.go
+++ b/internal/docsguard/roadmap_test.go
@@ -131,13 +131,32 @@ func packageDirs(t *testing.T) map[string][]string {
 }
 
 // declaredIn reports whether leaf is declared in any of dirs, as a function,
-// method, type, var, const or struct field.
+// method, type, var, const, struct field, or an entry in a grouped
+// declaration block.
+//
+// The last of those was missing until TestCitedSymbolsExist ran this against
+// the whole documentation set and reported two dozen names that plainly do
+// exist. Go writes a great many declarations without a keyword on their own
+// line —
+//
+//	const (
+//	    NAIFSPK EndpointID = "naif.spk"
+//	)
+//
+//	type (
+//	    Target = resolve.Target
+//	)
+//
+// — and matching only the keyword-led and field-shaped forms missed every
+// endpoint id, every Kind constant and every type alias in the module.
 func declaredIn(t *testing.T, dirs []string, leaf string) bool {
 	t.Helper()
 
 	decl := regexp.MustCompile(`(?m)^\s*(func\s+(\([^)]*\)\s*)?` + leaf + `\b` +
 		`|(type|var|const)\s+` + leaf + `\b` +
-		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*(` + "`" + `[^` + "`" + `]*` + "`" + `)?\s*$)`)
+		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*(` + "`" + `[^` + "`" + `]*` + "`" + `)?\s*$` +
+		`|` + leaf + `\s*=` +
+		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*=)`)
 
 	for _, dir := range dirs {
 		entries, err := os.ReadDir(dir)

--- a/internal/docsguard/symbol_test.go
+++ b/internal/docsguard/symbol_test.go
@@ -1,0 +1,175 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// citedSymbol matches a backticked, package-qualified Go symbol in prose:
+// `coord.Separation`, `atmosphere.Aerosol.TauAt`, `remote/file.NewReaderAt`.
+//
+// Backticks are what make this narrow enough to be worth having. Unquoted
+// prose is full of dotted phrases that are not symbols, and a guard that
+// reports them gets switched off — the lesson the roadmap guard's own comment
+// records after an audit where three of four reports were wrong.
+//
+// The package must start lower-case and the symbol upper-case, which is Go's
+// own rule for an exported name and excludes `basic.rvz_radvel` (a SIMBAD
+// column) and `object.kind` (a JSON field) without needing to know what those
+// are.
+var citedSymbol = regexp.MustCompile(
+	"`([a-z][a-z0-9]*(?:/[a-z][a-z0-9_]*)*)\\.([A-Z][A-Za-z0-9_]*(?:\\.[A-Za-z][A-Za-z0-9_]*)*)`")
+
+// unbuiltPromise matches an unchecked roadmap checkbox.
+//
+// A symbol named in one is the thing the box exists to build, so it is
+// supposed not to exist yet — `plan.Weather` and `plan.SatelliteIllumination`
+// are both promises, and flagging them would make this guard demand that the
+// roadmap only describe finished work.
+//
+// TestRoadmapBoxesMatchTheCode covers those from the other side: an unchecked
+// box whose symbol *has* appeared is finished work left looking open, and it
+// fails there.
+//
+// Deliberately not anchored to the line start. ROADMAP.md documents its own
+// checkbox convention by quoting an example inline, mid-sentence, and that
+// example names an unbuilt symbol for the same reason the real boxes do. It
+// is an illustration of the syntax rather than a claim about the code, which
+// reads as obvious to everyone except a regexp.
+var unbuiltPromise = regexp.MustCompile(`- \[ \]`)
+
+// TestCitedSymbolsExist checks that a symbol a document names is a symbol the
+// code declares.
+//
+// # Why, given the roadmap is already guarded
+//
+// Because the roadmap is one document and the guard on it is deliberately
+// narrow: it reads only a checkbox whose text *begins* with a symbol, since
+// that is the form meaning "this box delivers this thing". Everything else —
+// the equation-to-function maps in docs/skybrightness.md, the architecture
+// notes in CLAUDE.md, the API tour in the README — was unguarded.
+//
+// It rots the same way. docs/skybrightness.md carried
+// `atmosphere.AerosolOpticalDepth` for a function that has been
+// `Aerosol.TauAt` for some time, in a table row whose *test* column was stale
+// too. The test half was caught by TestCitedTestsExist and the function half
+// was not, because nothing looked at it. A table that maps an equation to the
+// code implementing it is worth exactly as much as the accuracy of both
+// columns.
+//
+// # What is skipped, and why that is not a weakness
+//
+// A qualifier that names no package in this module — `astropy.SkyCoord`,
+// `numpy.ndarray`, `gofa.Plan94` — is skipped rather than guessed at. The
+// guard reports how many it resolved so a change that silently stops
+// resolving anything fails the count check rather than passing vacuously.
+//
+// CHANGELOG.md is exempt for the reason it always is: it is forward-only, and
+// an entry describes the release it shipped in. Rewriting a released entry to
+// track a rename would falsify the record to satisfy a guard.
+func TestCitedSymbolsExist(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	pkgs := packageDirs(t)
+
+	var docs []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if strings.HasSuffix(path, ".md") {
+			docs = append(docs, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Resolving the same name repeatedly across a large document set is the
+	// difference between a fast guard and one people skip.
+	resolved := make(map[string]bool)
+
+	var checked, offenders int
+
+	for _, path := range docs {
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			continue
+		}
+
+		slash := filepath.ToSlash(rel)
+		if slash == "CHANGELOG.md" {
+			continue
+		}
+
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			continue
+		}
+
+		for n, line := range strings.Split(string(raw), "\n") {
+			if historicalMention.MatchString(line) || unbuiltPromise.MatchString(line) {
+				continue
+			}
+
+			for _, m := range citedSymbol.FindAllStringSubmatch(line, -1) {
+				pkgPath, symbol := m[1], m[2]
+
+				// The last path element is the package name.
+				name := pkgPath[strings.LastIndex(pkgPath, "/")+1:]
+
+				dirs := pkgs[name]
+				if len(dirs) == 0 {
+					continue // not a package in this module
+				}
+
+				checked++
+
+				key := name + "." + symbol
+
+				exists, seen := resolved[key]
+				if !seen {
+					// A qualified name may be pkg.Type.Method or a struct
+					// field; the leaf is what any of those declares.
+					leaf := symbol[strings.LastIndex(symbol, ".")+1:]
+					exists = declaredIn(t, dirs, leaf)
+					resolved[key] = exists
+				}
+
+				if exists {
+					continue
+				}
+
+				offenders++
+
+				t.Errorf("%s:%d: cites %s.%s, which %v does not declare.\n"+
+					"  Point at what implements this now, or drop the claim. If the name is "+
+					"deliberately historical, say so on the same line — \"since renamed\", "+
+					"\"no longer exists\".", slash, n+1, pkgPath, symbol, dirs)
+			}
+		}
+	}
+
+	if checked < 50 {
+		t.Fatalf("only %d qualified symbols resolved to a package in this module; the "+
+			"citation format or the package walk has probably changed", checked)
+	}
+
+	t.Logf("%d cited symbols checked across %d documents, %d unresolved",
+		checked, len(docs), offenders)
+}


### PR DESCRIPTION
Closes the gap left after #83: that PR guarded **test** names cited in documents, and nothing looked at the **function** column beside them.

`docs/skybrightness.md` carried `atmosphere.AerosolOpticalDepth` for something that has been `Aerosol.TauAt` for some time — in a table row whose *test* column was stale too. #83 caught one half and could not see the other. A table mapping an equation to the code implementing it is worth what **both** columns are worth.

## Two more, neither near a table

| document | cited | actually |
| :--- | :--- | :--- |
| `docs/ROADMAP.md` | `plan.NewStarFromTarget` | **has never existed** — `plan.FromCatalog` reads `HasRadialVelocity` |
| `docs/skybrightness.md` | `plan.ScoreObservableSky` | `plan.ScoreObservable` |

The roadmap one is the sharper miss: it credited a non-existent function with consuming the very field #70's guard was written to catch drifting.

## Getting the guard honest took two corrections

**`declaredIn` was blind to grouped declarations.** Go writes a great many without a keyword on their own line:

```go
const ( NAIFSPK EndpointID = "naif.spk" )
type  ( Target = resolve.Target )
```

Matching only the keyword-led and field-shaped forms reported **two dozen names that plainly exist** — every endpoint id in `remote`, every `Kind` in `resolve`, every type alias in `catalog`. Fixing it strengthens the roadmap guard too, which had the same blind spot and no reason to.

**An unchecked roadmap box names a symbol that is *supposed* not to exist.** `plan.Weather` and `plan.SatelliteIllumination` are promises; a guard failing on them would demand the roadmap describe only finished work. Those lines are skipped — including the inline example `ROADMAP.md` uses to document its own convention, which is why the match is not anchored to the line start.

Both corrections came from running it against the whole documentation set rather than reasoning about it, which is the only way the false-positive rate was ever going to be visible.

## Scope

**174 cited symbols across 45 documents, 0 unresolved.**

- `CHANGELOG.md` exempt — forward-only; rewriting a released entry to track a rename would falsify the record.
- A qualifier naming no package here (`astropy.SkyCoord`, `gofa.Plan94`) is skipped rather than guessed at.
- A floor on the resolved count, so a change that silently stops resolving anything fails rather than passing vacuously.

Mutation-checked both ways: reintroducing `atmosphere.AerosolOpticalDepth` fails, and a fabricated grouped-const name (`remote.NoSuchEndpointXYZ`) fails.

## Also: the JPL tagging decision, recorded

#95 left open whether `ephemeris/jpl`'s untagged tests belong behind the `network` tag. **They stay untagged**, and the helper's comment now says why rather than posing it as an open question: that package is intrinsically a network module — a JPL provider without a kernel is not a reduced version of itself, it is nothing — and tagging its tests would leave the default suite with no cover over the code most likely to break.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues** · `go vet` tagged.