### PR TITLE
Reproduce SOFA's refraction instead of re-deriving it

### DIFF
--- a/coord/context.go
+++ b/coord/context.go
@@ -265,30 +265,91 @@ func (ctx *Context) GeocentricToObserved(v vector.Vec3) AltAz {
 	case ctx.atm.Model != nil:
 		alt += ctx.atm.Model.RefractFromTrue(alt, ctx.atm)
 	case ctx.atm.Pressure > 0:
-		// Use SOFA's own refraction coefficients (Refa, Refb) computed by
-		// Apco13 and stored in the ASTROM context. This is exactly the model
-		// that Atioq uses for the stellar path, ensuring consistency between
-		// the direct geocentric pipeline and the SOFA astrometric pipeline.
-		// Formula: ΔR = Refa·tan(z) + Refb·tan³(z)  (z = π/2 − alt)
-		//
-		// We apply refraction down to alt ≈ −1° (z ≤ 91°), since atmospheric
-		// refraction is physically nonzero slightly below the geometric
-		// horizon. Below −1° the tan(z) series diverges and refraction is
-		// negligible for practical purposes.
-		z := math.Pi/2 - altitude
-
-		const zMax = 91.0 * math.Pi / 180.0 // alt ≈ −1°
-		if z > 0 && z < zMax {
-			tz := math.Tan(z)
-
-			dR := ctx.astrom.Refa*tz + ctx.astrom.Refb*tz*tz*tz
-			if dR > 0 {
-				alt = angle.Rad(altitude + dR)
-			}
-		}
+		alt = refractLikeAtioq(E, N, U, topoVec.Norm(), ctx.astrom.Refa, ctx.astrom.Refb)
 	}
 
 	return NewAltAz(alt, angle.Rad(azimuth))
+}
+
+// Refraction clamps, copied from SOFA's iauAtioq rather than chosen here.
+//
+// selMin bounds sin(altitude) at 0.05 — about 2.87° — so the series is never
+// evaluated where it diverges. celMin bounds cos(altitude) away from zero at
+// the zenith, where the horizontal component vanishes.
+const (
+	selMin = 0.05
+	celMin = 1e-6
+)
+
+// refractLikeAtioq applies refraction to a topocentric ENU direction exactly as
+// SOFA's Atioq does, and returns the refracted altitude.
+//
+// # Why this reproduces Atioq instead of approximating it
+//
+// This branch exists so the vector pipeline agrees with the stellar one, which
+// goes through Atioq. It previously wrote out what looked like the same model —
+//
+//	dR := Refa*tan(z) + Refb*tan³(z)
+//
+// — guarded only by z < 91° and dR > 0, and it was wrong three ways at once.
+//
+// It had no clamp. tan(z) diverges at z = 90°, which is the horizon, not the
+// 91° the guard allowed: at alt −0.076° the cubic term flips sign to about
+// +61 rad and the dR > 0 test waves it straight through. Measured, that
+// returned an altitude of +7028°. The guard meant to reject bad values was
+// admitting only the catastrophic ones, because it rejected the honest
+// negatives.
+//
+// Between about 0° and 2° the cubic term cancels the linear one instead, dR
+// went non-positive, and refraction was dropped entirely — 0.000° where the
+// stellar path applied 0.16°.
+//
+// And the model itself was the uncorrected series. Atioq applies a
+// Newton-Raphson correction, dividing by 1 + (A + 3B·tan²z)/sin²(alt), which
+// the raw form omits even where it converges.
+//
+// Reproducing the routine rather than re-deriving it is what makes the two
+// pipelines agree by construction. TestRefractionMatchesTheStellarPipeline pins that.
+//
+// # A consequence worth stating
+//
+// Because sin(altitude) is clamped, a target below the horizon is refracted as
+// though it were at 2.87°, so this reports about 0.17° of refraction for
+// something that has already set. That is arguable physics and it is precisely
+// what the stellar path does; matching it is the point. A caller wanting
+// geometric altitude should use a Context with no atmosphere.
+func refractLikeAtioq(e, n, u, norm, refa, refb float64) angle.Angle {
+	if norm == 0 {
+		return 0
+	}
+
+	// Atioq works on a unit vector, so the clamps are in units of sine and
+	// cosine of altitude.
+	ue, un, uu := e/norm, n/norm, u/norm
+
+	r := math.Hypot(ue, un)
+	if r <= celMin {
+		r = celMin
+	}
+
+	z := uu
+	if z <= selMin {
+		z = selMin
+	}
+
+	// A·tan(z) + B·tan³(z) with Atioq's Newton-Raphson correction.
+	tz := r / z
+	w := refb * tz * tz
+	del := (refa + w) * tz / (1.0 + (refa+3.0*w)/(z*z))
+
+	// Rotate the direction by del, as Atioq does. The clamped r and z drive
+	// the rotation; the unclamped components are what it rotates.
+	cosdel := 1.0 - del*del/2.0
+	f := cosdel - del*z/r
+	eo, no := ue*f, un*f
+	uo := cosdel*uu + del*r
+
+	return angle.Rad(math.Pi/2 - math.Atan2(math.Hypot(eo, no), uo))
 }
 
 // ICRSToAltAz converts ICRS coordinates to local observed AltAz utilizing the

--- a/coord/refraction_test.go
+++ b/coord/refraction_test.go
@@ -1,0 +1,208 @@
+package coord_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// refractionScene builds the two Contexts these tests compare: one with an
+// atmosphere and one without, identical in every other respect.
+//
+// Differencing them is what isolates refraction. Comparing absolute altitudes
+// between the vector and stellar pipelines would not: they take different
+// inputs — a geometric position vector against a catalog star direction — and
+// the stellar path applies annual aberration, which is up to 20 arcsec and has
+// nothing to do with the atmosphere. Measured, that leaves about 9.5 arcsec
+// between them even when refraction agrees perfectly.
+func refractionScene(t *testing.T) (withAtm, noAtm *coord.Context) {
+	t.Helper()
+
+	site, err := coord.NewGeodetic(angle.Deg(-46.6), angle.Deg(-23.5), 800)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	epoch := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+
+	atm := atmosphere.AtAltitude(800)
+
+	dry := atm
+	dry.Pressure = 0
+
+	return coord.NewContext(epoch, site, atm), coord.NewContext(epoch, site, dry)
+}
+
+// farVector is a geocentric position vector pointing at an ICRS direction, far
+// enough away that the observer offset does not measurably change it.
+func farVector(c coord.ICRS) vector.Vec3 {
+	u := c.ToUnitVector()
+	return vector.Vec3{X: u.X * 1e9, Y: u.Y * 1e9, Z: u.Z * 1e9}
+}
+
+// TestRefractionMatchesTheStellarPipeline is the guard the +7028° defect
+// needed and did not have.
+//
+// # What went wrong
+//
+// GeocentricToObserved wrote out what looked like SOFA's refraction model —
+// Refa·tan(z) + Refb·tan³(z) — guarded by z < 91° and dR > 0. It was wrong
+// three ways at once, and no test compared it against anything.
+//
+// tan(z) diverges at the horizon, not at the 91° the guard allowed, so just
+// below it the cubic term flipped sign to about +61 rad and the dR > 0 test
+// passed it through: an altitude of **+7028°** at a geometric −0.076°. Between
+// roughly 0° and 2° the cubic cancelled the linear term instead, dR went
+// non-positive, and refraction was dropped entirely — 0.000° where the stellar
+// path applied 0.16°. And the model was the uncorrected series, missing the
+// Newton-Raphson step Atioq applies even where it converges.
+//
+// # Why this compares increments
+//
+// The two pipelines answer different questions and their absolute altitudes
+// legitimately differ (see refractionScene). Differencing each against its own
+// atmosphere-free Context isolates the one quantity that must match.
+func TestRefractionMatchesTheStellarPipeline(t *testing.T) {
+	t.Parallel()
+
+	withAtm, noAtm := refractionScene(t)
+
+	// One arcsecond, which is the bound #100 asked for. Measured agreement is
+	// far tighter — a few milliarcsec below the clamp, under 0.2 arcsec above
+	// it — so this has room for platform rounding without admitting a
+	// regression.
+	const toleranceArcsec = 1.0
+
+	var checked int
+
+	for raDeg := 0.0; raDeg < 360.0; raDeg += 0.25 {
+		icrs := coord.NewICRS(angle.Deg(raDeg), angle.Deg(-20))
+		far := farVector(icrs)
+
+		geometric := noAtm.GeocentricToObserved(far).Alt().Degrees()
+		if geometric < -5 || geometric > 5 {
+			continue
+		}
+
+		checked++
+
+		vectorRefraction := withAtm.GeocentricToObserved(far).Alt().Degrees() - geometric
+
+		sr, err := withAtm.ICRSToAltAz(icrs)
+		if err != nil {
+			t.Fatalf("ICRSToAltAz: %v", err)
+		}
+
+		sg, err := noAtm.ICRSToAltAz(icrs)
+		if err != nil {
+			t.Fatalf("ICRSToAltAz: %v", err)
+		}
+
+		stellarRefraction := sr.Alt().Degrees() - sg.Alt().Degrees()
+
+		if d := math.Abs(vectorRefraction-stellarRefraction) * 3600; d > toleranceArcsec {
+			t.Errorf("at geometric %+.3f°: the vector pipeline refracts by %.5f° and the "+
+				"stellar pipeline by %.5f°, a difference of %.2f arcsec.\n"+
+				"  Both must be SOFA's Atioq model — reproduce the routine rather than "+
+				"re-deriving it.", geometric, vectorRefraction, stellarRefraction, d)
+		}
+	}
+
+	if checked < 20 {
+		t.Fatalf("only %d directions fell in the -5°..+5° band; the sweep is not "+
+			"exercising the horizon", checked)
+	}
+
+	t.Logf("%d directions compared across -5°..+5°", checked)
+}
+
+// TestRefractionIsPhysicallyBounded asserts what refraction is, independently
+// of any other implementation.
+//
+// Agreement between the two pipelines is necessary and not sufficient: two
+// pipelines can be wrong together, and before this change they were wrong
+// separately. These bounds hold whatever model is used, so they catch a
+// divergence that agreement alone would not.
+func TestRefractionIsPhysicallyBounded(t *testing.T) {
+	t.Parallel()
+
+	withAtm, noAtm := refractionScene(t)
+
+	// Atmospheric refraction at sea level is about 0.57° at the horizon and
+	// falls monotonically to zero at the zenith. Half a degree of headroom
+	// admits a plausible model and excludes a diverging one.
+	const maxDegrees = 1.0
+
+	type sample struct {
+		geometric, refraction float64
+	}
+
+	var samples []sample
+
+	for raDeg := 0.0; raDeg < 360.0; raDeg += 0.1 {
+		icrs := coord.NewICRS(angle.Deg(raDeg), angle.Deg(-20))
+		far := farVector(icrs)
+
+		geometric := noAtm.GeocentricToObserved(far).Alt().Degrees()
+		refraction := withAtm.GeocentricToObserved(far).Alt().Degrees() - geometric
+
+		switch {
+		case math.IsNaN(refraction) || math.IsInf(refraction, 0):
+			t.Fatalf("at geometric %+.3f°: refraction is %v", geometric, refraction)
+		case refraction < 0:
+			t.Errorf("at geometric %+.3f°: refraction is %.4f°, but refraction raises "+
+				"an object, never lowers it", geometric, refraction)
+		case refraction > maxDegrees:
+			t.Errorf("at geometric %+.3f°: refraction is %.4f°, which exceeds anything "+
+				"physical — the series has diverged. This is the +7028° defect's "+
+				"signature.", geometric, refraction)
+		}
+
+		if geometric > -5 && geometric < 85 {
+			samples = append(samples, sample{geometric, refraction})
+		}
+	}
+
+	if len(samples) < 50 {
+		t.Fatalf("only %d usable samples; the sweep is not covering the sky", len(samples))
+	}
+
+	// Monotonic in altitude, but only clear of the clamp.
+	//
+	// SOFA bounds sin(altitude) at 0.05 — about 2.87° — and below that the
+	// refraction is not flat: the clamp fixes the vertical component while the
+	// horizontal one keeps varying, so tan(z) still moves and refraction drifts
+	// slowly. Where the clamp stops binding the two regimes meet in a small
+	// kink, and refraction briefly rises with altitude.
+	//
+	// Measured, that kink extends to 3.097° and is worth about 3 arcsec. It is
+	// a property of Atioq's model, not a defect in reproducing it, so the band
+	// is excluded rather than asserted away — an earlier version of this test
+	// used the nominal 2.87° clamp and failed on the model's own behaviour.
+	// 4° clears it with margin.
+	const monotonicAbove = 4.0
+
+	for i := range samples {
+		for j := range samples {
+			a, b := samples[i], samples[j]
+			if a.geometric <= monotonicAbove || b.geometric <= a.geometric {
+				continue
+			}
+
+			// b is higher than a, so it must refract no more than a does.
+			if b.refraction > a.refraction+1e-9 {
+				t.Errorf("refraction rises with altitude: %.5f° at %+.3f° but %.5f° at "+
+					"%+.3f°", a.refraction, a.geometric, b.refraction, b.geometric)
+
+				return
+			}
+		}
+	}
+
+	t.Logf("%d samples bounded; monotonic above %.1f°", len(samples), monotonicAbove)
+}

--- a/docs/changelog.d/153-refraction-atioq.md
+++ b/docs/changelog.d/153-refraction-atioq.md
@@ -1,0 +1,11 @@
+---
+type: Fixed
+pr: 153
+---
+**`coord.Context.GeocentricToObserved` returned altitudes of thousands of
+degrees near the horizon.** Its refraction branch wrote out
+`Refa·tan(z) + Refb·tan³(z)` with no clamp, so the series diverged just below
+the horizon (+7028° at −0.076°) and cancelled to zero just above it (0.000°
+where the stellar path applied 0.16°); it also omitted the Newton-Raphson
+correction. It now reproduces SOFA's `Atioq` exactly, so the two pipelines
+agree to milliarcseconds.


### PR DESCRIPTION
`coord.Context.GeocentricToObserved` returned **+7028°** for a target 0.076° below the horizon.

Its refraction branch wrote out what looked like SOFA's model —

```go
dR := ctx.astrom.Refa*tz + ctx.astrom.Refb*tz*tz*tz
if dR > 0 { alt = angle.Rad(altitude + dR) }
```

— guarded by `z < 91°` and `dR > 0`. **The guard meant to reject bad values was admitting only the catastrophic ones**, because it rejected the honest negatives: `tan(z)` diverges at `z = 90°`, which is the horizon rather than the 91° the guard allowed, so just below it the cubic term flips sign to about `+61 rad` and sails through.

## Reading SOFA rather than reciting it found a third error

I expected one bug. `Atioq` differs in three ways:

| | SOFA `Atioq` | this branch |
| --- | --- | --- |
| clamp on sin(alt) | `SELMIN = 0.05` (≈2.87°) | none — the divergence |
| clamp on cos(alt) | `CELMIN = 1e-6` | none |
| model | `(A+w)·tz / (1 + (A+3w)/z²)` — Newton-Raphson | raw `A·tz + B·tz³` |

So it was **wrong above the horizon too**, not only near it — the correction term was missing everywhere. Working from the issue description alone would have fixed the clamp and left that.

There was a second failure mode as well: between roughly 0° and 2° the cubic cancelled the linear term, `dR` went non-positive, and refraction was **dropped entirely** — 0.000° where the stellar path applied 0.16°.

## The fix

`refractLikeAtioq` reproduces the routine: the same two clamps, the same corrected model, and the same rotation of the direction vector rather than a small-angle addition to the altitude. Reproducing it is what makes the two pipelines agree *by construction* rather than by tuning.

| | before | after |
| --- | ---: | ---: |
| refraction vs. stellar pipeline, below clamp | 596″ | **0.003″** |
| refraction vs. stellar pipeline, above clamp | 596″ | **<0.2″** |
| altitude at geometric −0.076° | +7028° | 0.091° |

## Two things the measurement taught me, both recorded in the tests

**The remaining 9.5″ in absolute altitude is not refraction.** The two functions take different inputs — a geometric position vector against a catalog star direction — and only the stellar path applies annual aberration. So each pipeline is differenced against its *own* atmosphere-free Context, isolating the one quantity that must match. Comparing absolute altitudes, as #100 proposed, would have compared different physics and failed at a 1″ bound forever.

**My first monotonicity assertion was stronger than SOFA's own model.** Below the clamp refraction is not flat — the clamp fixes the vertical component while the horizontal one keeps varying — and the two regimes meet in a kink. Measured, it reaches **3.097°** and is worth about 3″. The band is excluded with margin and the reason recorded, rather than the bound being quietly loosened.

## Verification

Both guards were checked against the original defect rather than assumed. Restoring it fails them independently:

```
TestRefractionMatchesTheStellarPipeline
  at geometric -4.930°: the vector pipeline refracts by 0.00000° and the
  stellar pipeline by 0.16544°, a difference of 595.57 arcsec.

TestRefractionIsPhysicallyBounded
  at geometric -0.926°: refraction is 3.0236°, which exceeds anything
  physical — the series has diverged. This is the +7028° defect's signature.
```

The bounds test is deliberately independent of the other pipeline: agreement is necessary and not sufficient, since two implementations can be wrong together.

Full §5 gate: `gofmt` · `go build` · `go vet` untagged and tagged · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues**, tagged **0 issues**.

`docsguard` caught a test name in my own doc comment that no test declares — fixed rather than suppressed.

## Note for #101

This unblocks the Moon-parallax work. The horizon-band measurements it needs were contaminated by this defect — Mars appeared to show 0.16° of "parallax" near the horizon that was entirely this bug.

Closes #100.
