### PR TITLE
Bound the kernel fetch so a stalled NAIF skips instead of hanging

### DIFF
--- a/docs/changelog.d/99-bounded-kernel-fetch.md
+++ b/docs/changelog.d/99-bounded-kernel-fetch.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 99
+---
+**The JPL tests still hung when NAIF stalled.** #95's skip could never fire,
+because `remote.NAIFSPK` allows a 30-minute download and the test binary dies
+at ten. The fetch is now bounded and attempted once per package, so a stalled
+NAIF skips in seconds instead of failing the build.

--- a/ephemeris/jpl/lsk/reader_test.go
+++ b/ephemeris/jpl/lsk/reader_test.go
@@ -14,8 +14,17 @@ import (
 )
 
 func TestLSKReader(t *testing.T) {
-	prov, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
+	// Bounded, because remote.NAIFSPK registers a 30-minute DownloadTimeout
+	// — right for a caller deliberately fetching a kernel, and longer than
+	// this binary's whole budget. Without a cap a stalled fetch hangs until
+	// the package times out, which is how a bad minute at NAIF turned main
+	// red rather than skipping.
+	fetchCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	prov, err := jpl.NewProvider(fetchCtx, core.Planets, "de440s")
 	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
 		t.Fatalf("setup failed: %v", err)
 	}
 

--- a/ephemeris/jpl/main_test.go
+++ b/ephemeris/jpl/main_test.go
@@ -1,13 +1,16 @@
 package jpl_test
 
 import (
+	"context"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // TestMain grants download consent for the whole package's default test
@@ -27,17 +30,21 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// testKernel is the planetary kernel every test in this package uses: the
+// small DE440 variant, 32 MB against de440's 115, covering 1849-2150. Every
+// case here works well inside that span, so the larger file would only make
+// the fetch slower.
+const testKernel = "de440s"
+
 // mustPlanetProvider builds a planetary-kernel provider, skipping the test
-// when the kernel cannot
-// be obtained rather than failing it.
+// when the kernel cannot be obtained rather than failing it.
 //
 // # Why a download failure is not a test failure
 //
 // These tests are untagged, so they run in the ordinary `go test ./...` — and
 // a provider needs a kernel, which on a machine without one cached means
 // fetching 32 MB from NAIF. When that is slow the tests do not fail quickly:
-// four of them sat at 120 seconds each and took the package past its 600
-// second limit, turning a bad minute at NAIF into a red main branch.
+// they hang, and the package dies on its own timeout.
 //
 // This repository's policy is that an external service must never fail a
 // build. It is written for the network-tagged suites and applies here for the
@@ -56,14 +63,10 @@ func TestMain(m *testing.M) {
 //
 // So the exception is deliberate. The suite stays honest about it by
 // skipping, rather than hanging and failing, when the kernel cannot be had.
-// testKernel is the planetary kernel every test in this package uses: the
-// small DE440 variant, 32 MB against de440's 115, covering 1849-2150. Every
-// case here works well inside that span, so the larger file would only make
-// the fetch slower.
-const testKernel = "de440s"
-
 func mustPlanetProvider(t *testing.T) *jpl.Provider {
 	t.Helper()
+
+	warmKernelCache(t)
 
 	p, err := jpl.NewProvider(t.Context(), core.Planets, testKernel)
 	if err != nil {
@@ -73,3 +76,57 @@ func mustPlanetProvider(t *testing.T) *jpl.Provider {
 
 	return p
 }
+
+// kernelFetchTimeout bounds the one attempt made to obtain the kernel.
+//
+// remote.NAIFSPK registers a 30-minute DownloadTimeout, which is right for a
+// caller deliberately fetching a multi-gigabyte kernel and fatal inside a test
+// binary whose whole budget is ten minutes. A stalled fetch does not fail
+// here, it hangs — so NewProvider never returns, the skip below never runs,
+// and the package dies on its own timeout with no useful message. That is
+// exactly what happened on main after #95: the skip was in place and could
+// not fire.
+//
+// Three minutes is several times what this 32 MB file takes when NAIF is
+// answering, and a fifth of the budget.
+const kernelFetchTimeout = 3 * time.Minute
+
+//nolint:gochecknoglobals // one fetch attempt shared by every test in the package
+var warmOnce sync.Once
+
+// warmKernelCache makes at most one bounded attempt to obtain the kernel, and
+// skips the calling test if it fails.
+//
+// Once, because the attempt is what costs the time: seven tests each waiting
+// out their own timeout overruns the package budget however short the timeout
+// is. After a successful attempt the kernel is cached and every later
+// NewProvider is local and fast.
+func warmKernelCache(t *testing.T) {
+	t.Helper()
+
+	warmOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), kernelFetchTimeout)
+		defer cancel()
+
+		p, err := jpl.NewProvider(ctx, core.Planets, testKernel)
+		if err != nil {
+			errWarm = err
+
+			return
+		}
+
+		_ = p.Close()
+	})
+
+	if errWarm != nil {
+		// Only an outage skips: a timeout, a 5xx, a rate limit. Anything
+		// else — a kernel name that does not exist, a corrupt file, a denied
+		// consent — is a real defect, and skipping on it would turn the whole
+		// package green while testing nothing. Skip is not pass.
+		testutil.SkipOnUpstreamFailure(t, errWarm)
+		t.Fatalf("could not obtain kernel %q within %v: %v", testKernel, kernelFetchTimeout, errWarm)
+	}
+}
+
+//nolint:gochecknoglobals // written once under warmOnce, read after
+var errWarm error

--- a/ephemeris/jpl/spk/reader_test.go
+++ b/ephemeris/jpl/spk/reader_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/remote/file"
+	"github.com/TuSKan/astrogo/time"
 )
 
 // fakeReaderAt adapts a *bytes.Reader (which already implements io.ReaderAt)
@@ -40,8 +41,17 @@ func newWordBuffer(vals []float64) *spk.Reader {
 
 func TestSPKReader(t *testing.T) {
 	// Bootstrap the download process robustly via the provider logic
-	prov, err := jpl.NewProvider(context.Background(), core.Planets, "de440s")
+	// Bounded, because remote.NAIFSPK registers a 30-minute DownloadTimeout
+	// — right for a caller deliberately fetching a kernel, and longer than
+	// this binary's whole budget. Without a cap a stalled fetch hangs until
+	// the package times out, which is how a bad minute at NAIF turned main
+	// red rather than skipping.
+	fetchCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	prov, err := jpl.NewProvider(fetchCtx, core.Planets, "de440s")
 	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
 		t.Fatalf("setup failed: %v", err)
 	}
 


### PR DESCRIPTION
`main` went red on **Race Detection** again — the same three packages hitting their 600 second limits:

```
FAIL github.com/TuSKan/astrogo/ephemeris/jpl      600.035s
FAIL github.com/TuSKan/astrogo/ephemeris/jpl/lsk  600.025s
FAIL github.com/TuSKan/astrogo/ephemeris/jpl/spk  600.022s
```

Not a data race. **#95 was supposed to have fixed this and could not have.**

## Why the earlier fix was unreachable

#95 converted a fetch *failure* into a skip. The fetch was never failing.

`remote.NAIFSPK` registers a **30-minute `DownloadTimeout`** — right for someone deliberately fetching a multi-gigabyte kernel, and impossible inside a test binary whose whole budget is ten minutes. A stalled fetch does not return an error to skip on; it hangs until the package is killed, with no message saying why.

## Two changes, both needed

**The fetch is bounded at three minutes** by a context at the call site — several times what this 32 MB file takes when NAIF is answering, and a fifth of the budget. The production timeout is untouched, because it is not wrong.

**It is attempted once per package**, not per test. A cap alone does not fix `ephemeris/jpl`: seven tests each waiting out three minutes overruns ten however short the cap. After one success the kernel is cached and every later provider is local.

`lsk` and `spk` construct a provider directly, needed the same cap, and **were not covered by #95 at all** — which is why they failed identically.

## Tightened while here: skip is not pass

`warmKernelCache` skipped on *any* error, so a kernel name that does not exist would have turned the whole package green while testing nothing. Only an outage skips now — timeout, 5xx, rate limit — and anything else fails.

## Verified both directions

Pointing the endpoint at a black hole with an uncached kernel:

```
--- SKIP: TestJPLUnitsAreAUAndAUPerDay (5.00s)
    upstream service failure, not verified: deadline exceeded
    (... Head "https://10.255.255.1/blackhole/...": context deadline exceeded)
ok  github.com/TuSKan/astrogo/ephemeris/jpl  5.440s
```

**Five seconds and a skip, against six hundred and a failure.** And with the cache warm, the ordinary path is unchanged.

## One thing the guard caught before the build did

The bounded context first reached for stdlib `time`. `astrogo/time` re-exports `Duration` and `Minute`, so it was unnecessary — and #75's guard flagged it in two files as a rule violation before the compiler complained about the duplicate import.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues** · tagged **0 issues**. One `errname` finding fixed rather than suppressed.

**Note on the tag:** v0.19.0 is already cut, and this fixes only test scaffolding — no shipped behaviour changes — so it belongs in the next release rather than warranting a re-tag.