### PR TITLE
Select Go by minor version in CI, not from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,23 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          # '1.25' rather than go-version-file: go.mod, deliberately.
+          #
+          # go.mod declares `go 1.25.8` — a patch-level minimum astrogo does
+          # not need and does not set: `go mod tidy` raises the directive to
+          # the maximum any dependency declares, and gocloud-ext's seven
+          # modules declare 1.25.8 (see #109). Reading it here made setup-go
+          # demand that exact patch, and every observed job then logged
+          # "Attempting to download 1.25.8" — so the toolchain was fetched and
+          # extracted before the job could start. On PR #151 that step hung
+          # for 25 minutes without running a single test.
+          #
+          # A minor-version spec resolves to whatever 1.25.x the runner
+          # already has. It cannot silently diverge from go.mod: Go refuses to
+          # build below the declared directive and fetches the required
+          # toolchain itself, so a future bump past 1.25 degrades to today's
+          # behaviour (a download) rather than to a wrong result.
+          go-version: '1.25'
           cache: true
 
       - name: Verify dependencies
@@ -152,7 +168,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          # See the Setup Go step in the lint-and-test job for why this is a
+          # minor-version spec rather than go-version-file: go.mod (#109).
+          go-version: '1.25'
           cache: true
 
       - name: Run tests with race detector
@@ -170,7 +188,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          # See the Setup Go step in the lint-and-test job for why this is a
+          # minor-version spec rather than go-version-file: go.mod (#109).
+          go-version: '1.25'
           cache: true
 
       - name: Run benchmarks
@@ -203,7 +223,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          # See the Setup Go step in the lint-and-test job for why this is a
+          # minor-version spec rather than go-version-file: go.mod (#109).
+          go-version: '1.25'
           cache: true
 
       - name: Run integration tests

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           # Track go.mod rather than a hardcoded version, so this workflow
           # cannot drift onto a different toolchain from ci.yml.
-          go-version-file: go.mod
+          # See the Setup Go step in the lint-and-test job for why this is a
+          # minor-version spec rather than go-version-file: go.mod (#109).
+          go-version: '1.25'
           cache: true
 
       - name: Prepare output directory

--- a/docs/changelog.d/152-ci-go-version.md
+++ b/docs/changelog.d/152-ci-go-version.md
@@ -1,0 +1,9 @@
+---
+type: Changed
+pr: 152
+---
+**CI selects Go by minor version instead of reading go.mod.** The `go 1.25.8`
+directive — inherited from gocloud-ext, not needed by astrogo (#109) — made
+`setup-go` demand that exact patch and download a toolchain before every job,
+which hung for 25 minutes on one run. `go-version: '1.25'` resolves to whatever
+1.25.x the runner already has.


### PR DESCRIPTION
`Lint and Test (ubuntu-latest)` hung for **25 minutes** on #151 and never ran a test. The step status told the story:

```
Set up job      ✓ 1s
Checkout code   ✓ 2s
Setup Go        ⧗ in_progress   (25+ min)
Verify deps     · pending
Run tests       · pending
```

`setup-go` was reading `go-version-file: go.mod`, so it demanded exactly **1.25.8** and logged *"Attempting to download 1.25.8"* — fetching and extracting a toolchain before the job could begin. That is a network dependency in the critical path of jobs that otherwise have none, on every job of every run.

## The 1.25.8 is not astrogo's

`go mod tidy` raises the `go` directive to the maximum any dependency declares. Surveying the graph, every dependency caps at **1.25.0** — `cloud.google.com/go/*`, `arrow-go/v18`, the OTel GCP exporters — except:

```
1.25.8  github.com/TuSKan/gocloud-ext
1.25.8  github.com/TuSKan/gocloud-ext/blob/httpblob
```

Lowering it here does not work; `tidy` puts it straight back:

```
$ sed -i 's/^go 1.25.8$/go 1.25/' go.mod && go mod tidy && grep '^go ' go.mod
go 1.25.8
```

And lowering it at the source is a **three-release chain across two repositories** — seven gocloud-ext modules declare it, and the submodules depend on the *published* parent, so `httpblob` reverts on `tidy` for the same reason astrogo's does. #109 now carries that diagnosis; this PR does not attempt it.

## The objection, and why it is weaker than it looks

A minor-version spec means CI's Go and go.mod's declared minimum can drift. But **Go refuses to build below the declared directive and fetches the required toolchain itself**, so a future bump past 1.25 degrades to exactly today's behaviour — a download — rather than to a wrong answer. The failure mode is a slow job, not a bad build.

Applied to **all five** `setup-go` steps, `pre-release.yml` included, so the tagged suites don't keep the old behaviour by omission.

## This needs verifying, not assuming

**The stall was transient.** macos (1m45s), windows (2m50s) and Race Detection (5m24s) all did the identical download on the same commit and passed. This removes an *exposure*, not a reproducible failure.

So the check that matters is this PR's own CI: if `Setup Go` still logs *"Attempting to download"*, then the runner has no 1.25.x preinstalled, this buys nothing, and it should be reverted rather than left looking like a fix. I have not verified what the ubuntu image preinstalls — every job observed so far asked for 1.25.8 specifically, so none of them says what was already on the box.

Refs #109.