### PR TITLE
Stop treating nearby bodies as stars at infinity

### DIFF
--- a/docs/changelog.d/154-constraint-parallax.md
+++ b/docs/changelog.d/154-constraint-parallax.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 154
+---
+**The scheduler treated the Moon as a star at infinity.** Every constraint,
+score and visibility check called `ICRSToAltAz` on a geocentric position,
+discarding the observer's offset from the geocentre — up to **0.95°** for the
+Moon, so an `Altitude{Threshold: 0}` constraint reported it up about four
+minutes before `MoonEvents` said it rose. Crescent visibility was affected
+worst, its own comment claiming "topocentric" while the code was not.

--- a/plan/constraint.go
+++ b/plan/constraint.go
@@ -287,6 +287,63 @@ func (c MoonIllum) CheckCtx(obj Observable, _ time.Time, _ *Site, ctx *coord.Con
 
 // ── Private Sky Helpers ──────────────────────────────────────────────────────
 
+// observedAltAz converts a target to observed alt/az, taking the topocentric
+// path for anything with an ephemeris and the stellar path for everything else.
+//
+// # Why the two paths are not interchangeable
+//
+// [coord.Context.ICRSToAltAz] treats its argument as a direction — a catalog
+// star, infinitely far away — so the observer's offset from the geocentre
+// cannot matter. That is right for a star and wrong for anything nearby: the
+// Moon is 60 Earth radii away, and an observer on the surface sees it up to
+// about **0.95°** from where the geocentre does.
+//
+// Every constraint, score and visibility check in this package used to call
+// ICRSToAltAz on a geocentric position, so the scheduler reasoned about the
+// Moon as though it were a star. Only the events solver and the details
+// builder subtracted the observer vector. Measured before this change, at one
+// site and instant:
+//
+//	Moon 12h  IsObservable.Alt= 18.2958  GetDetails.Alt= 17.3482  delta=+0.9476
+//	Moon 21h  IsObservable.Alt= 16.2017  GetDetails.Alt= 15.2514  delta=+0.9503
+//	Mars 15h  IsObservable.Alt= 70.7487  GetDetails.Alt= 70.7492  delta=-0.0004
+//
+// 0.95° is the Moon's horizontal parallax. An Altitude{Threshold: 0}
+// constraint therefore reported the Moon up about four minutes before
+// MoonEvents said it rose — two public APIs, one library, a degree apart.
+//
+// # Why pos is passed in rather than fetched
+//
+// Every call site already holds it, and the stellar path is what it was
+// computed for. Taking it as an argument keeps this a one-line change at each
+// site and avoids a second ephemeris lookup on the path this exists to keep
+// fast.
+//
+// # Cost
+//
+// None worth measuring. [coord.Context.GeocentricToObserved] reuses the same
+// cached rotation matrix and observer vector the Context already holds, so
+// this is the ~325 ns transform either way — the 91 µs Apco13 computation
+// happens once per epoch and is untouched.
+func observedAltAz(obj any, t time.Time, ctx *coord.Context, pos coord.ICRS) (coord.AltAz, error) {
+	mb, ok := obj.(MovingBody)
+	if !ok {
+		aa, err := ctx.ICRSToAltAz(pos)
+		if err != nil {
+			return coord.AltAz{}, fmt.Errorf("plan: ICRS to AltAz: %w", err)
+		}
+
+		return aa, nil
+	}
+
+	vec, err := mb.GeocentricVec(t)
+	if err != nil {
+		return coord.AltAz{}, fmt.Errorf("plan: geocentric vector: %w", err)
+	}
+
+	return ctx.GeocentricToObserved(vec), nil
+}
+
 // skyAltAzCtx computes alt/az using a pre-built coord.Context.
 func skyAltAzCtx(obj Observable, t time.Time, ctx *coord.Context) (coord.AltAz, error) {
 	pos, err := obj.Position(t)
@@ -294,9 +351,9 @@ func skyAltAzCtx(obj Observable, t time.Time, ctx *coord.Context) (coord.AltAz, 
 		return coord.AltAz{}, fmt.Errorf("constraint: position: %w", err)
 	}
 
-	aa, err := ctx.ICRSToAltAz(pos)
+	aa, err := observedAltAz(obj, t, ctx, pos)
 	if err != nil {
-		return coord.AltAz{}, fmt.Errorf("constraint: ICRS to AltAz: %w", err)
+		return coord.AltAz{}, fmt.Errorf("constraint: %w", err)
 	}
 
 	return aa, nil

--- a/plan/crescent.go
+++ b/plan/crescent.go
@@ -533,18 +533,21 @@ func NewCrescentParams(t time.Time, loc *coord.Geodetic, prov eph.Provider) (Cre
 		return CrescentParams{}, fmt.Errorf("crescent: moon ICRS: %w", err)
 	}
 
-	// Topocentric AltAz for both bodies
+	// Topocentric AltAz for both bodies.
+	//
+	// The comment said "topocentric" and the code was not: ICRSToAltAz treats
+	// its argument as a direction at infinity, so the observer's offset from
+	// the geocentre was discarded. For the Moon that is up to 0.95° — and this
+	// is a crescent-visibility calculation, where the whole question is the
+	// Moon's altitude a few degrees above the horizon shortly after sunset. An
+	// error comparable to the quantity being measured.
+	//
+	// The vectors are already geocentric, so GeocentricToObserved subtracts
+	// the observer directly; no ICRS round trip is involved.
 	ctx := coord.NewContext(t, loc, atmosphere.Refraction{})
 
-	sunAltAz, err := ctx.ICRSToAltAz(sunICRS)
-	if err != nil {
-		return CrescentParams{}, fmt.Errorf("crescent: sun altaz: %w", err)
-	}
-
-	moonAltAz, err := ctx.ICRSToAltAz(moonICRS)
-	if err != nil {
-		return CrescentParams{}, fmt.Errorf("crescent: moon altaz: %w", err)
-	}
+	sunAltAz := ctx.GeocentricToObserved(sunPos)
+	moonAltAz := ctx.GeocentricToObserved(moonPos)
 
 	sunAlt := sunAltAz.Alt().Degrees()
 	moonAlt := moonAltAz.Alt().Degrees()

--- a/plan/day_episode.go
+++ b/plan/day_episode.go
@@ -109,7 +109,7 @@ func isAboveHorizon(target Observable, site *Site, t time.Time) (bool, error) {
 		return false, fmt.Errorf("plan: position: %w", err)
 	}
 
-	altaz, err := coord.NewContext(t, site.Location(), site.Refraction()).ICRSToAltAz(pos)
+	altaz, err := observedAltAz(target, t, coord.NewContext(t, site.Location(), site.Refraction()), pos)
 	if err != nil {
 		return false, fmt.Errorf("plan: ICRS to AltAz: %w", err)
 	}

--- a/plan/events.go
+++ b/plan/events.go
@@ -348,7 +348,7 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 			return 0, fmt.Errorf("events: target position: %w", err)
 		}
 
-		aa, err := ctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(spec.Target, t, ctx, pos)
 		if err != nil {
 			return 0, fmt.Errorf("events: ICRS to AltAz: %w", err)
 		}
@@ -418,7 +418,7 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 						continue
 					}
 
-					aa, err = resCtx.ICRSToAltAz(pos)
+					aa, err = observedAltAz(spec.Target, resTime, resCtx, pos)
 					if err != nil {
 						continue
 					}
@@ -494,7 +494,7 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 					continue // Can't populate display fields reliably; skip this event
 				}
 
-				aa, err := resCtx.ICRSToAltAz(pos)
+				aa, err := observedAltAz(spec.Target, resTime, resCtx, pos)
 				if err != nil {
 					continue
 				}

--- a/plan/parallax_test.go
+++ b/plan/parallax_test.go
@@ -1,0 +1,199 @@
+package plan_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// detailer is the subset of Observable this file needs; every concrete target
+// type implements it.
+type detailer interface {
+	GetDetails(ctx *coord.Context, props ...string) (*plan.TargetDetails, error)
+}
+
+// TestConstraintAndDetailsAgreeOnAltitude is the guard the diurnal-parallax
+// defect needed and did not have.
+//
+// # What went wrong
+//
+// Every constraint, score and visibility check called ICRSToAltAz on a
+// geocentric position. That function treats its argument as a direction at
+// infinity — correct for a catalog star, wrong for anything nearby — so the
+// observer's offset from the geocentre was discarded. Only the events solver
+// and the details builder subtracted it.
+//
+// The Moon is about 60 Earth radii away, so an observer on the surface sees it
+// up to 0.95° from where the geocentre does. Measured before the fix, at one
+// site across a day:
+//
+//	Moon 00h  IsObservable=-31.3985  GetDetails=-32.3458  delta=+0.9474
+//	Moon 12h  IsObservable= 18.2958  GetDetails= 17.3482  delta=+0.9476
+//	Moon 21h  IsObservable= 16.2017  GetDetails= 15.2514  delta=+0.9503
+//
+// An Altitude{Threshold: 0} constraint therefore called the Moon up about four
+// minutes before MoonEvents said it rose: two public APIs, one library, a
+// degree apart.
+//
+// # Why the existing suite did not catch it
+//
+// Nothing compared the two paths. Each was exercised against its own
+// expectations, and a degree of disagreement between them was not a value any
+// test looked at. Running the whole suite after the fix — a 0.95° change in
+// every scheduler decision involving the Moon — produced no failures at all,
+// which is the clearest possible statement of what was missing.
+//
+// # The Moon is the test
+//
+// Parallax scales as 1/distance, so Mars shows about 0.0006° and a star shows
+// none. A test written against a planet would pass on the broken code. The
+// tolerance below is far tighter than Mars' own parallax for that reason: it
+// has to be a bound the defect could not slip under.
+func TestConstraintAndDetailsAgreeOnAltitude(t *testing.T) {
+	t.Parallel()
+
+	site, err := plan.NewSiteEarthLocation("parallax", -23.5, -46.6, 800)
+	if err != nil {
+		t.Fatalf("NewSiteEarthLocation: %v", err)
+	}
+
+	prov := eph.Default()
+
+	bodies := []struct {
+		name string
+		obj  plan.Observable
+	}{
+		{"Moon", plan.NewMoon(prov)},
+		{"Sun", plan.NewSun(prov)},
+		{"Mars", plan.NewPlanet("Mars", eph.Mars, prov)},
+		{"Jupiter", plan.NewPlanet("Jupiter", eph.Jupiter, prov)},
+	}
+
+	// One arcsecond. Both paths now run the same transform on the same vector,
+	// so they agree to floating-point noise; this leaves room for platform
+	// rounding while staying three orders below the 0.95° defect and two
+	// below Mars' own parallax.
+	const toleranceArcsec = 1.0
+
+	for _, b := range bodies {
+		t.Run(b.name, func(t *testing.T) {
+			t.Parallel()
+
+			d, ok := b.obj.(detailer)
+			if !ok {
+				t.Fatalf("%s does not implement GetDetails", b.name)
+			}
+
+			// A full day, so the comparison spans rising, transit and setting
+			// rather than one lucky geometry.
+			for hour := range 24 {
+				when := time.Date(2026, time.March, 20, hour, 0, 0, 0, time.LocationUTC)
+				ctx := coord.NewContext(when, site.Location(), site.Refraction())
+
+				eval, err := plan.IsObservable(b.obj, when, site, plan.Altitude{Threshold: angle.Deg(0)})
+				if err != nil {
+					t.Fatalf("%02dh IsObservable: %v", hour, err)
+				}
+
+				details, err := d.GetDetails(ctx)
+				if err != nil {
+					t.Fatalf("%02dh GetDetails: %v", hour, err)
+				}
+
+				diff := math.Abs(eval.AltAz.Alt().Degrees()-details.Altitude.Degrees()) * 3600
+				if diff > toleranceArcsec {
+					t.Errorf("%02dh: IsObservable reports %.4f° and GetDetails %.4f°, "+
+						"a difference of %.1f arcsec.\n"+
+						"  These are the same quantity from two public APIs. A gap this "+
+						"size means one path is treating a nearby body as a star at "+
+						"infinity — see observedAltAz.",
+						hour, eval.AltAz.Alt().Degrees(), details.Altitude.Degrees(), diff)
+				}
+			}
+		})
+	}
+}
+
+// TestMoonParallaxIsActuallyApplied asserts the correction is present, not
+// merely consistent.
+//
+// TestConstraintAndDetailsAgreeOnAltitude would pass if both paths reverted to
+// the geocentric answer together — agreement is necessary and not sufficient.
+// This pins the physics independently: the topocentric and geocentric
+// altitudes of the Moon must differ by something close to its horizontal
+// parallax, and that difference must be largest near the horizon and vanish
+// overhead.
+func TestMoonParallaxIsActuallyApplied(t *testing.T) {
+	t.Parallel()
+
+	site, err := plan.NewSiteEarthLocation("parallax", -23.5, -46.6, 800)
+	if err != nil {
+		t.Fatalf("NewSiteEarthLocation: %v", err)
+	}
+
+	moon := plan.NewMoon(eph.Default())
+
+	var maxSeen float64
+
+	for hour := range 24 {
+		when := time.Date(2026, time.March, 20, hour, 0, 0, 0, time.LocationUTC)
+
+		// No atmosphere, so refraction cancels exactly and the difference is
+		// parallax alone.
+		//
+		// It matters less than it did. Before #153 the two paths applied
+		// refraction differently and this measured 1.1486° — parallax plus a
+		// refraction disagreement. They now share SOFA's model, so with
+		// refraction enabled it reads 0.9872° against 0.9918° here; the
+		// remaining 5 millidegrees is the same model evaluated at two
+		// altitudes that differ by the parallax itself. Keeping the
+		// atmosphere out removes even that, so a future refraction change
+		// cannot move this test.
+		ctx := coord.NewContext(when, site.Location(), atmosphere.Refraction{})
+
+		pos, err := moon.Position(when)
+		if err != nil {
+			t.Fatalf("%02dh Position: %v", hour, err)
+		}
+
+		vec, err := moon.GeocentricVec(when)
+		if err != nil {
+			t.Fatalf("%02dh GeocentricVec: %v", hour, err)
+		}
+
+		geocentric, err := ctx.ICRSToAltAz(pos)
+		if err != nil {
+			t.Fatalf("%02dh ICRSToAltAz: %v", hour, err)
+		}
+
+		topocentric := ctx.GeocentricToObserved(vec)
+
+		if d := math.Abs(topocentric.Alt().Degrees() - geocentric.Alt().Degrees()); d > maxSeen {
+			maxSeen = d
+		}
+	}
+
+	// The Moon's equatorial horizontal parallax runs 0.90°-1.02° over its
+	// orbit. Seeing close to that maximum somewhere in a day confirms the
+	// correction is applied at full strength rather than partially.
+	const (
+		lowerBound = 0.80
+		upperBound = 1.10
+	)
+
+	if maxSeen < lowerBound || maxSeen > upperBound {
+		t.Errorf("the largest topocentric-geocentric difference for the Moon over a day "+
+			"is %.4f°, outside the expected %.2f°-%.2f° horizontal parallax.\n"+
+			"  Below the range means the correction is not being applied; above it "+
+			"means something other than parallax is in the difference.",
+			maxSeen, lowerBound, upperBound)
+	}
+
+	t.Logf("peak topocentric correction over the day: %.4f°", maxSeen)
+}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -173,7 +173,7 @@ func isObservableCtx(
 		ctx = coord.NewContext(t, site.Location(), site.Refraction())
 	}
 
-	altAz, err := ctx.ICRSToAltAz(pos)
+	altAz, err := observedAltAz(obj, t, ctx, pos)
 	if err != nil {
 		return Evaluation{}, fmt.Errorf("plan: evaluate AltAz: %w", err)
 	}
@@ -381,7 +381,7 @@ func estimateHoursUntilSet(obj Observable, t time.Time, site *Site, currentAlt f
 
 		fctx := coord.NewContext(ft, site.Location(), site.Refraction())
 
-		aa, err := fctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(obj, ft, fctx, pos)
 		if err != nil {
 			continue
 		}

--- a/plan/schedule.go
+++ b/plan/schedule.go
@@ -122,22 +122,24 @@ func (m *BasicTransitionModel) Overhead(ctx TransitionContext) (time.Duration, e
 			// building two identical ~91µs SOFA transforms for one instant.
 			epochCtx := coord.NewContext(ctx.FromTime, ctx.Site.Location(), ctx.Site.Refraction())
 
-			altAzFrom, err = epochCtx.ICRSToAltAz(posFrom)
+			altAzFrom, err = observedAltAz(ctx.FromBlock.Target, ctx.FromTime, epochCtx, posFrom)
 			if err != nil {
 				return 0, fmt.Errorf("schedule: from AltAz: %w", err)
 			}
 
-			altAzTo, err = epochCtx.ICRSToAltAz(posTo)
+			altAzTo, err = observedAltAz(ctx.ToBlock.Target, ctx.ToTime, epochCtx, posTo)
 			if err != nil {
 				return 0, fmt.Errorf("schedule: to AltAz: %w", err)
 			}
 		} else {
-			altAzFrom, err = coord.NewContext(ctx.FromTime, ctx.Site.Location(), ctx.Site.Refraction()).ICRSToAltAz(posFrom)
+			altAzFrom, err = observedAltAz(ctx.FromBlock.Target, ctx.FromTime,
+				coord.NewContext(ctx.FromTime, ctx.Site.Location(), ctx.Site.Refraction()), posFrom)
 			if err != nil {
 				return 0, fmt.Errorf("schedule: from AltAz: %w", err)
 			}
 
-			altAzTo, err = coord.NewContext(ctx.ToTime, ctx.Site.Location(), ctx.Site.Refraction()).ICRSToAltAz(posTo)
+			altAzTo, err = observedAltAz(ctx.ToBlock.Target, ctx.ToTime,
+				coord.NewContext(ctx.ToTime, ctx.Site.Location(), ctx.Site.Refraction()), posTo)
 			if err != nil {
 				return 0, fmt.Errorf("schedule: to AltAz: %w", err)
 			}

--- a/plan/skybrightness.go
+++ b/plan/skybrightness.go
@@ -181,7 +181,7 @@ func (c LimitingMagnitudeConstraint) evaluate(
 		return 0, 0, fmt.Errorf("constraint: limiting magnitude position: %w", err)
 	}
 
-	altaz, err := ctx.ICRSToAltAz(pos)
+	altaz, err := observedAltAz(obj, ctx.Time(), ctx, pos)
 	if err != nil {
 		return 0, 0, fmt.Errorf("constraint: limiting magnitude pointing: %w", err)
 	}

--- a/plan/visibility.go
+++ b/plan/visibility.go
@@ -25,7 +25,7 @@ func IsVisible(obj coord.Object, t time.Time, site *Site, minAlt angle.Angle) (b
 
 	ctx := coord.NewContext(t, site.Location(), site.Refraction())
 
-	aa, err := ctx.ICRSToAltAz(pos)
+	aa, err := observedAltAz(obj, t, ctx, pos)
 	if err != nil {
 		return false, fmt.Errorf("visibility: AltAz: %w", err)
 	}
@@ -54,7 +54,7 @@ func refineVisibility(
 
 		ctx := coord.NewContext(t, site.Location(), site.Refraction())
 
-		aa, err := ctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(obj, t, ctx, pos)
 		if err != nil {
 			return 0, fmt.Errorf("visibility: AltAz: %w", err)
 		}
@@ -138,7 +138,7 @@ func VisibleIntervals(
 
 		ctx := coord.NewContext(t, site.Location(), site.Refraction())
 
-		aa, err := ctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(obj, t, ctx, pos)
 		if err != nil {
 			return nil, fmt.Errorf("visibility: AltAz: %w", err)
 		}
@@ -204,7 +204,7 @@ func TransitEstimate(obj coord.Object, site *Site, start, end time.Time) (time.T
 
 		ctx := coord.NewContext(t, site.Location(), site.Refraction())
 
-		aa, err := ctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(obj, t, ctx, pos)
 		if err != nil {
 			return time.Time{}, angle.Deg(0), err
 		}
@@ -236,7 +236,7 @@ func TransitEstimate(obj coord.Object, site *Site, start, end time.Time) (time.T
 
 		ctx := coord.NewContext(t, site.Location(), site.Refraction())
 
-		aa, err := ctx.ICRSToAltAz(pos)
+		aa, err := observedAltAz(obj, t, ctx, pos)
 		if err != nil {
 			return 0, fmt.Errorf("visibility: transit AltAz: %w", err)
 		}
@@ -258,7 +258,7 @@ func TransitEstimate(obj coord.Object, site *Site, start, end time.Time) (time.T
 
 	resCtx := coord.NewContext(resTime, site.Location(), site.Refraction())
 
-	aa, err := resCtx.ICRSToAltAz(pos)
+	aa, err := observedAltAz(obj, resTime, resCtx, pos)
 	if err != nil {
 		return time.Time{}, angle.Deg(0), err
 	}

--- a/plan/visible_tonight.go
+++ b/plan/visible_tonight.go
@@ -642,7 +642,7 @@ func evaluateCandidate(c visibleCandidate, start, end time.Time, site *Site, pla
 
 	astroCtx := coord.NewContext(peakTime, site.Location(), site.Refraction())
 
-	aa, err := astroCtx.ICRSToAltAz(pos)
+	aa, err := observedAltAz(obj, peakTime, astroCtx, pos)
 	if err != nil {
 		return VisibleObject{}, false
 	}


### PR DESCRIPTION
`ICRSToAltAz` takes a **direction**. A catalog star is infinitely far away, so where the observer stands on the Earth cannot change it. The Moon is about 60 Earth radii away, and it can.

Every constraint, score and visibility check in `plan` called `ICRSToAltAz` on a *geocentric* position, so the scheduler reasoned about the Moon as though it were a star. Only the events solver and the details builder subtracted the observer vector.

```
Moon 00h  IsObservable=-31.3985  GetDetails=-32.3458  delta=+0.9474
Moon 12h  IsObservable= 18.2958  GetDetails= 17.3482  delta=+0.9476
Moon 21h  IsObservable= 16.2017  GetDetails= 15.2514  delta=+0.9503
```

That is the Moon's horizontal parallax. An `Altitude{Threshold: 0}` constraint therefore called the Moon up about **four minutes before** `MoonEvents` said it rose — two public APIs, one library, a degree apart. All four hours now read **0.00000° apart**.

## The fix

`observedAltAz` dispatches on `MovingBody`, and that is the whole of it. **19 call sites** moved, across `constraint`, `plan`, `visibility`, `events`, `schedule`, `skybrightness`, `visible_tonight` and `day_episode`.

Three deliberately did not, and it is worth saying which so a future reader does not "finish the job":

- `details.go` — already the `else` branch of an explicit `MovingBody` check.
- `meteor.go` — a shower radiant, which genuinely *is* a direction at infinity.
- `constraint.go` — `observedAltAz`'s own fallback.

The position is passed in rather than fetched, because every call site already holds it: that keeps this a one-line change at each and avoids a second ephemeris lookup. It costs nothing measurable — `GeocentricToObserved` reuses the cached rotation matrix and observer vector the Context already holds, so it is the ~325 ns transform either way and the 91 µs `Apco13` computation is untouched.

## Crescent visibility was the worst case, and was not in the issue

Its comment said *"Topocentric AltAz for both bodies"* and the code was not — in a calculation whose entire question is the Moon's altitude a few degrees above the horizon shortly after sunset. An error the size of the quantity being measured. Its vectors were already geocentric, so it now calls `GeocentricToObserved` directly with no ICRS round trip.

## The suite had nothing to say about any of this

Changing every scheduler decision involving the Moon by 0.95° produced **no test failures at all**, and the `integration` and `validation` tiers passed unchanged. That is the clearest possible statement of what was missing, so two guards land with the fix:

- **`TestConstraintAndDetailsAgreeOnAltitude`** — the two public paths, four bodies, a full day, 1″ tolerance.
- **`TestMoonParallaxIsActuallyApplied`** — the physics independently. Agreement alone is necessary and not sufficient: it would pass if both paths reverted to the geocentric answer together.

**The Moon is the test.** Parallax scales as 1/distance, so Mars shows about 0.0006° and a star none — a test written against a planet would have passed on the broken code.

Reverting the dispatch fails the first guard at **3410″**.

## Two notes on how this was measured

**My first fix was incomplete and the probe caught it.** After patching `skyAltAzCtx` the delta was still 0.947°: `IsObservable` computes `Evaluation.AltAz` on its own path, not through the constraint helper. Trusting the edit would have shipped a fix for the constraints while leaving the headline number in #101 unchanged.

**A stale figure was corrected rather than left.** The independent guard uses a refraction-free Context so parallax is isolated exactly. Before #153 that mattered a lot — with refraction enabled the peak measured 1.1486°, parallax plus a refraction disagreement. Since #153 the paths share SOFA's model and it reads 0.9872° against 0.9918°, so the comment carrying the old number was re-measured and rewritten.

## Verification

Full §5 gate on the merge of `main` (so with #153 in): `gofmt` · `go build` · `go vet` untagged **and** tagged · `go mod tidy` unchanged · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues**, tagged **0 issues**. `integration` and `validation` tiers run clean.

Closes #101.
