### PR TITLE
Resolve cited symbols with a parser, not a regular expression

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -392,7 +392,7 @@ implementing `MeasuredRadialVelocity` (currently `*Star`).
 
 - [x] `coord.Context.BarycentricVelocity` — observer's barycentric velocity from `Apco13`'s
       already-computed astrometry, no new SOFA call
-- [x] `coord.BarycentricRVCorrection`/`HeliocentricRVCorrection` — classical velocity
+- [x] `coord.Context.BarycentricRVCorrection`/`HeliocentricRVCorrection` — classical velocity
       projection, sign convention documented and tested explicitly
 - [x] Analytic property tests (bounded magnitude, annual sinusoid, antipodal sign flip,
       diurnal amplitude vs. site latitude)

--- a/docs/changelog.d/97-symbol-guard-ast.md
+++ b/docs/changelog.d/97-symbol-guard-ast.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 97
+---
+**The documentation guards matched symbols with a regular expression**, which
+could not tell a method from a same-named function, nor `plan` from
+`skybrightness/plan`. They now read the module with Go's own parser, and both
+guards share one index. Two more stale citations found and fixed.

--- a/ephemeris/jpl/validation/README.md
+++ b/ephemeris/jpl/validation/README.md
@@ -87,7 +87,7 @@ Its intermediate place is measured but deliberately **not** contracted.
 `eph.ApparentState` retards the whole geocentric vector, carrying light-time
 and annual aberration together, while Horizons' astrometric column has
 light-time only and its apparent column is referred to the true equinox of
-date where `coord.AstrometricToApparent` produces CIRS. Neither published
+date where `coord.Context.AstrometricToApparent` produces CIRS. Neither published
 column is the quantity astrogo computes, so the gap is named and quantified —
 Earth's motion over the light time, up to 21.2 arcsec — rather than hidden
 under a widened tolerance. That test's doc comment has the full account.

--- a/internal/docsguard/index_test.go
+++ b/internal/docsguard/index_test.go
@@ -1,0 +1,297 @@
+package docsguard_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// symbolIndex is every declaration this module makes, read with Go's own
+// parser rather than matched with a regular expression.
+//
+// # Why not a regular expression
+//
+// Because the one this replaces was wrong in both directions and neither was
+// visible without running it across every document.
+//
+// It missed entries in grouped const/var/type blocks, which is most of the
+// module's constants — every endpoint id in remote, every Kind in resolve,
+// every type alias in catalog — and reported two dozen names that plainly
+// exist. Widening it to match `Name =` then made it match plain assignment
+// inside a function body, so a local variable could satisfy a citation of an
+// exported symbol.
+//
+// It also could not tell a method from a name that merely appears somewhere
+// in the package: `atmosphere.Aerosol.TauAt` was checked by looking for
+// `TauAt` anywhere in atmosphere, so citing a real method on the wrong type
+// passed.
+//
+// A parser has neither problem, costs about the same, and cannot be talked
+// into a false positive by an unusual formatting choice.
+type symbolIndex struct {
+	// decls maps a package directory to every name it declares: top-level
+	// names on their own, and members qualified as "Type.Member" — a method
+	// by its receiver, a struct field by its struct, an interface method by
+	// its interface.
+	decls map[string]map[string]bool
+
+	// dirsByName maps a package name to the directories declaring it. Three
+	// directories declare package plan, so a citation of `plan.Foo` has to
+	// be resolved against all of them.
+	dirsByName map[string][]string
+
+	// varTypes maps a package-level variable to its named type, so that a
+	// field reached through it resolves.
+	//
+	// `constants.WGS84.AngularVelocity` is how anyone would write that
+	// citation and it is correct Go, but WGS84 is a var and AngularVelocity
+	// is a field of WGS84Set, so the two names never meet without this. The
+	// same shape covers constants.IAU, constants.Derived and every other
+	// published table in the module.
+	varTypes map[string]map[string]string
+}
+
+//nolint:gochecknoglobals // a parse of the whole module, built once per test binary
+var (
+	indexOnce  sync.Once
+	indexValue *symbolIndex
+	errIndex   error
+)
+
+// moduleSymbols parses the module once and shares the result.
+//
+// Both guards that consume it walk every document in the repository, so
+// re-parsing per lookup — or per guard — is the difference between a check
+// people run and one they skip.
+func moduleSymbols(t *testing.T) *symbolIndex {
+	t.Helper()
+
+	indexOnce.Do(func() { indexValue, errIndex = buildSymbolIndex(filepath.Join("..", "..")) })
+
+	if errIndex != nil {
+		t.Fatalf("index the module: %v", errIndex)
+	}
+
+	return indexValue
+}
+
+func buildSymbolIndex(root string) (*symbolIndex, error) {
+	idx := &symbolIndex{
+		decls:      make(map[string]map[string]bool),
+		dirsByName: make(map[string][]string),
+		varTypes:   make(map[string]map[string]string),
+	}
+
+	fset := token.NewFileSet()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path contributes nothing and is not fatal
+		}
+
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "node_modules", "testdata":
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		// Test files declare helpers that are not part of any package's
+		// documented surface, so a document citing one is still wrong.
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		// Parsed with no build context, so a file behind any tag still
+		// counts: a symbol declared only under `network` is declared.
+		file, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil //nolint:nilerr // an unparseable file is the compiler's problem, not this guard's
+		}
+
+		dir := filepath.Dir(path)
+		idx.add(dir, file.Name.Name, file)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk %s: %w", root, err)
+	}
+
+	return idx, nil
+}
+
+// add records every declaration in one file.
+func (idx *symbolIndex) add(dir, pkgName string, file *ast.File) {
+	names, ok := idx.decls[dir]
+	if !ok {
+		names = make(map[string]bool)
+		idx.decls[dir] = names
+
+		idx.dirsByName[pkgName] = append(idx.dirsByName[pkgName], dir)
+		idx.varTypes[dir] = make(map[string]string)
+	}
+
+	for _, d := range file.Decls {
+		switch decl := d.(type) {
+		case *ast.FuncDecl:
+			if decl.Recv == nil || len(decl.Recv.List) == 0 {
+				names[decl.Name.Name] = true
+
+				continue
+			}
+
+			// A method belongs to its receiver, and is recorded only there:
+			// citing pkg.Method without the type is not a thing Go lets a
+			// caller write, so it should not satisfy a citation either.
+			if recv := receiverName(decl.Recv.List[0].Type); recv != "" {
+				names[recv+"."+decl.Name.Name] = true
+			}
+
+		case *ast.GenDecl:
+			for _, spec := range decl.Specs {
+				addSpec(names, idx.varTypes[dir], spec)
+			}
+		}
+	}
+}
+
+// addSpec records one declaration inside a const, var or type block —
+// including the grouped forms that carry no keyword on their own line.
+func addSpec(names map[string]bool, varTypes map[string]string, spec ast.Spec) {
+	switch s := spec.(type) {
+	case *ast.ValueSpec:
+		for i, n := range s.Names {
+			names[n.Name] = true
+
+			if typ := valueTypeName(s, i); typ != "" {
+				varTypes[n.Name] = typ
+			}
+		}
+
+	case *ast.TypeSpec:
+		names[s.Name.Name] = true
+
+		switch t := s.Type.(type) {
+		case *ast.StructType:
+			addFieldNames(names, s.Name.Name, t.Fields)
+		case *ast.InterfaceType:
+			addFieldNames(names, s.Name.Name, t.Methods)
+		}
+	}
+}
+
+// addFieldNames records a struct's fields or an interface's methods under
+// their owning type.
+func addFieldNames(names map[string]bool, owner string, fields *ast.FieldList) {
+	if fields == nil {
+		return
+	}
+
+	for _, f := range fields.List {
+		for _, n := range f.Names {
+			names[owner+"."+n.Name] = true
+		}
+
+		// An embedded field is reachable by its own type name, which is how
+		// a document would cite it.
+		if len(f.Names) == 0 {
+			if embedded := receiverName(f.Type); embedded != "" {
+				names[owner+"."+embedded] = true
+			}
+		}
+	}
+}
+
+// valueTypeName gives the named type of one entry in a var or const spec,
+// from an explicit type or from a composite literal's own.
+//
+// `var WGS84 = WGS84Set{...}` carries its type only on the literal, which is
+// the form every published constant table in this module uses.
+func valueTypeName(spec *ast.ValueSpec, i int) string {
+	if spec.Type != nil {
+		return receiverName(spec.Type)
+	}
+
+	if i < len(spec.Values) {
+		if lit, ok := spec.Values[i].(*ast.CompositeLit); ok {
+			return receiverName(lit.Type)
+		}
+	}
+
+	return ""
+}
+
+// receiverName reduces a receiver or embedded-field expression to the bare
+// type name: T, *T, T[P] and *T[P] all give T.
+func receiverName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return receiverName(e.X)
+	case *ast.IndexExpr:
+		return receiverName(e.X)
+	case *ast.IndexListExpr:
+		return receiverName(e.X)
+	case *ast.SelectorExpr:
+		// An embedded type from another package, e.g. unit.Unit.
+		return e.Sel.Name
+	}
+
+	return ""
+}
+
+// lookup reports whether pkgPath declares symbol, and which directories were
+// searched.
+//
+// pkgPath may be a bare package name or a module-relative path. The path form
+// is what disambiguates: three directories declare package plan, so `plan.X`
+// is satisfied by any of them while `skybrightness/plan.X` is satisfied only
+// by the one.
+func (idx *symbolIndex) lookup(root, pkgPath, symbol string) (found bool, searched []string) {
+	if strings.Contains(pkgPath, "/") {
+		dir := filepath.Join(root, filepath.FromSlash(pkgPath))
+		if _, ok := idx.decls[dir]; ok {
+			return idx.declares(dir, symbol), []string{dir}
+		}
+
+		return false, nil
+	}
+
+	dirs := idx.dirsByName[pkgPath]
+	for _, dir := range dirs {
+		if idx.declares(dir, symbol) {
+			return true, dirs
+		}
+	}
+
+	return false, dirs
+}
+
+// declares reports whether one directory declares symbol, following a
+// package-level variable to its type when the citation reaches through one.
+func (idx *symbolIndex) declares(dir, symbol string) bool {
+	if idx.decls[dir][symbol] {
+		return true
+	}
+
+	owner, member, ok := strings.Cut(symbol, ".")
+	if !ok {
+		return false
+	}
+
+	if typ := idx.varTypes[dir][owner]; typ != "" {
+		return idx.decls[dir][typ+"."+member]
+	}
+
+	return false
+}

--- a/internal/docsguard/roadmap_test.go
+++ b/internal/docsguard/roadmap_test.go
@@ -40,7 +40,8 @@ func TestRoadmapBoxesMatchTheCode(t *testing.T) {
 		t.Fatalf("read %s: %v", roadmapDoc, err)
 	}
 
-	pkgs := packageDirs(t)
+	root := filepath.Join("..", "..")
+	idx := moduleSymbols(t)
 
 	var checked int
 
@@ -52,19 +53,14 @@ func TestRoadmapBoxesMatchTheCode(t *testing.T) {
 
 		done, pkgPath, symbol := m[1] == "x", m[2], m[3]
 
-		// The last path element is the package name; a qualifier this guard
-		// cannot resolve is skipped rather than guessed at.
-		name := pkgPath[strings.LastIndex(pkgPath, "/")+1:]
-
-		dirs := pkgs[name]
+		// A qualifier naming no package in this module is skipped rather
+		// than guessed at.
+		exists, dirs := idx.lookup(root, pkgPath, symbol)
 		if len(dirs) == 0 {
 			continue
 		}
 
 		checked++
-
-		leaf := symbol[strings.LastIndex(symbol, ".")+1:]
-		exists := declaredIn(t, dirs, leaf)
 
 		switch {
 		case !done && exists:
@@ -82,99 +78,4 @@ func TestRoadmapBoxesMatchTheCode(t *testing.T) {
 	}
 
 	t.Logf("%d roadmap boxes checked against the code", checked)
-}
-
-// packageDirs maps a package name to the directories declaring it.
-func packageDirs(t *testing.T) map[string][]string {
-	t.Helper()
-
-	clause := regexp.MustCompile(`(?m)^package ([a-z][A-Za-z0-9_]*)`)
-	out := make(map[string][]string)
-	seen := make(map[string]bool)
-
-	root := filepath.Join("..", "..")
-
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") ||
-			strings.HasSuffix(path, "_test.go") {
-			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
-		}
-
-		src, rerr := os.ReadFile(path)
-		if rerr != nil {
-			return nil //nolint:nilerr // a file we cannot read contributes no package, and is not worth failing the walk for
-		}
-
-		m := clause.FindSubmatch(src)
-		if m == nil {
-			return nil
-		}
-
-		name, dir := string(m[1]), filepath.Dir(path)
-
-		key := name + "\x00" + dir
-		if seen[key] {
-			return nil
-		}
-
-		seen[key] = true
-
-		out[name] = append(out[name], dir)
-
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk: %v", err)
-	}
-
-	return out
-}
-
-// declaredIn reports whether leaf is declared in any of dirs, as a function,
-// method, type, var, const, struct field, or an entry in a grouped
-// declaration block.
-//
-// The last of those was missing until TestCitedSymbolsExist ran this against
-// the whole documentation set and reported two dozen names that plainly do
-// exist. Go writes a great many declarations without a keyword on their own
-// line —
-//
-//	const (
-//	    NAIFSPK EndpointID = "naif.spk"
-//	)
-//
-//	type (
-//	    Target = resolve.Target
-//	)
-//
-// — and matching only the keyword-led and field-shaped forms missed every
-// endpoint id, every Kind constant and every type alias in the module.
-func declaredIn(t *testing.T, dirs []string, leaf string) bool {
-	t.Helper()
-
-	decl := regexp.MustCompile(`(?m)^\s*(func\s+(\([^)]*\)\s*)?` + leaf + `\b` +
-		`|(type|var|const)\s+` + leaf + `\b` +
-		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*(` + "`" + `[^` + "`" + `]*` + "`" + `)?\s*$` +
-		`|` + leaf + `\s*=` +
-		`|` + leaf + `\s+(\[\]|\*|map\[)?[A-Za-z][A-Za-z0-9_.\[\]]*\s*=)`)
-
-	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue
-		}
-
-		for _, e := range entries {
-			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
-				continue
-			}
-
-			src, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
-			if rerr == nil && decl.Match(src) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/internal/docsguard/symbol_test.go
+++ b/internal/docsguard/symbol_test.go
@@ -72,8 +72,7 @@ var unbuiltPromise = regexp.MustCompile(`- \[ \]`)
 // track a rename would falsify the record to satisfy a guard.
 func TestCitedSymbolsExist(t *testing.T) {
 	root := filepath.Join("..", "..")
-
-	pkgs := packageDirs(t)
+	idx := moduleSymbols(t)
 
 	var docs []string
 
@@ -99,10 +98,6 @@ func TestCitedSymbolsExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("walk: %v", err)
 	}
-
-	// Resolving the same name repeatedly across a large document set is the
-	// difference between a fast guard and one people skip.
-	resolved := make(map[string]bool)
 
 	var checked, offenders int
 
@@ -130,26 +125,12 @@ func TestCitedSymbolsExist(t *testing.T) {
 			for _, m := range citedSymbol.FindAllStringSubmatch(line, -1) {
 				pkgPath, symbol := m[1], m[2]
 
-				// The last path element is the package name.
-				name := pkgPath[strings.LastIndex(pkgPath, "/")+1:]
-
-				dirs := pkgs[name]
-				if len(dirs) == 0 {
+				exists, searched := idx.lookup(root, pkgPath, symbol)
+				if len(searched) == 0 {
 					continue // not a package in this module
 				}
 
 				checked++
-
-				key := name + "." + symbol
-
-				exists, seen := resolved[key]
-				if !seen {
-					// A qualified name may be pkg.Type.Method or a struct
-					// field; the leaf is what any of those declares.
-					leaf := symbol[strings.LastIndex(symbol, ".")+1:]
-					exists = declaredIn(t, dirs, leaf)
-					resolved[key] = exists
-				}
 
 				if exists {
 					continue
@@ -160,7 +141,7 @@ func TestCitedSymbolsExist(t *testing.T) {
 				t.Errorf("%s:%d: cites %s.%s, which %v does not declare.\n"+
 					"  Point at what implements this now, or drop the claim. If the name is "+
 					"deliberately historical, say so on the same line — \"since renamed\", "+
-					"\"no longer exists\".", slash, n+1, pkgPath, symbol, dirs)
+					"\"no longer exists\".", slash, n+1, pkgPath, symbol, searched)
 			}
 		}
 	}


### PR DESCRIPTION
#96 added a guard over the symbols documents name, and getting it honest took **two corrections to the regular expression** underneath. That was the signal: the expression was the problem, not its calibration.

## Three faults it could not see

Each verified by reintroducing it and watching the new guard fail:

| fault | why the regex passed it |
| :--- | :--- |
| `coord.BarycentricRVCorrection` — a **method on `Context`**, cited as a package function | the name appears somewhere in `coord`, and only the leaf was checked |
| `atmosphere.Rayleigh.TauAt` — a real method attributed to the **wrong type** | same: `TauAt` exists, the receiver was never consulted |
| `skybrightness/plan.NewAsteroid` — **wrong package** where three share a name | any of `fits/plan`, `plan`, `skybrightness/plan` satisfied a citation meant for one |

It had the mirror problem too. Widening it to `Name =` so grouped `const` blocks would resolve also made it match **plain assignment inside a function body** — a local variable could satisfy a citation of an exported symbol.

## What replaces it

`symbolIndex` reads every non-test file with `go/parser` and records what Go says is declared: top-level names, methods under their receiver, fields under their struct, interface methods under their interface. `pkg.Type.Member` resolves exactly, and a path-qualified package resolves to the one directory.

Files behind any build tag are parsed too, so a symbol declared only under `network` counts as declared.

## One shape needed care rather than exactness

`constants.WGS84.AngularVelocity` is how anyone would write that citation and it is correct Go — but `WGS84` is a *var* and `AngularVelocity` is a field of `WGS84Set`, so the two names never meet. Exactness alone would reject it.

The index follows a package-level variable to its type, **including the type carried only on a composite literal** (`var WGS84 = WGS84Set{…}`), which is the form every published constant table in this module uses. That covers `constants.IAU`, `constants.Derived`, `constants.DE440` and the rest.

## Two more stale citations fell out

Both methods on `coord.Context` written as package functions: `BarycentricRVCorrection` in `ROADMAP.md`, `AstrometricToApparent` in `ephemeris/jpl/validation/README.md`.

## The roadmap guard moves too, and `declaredIn` is gone

It had the identical blind spots and no reason to keep them. One accurate index is also cheaper than two approximate ones: the parse happens once per test binary and both guards share it.

```
174 cited symbols across 46 documents, 0 unresolved
14 roadmap boxes checked against the code
```

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues** · `go vet` tagged.

Three linter findings on the new file fixed rather than suppressed: `errname`, `wrapcheck` and `wsl_v5`.