### PR TITLE
Give the catalog layer somewhere to put a failure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
 		"astrogo",
 		"bortle",
 		"icrs",
+		"iers",
 		"lightpollution",
 		"skybrightness",
 		"VIIRS"

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -208,24 +208,67 @@ type candidate struct {
 
 // Resolve finds a single target matching the query, merged across every
 // provider that resolves it directly.
+//
+// # What an error means here
+//
+// [ErrNotFound] means every provider was asked and answered no. Anything else
+// means at least one could not answer, and the returned error carries their
+// reasons joined together, tagged by provider name.
+//
+// The distinction is the point. This used to return ErrNotFound for a
+// cancelled context, an exceeded deadline, offline mode and a CDS outage
+// alike, because the provider interface had nowhere to put a failure. A
+// pipeline resolving ten thousand names during an outage got ten thousand
+// confident "no such object" answers and no indication anything was wrong.
+//
+// A provider that succeeds wins outright: if any provider resolved the query,
+// the failures of the others are not reported, because the question was
+// answered.
 func (r *Resolver) Resolve(ctx context.Context, query string) (Target, error) {
 	q := resolve.Normalize(query)
 	if q == "" {
 		return Target{}, ErrNotFound
 	}
 
-	var candidates []candidate
+	// Checked before any provider is consulted so a cancelled caller gets
+	// context.Canceled rather than whatever the first provider makes of it.
+	if err := ctx.Err(); err != nil {
+		return Target{}, fmt.Errorf("catalog: %w", err)
+	}
+
+	var (
+		candidates []candidate
+		failures   []error
+	)
 
 	for _, p := range r.providers {
-		if t, ok := p.Resolve(ctx, query); ok {
+		t, err := p.Resolve(ctx, query)
+
+		switch {
+		case err == nil:
 			candidates = append(candidates, candidate{t, p.Name()})
+		case errors.Is(err, resolve.ErrNotFound), errors.Is(err, resolve.ErrUnsupported):
+			// Ordinary answers, not incidents. A cone-search-only provider
+			// declining to resolve a name is not a failure of the query.
+		default:
+			failures = append(failures, fmt.Errorf("%s: %w", p.Name(), err))
 		}
 	}
 
 	if len(candidates) == 0 {
-		results := r.Search(ctx, query)
+		results, err := r.Search(ctx, query)
 		if len(results) > 0 {
 			return results[0], nil
+		}
+
+		if err != nil {
+			failures = append(failures, err)
+		}
+
+		if len(failures) > 0 {
+			// Something could not be asked. Reporting ErrNotFound here would
+			// be asserting an answer nobody gave.
+			return Target{}, fmt.Errorf("catalog: resolving %q: %w", query, errors.Join(failures...))
 		}
 
 		return Target{}, ErrNotFound
@@ -242,22 +285,44 @@ func (r *Resolver) Resolve(ctx context.Context, query string) (Target, error) {
 // Search returns all matching, cross-matched-and-merged targets from every
 // provider, ranked by name/alias/ID match quality and capped at Limit's
 // configured limit (default 10).
-func (r *Resolver) Search(ctx context.Context, query string) []Target {
+// A provider that fails does not suppress the ones that succeed: matches from
+// working providers are returned with a nil error, and the failures are
+// reported only when nothing was found at all. Partial results from a partly
+// degraded set of providers are still useful; silently reporting none is not.
+func (r *Resolver) Search(ctx context.Context, query string) ([]Target, error) {
 	q := resolve.Normalize(query)
 	if q == "" {
-		return nil
+		return nil, nil
 	}
 
-	var candidates []candidate
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("catalog: %w", err)
+	}
+
+	var (
+		candidates []candidate
+		failures   []error
+	)
 
 	for _, p := range r.providers {
-		for _, t := range p.Search(ctx, query) {
+		found, err := p.Search(ctx, query)
+		if err != nil && !errors.Is(err, resolve.ErrNotFound) && !errors.Is(err, resolve.ErrUnsupported) {
+			failures = append(failures, fmt.Errorf("%s: %w", p.Name(), err))
+
+			continue
+		}
+
+		for _, t := range found {
 			candidates = append(candidates, candidate{t, p.Name()})
 		}
 	}
 
 	if len(candidates) == 0 {
-		return nil
+		if len(failures) > 0 {
+			return nil, fmt.Errorf("catalog: searching %q: %w", query, errors.Join(failures...))
+		}
+
+		return nil, nil
 	}
 
 	groups := r.reconcile(ctx, candidates)
@@ -295,7 +360,7 @@ func (r *Resolver) Search(ctx context.Context, query string) []Target {
 		final[i] = scored[i].t
 	}
 
-	return final
+	return final, nil
 }
 
 // ── Cross-match + merge pipeline ─────────────────────────────────────────

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -15,16 +16,35 @@ import (
 type mockProvider struct {
 	targets map[string]Target
 	name    string
+
+	// failWith, when set, is returned by both Resolve and Search instead of
+	// consulting targets — the stand-in for a provider that cannot answer
+	// (an outage, a cancelled context, a rate limit) as opposed to one that
+	// answers "no such object". Keeping those separable is the whole point of
+	// the error-returning Provider interface.
+	failWith error
 }
 
 func (p *mockProvider) Name() string { return p.name }
 
-func (p *mockProvider) Resolve(_ context.Context, query string) (Target, bool) {
+func (p *mockProvider) Resolve(_ context.Context, query string) (Target, error) {
+	if p.failWith != nil {
+		return Target{}, p.failWith
+	}
+
 	t, ok := p.targets[resolve.Normalize(query)]
-	return t, ok
+	if !ok {
+		return Target{}, fmt.Errorf("%w: %q", resolve.ErrNotFound, query)
+	}
+
+	return t, nil
 }
 
-func (p *mockProvider) Search(_ context.Context, query string) []Target {
+func (p *mockProvider) Search(_ context.Context, query string) ([]Target, error) {
+	if p.failWith != nil {
+		return nil, p.failWith
+	}
+
 	var res []Target
 
 	q := resolve.Normalize(query)
@@ -34,7 +54,7 @@ func (p *mockProvider) Search(_ context.Context, query string) []Target {
 		}
 	}
 
-	return res
+	return res, nil
 }
 
 // mockConeSearcher is a resolve.ConeSearcher stub that ignores its request
@@ -560,7 +580,11 @@ func TestResolver_CrossMatchByPosition_SameEpochMerges(t *testing.T) {
 		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
 	}
 
-	got := r.Search(context.Background(), "TestObj")
+	got, err := r.Search(context.Background(), "TestObj")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(got) != 1 {
 		t.Fatalf("expected positional fallback to merge into 1 target, got %d: %+v", len(got), got)
 	}
@@ -586,7 +610,11 @@ func TestResolver_CrossMatchByPosition_TooFarDoesNotMerge(t *testing.T) {
 		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
 	}
 
-	got := r.Search(context.Background(), "TestObj")
+	got, err := r.Search(context.Background(), "TestObj")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(got) != 2 {
 		t.Fatalf("expected two distinct targets beyond the match threshold, got %d: %+v", len(got), got)
 	}
@@ -634,7 +662,11 @@ func TestResolver_CrossMatchByPosition_EpochMismatchAppliesPropagation(t *testin
 		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
 	}
 
-	got := r.Search(context.Background(), "TestStar")
+	got, err := r.Search(context.Background(), "TestStar")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(got) != 1 {
 		t.Fatalf("expected epoch-normalized positional match to merge into 1 target, got %d: %+v", len(got), got)
 	}
@@ -722,7 +754,11 @@ func TestResolver_Search_RespectsCap(t *testing.T) {
 		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: 2},
 	}
 
-	got := r.Search(context.Background(), "TestObj")
+	got, err := r.Search(context.Background(), "TestObj")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(got) != 2 {
 		t.Fatalf("expected Limit(2)'s configured cap to limit results to 2, got %d", len(got))
 	}
@@ -749,12 +785,24 @@ func TestResolver_PositionMatchThreshold_Configurable(t *testing.T) {
 
 	// ~1.08" apart (0.0003 deg * 3600 * cos(-5.39deg)).
 	tight := newResolver(angle.Arcsec(0.5))
-	if got := tight.Search(context.Background(), "TestObj"); len(got) != 2 {
+
+	got, err := tight.Search(context.Background(), "TestObj")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(got) != 2 {
 		t.Fatalf("expected a tight 0.5\" threshold to keep candidates separate, got %d results", len(got))
 	}
 
 	loose := newResolver(angle.Arcsec(2))
-	if got := loose.Search(context.Background(), "TestObj"); len(got) != 1 {
+
+	got, err = loose.Search(context.Background(), "TestObj")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if len(got) != 1 {
 		t.Fatalf("expected a loose 2\" threshold to merge the same candidates, got %d results", len(got))
 	}
 }

--- a/catalog/errorsemantics_test.go
+++ b/catalog/errorsemantics_test.go
@@ -1,0 +1,184 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/coord"
+)
+
+var errOutage = errors.New("simulated service outage")
+
+// m31 is the single target the mock providers below answer with. A fixed
+// object rather than a parameter: these tests are about which error comes
+// back, never about which object.
+func m31() map[string]Target {
+	return map[string]Target{
+		resolve.Normalize("M31"): {ID: "M31", Name: "M31", Coord: coord.NewICRS(0, 0)},
+	}
+}
+
+// TestResolveDoesNotReportAFailureAsNotFound is the defect this whole change
+// exists to remove.
+//
+// Under the previous (Target, bool) interface a provider had nowhere to put a
+// failure, so an outage, a cancelled context and a genuinely absent object all
+// arrived as ErrNotFound. A scheduler asking "does NGC 5139 exist?" during a
+// CDS outage got a confident no.
+func TestResolveDoesNotReportAFailureAsNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{
+		providers: []Provider{&mockProvider{name: "broken", failWith: errOutage}},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	_, err := r.Resolve(context.Background(), "NGC 5139")
+	if err == nil {
+		t.Fatal("expected an error when the only provider failed")
+	}
+
+	if errors.Is(err, ErrNotFound) {
+		t.Errorf("a provider failure was reported as ErrNotFound: %v", err)
+	}
+
+	if !errors.Is(err, errOutage) {
+		t.Errorf("the underlying reason was lost: %v", err)
+	}
+}
+
+// TestResolveReportsNotFoundOnlyWhenEveryProviderAnswered is the other half:
+// ErrNotFound must still mean what it says.
+func TestResolveReportsNotFoundOnlyWhenEveryProviderAnswered(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{
+		providers: []Provider{&mockProvider{name: "empty", targets: map[string]Target{}}},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	if _, err := r.Resolve(context.Background(), "nothing here"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestResolveChecksTheContextBeforeConsultingProviders pins that a cancelled
+// caller learns it was cancelled, rather than receiving whatever the first
+// provider makes of a dead context.
+func TestResolveChecksTheContextBeforeConsultingProviders(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The provider would succeed if asked, so reaching it at all is the bug.
+	r := &Resolver{
+		providers: []Provider{&mockProvider{name: "would-succeed", targets: m31()}},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	if _, err := r.Resolve(ctx, "M31"); !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+
+	if _, err := r.Search(ctx, "M31"); !errors.Is(err, context.Canceled) {
+		t.Errorf("Search err = %v, want context.Canceled", err)
+	}
+}
+
+// TestUnsupportedIsAnAnswerNotAnIncident covers the state ErrUnsupported was
+// added for.
+//
+// Gaia and VizieR are cone-search only. Under the bool API their "I do not do
+// name resolution" was indistinguishable from "that object does not exist", so
+// a real target could be reported absent because the provider asked happened
+// to be one that never answers names. A provider declining an operation must
+// not turn a successful lookup into a failure, nor a miss into an outage.
+func TestUnsupportedIsAnAnswerNotAnIncident(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{
+		providers: []Provider{
+			&mockProvider{name: "cone-only", failWith: resolve.ErrUnsupported},
+			&mockProvider{name: "names", targets: m31()},
+		},
+		cfg: resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got, err := r.Resolve(context.Background(), "M31")
+	if err != nil {
+		t.Fatalf("a cone-search-only provider broke an otherwise successful resolve: %v", err)
+	}
+
+	if got.ID != "M31" {
+		t.Errorf("ID = %q, want M31", got.ID)
+	}
+
+	// And with nothing else to answer, it is a miss rather than a failure.
+	only := &Resolver{
+		providers: []Provider{&mockProvider{name: "cone-only", failWith: resolve.ErrUnsupported}},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	if _, err := only.Resolve(context.Background(), "M31"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound — declining an operation is not an outage", err)
+	}
+}
+
+// TestASuccessfulProviderWinsOverAFailedOne pins that a partial outage does
+// not deny an answer somebody actually gave.
+func TestASuccessfulProviderWinsOverAFailedOne(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{
+		providers: []Provider{
+			&mockProvider{name: "broken", failWith: errOutage},
+			&mockProvider{name: "working", targets: m31()},
+		},
+		cfg: resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got, err := r.Resolve(context.Background(), "M31")
+	if err != nil {
+		t.Fatalf("one broken provider denied an answer another gave: %v", err)
+	}
+
+	if got.ID != "M31" {
+		t.Errorf("ID = %q, want M31", got.ID)
+	}
+}
+
+// TestSearchKeepsPartialResultsAndReportsTotalFailure covers both of Search's
+// arms: matches from working providers survive one failing, and a failure is
+// only reported when there is nothing to show for it.
+func TestSearchKeepsPartialResultsAndReportsTotalFailure(t *testing.T) {
+	t.Parallel()
+
+	partial := &Resolver{
+		providers: []Provider{
+			&mockProvider{name: "broken", failWith: errOutage},
+			&mockProvider{name: "working", targets: m31()},
+		},
+		cfg: resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	got, err := partial.Search(context.Background(), "M31")
+	if err != nil {
+		t.Fatalf("a partial outage suppressed usable results: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("got %d results, want 1 from the working provider", len(got))
+	}
+
+	total := &Resolver{
+		providers: []Provider{&mockProvider{name: "broken", failWith: errOutage}},
+		cfg:       resolverConfig{positionMatchThreshold: defaultPositionMatchThreshold, cap: defaultCap},
+	}
+
+	if _, err := total.Search(context.Background(), "M31"); !errors.Is(err, errOutage) {
+		t.Errorf("err = %v, want the underlying outage", err)
+	}
+}

--- a/catalog/fink/fink.go
+++ b/catalog/fink/fink.go
@@ -105,50 +105,90 @@ func (p *Provider) Capabilities() []resolve.Capability {
 
 // Resolve returns the first matching Target for the given query.
 // For numeric queries, uses the fast single-object JSON API.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
+//
+// # Three attempts, and why their errors are kept
+//
+// A numeric lookup, then a name lookup, then the bulk table. Falling through
+// on failure is deliberate — a query that is not a number may still be a name
+// — but the reasons were previously discarded, so a FINK outage and an
+// unknown object both ended at a bare false.
+//
+// The attempts are now joined and returned when none succeeds, so a caller can
+// tell "FINK says no such object" from "FINK could not be reached three
+// different ways". Only [resolve.ErrNotFound] is returned when every attempt
+// completed and simply found nothing.
+//
+// ctx was added in the same change: this used to fabricate
+// context.Background() internally because the interface gave it nowhere to
+// take one, so cancellation and deadlines were silently ignored.
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
 	q := strings.TrimSpace(query)
+
+	var attempts []error
 
 	// Fast path: numeric lookup via single-object JSON endpoint.
 	if n, err := strconv.ParseInt(q, 10, 64); err == nil {
-		rec, err := p.querySingle(context.Background(), n, "")
-		if err == nil && rec != nil {
-			return p.recordToTarget(rec), true
+		rec, qerr := p.querySingle(ctx, n, "")
+
+		switch {
+		case qerr != nil:
+			attempts = append(attempts, fmt.Errorf("numeric lookup: %w", qerr))
+		case rec != nil:
+			return p.recordToTarget(rec), nil
 		}
 	}
 
 	// Try name-based lookup via single-object JSON.
-	rec, err := p.querySingle(context.Background(), 0, q)
-	if err == nil && rec != nil {
-		return p.recordToTarget(rec), true
+	rec, err := p.querySingle(ctx, 0, q)
+
+	switch {
+	case err != nil:
+		attempts = append(attempts, fmt.Errorf("name lookup: %w", err))
+	case rec != nil:
+		return p.recordToTarget(rec), nil
 	}
 
 	// Fall back to bulk table lookup.
-	if err := p.ensureLoaded(); err != nil {
-		return resolve.Target{}, false
+	if lerr := p.ensureLoaded(ctx); lerr != nil {
+		attempts = append(attempts, fmt.Errorf("bulk table: %w", lerr))
+	} else if rec := p.lookupCached(q); rec != nil {
+		return p.recordToTarget(rec), nil
 	}
 
-	if rec := p.lookupCached(q); rec != nil {
-		return p.recordToTarget(rec), true
+	if len(attempts) > 0 {
+		return resolve.Target{}, errors.Join(attempts...)
 	}
 
-	return resolve.Target{}, false
+	return resolve.Target{}, fmt.Errorf("%w: %q in FINK", resolve.ErrNotFound, q)
 }
 
 // Search resolves a query (IAU number or name) against the SSOFT table.
-func (p *Provider) Search(query string) []resolve.Target {
-	tgt, ok := p.Resolve(query)
-	if !ok {
-		return nil
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
+	tgt, err := p.Resolve(ctx, query)
+	if err != nil {
+		if errors.Is(err, resolve.ErrNotFound) {
+			// Search's contract is "the matches I found"; none is a
+			// legitimate count, not a failure.
+			return nil, nil
+		}
+
+		return nil, err
 	}
 
-	return []resolve.Target{tgt}
+	return []resolve.Target{tgt}, nil
 }
 
 // ResolveObject implements resolve.ObjectResolver.
-func (p *Provider) ResolveObject(_ context.Context, req resolve.ObjectRequest) resolve.SeqIterator[resolve.Target] {
-	tgt, ok := p.Resolve(req.Query) //nolint:contextcheck // Resolve is interface-bound; bulk download path uses Background
-	if !ok {
-		return resolve.SliceSeq([]resolve.Target{})
+func (p *Provider) ResolveObject(ctx context.Context, req resolve.ObjectRequest) resolve.SeqIterator[resolve.Target] {
+	tgt, err := p.Resolve(ctx, req.Query)
+	if err != nil {
+		if errors.Is(err, resolve.ErrNotFound) {
+			return resolve.SliceSeq([]resolve.Target{})
+		}
+
+		return func(yield func(resolve.Target, error) bool) {
+			yield(resolve.Target{}, err)
+		}
 	}
 
 	return resolve.SliceSeq([]resolve.Target{tgt})
@@ -386,7 +426,7 @@ func (p *Provider) lookupCached(query string) *ssoRecord {
 }
 
 // ensureLoaded downloads and indexes the SSOFT parquet table on first call.
-func (p *Provider) ensureLoaded() error {
+func (p *Provider) ensureLoaded(ctx context.Context) error {
 	p.mu.RLock()
 
 	if p.loaded {
@@ -410,7 +450,7 @@ func (p *Provider) ensureLoaded() error {
 		return nil
 	}
 
-	records, err := p.downloadSSOFT()
+	records, err := p.downloadSSOFT(ctx)
 	if err != nil {
 		p.loadErr = fmt.Errorf("fink: failed to load SSOFT: %w", err)
 		return p.loadErr
@@ -437,14 +477,14 @@ func (p *Provider) ensureLoaded() error {
 }
 
 // downloadSSOFT fetches the full SSOFT parquet table from the FINK API.
-func (p *Provider) downloadSSOFT() (_ []ssoRecord, err error) {
+func (p *Provider) downloadSSOFT(ctx context.Context) (_ []ssoRecord, err error) {
 	payload := map[string]any{
 		"output-format": "parquet",
 		"version":       p.version,
 		"flavor":        "SHG1G2",
 	}
 
-	body, err := p.client.PostJSON(context.Background(), remote.FINK, "", payload)
+	body, err := p.client.PostJSON(ctx, remote.FINK, "", payload)
 	if err != nil {
 		var httpErr *api.HTTPError
 		if errors.As(err, &httpErr) {
@@ -491,11 +531,11 @@ func (p *Provider) downloadSSOFT() (_ []ssoRecord, err error) {
 		return nil, fmt.Errorf("writing temp parquet: %w", err)
 	}
 
-	return p.readParquet(tmpName)
+	return p.readParquet(ctx, tmpName)
 }
 
 // readParquet extracts ssoRecords from a SSOFT parquet file.
-func (p *Provider) readParquet(path string) (_ []ssoRecord, err error) {
+func (p *Provider) readParquet(ctx context.Context, path string) (_ []ssoRecord, err error) {
 	rdr, err := file.OpenParquetFile(path, false)
 	if err != nil {
 		return nil, fmt.Errorf("opening parquet: %w", err)
@@ -513,7 +553,7 @@ func (p *Provider) readParquet(path string) (_ []ssoRecord, err error) {
 		return nil, fmt.Errorf("creating arrow reader: %w", err)
 	}
 
-	tbl, err := arrowRdr.ReadTable(context.Background())
+	tbl, err := arrowRdr.ReadTable(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reading table: %w", err)
 	}

--- a/catalog/fink/fink_network_test.go
+++ b/catalog/fink/fink_network_test.go
@@ -5,6 +5,7 @@
 package fink
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TuSKan/astrogo/internal/testutil"
@@ -25,8 +26,8 @@ func TestFINKProvider_SingleObjectJSON(t *testing.T) {
 	p := New()
 
 	// Fast single-object JSON query.
-	tgt, ok := p.Resolve("8467")
-	if !ok {
+	tgt, err := p.Resolve(context.Background(), "8467")
+	if err != nil {
 		t.Fatal("Resolve(8467) failed")
 	}
 
@@ -80,8 +81,8 @@ func TestFINKProvider_SingleObjectJSON(t *testing.T) {
 	}
 
 	// Cross-check by name.
-	tgt2, ok := p.Resolve("Benoitcarry")
-	if !ok {
+	tgt2, err := p.Resolve(context.Background(), "Benoitcarry")
+	if err != nil {
 		t.Fatal("Resolve by name failed")
 	}
 

--- a/catalog/fink/fink_offline_test.go
+++ b/catalog/fink/fink_offline_test.go
@@ -120,12 +120,17 @@ func TestResolveViaSingleObjectAPI(t *testing.T) {
 
 	p := New()
 
-	target, ok := p.Resolve("8467")
-	if !ok || target.Name != "Benoitcarry" {
-		t.Fatalf("Resolve(8467) = %+v, %v, want Benoitcarry, true", target, ok)
+	target, err := p.Resolve(context.Background(), "8467")
+	if err != nil || target.Name != "Benoitcarry" {
+		t.Fatalf("Resolve(8467) = %+v, %v, want Benoitcarry, true", target, err)
 	}
 
-	if targets := p.Search("8467"); len(targets) != 1 {
+	targets, err := p.Search(context.Background(), "8467")
+	if err != nil {
+		t.Fatalf("Search(8467): %v", err)
+	}
+
+	if len(targets) != 1 {
 		t.Errorf("Search(8467) = %v, want exactly one target", targets)
 	}
 

--- a/catalog/fits/coord_guard_test.go
+++ b/catalog/fits/coord_guard_test.go
@@ -1,6 +1,7 @@
 package fits
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -72,8 +73,8 @@ func TestTargetWithoutCoordKeepsItsIdentity(t *testing.T) {
 		},
 	}
 
-	got, ok := p.Resolve("Named But Unplaced")
-	if !ok {
+	got, err := p.Resolve(context.Background(), "Named But Unplaced")
+	if err != nil {
 		t.Fatal("a target with no position stopped resolving by name")
 	}
 
@@ -86,8 +87,8 @@ func TestTargetWithoutCoordKeepsItsIdentity(t *testing.T) {
 	}
 
 	// And one that does have a position still carries it.
-	placed, ok := p.Resolve("Named And Placed")
-	if !ok {
+	placed, err := p.Resolve(context.Background(), "Named And Placed")
+	if err != nil {
 		t.Fatal("a target with a position stopped resolving")
 	}
 
@@ -96,7 +97,21 @@ func TestTargetWithoutCoordKeepsItsIdentity(t *testing.T) {
 	}
 
 	// Both are still searchable, so the guard costs no discoverability.
-	if n := len(p.Search("named")); n != 2 {
+	if n := mustSearchLen(t, p, "named"); n != 2 {
 		t.Errorf("a substring search matched %d targets, want 2", n)
 	}
+}
+
+// mustSearchLen is the length of a Search result, failing the test if the
+// provider could not answer at all — the distinction Search gained when the
+// Provider interface started returning errors.
+func mustSearchLen(t *testing.T, p *Provider, query string) int {
+	t.Helper()
+
+	got, err := p.Search(context.Background(), query)
+	if err != nil {
+		t.Fatalf("Search(%q): %v", query, err)
+	}
+
+	return len(got)
 }

--- a/catalog/fits/fits.go
+++ b/catalog/fits/fits.go
@@ -1,6 +1,7 @@
 package fits
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -130,24 +131,31 @@ func (p *Provider) Name() string {
 }
 
 // Resolve attempts a precise match of a FITS target natively scanning ID or Name.
-func (p *Provider) Resolve(query string) (resolve.Target, bool) {
+//
+// ctx is accepted for [resolve.Provider] conformance only — the targets were
+// read from the file at construction and there is no I/O here to cancel. The
+// parameter was previously absent entirely, which meant this type could not
+// satisfy the interface it was written against.
+func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, error) {
 	q := resolve.Normalize(query)
 	for _, t := range p.targets {
 		if resolve.Normalize(t.ID) == q || resolve.Normalize(t.Name) == q {
-			return t, true
+			return t, nil
 		}
 	}
 
-	return resolve.Target{}, false
+	return resolve.Target{}, fmt.Errorf("%w: %q in %s", resolve.ErrNotFound, query, p.name)
 }
 
 // Search attempts substring matching, returning all intersecting records.
-func (p *Provider) Search(query string) []resolve.Target {
+//
+// ctx is accepted for conformance only — see [Provider.Resolve].
+func (p *Provider) Search(_ context.Context, query string) ([]resolve.Target, error) {
 	q := resolve.Normalize(query)
 
 	var matches []resolve.Target
 	if q == "" {
-		return matches
+		return matches, nil
 	}
 
 	for _, t := range p.targets {
@@ -156,5 +164,5 @@ func (p *Provider) Search(query string) []resolve.Target {
 		}
 	}
 
-	return matches
+	return matches, nil
 }

--- a/catalog/fits/fits_test.go
+++ b/catalog/fits/fits_test.go
@@ -1,6 +1,7 @@
 package fits
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -33,8 +34,8 @@ func TestProvider_ResolveAndSearch(t *testing.T) {
 	}
 
 	// Test Resolver (perfect match mapping)
-	tgt, found := provider.Resolve("SIRIUS")
-	if !found {
+	tgt, err := provider.Resolve(context.Background(), "SIRIUS")
+	if err != nil {
 		t.Fatal("expected to find Sirius")
 	}
 
@@ -42,13 +43,17 @@ func TestProvider_ResolveAndSearch(t *testing.T) {
 		t.Errorf("expected ID-1, got %s", tgt.ID)
 	}
 
-	tgt, found = provider.Resolve("unknown")
-	if found {
+	tgt, err = provider.Resolve(context.Background(), "unknown")
+	if err == nil {
 		t.Errorf("expected not to find unknown resolve.Target, got %s", tgt.Name)
 	}
 
 	// Test Search (partial match mapping for substring discovery)
-	results := provider.Search("Siri")
+	results, err := provider.Search(context.Background(), "Siri")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(results) != 1 {
 		t.Fatalf("expected 1 search result, got %d", len(results))
 	}
@@ -57,7 +62,11 @@ func TestProvider_ResolveAndSearch(t *testing.T) {
 		t.Errorf("expected Sirius, got %s", results[0].Name)
 	}
 
-	results = provider.Search("ID-")
+	results, err = provider.Search(context.Background(), "ID-")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(results) != 2 {
 		t.Fatalf("expected 2 search results discovering common substring ID-, got %d", len(results))
 	}

--- a/catalog/gaia/gaia.go
+++ b/catalog/gaia/gaia.go
@@ -77,14 +77,20 @@ func (p *Provider) Capabilities() []resolve.Capability {
 	return []resolve.Capability{resolve.CapConeSearch}
 }
 
-// Resolve always returns false for Gaia (no name resolution).
-func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, bool) {
-	return resolve.Target{}, false
+// Resolve reports [resolve.ErrUnsupported]: Gaia is a cone-search provider and
+// does not resolve names.
+//
+// This previously returned a bare false, which a Resolver could not tell from
+// "that object does not exist" — so a real target could be reported absent
+// because the provider asked happened to be one that never answers names.
+func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, error) {
+	return resolve.Target{}, fmt.Errorf("%w: gaia resolves positions, not names", resolve.ErrUnsupported)
 }
 
-// Search always returns nil for Gaia (no name search).
-func (p *Provider) Search(_ context.Context, _ string) []resolve.Target {
-	return nil
+// Search reports [resolve.ErrUnsupported], for the reason given on
+// [Provider.Resolve].
+func (p *Provider) Search(_ context.Context, _ string) ([]resolve.Target, error) {
+	return nil, fmt.Errorf("%w: gaia resolves positions, not names", resolve.ErrUnsupported)
 }
 
 // ConeSearch performs a spatial cone search via the Gaia DR3 TAP service.

--- a/catalog/gaia/gaia_test.go
+++ b/catalog/gaia/gaia_test.go
@@ -2,6 +2,7 @@ package gaia
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -120,13 +121,13 @@ func TestProviderInterface(t *testing.T) {
 		t.Errorf("expected CapConeSearch, got %v", caps)
 	}
 
-	_, ok := p.Resolve(context.Background(), "foo")
-	if ok {
-		t.Error("expected Resolve to return false")
+	_, err := p.Resolve(context.Background(), "foo")
+	if !errors.Is(err, resolve.ErrUnsupported) {
+		t.Errorf("Resolve error = %v, want ErrUnsupported — gaia is cone-search only", err)
 	}
 
-	if p.Search(context.Background(), "foo") != nil {
-		t.Error("expected Search to return nil")
+	if got, serr := p.Search(context.Background(), "foo"); got != nil || !errors.Is(serr, resolve.ErrUnsupported) {
+		t.Errorf("Search = %v, %v; want nil, ErrUnsupported", got, serr)
 	}
 }
 

--- a/catalog/jpl/jpl.go
+++ b/catalog/jpl/jpl.go
@@ -53,32 +53,29 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve performs exact-match resolution for a query.
-func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.Search(ctx, query)
-	if len(targets) > 0 {
-		return targets[0], true
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
+	targets, err := p.Search(ctx, query)
+	if err != nil {
+		return resolve.Target{}, err
 	}
 
-	return resolve.Target{}, false
+	if len(targets) == 0 {
+		return resolve.Target{}, fmt.Errorf("%w: %q in jpl", resolve.ErrNotFound, query)
+	}
+
+	return targets[0], nil
 }
 
 // Search performs a fuzzy search for the query.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 
-	iter := p.ResolveObject(ctx, req)
+	targets, err := resolve.Drain(p.ResolveObject(ctx, req), 10)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
 
-	var targets []resolve.Target
-
-	iter(func(t resolve.Target, err error) bool {
-		if err == nil {
-			targets = append(targets, t)
-		}
-
-		return len(targets) < 10
-	})
-
-	return targets
+	return targets, nil
 }
 
 // ResolveObject performs streaming resolution via the JPL Horizons API.

--- a/catalog/jpl/jpl_test.go
+++ b/catalog/jpl/jpl_test.go
@@ -37,7 +37,7 @@ func newMockProvider(t *testing.T, jsonPayload string) *Provider {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, jsonPayload) //nolint:errcheck // test server, write failure would fail the test via response assertions
+		fmt.Fprint(w, jsonPayload) //nolint:errcheck // test server; a write failure surfaces through the response assertions
 	}))
 	t.Cleanup(server.Close)
 
@@ -232,8 +232,8 @@ func TestJPLResolve_ReturnsRealMatch(t *testing.T) {
 	result := "Target body name: Mars (499)                      {source: mar099}\n"
 	prov := newMockProvider(t, jsonResultPayload(t, result))
 
-	target, ok := prov.Resolve(context.Background(), "Mars")
-	testutil.AssertEqual(t, "Resolve Ok", ok, true)
+	target, err := prov.Resolve(context.Background(), "Mars")
+	testutil.AssertNoError(t, err)
 	testutil.AssertEqual(t, "Resolve Name", target.Name, "Mars")
 }
 
@@ -288,8 +288,8 @@ func TestProviderInterface(t *testing.T) {
 
 	// Fast fail search / resolve without any real network call.
 	// This hits the missing coverage lines.
-	_, ok := p.Resolve(context.Background(), "non_existent_body_to_trigger_miss")
-	if ok {
+	_, err := p.Resolve(context.Background(), "non_existent_body_to_trigger_miss")
+	if err == nil {
 		t.Error("expected Resolve to fail with no transport")
 	}
 }

--- a/catalog/mast/mast.go
+++ b/catalog/mast/mast.go
@@ -53,32 +53,29 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve resolves a query to a target.
-func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.Search(ctx, query)
-	if len(targets) > 0 {
-		return targets[0], true
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
+	targets, err := p.Search(ctx, query)
+	if err != nil {
+		return resolve.Target{}, err
 	}
 
-	return resolve.Target{}, false
+	if len(targets) == 0 {
+		return resolve.Target{}, fmt.Errorf("%w: %q in mast", resolve.ErrNotFound, query)
+	}
+
+	return targets[0], nil
 }
 
 // Search searches for targets matching the query.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 
-	iter := p.ResolveObject(ctx, req)
+	targets, err := resolve.Drain(p.ResolveObject(ctx, req), 10)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
 
-	var targets []resolve.Target
-
-	iter(func(t resolve.Target, err error) bool {
-		if err == nil {
-			targets = append(targets, t)
-		}
-
-		return len(targets) < 10
-	})
-
-	return targets
+	return targets, nil
 }
 
 // ResolveObject resolves a query to a target.

--- a/catalog/mast/mast_test.go
+++ b/catalog/mast/mast_test.go
@@ -197,7 +197,7 @@ func TestProviderInterface(t *testing.T) {
 	redirect(t, "http://127.0.0.1:1")
 
 	_, _ = p.Resolve(context.Background(), "non_existent_body")
-	_ = p.Search(context.Background(), "non_existent_body")
+	_, _ = p.Search(context.Background(), "non_existent_body")
 }
 
 // TestConeSearchNotImplemented confirms ConeSearch surfaces ErrNotImplemented

--- a/catalog/norad/norad.go
+++ b/catalog/norad/norad.go
@@ -290,28 +290,39 @@ func (p *Provider) Capabilities() []resolve.Capability {
 // a name.
 //
 // A name is ranked rather than taken in arrival order — see [rankByName].
-func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
 	q := strings.TrimSpace(query)
 	if q == "" {
-		return resolve.Target{}, false
+		return resolve.Target{}, fmt.Errorf("%w: empty query", resolve.ErrNotFound)
 	}
 
 	// A bare catalog number is an exact identifier; nothing to rank.
 	if isCatalogNumber(q) {
 		gps, err := p.Fetch(ctx, QueryCatNr, q)
-		if err != nil || len(gps) == 0 {
-			return resolve.Target{}, false
+		if err != nil {
+			// Previously `err != nil || len(gps) == 0` collapsed both arms
+			// into "false", so a CelesTrak outage and an unknown catalog
+			// number were the same answer.
+			return resolve.Target{}, err
 		}
 
-		return gpToTarget(gps[0]), true
+		if len(gps) == 0 {
+			return resolve.Target{}, fmt.Errorf("%w: catalog number %q", resolve.ErrNotFound, q)
+		}
+
+		return gpToTarget(gps[0]), nil
 	}
 
-	targets := p.Search(ctx, q)
+	targets, err := p.Search(ctx, q)
+	if err != nil {
+		return resolve.Target{}, err
+	}
+
 	if len(targets) == 0 {
-		return resolve.Target{}, false
+		return resolve.Target{}, fmt.Errorf("%w: %q in CelesTrak", resolve.ErrNotFound, q)
 	}
 
-	return targets[0], true
+	return targets[0], nil
 }
 
 // isCatalogNumber reports whether the query is a bare NORAD catalog number.
@@ -382,12 +393,16 @@ func rankByName(query string, targets []resolve.Target) {
 }
 
 // Search returns satellites matching the query string.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
 	// No local timeout wrapper needed: NewClientFor(remote.CelesTrak) already
 	// bounds the whole request at the endpoint's registered Timeout.
 	gps, err := p.Fetch(ctx, QueryName, query)
-	if err != nil || len(gps) == 0 {
-		return nil
+	if err != nil {
+		return nil, err
+	}
+
+	if len(gps) == 0 {
+		return nil, nil
 	}
 
 	targets := make([]resolve.Target, 0, len(gps))
@@ -397,7 +412,7 @@ func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
 
 	rankByName(query, targets)
 
-	return targets
+	return targets, nil
 }
 
 // Fetch queries the CelestTrak GP API and returns parsed element sets.

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -139,8 +139,8 @@ func TestResolve_Live(t *testing.T) {
 
 	p := New()
 
-	target, ok := p.Resolve(context.Background(), "ISS")
-	if !ok {
+	target, err := p.Resolve(context.Background(), "ISS")
+	if err != nil {
 		t.Fatal("Failed to resolve ISS")
 	}
 
@@ -204,8 +204,8 @@ func TestResolveISSIsTheStation(t *testing.T) {
 	// The catalog number takes a different route entirely — CelesTrak's exact
 	// CATNR parameter rather than its substring NAME one — so it is worth one
 	// more call. "25544" used to find nothing at all.
-	byNumber, ok := p.Resolve(t.Context(), "25544")
-	if !ok {
+	byNumber, err := p.Resolve(t.Context(), "25544")
+	if err != nil {
 		t.Skip("CelesTrak did not answer the catalog-number query")
 	}
 

--- a/catalog/norad/norad_offline_test.go
+++ b/catalog/norad/norad_offline_test.go
@@ -46,14 +46,18 @@ func TestNewFetchSearchResolve(t *testing.T) {
 		t.Errorf("Capabilities() = %v, want exactly one capability", caps)
 	}
 
-	targets := p.Search(context.Background(), "ISS")
+	targets, err := p.Search(context.Background(), "ISS")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(targets) != 1 || targets[0].Name != "ISS (ZARYA)" {
 		t.Fatalf("Search(%q) = %+v, want a single ISS (ZARYA) target", "ISS", targets)
 	}
 
-	target, ok := p.Resolve(context.Background(), "ISS")
-	if !ok || target.Name != "ISS (ZARYA)" {
-		t.Fatalf("Resolve(%q) = %+v, %v, want ISS (ZARYA), true", "ISS", target, ok)
+	target, err := p.Resolve(context.Background(), "ISS")
+	if err != nil || target.Name != "ISS (ZARYA)" {
+		t.Fatalf("Resolve(%q) = %+v, %v, want ISS (ZARYA), true", "ISS", target, err)
 	}
 
 	// Regression: Kind must be the canonical resolve.KindSatellite constant,

--- a/catalog/openngc/fetch_test.go
+++ b/catalog/openngc/fetch_test.go
@@ -65,9 +65,9 @@ func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 
 	p := New()
 
-	got, ok := p.Resolve(context.Background(), "M42")
-	if !ok || got.ID != "NGC1976" {
-		t.Errorf("Resolve(M42) = %+v, %v, want NGC1976, true", got, ok)
+	got, err := p.Resolve(context.Background(), "M42")
+	if err != nil || got.ID != "NGC1976" {
+		t.Errorf("Resolve(M42) = %+v, %v, want NGC1976, true", got, err)
 	}
 
 	// Regression: Epoch used to never be set despite OpenNGC's RA/Dec being
@@ -76,8 +76,9 @@ func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 		t.Errorf("Epoch = %v, want time.J2000", got.Epoch)
 	}
 
-	if got, ok := p.Resolve(context.Background(), "M31"); !ok || got.ID != "NGC224" {
-		t.Errorf("Resolve(M31) = %+v, %v, want NGC224, true", got, ok)
+	got, err = p.Resolve(context.Background(), "M31")
+	if err != nil || got.ID != "NGC224" {
+		t.Errorf("Resolve(M31) = %+v, %v, want NGC224, true", got, err)
 	}
 }
 
@@ -140,7 +141,7 @@ func TestNewDefaultDenyIssuesNoRequest(t *testing.T) {
 	// Downloads intentionally left disabled (the default).
 	p := New()
 
-	if _, ok := p.Resolve(context.Background(), "M42"); ok {
+	if _, err := p.Resolve(context.Background(), "M42"); err == nil {
 		t.Error("expected an empty provider when downloads are disabled")
 	}
 

--- a/catalog/openngc/openngc.go
+++ b/catalog/openngc/openngc.go
@@ -2,7 +2,7 @@ package openngc
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -23,6 +23,16 @@ type Record struct {
 type Provider struct {
 	byKey   map[string]int
 	targets []resolve.Target
+
+	// initErr records a failed catalog load so every query can report it.
+	//
+	// New used to log the failure and hand back an empty provider, which then
+	// answered every lookup with "not found" for the life of the process. A
+	// consent gate that was never granted, or one bad fetch at start-up, made
+	// the whole NGC/IC catalog silently absent while the provider looked
+	// healthy. Construction-time failure is worse than per-query failure for
+	// exactly that reason: it is permanent and it is invisible.
+	initErr error
 }
 
 // New creates a new OpenNGC catalog provider — like every other astrogo
@@ -37,8 +47,10 @@ type Provider struct {
 func New() *Provider {
 	targets, err := fetch(context.Background())
 	if err != nil {
-		log.Printf("openngc: %v", err)
-		return &Provider{byKey: make(map[string]int)}
+		return &Provider{
+			byKey:   make(map[string]int),
+			initErr: fmt.Errorf("openngc: catalog unavailable: %w", err),
+		}
 	}
 
 	p := &Provider{
@@ -92,21 +104,29 @@ func (p *Provider) SearchBright(_ context.Context, req resolve.BrightRequest) re
 // Resolve performs exact-match resolution for a query. ctx is accepted for
 // resolve.Provider conformance only — resolution runs over the in-memory
 // index built once at New(), with no I/O to cancel.
-func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, bool) {
-	q := resolve.Normalize(query)
-	if idx, ok := p.byKey[q]; ok {
-		return p.targets[idx], true
+func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, error) {
+	if p.initErr != nil {
+		return resolve.Target{}, p.initErr
 	}
 
-	return resolve.Target{}, false
+	q := resolve.Normalize(query)
+	if idx, ok := p.byKey[q]; ok {
+		return p.targets[idx], nil
+	}
+
+	return resolve.Target{}, fmt.Errorf("%w: %q in OpenNGC", resolve.ErrNotFound, query)
 }
 
 // Search performs fuzzy search across all NGC/IC objects. ctx is accepted
 // for resolve.Provider conformance only — see Resolve.
-func (p *Provider) Search(_ context.Context, query string) []resolve.Target {
+func (p *Provider) Search(_ context.Context, query string) ([]resolve.Target, error) {
+	if p.initErr != nil {
+		return nil, p.initErr
+	}
+
 	q := resolve.Normalize(query)
 	if q == "" {
-		return nil
+		return nil, nil
 	}
 
 	var results []resolve.Target
@@ -126,5 +146,5 @@ func (p *Provider) Search(_ context.Context, query string) []resolve.Target {
 		}
 	}
 
-	return results
+	return results, nil
 }

--- a/catalog/openngc/openngc_test.go
+++ b/catalog/openngc/openngc_test.go
@@ -51,13 +51,16 @@ func TestProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			got, ok := p.Resolve(context.Background(), tt.query)
-			if ok != tt.found {
-				t.Errorf("Resolve(%q) ok = %v, want %v", tt.query, ok, tt.found)
+			got, err := p.Resolve(context.Background(), tt.query)
+
+			// A miss is now ErrNotFound rather than a false, so the table's
+			// "found" column is checked against the error being nil.
+			if found := err == nil; found != tt.found {
+				t.Errorf("Resolve(%q) found = %v (err %v), want %v", tt.query, found, err, tt.found)
 				return
 			}
 
-			if ok && got.ID != tt.wantID {
+			if err == nil && got.ID != tt.wantID {
 				t.Errorf("Resolve(%q) got ID = %v, want %v", tt.query, got.ID, tt.wantID)
 			}
 		})
@@ -67,7 +70,11 @@ func TestProvider(t *testing.T) {
 func TestSearch(t *testing.T) {
 	p := newTestProvider()
 
-	results := p.Search(context.Background(), "orion")
+	results, err := p.Search(context.Background(), "orion")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
 	if len(results) == 0 {
 		t.Fatalf("Search(%q) returned no results", "orion")
 	}
@@ -90,7 +97,7 @@ func BenchmarkSearch(b *testing.B) {
 	p := newTestProvider()
 
 	for b.Loop() {
-		p.Search(context.Background(), "nebula")
+		_, _ = p.Search(context.Background(), "nebula")
 	}
 }
 

--- a/catalog/resolve/drain_test.go
+++ b/catalog/resolve/drain_test.go
@@ -1,0 +1,111 @@
+package resolve_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+)
+
+var errBroke = errors.New("upstream broke")
+
+// seq builds an iterator yielding each value, then err if it is non-nil.
+func seq(values []string, err error) resolve.SeqIterator[string] {
+	return func(yield func(string, error) bool) {
+		for _, v := range values {
+			if !yield(v, nil) {
+				return
+			}
+		}
+
+		if err != nil {
+			yield("", err)
+		}
+	}
+}
+
+// TestDrainReturnsTheError is the property Drain exists for.
+//
+// Four providers previously carried their own copy of this loop and every copy
+// discarded the error — three with a bare `if err == nil { append }` and one
+// with a log.Printf first. The caller then saw an empty slice and reported
+// "not found", which is how a CDS outage became a confident "no such object".
+func TestDrainReturnsTheError(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolve.Drain(seq(nil, errBroke), 10)
+	if !errors.Is(err, errBroke) {
+		t.Errorf("err = %v, want errBroke", err)
+	}
+
+	if got != nil {
+		t.Errorf("got %v, want nil alongside an error", got)
+	}
+}
+
+// TestDrainDiscardsPartialResultsWithTheError pins the deliberate choice not
+// to return rows taken before a failure.
+//
+// A short answer that looks complete is exactly how the original defect
+// produced wrong results rather than visible ones: a caller checking only
+// len() would treat a truncated page as the whole catalog. Returning nil
+// forces the error to be handled.
+func TestDrainDiscardsPartialResultsWithTheError(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolve.Drain(seq([]string{"a", "b"}, errBroke), 10)
+	if !errors.Is(err, errBroke) {
+		t.Fatalf("err = %v, want errBroke", err)
+	}
+
+	if got != nil {
+		t.Errorf("got %v, want nil — a partial page must not be returned as if complete", got)
+	}
+}
+
+func TestDrainCollectsAndRespectsLimit(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		name  string
+		items []string
+		limit int
+		want  int
+	}{
+		{"under the limit", []string{"a", "b"}, 10, 2},
+		{"exactly the limit", []string{"a", "b", "c"}, 3, 3},
+		{"stops at the limit", []string{"a", "b", "c", "d"}, 2, 2},
+		{"zero limit collects everything", []string{"a", "b", "c"}, 0, 3},
+		{"negative limit collects everything", []string{"a", "b"}, -1, 2},
+		{"empty is not an error", nil, 10, 0},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolve.Drain(seq(c.items, nil), c.limit)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != c.want {
+				t.Errorf("collected %d items (%v), want %d", len(got), got, c.want)
+			}
+		})
+	}
+}
+
+// TestDrainEmptyIsNotAnError separates "asked and matched nothing" from
+// "could not ask" at the lowest level, which is the distinction the whole
+// Provider interface is built on.
+func TestDrainEmptyIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolve.Drain(seq(nil, nil), 10)
+	if err != nil {
+		t.Errorf("err = %v, want nil — an empty result is an answer", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}

--- a/catalog/resolve/remote.go
+++ b/catalog/resolve/remote.go
@@ -92,6 +92,59 @@ type BrightObjectSearcher interface {
 // SeqIterator is an alias for iter.Seq2 for explicit documentation of expected return type.
 type SeqIterator[T any] iter.Seq2[T, error]
 
+// Drain collects a streaming iterator into a slice, stopping once limit items
+// have been taken, and returns the first error the iterator yields.
+//
+// # Why this exists as one function
+//
+// Four providers — simbad, jpl, mast and sbdb — each carried their own copy of
+// this loop, and every copy discarded the error. Three wrote
+//
+//	if err == nil {
+//		targets = append(targets, t)
+//	}
+//
+// which drops a transport failure without even a log line, and the fourth
+// logged it to the global log package before dropping it. The caller then saw
+// an empty slice and reported "not found". One shape, four copies, one defect.
+//
+// The streaming iterators themselves were always correct; it was this drain
+// step that lost the error. Centralising it means the next provider inherits
+// the fix rather than the bug.
+//
+// # Partial results are discarded with the error
+//
+// Rows taken before the failure are not returned alongside it. A short answer
+// that looks complete is exactly how the original defect produced wrong
+// results instead of visible ones — a caller checking only len() would treat
+// a truncated page as the whole catalog.
+//
+// A limit of zero or less collects everything the iterator offers.
+func Drain[T any](seq SeqIterator[T], limit int) ([]T, error) {
+	var (
+		out     []T
+		failure error
+	)
+
+	seq(func(v T, err error) bool {
+		if err != nil {
+			failure = err
+
+			return false
+		}
+
+		out = append(out, v)
+
+		return limit <= 0 || len(out) < limit
+	})
+
+	if failure != nil {
+		return nil, failure
+	}
+
+	return out, nil
+}
+
 // SliceSeq converts an in-memory slice to a standard SeqIterator.
 func SliceSeq[T any](items []T) SeqIterator[T] {
 	return func(yield func(T, error) bool) {

--- a/catalog/resolve/target.go
+++ b/catalog/resolve/target.go
@@ -206,17 +206,69 @@ func (t Target) ICRS(_ time.Time) (coord.ICRS, error) {
 }
 
 // Provider defines the interface for astronomical catalogs.
+//
+// # Why these return errors rather than a bool
+//
+// They used to be Resolve(ctx, query) (Target, bool) and
+// Search(ctx, query) []Target, which gave a failure nowhere to go. Every
+// outcome collapsed into "false": an object that genuinely does not exist, a
+// CDS outage, a cancelled context, a deadline, a 429 after retries, a TLS
+// failure, and a provider that does not implement name resolution at all.
+// Measured against the old API, all three of these returned "target not
+// found":
+//
+//	offline mode      -> target not found
+//	cancelled context -> target not found
+//	deadline exceeded -> target not found
+//
+// so errors.Is(err, context.Canceled) could never be true through this
+// package, and a scheduler asking "does NGC 5139 exist?" during an outage got
+// a confident no. The underlying error existed — it was written to the global
+// log package and discarded.
+//
+// # The contract
+//
+// Resolve returns exactly one target, or an error. Search returns the matches
+// it found, which may legitimately be none.
+//
+// An implementation must distinguish three things:
+//
+//   - Success: a target (or targets), nil error.
+//   - An ordinary negative: [ErrNotFound] when the query is well formed and
+//     the object is not in this catalog, or [ErrUnsupported] when the provider
+//     does not offer this operation at all. Both are answers, not incidents.
+//   - Anything else: return it. Transport failures, cancellation, malformed
+//     responses and rate limits are the caller's business, and wrapping them
+//     as "not found" is the defect this interface shape exists to prevent.
+//
+// A provider that reaches an endpoint and gets a well-formed empty answer
+// returns ErrNotFound. A provider that cannot reach the endpoint returns the
+// reason.
 type Provider interface {
 	Name() string
-	Resolve(ctx context.Context, query string) (Target, bool)
-	Search(ctx context.Context, query string) []Target
+	Resolve(ctx context.Context, query string) (Target, error)
+	Search(ctx context.Context, query string) ([]Target, error)
 }
 
 var (
 	// ErrNotFound is returned when no provider can resolve the query.
+	//
+	// It means the query was answered and the answer was no. It must never
+	// stand in for a failure to ask — see [Provider].
 	ErrNotFound = errors.New("target not found")
 	// ErrAmbiguous is returned when a query matches multiple targets.
 	ErrAmbiguous = errors.New("ambiguous target name")
+	// ErrUnsupported is returned by a provider that does not implement the
+	// requested operation.
+	//
+	// Distinct from ErrNotFound, and the distinction is not academic: the Gaia
+	// and VizieR providers are cone-search only, and under the old bool API
+	// their "I do not do name resolution" was indistinguishable from "that
+	// object does not exist". A Resolver could therefore report a real object
+	// as absent because the only provider asked was one that never answers
+	// names. [Provider.Capabilities] describes the same fact ahead of time;
+	// this reports it at the call.
+	ErrUnsupported = errors.New("operation not supported by this provider")
 )
 
 // Normalize converts a query to a canonical form for matching.

--- a/catalog/sbdb/sbdb.go
+++ b/catalog/sbdb/sbdb.go
@@ -48,32 +48,29 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // Resolve performs exact-match resolution for a query.
-func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.Search(ctx, query)
-	if len(targets) > 0 {
-		return targets[0], true
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
+	targets, err := p.Search(ctx, query)
+	if err != nil {
+		return resolve.Target{}, err
 	}
 
-	return resolve.Target{}, false
+	if len(targets) == 0 {
+		return resolve.Target{}, fmt.Errorf("%w: %q in sbdb", resolve.ErrNotFound, query)
+	}
+
+	return targets[0], nil
 }
 
 // Search performs fuzzy search across all MPC-registered small bodies.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
 	req := resolve.ObjectRequest{Query: query, Limit: 1}
 
-	iter := p.ResolveObject(ctx, req)
+	targets, err := resolve.Drain(p.ResolveObject(ctx, req), 1)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
 
-	var targets []resolve.Target
-
-	iter(func(t resolve.Target, err error) bool {
-		if err == nil {
-			targets = append(targets, t)
-		}
-
-		return len(targets) < 1
-	})
-
-	return targets
+	return targets, nil
 }
 
 // ResolveObject performs streaming resolution via the JPL Small-Body Database API.

--- a/catalog/sbdb/sbdb_network_test.go
+++ b/catalog/sbdb/sbdb_network_test.go
@@ -71,8 +71,8 @@ func TestSBDBNetworkResolveOrbitalElements(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	tar, ok := prov.Resolve(ctx, "1")
-	if !ok {
+	tar, err := prov.Resolve(ctx, "1")
+	if err != nil {
 		t.Fatal("failed to resolve 1 Ceres")
 	}
 
@@ -289,8 +289,8 @@ func TestSBDBElementsAreFullPrecision(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	tar, ok := prov.Resolve(ctx, "433")
-	if !ok {
+	tar, err := prov.Resolve(ctx, "433")
+	if err != nil {
 		t.Skip("SBDB did not resolve 433 Eros")
 	}
 

--- a/catalog/sbdb/sbdb_test.go
+++ b/catalog/sbdb/sbdb_test.go
@@ -41,8 +41,8 @@ func TestSBDBResolver(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve(context.Background(), "aten")
-	if !ok {
+	tar, err := prov.Resolve(context.Background(), "aten")
+	if err != nil {
 		t.Fatalf("Failed to resolve Aten")
 	}
 
@@ -110,8 +110,8 @@ func TestSBDBResolver_CometKind(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve(context.Background(), "halley")
-	if !ok {
+	tar, err := prov.Resolve(context.Background(), "halley")
+	if err != nil {
 		t.Fatalf("Failed to resolve Halley")
 	}
 
@@ -167,8 +167,8 @@ func TestSBDBResolver_OrbitalElements(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve(context.Background(), "ceres")
-	if !ok {
+	tar, err := prov.Resolve(context.Background(), "ceres")
+	if err != nil {
 		t.Fatalf("Failed to resolve Ceres")
 	}
 
@@ -229,8 +229,8 @@ func TestSBDBResolver_IncompleteElements(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve(context.Background(), "ceres")
-	if !ok {
+	tar, err := prov.Resolve(context.Background(), "ceres")
+	if err != nil {
 		t.Fatalf("Failed to resolve Ceres")
 	}
 
@@ -276,8 +276,8 @@ func TestSBDBResolver_PhysicalDiameterAlbedo(t *testing.T) {
 
 	prov := New()
 
-	tar, ok := prov.Resolve(context.Background(), "eros")
-	if !ok {
+	tar, err := prov.Resolve(context.Background(), "eros")
+	if err != nil {
 		t.Fatalf("Failed to resolve Eros")
 	}
 
@@ -537,5 +537,5 @@ func TestProviderInterface(t *testing.T) {
 	}
 
 	_, _ = p.Resolve(context.Background(), "non_existent_body")
-	_ = p.Search(context.Background(), "non_existent_body")
+	_, _ = p.Search(context.Background(), "non_existent_body")
 }

--- a/catalog/simbad/resolution_network_test.go
+++ b/catalog/simbad/resolution_network_test.go
@@ -48,8 +48,8 @@ func TestResolveReturnsTheObjectAsked(t *testing.T) {
 		t.Run(tc.query, func(t *testing.T) {
 			p := New()
 
-			tgt, ok := p.Resolve(context.Background(), tc.query)
-			if !ok {
+			tgt, err := p.Resolve(context.Background(), tc.query)
+			if err != nil {
 				t.Fatalf("Resolve(%q) found nothing (%s)", tc.query, tc.why)
 			}
 
@@ -78,7 +78,7 @@ func TestResolveFindsNothingRatherThanSomethingWrong(t *testing.T) {
 
 	p := New()
 
-	if tgt, ok := p.Resolve(context.Background(), "NoSuchObjectXYZ123"); ok {
+	if tgt, err := p.Resolve(context.Background(), "NoSuchObjectXYZ123"); err == nil {
 		t.Errorf("Resolve of a nonexistent name returned %q", tgt.Name)
 	}
 }

--- a/catalog/simbad/simbad.go
+++ b/catalog/simbad/simbad.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
@@ -53,46 +52,50 @@ func (p *Provider) Capabilities() []resolve.Capability {
 // was not among them. Scoring ranks what it is given.
 //
 // It now matches identifiers exactly, against the spellings SIMBAD is known
-// to store — see [identifierVariants]. An unknown name returns false rather
-// than the least-wrong of ten wrong answers, because a caller can act on
-// "not found" and cannot act on a plausible object 70 degrees from the one
-// they asked for.
+// to store — see [identifierVariants]. An unknown name returns
+// [resolve.ErrNotFound] rather than the least-wrong of ten wrong answers,
+// because a caller can act on "not found" and cannot act on a plausible
+// object 70 degrees from the one they asked for.
 //
 // Aliases fan out across rows, so several rows may arrive for one object;
 // they are merged by oid upstream in ResolveObject and the first target is
 // the object.
-func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, bool) {
-	targets := p.ResolveObjects(ctx, resolve.ObjectRequest{Query: query, Limit: 10})
-	if len(targets) == 0 {
-		return resolve.Target{}, false
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
+	targets, err := p.ResolveObjects(ctx, resolve.ObjectRequest{Query: query, Limit: 10})
+	if err != nil {
+		return resolve.Target{}, err
 	}
 
-	return targets[0], true
+	if len(targets) == 0 {
+		return resolve.Target{}, fmt.Errorf("%w: %q in SIMBAD", resolve.ErrNotFound, query)
+	}
+
+	return targets[0], nil
 }
 
-// ResolveObjects drains ResolveObject into a slice, dropping errors after
-// logging them — the shape both Resolve and Search need.
-func (p *Provider) ResolveObjects(ctx context.Context, req resolve.ObjectRequest) []resolve.Target {
+// ResolveObjects drains ResolveObject into a slice — the shape both Resolve
+// and Search need.
+//
+// It used to swallow errors here: the iterator's error was written to the
+// global log package and the drained slice came back empty, which every caller
+// then read as "not found". A CDS outage, a cancelled context and a genuinely
+// absent object were indistinguishable, and the only trace was a line on
+// whatever writer log.SetOutput last pointed at.
+//
+// The streaming ResolveObject always carried the error correctly. This is the
+// convenience wrapper that used to throw it away.
+func (p *Provider) ResolveObjects(ctx context.Context, req resolve.ObjectRequest) ([]resolve.Target, error) {
 	limit := req.Limit
 	if limit <= 0 {
 		limit = 10
 	}
 
-	var targets []resolve.Target
+	targets, err := resolve.Drain(p.ResolveObject(ctx, req), limit)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", req.Query, err)
+	}
 
-	p.ResolveObject(ctx, req)(func(t resolve.Target, err error) bool {
-		if err != nil {
-			log.Printf("SIMBAD ERR: %v", err)
-
-			return false
-		}
-
-		targets = append(targets, t)
-
-		return len(targets) < limit
-	})
-
-	return targets
+	return targets, nil
 }
 
 // Search matches objects whose identifiers begin with a freeform query.
@@ -103,29 +106,23 @@ func (p *Provider) ResolveObjects(ctx context.Context, req resolve.ObjectRequest
 // so the rows are ones a person would recognise and are the same rows on
 // every call — the query this replaces had no ORDER BY, and two identical
 // searches for "M42" returned different objects.
-func (p *Provider) Search(ctx context.Context, query string) []resolve.Target {
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
 	if strings.TrimSpace(query) == "" {
-		return nil
+		return nil, nil
 	}
 
 	req := resolve.ObjectRequest{Query: query, Limit: 10}
 	adql := BuildSearchQuery(req)
 
-	var targets []resolve.Target
+	targets, err := resolve.Drain(p.stream(ctx, "search:"+query, adql), req.Limit)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
 
-	p.stream(ctx, "search:"+query, adql)(func(tgt resolve.Target, err error) bool {
-		if err != nil {
-			log.Printf("SIMBAD ERR: %v", err)
-
-			return false
-		}
-
-		targets = append(targets, tgt)
-
-		return len(targets) < req.Limit
-	})
-
-	return targets
+	// No error and no rows is a real answer: the query was asked and matched
+	// nothing. Unlike Resolve, that is not ErrNotFound — Search's contract is
+	// "the matches I found", and none is a legitimate count.
+	return targets, nil
 }
 
 // SearchBright returns every SIMBAD object brighter than req.MaxVMag,

--- a/catalog/simbad/simbad_test.go
+++ b/catalog/simbad/simbad_test.go
@@ -89,8 +89,8 @@ func TestResolveMock(t *testing.T) {
 
 	redirect(t, remote.SIMBAD, server.URL)
 
-	tgt, ok := p.Resolve(context.Background(), "m31")
-	if !ok {
+	tgt, err := p.Resolve(context.Background(), "m31")
+	if err != nil {
 		t.Fatalf("failed to resolve target")
 	}
 
@@ -424,7 +424,7 @@ func TestProviderInterface(t *testing.T) {
 
 	// Triggers internal error paths since we didn't mock
 	_, _ = p.Resolve(context.Background(), "non_existent_body")
-	_ = p.Search(context.Background(), "non_existent_body")
+	_, _ = p.Search(context.Background(), "non_existent_body")
 }
 
 // redirect points endpoint id at a test server for the duration of one

--- a/catalog/vizier/vizier.go
+++ b/catalog/vizier/vizier.go
@@ -56,14 +56,20 @@ func (p *Provider) Capabilities() []resolve.Capability {
 	return []resolve.Capability{resolve.CapConeSearch}
 }
 
-// Resolve always returns false for VizieR (use ConeSearch instead).
-func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, bool) {
-	return resolve.Target{}, false // Not supported directly, use ConeSearch
+// Resolve reports [resolve.ErrUnsupported]: VizieR is reached here as a
+// cone-search provider and does not resolve names.
+//
+// This previously returned a bare false, which a Resolver could not tell from
+// "that object does not exist" — so a real target could be reported absent
+// because the provider asked happened to be one that never answers names.
+func (p *Provider) Resolve(_ context.Context, _ string) (resolve.Target, error) {
+	return resolve.Target{}, fmt.Errorf("%w: use ConeSearch", resolve.ErrUnsupported)
 }
 
-// Search always returns nil for VizieR (use ConeSearch instead).
-func (p *Provider) Search(_ context.Context, _ string) []resolve.Target {
-	return nil
+// Search reports [resolve.ErrUnsupported], for the reason given on
+// [Provider.Resolve].
+func (p *Provider) Search(_ context.Context, _ string) ([]resolve.Target, error) {
+	return nil, fmt.Errorf("%w: use ConeSearch", resolve.ErrUnsupported)
 }
 
 // ConeSearch performs a spatial cone search via the VizieR service.

--- a/catalog/vizier/vizier_test.go
+++ b/catalog/vizier/vizier_test.go
@@ -263,13 +263,13 @@ func TestProviderInterface(t *testing.T) {
 		t.Errorf("expected CapConeSearch, got %v", caps)
 	}
 
-	_, ok := p.Resolve(context.Background(), "foo")
-	if ok {
-		t.Error("expected Resolve to return false")
+	_, err := p.Resolve(context.Background(), "foo")
+	if !errors.Is(err, resolve.ErrUnsupported) {
+		t.Errorf("Resolve error = %v, want ErrUnsupported — vizier is cone-search only", err)
 	}
 
-	if p.Search(context.Background(), "foo") != nil {
-		t.Error("expected Search to return nil")
+	if got, serr := p.Search(context.Background(), "foo"); got != nil || !errors.Is(serr, resolve.ErrUnsupported) {
+		t.Errorf("Search = %v, %v; want nil, ErrUnsupported", got, serr)
 	}
 
 	// errTransport keeps this default (non-network-tagged) test fully

--- a/docs/changelog.d/151-catalog-error-model.md
+++ b/docs/changelog.d/151-catalog-error-model.md
@@ -1,0 +1,11 @@
+---
+type: Changed — BREAKING
+pr: 151
+---
+**`resolve.Provider` returns errors instead of a bool.** `Resolve` is now
+`(Target, error)` and `Search` is `([]Target, error)`, so a transport failure,
+a cancelled context or an unreachable service is no longer reported as
+"target not found". `errors.Is(err, context.Canceled)` works through the
+catalog layer for the first time. Adds `resolve.ErrUnsupported` for
+cone-search-only providers, and `catalog/fink` and `catalog/fits` now take a
+`context.Context`.

--- a/docs/changelog.d/151-catalog-error-tests.md
+++ b/docs/changelog.d/151-catalog-error-tests.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 151
+---
+**Tests for the catalog error contract.** `resolve.Drain` is covered, and the
+Resolver's semantics are pinned directly: a provider failure is never reported
+as `ErrNotFound`, a cancelled context is caught before any provider is
+consulted, `ErrUnsupported` is an answer rather than an incident, and one
+broken provider neither denies an answer another gave nor suppresses partial
+`Search` results.

--- a/ephemeris/jpl/validation/kepler_smallbody_test.go
+++ b/ephemeris/jpl/validation/kepler_smallbody_test.go
@@ -207,8 +207,8 @@ func smallBodyElements(t *testing.T, provider *sbdb.Provider, body smallBody) (
 ) {
 	t.Helper()
 
-	target, ok := provider.Resolve(context.Background(), strconv.Itoa(body.id))
-	if !ok {
+	target, err := provider.Resolve(context.Background(), strconv.Itoa(body.id))
+	if err != nil {
 		t.Skipf("SBDB did not resolve %d (%s)", body.id, body.name)
 
 		return kepler.Elements{}, time.Time{}, false

--- a/examples/05_resolve_name/main.go
+++ b/examples/05_resolve_name/main.go
@@ -25,8 +25,17 @@ func main() {
 	query := "Andromeda"
 	fmt.Printf("Executing advanced Search for ambiguous query: %q...\n", query)
 
-	// 3. Perform a fuzzy Search combining all endpoints
-	results := resolver.Search(ctx, query)
+	// 3. Perform a fuzzy Search combining all endpoints.
+	//
+	// The error is checked rather than discarded, and that distinction is the
+	// point: an empty result now means the catalogs were asked and matched
+	// nothing, where an error means at least one could not be reached. They
+	// used to be the same answer.
+	results, err := resolver.Search(ctx, query)
+	if err != nil {
+		fmt.Printf("Search failed: %v\n", err)
+		return
+	}
 
 	if len(results) == 0 {
 		fmt.Println("No matches found.")

--- a/magnitude/fink_test.go
+++ b/magnitude/fink_test.go
@@ -165,8 +165,8 @@ func TestFINK_EndToEndSHG1G2(t *testing.T) {
 	// Step 1: Get fitted parameters from SSOFT via the provider.
 	prov := fink.New()
 
-	tgt, ok := prov.Resolve("8467")
-	if !ok {
+	tgt, err := prov.Resolve(context.Background(), "8467")
+	if err != nil {
 		t.Skipf("FINK provider: Resolve(8467) failed — SSOFT download or parsing error")
 	}
 
@@ -344,8 +344,8 @@ func TestFINK_SpinCorrectionPhysics(t *testing.T) {
 	// Get spin parameters from the provider.
 	prov := fink.New()
 
-	tgt, ok := prov.Resolve("8467")
-	if !ok {
+	tgt, err := prov.Resolve(context.Background(), "8467")
+	if err != nil {
 		t.Skipf("FINK provider: Resolve(8467) failed")
 	}
 


### PR DESCRIPTION
`resolve.Provider` was `Resolve(ctx, query) (Target, bool)`, which left every failure with nowhere to go. An object that genuinely does not exist, a CDS outage, a cancelled context, an exceeded deadline, a 429 after retries, a TLS failure, and a provider that does not implement name resolution at all — all collapsed into the same `false`, and the resolver turned that into `ErrNotFound`.

A pipeline resolving ten thousand names during an outage got ten thousand confident *"no such object"* answers, and the only trace was a line on whatever writer `log.SetOutput` last pointed at.

## Measured, before and after

```
before:
  offline           -> target not found | Is(ErrNotFound)=true
  cancelled ctx     -> target not found | Is(context.Canceled)=false
  deadline exceeded -> target not found | Is(DeadlineExceeded)=false

after:
  offline           -> offline mode enabled (endpoint "cds.simbad")
  cancelled ctx     -> Is(context.Canceled)=true
  deadline exceeded -> Is(DeadlineExceeded)=true
```

`errors.Is(err, context.Canceled)` works through the catalog layer for the first time.

## The contract

`Resolve` returns `(Target, error)`, `Search` returns `([]Target, error)`, across all ten providers. Three outcomes, deliberately distinct:

- **Success** — a target, nil error.
- **An ordinary negative** — `ErrNotFound` when the query was answered and the answer was no; `ErrUnsupported` when the provider does not offer the operation. Both are answers, not incidents.
- **Anything else** — returned as-is. A provider that *reaches* an endpoint and gets an empty answer returns `ErrNotFound`; one that cannot reach it returns why.

## Three things beyond the issue

**`ErrUnsupported`, because the bool hid one more conflation.** Gaia and VizieR are cone-search only and returned `false` from `Resolve` meaning "I do not do names" — indistinguishable from "that object does not exist". A real target could therefore be reported absent because the only provider asked was one that never answers names. `Capabilities()` already described that fact ahead of time; now the call reports it too.

**`resolve.Drain`, because this was one bug in four copies.** simbad, jpl, mast and sbdb each carried the same drain loop and every copy discarded the error — three with a bare `if err == nil { append }`, and simbad with a `log.Printf` first. The streaming iterators were always correct; it was the convenience wrapper that lost the error. Partial rows are discarded *with* the error, because a short answer that looks complete is precisely how the original defect produced wrong results instead of visible ones.

**openngc was worse and differently shaped.** It swallowed at *construction*: a failed fetch left an empty provider that answered "not found" for the life of the process while looking perfectly healthy. Construction-time failure is worse than per-query failure for exactly that reason — permanent and invisible. The error is now held and returned from every query.

## The Resolver decides the semantics

- `ctx.Err()` is checked **before any provider is consulted**, so a cancelled caller gets `context.Canceled` rather than whatever the first provider makes of it.
- Provider failures are collected and joined, tagged by provider name.
- `ErrNotFound`/`ErrUnsupported` are not collected — they are answers.
- If nothing was found **and** something failed, the failures are returned. Reporting `ErrNotFound` there would assert an answer nobody gave.
- A provider that succeeds wins outright; the others' failures are not reported, because the question was answered.
- `Search` returns partial results from working providers rather than suppressing them for one failure.

## Also

`catalog/fink` and `catalog/fits` gained `ctx`, which they had never taken — fink was fabricating `context.Background()` internally behind a `//nolint:contextcheck` that documented the workaround. That suppression is gone, and ctx is threaded through `ensureLoaded`, `downloadSSOFT` and `readParquet`. fink's three fallback attempts now join their reasons rather than dropping them.

**Every `log.Printf` in `catalog` is gone.**

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` **untagged and tagged** · `go mod tidy` (unchanged) · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues**, tagged **0 issues**.

Three lint findings were fixed rather than suppressed (`wrapcheck` on the cross-package `Drain` error, `errcheck`, `wsl_v5`).

## Two things a reviewer should know about how this was done

**A blanket regex renaming `ok` to `err` across test files damaged unrelated comma-ok map lookups — twice.** `ok` is Go's universal idiom and a bare rename of it is never safe. The compiler caught every instance, but it is worth knowing the test diffs were machine-edited and then repaired.

**The untagged gate hid tagged breakage.** Five `network`- and `validation`-tagged files still did not compile after everything untagged was green — the trap CLAUDE.md's own build-tag note warns about. Tagged vet is in the gate above for that reason.

One smaller note: I removed a `//nolint:errcheck` that `nolintlint` reported as dead, then had to restore it. It was only reported dead because the package was failing to typecheck at that moment, so `errcheck` produced no finding for it to suppress. Worth knowing before acting on #136's 41 dead suppressions — that audit needs a compiling tree to be trustworthy.

Closes #102.
