### PR TITLE
Compare the third altitude pipeline against the other two

### DIFF
--- a/docs/changelog.d/157-pipeline-equivalence.md
+++ b/docs/changelog.d/157-pipeline-equivalence.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 157
+---
+**The third altitude pipeline is now compared against the other two.** A
+satellite joins the constraint-versus-details guard — the body class with the
+most parallax of all — and the events pipeline is pinned against its own
+convention, which turned out to differ by event kind: `Event.Altitude` is
+geometric at rise and set and refracted at transit (#156).

--- a/plan/pipelines_test.go
+++ b/plan/pipelines_test.go
@@ -1,0 +1,187 @@
+package plan_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The ISS, so a satellite's altitude is exercised offline. Its own package's
+// test elements, reused rather than fetched.
+const (
+	issLine1 = "1 25544U 98067A   26109.48995873  .00010082  00000-0  19194-3 0  9999"
+	issLine2 = "2 25544  51.6329 230.6068 0006631 325.6576  34.3983 15.48833250562656"
+)
+
+// TestSatelliteAltitudePipelinesAgree extends the constraint-versus-details
+// comparison to the body class with the most parallax of all.
+//
+// [TestConstraintAndDetailsAgreeOnAltitude] covers the Sun, Moon and two
+// planets. A satellite is the extreme case and the one a star-shaped test is
+// least like: the ISS orbits at about 400 km, so an observer's offset from the
+// geocentre is a large fraction of its whole distance, where for the Moon it is
+// 1/60th and for Mars nothing. If the topocentric dispatch were ever removed
+// again, this is the case that would show it most violently.
+func TestSatelliteAltitudePipelinesAgree(t *testing.T) {
+	t.Parallel()
+
+	site, err := plan.NewSiteEarthLocation("pipelines", -23.5, -46.6, 800)
+	if err != nil {
+		t.Fatalf("NewSiteEarthLocation: %v", err)
+	}
+
+	prov, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	iss := plan.NewSatellite("ISS", eph.ID(0), prov)
+
+	const toleranceArcsec = 1.0
+
+	// Two orbits at ten-minute steps, so the comparison spans a full sweep of
+	// geometry rather than one point on one pass.
+	for minute := 0; minute < 180; minute += 10 {
+		when := time.Date(2026, time.April, 19, 12, minute, 0, 0, time.LocationUTC)
+		ctx := coord.NewContext(when, site.Location(), site.Refraction())
+
+		eval, err := plan.IsObservable(iss, when, site, plan.Altitude{Threshold: angle.Deg(0)})
+		if err != nil {
+			t.Fatalf("+%dmin IsObservable: %v", minute, err)
+		}
+
+		details, err := iss.GetDetails(ctx)
+		if err != nil {
+			t.Fatalf("+%dmin GetDetails: %v", minute, err)
+		}
+
+		if d := math.Abs(eval.AltAz.Alt().Degrees()-details.Altitude.Degrees()) * 3600; d > toleranceArcsec {
+			t.Errorf("+%dmin: IsObservable reports %.4f° and GetDetails %.4f°, a difference "+
+				"of %.1f arcsec.\n  A satellite is where a geocentric shortcut shows up "+
+				"worst — see observedAltAz.",
+				minute, eval.AltAz.Alt().Degrees(), details.Altitude.Degrees(), d)
+		}
+	}
+}
+
+// TestEventAltitudeConventionIsWhatItClaims pins the third pipeline against the
+// other two, and the answer is more interesting than "they agree".
+//
+// # What comparing them found
+//
+// At transit, Event.Altitude matches IsObservable and GetDetails exactly. At
+// rise and set it differs by 0.1668°, at both ends, for the Moon:
+//
+//	Rise       Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
+//	Transit    Event= 54.2489  IsObservable= 54.2489  GetDetails= 54.2489
+//	Set        Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
+//
+// That 0.1668° is refraction — the same value coord's own refraction tests
+// measure at these altitudes. A constant offset at both ends, and none at
+// transit, rules out a timing difference and identifies the cause exactly.
+//
+// It is deliberate. The solver builds the rise/set context with a
+// no-refraction atmosphere (events.go, "using the same no-refraction
+// atmosphere as the solver") because rise and set are solved against a
+// geometric threshold plus a constant horizon allowance, the USNO convention.
+// Transit is built with the site's real refraction.
+//
+// So Event.Altitude means different things for different event kinds, and
+// nothing said so. Asserting a three-way equality would have been asserting
+// something false; this asserts the convention instead, which is the useful
+// thing to hold still.
+//
+// # Why this belongs with the others
+//
+// #100 and #101 were both two public APIs computing one quantity by different
+// routes and disagreeing, with no test looking. This is the third route. It
+// does not disagree — it answers a different question — but until something
+// compared them, nobody could tell those apart, which is the same gap.
+func TestEventAltitudeConventionIsWhatItClaims(t *testing.T) {
+	t.Parallel()
+
+	site, err := plan.NewSiteEarthLocation("pipelines", -23.5, -46.6, 800)
+	if err != nil {
+		t.Fatalf("NewSiteEarthLocation: %v", err)
+	}
+
+	prov := eph.Default()
+	moon := plan.NewMoon(prov)
+
+	start := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+	end := time.Date(2026, time.March, 21, 0, 0, 0, 0, time.LocationUTC)
+
+	events, err := plan.MoonEvents(start, end, site, prov)
+	if err != nil {
+		t.Fatalf("MoonEvents: %v", err)
+	}
+
+	if len(events) < 3 {
+		t.Fatalf("got %d events over a day, expected rise, transit and set", len(events))
+	}
+
+	const toleranceArcsec = 1.0
+
+	var checked int
+
+	for _, e := range events {
+		// The same instant through both conventions, so the comparison does
+		// not depend on which one the event happens to use.
+		refracted := coord.NewContext(e.Time, site.Location(), site.Refraction())
+		geometric := coord.NewContext(e.Time, site.Location(), atmosphere.Refraction{})
+
+		vec, err := moon.GeocentricVec(e.Time)
+		if err != nil {
+			t.Fatalf("%s GeocentricVec: %v", e.Kind, err)
+		}
+
+		withRefraction := refracted.GeocentricToObserved(vec).Alt().Degrees()
+		withoutRefraction := geometric.GeocentricToObserved(vec).Alt().Degrees()
+
+		var (
+			want float64
+			why  string
+		)
+
+		if e.Kind == plan.EventTransit {
+			want, why = withRefraction, "transit is solved with the site's own refraction"
+		} else {
+			want, why = withoutRefraction, "rise and set are solved against a geometric "+
+				"threshold with a constant horizon allowance, so the reported altitude "+
+				"carries no refraction"
+		}
+
+		checked++
+
+		if d := math.Abs(e.Altitude.Degrees()-want) * 3600; d > toleranceArcsec {
+			t.Errorf("%s: Event.Altitude is %.4f°, expected %.4f° (%.1f arcsec out).\n"+
+				"  %s.\n  Refracted here is %.4f° and geometric %.4f°; if the event now "+
+				"matches the other one, the convention changed and this test is the "+
+				"record of what it used to be.",
+				e.Kind, e.Altitude.Degrees(), want, d, why, withRefraction, withoutRefraction)
+		}
+
+		// Altitude and GeometricAltitude are assigned the same value at both
+		// construction sites, so they carry one quantity under two names. That
+		// is worth knowing about rather than relying on.
+		if e.Altitude != e.GeometricAltitude {
+			t.Errorf("%s: Altitude %v and GeometricAltitude %v differ; they have always "+
+				"been assigned the same value, so something now distinguishes them and "+
+				"the convention above needs revisiting",
+				e.Kind, e.Altitude, e.GeometricAltitude)
+		}
+	}
+
+	if checked < 3 {
+		t.Fatalf("only %d events checked", checked)
+	}
+
+	t.Logf("%d events checked against their own altitude convention", checked)
+}


### PR DESCRIPTION
#100 and #101 were the same shape: one physical quantity, two public routes, disagreeing, and no test looking. #104 asked for the guard covering all three routes at once. Two of its three legs shipped with the fixes (#153, #154); this is the third, and it found something.

## A satellite joins the comparison

The existing guard covers the Sun, Moon and two planets. A satellite is the extreme case and the one a star-shaped test is least like: the ISS orbits at about **400 km**, so an observer's offset from the geocentre is a large fraction of its whole distance — where for the Moon it is a sixtieth, and for Mars nothing.

Two orbits at ten-minute steps. The two paths agree exactly.

## The events pipeline was the interesting one

At transit it matches the other two exactly. At rise and set it differs by **0.1668°, at both ends**:

```
Rise       Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
Transit    Event= 54.2489  IsObservable= 54.2489  GetDetails= 54.2489
Set        Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
```

That 0.1668° is **refraction** — the same value `coord`'s own refraction tests measure at those altitudes. A constant offset at both ends and none at transit rules out a timing difference and names the cause.

**It is deliberate.** The solver builds the rise/set context with a no-refraction atmosphere, because rise and set are solved against a geometric threshold plus a constant horizon allowance — the USNO convention, which this package follows correctly. Transit uses the site's real refraction.

## So the assertion #104 asked for would have been false

`Event.Altitude` means one thing at rise and set and another at transit, and nothing in the type says so. Asserting a three-way equality would have asserted something untrue.

The test pins **the convention per event kind** instead, which is the thing actually worth holding still. It also asserts `Altitude` and `GeometricAltitude` stay equal — they are assigned the same value at both construction sites, so the second name currently carries no information.

Filed as #156 rather than changed here: making those fields mean what they are called is a behaviour change for anyone reading `Altitude` at rise or set today, and belongs in a release that carries them.

## Verification

Non-vacuous by construction check: swapping which convention each kind expects fails at **600″** for rise and set and **38″** for transit.

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `go test -race -short` · `golangci-lint run` **0 issues**, tagged **0 issues**.

## What this did not find, which is worth saying

The satellite path already agreed, and so did every body in the existing guard. The sweep's value here was not another defect but **a convention nobody had written down** — the quieter half of the same problem, because until something compared the routes, a disagreement and a different question looked identical.

Closes #104.