### PR TITLE
Make Sub measure elapsed time, not the difference of two labels

### DIFF
--- a/docs/changelog.d/160-sub-elapsed-seconds.md
+++ b/docs/changelog.d/160-sub-elapsed-seconds.md
@@ -1,0 +1,12 @@
+---
+type: Fixed
+pr: 160
+---
+**`Time.Sub` between two UTC epochs was short by every leap second between
+them** — 27 s across 1972-2026, or 207 km of ISS track. It unified scales only
+when they *differed*, so mixing scales gave the right answer and being
+consistent gave the wrong one. Both operands now go through TT unless they
+share a uniform scale (TAI/TT/TDB), where label arithmetic already is elapsed
+time. `Sub` also saturates instead of wrapping past ±292 years — year 1 to 2026
+used to return a negative duration — and rounds to the nearest nanosecond
+rather than truncating (#149).

--- a/plan/strategy_test.go
+++ b/plan/strategy_test.go
@@ -130,7 +130,7 @@ func TestSwapOptimizedGapInsertion(t *testing.T) {
 
 // TestScheduleGaps verifies gap computation between scheduled blocks.
 func TestScheduleGaps(t *testing.T) {
-	start := time.ZeroTime()
+	start := scheduleBase()
 	window := Window{Start: start, End: start.Add(1 * time.Hour)}
 
 	blocks := []ScheduledBlock{
@@ -174,7 +174,7 @@ func TestScheduleGaps(t *testing.T) {
 
 // TestEmptyScheduleGaps verifies gap computation on an empty schedule.
 func TestEmptyScheduleGaps(t *testing.T) {
-	start := time.ZeroTime()
+	start := scheduleBase()
 	window := Window{Start: start, End: start.Add(1 * time.Hour)}
 
 	gaps := scheduleGaps(nil, window)
@@ -233,4 +233,21 @@ func TestScoreBlockPlacement(t *testing.T) {
 	if score < 0 {
 		t.Errorf("score should be non-negative, got %.2f", score)
 	}
+}
+
+// scheduleBase is an arbitrary but *real* epoch for schedule arithmetic tests.
+//
+// These used to start from time.ZeroTime(), which is FromJD(0, UTC) — a
+// zero-value sentinel, not a valid UTC epoch. It is Julian Date 0, in the year
+// −4712, where the Espenak & Meeus ΔT polynomial reads 135,943 s and drifts
+// 0.144 s per hour. Since Time.Sub measures physical elapsed time rather than
+// the difference of two calendar labels, an hour-long window based there
+// really does span 59m59.855s, and the assertions below were reading that
+// drift rather than the scheduler.
+//
+// Any ordinary epoch avoids it: ΔAT is piecewise constant, so within a window
+// that crosses no leap second, label arithmetic and physical arithmetic agree
+// exactly.
+func scheduleBase() time.Time {
+	return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
 }

--- a/time/bench_test.go
+++ b/time/bench_test.go
@@ -104,3 +104,19 @@ func BenchmarkSub_CrossScale(b *testing.B) {
 		_ = t1.Sub(t2)
 	}
 }
+
+// BenchmarkSub_SameScale_Uniform is the counterpart to BenchmarkSub_SameScale,
+// which uses UTC.
+//
+// Sub converts to TT whenever it is handed a non-uniform scale, so two UTC
+// epochs now cost two conversions (measured: 2.0 -> 91.5 ns/op) in exchange for
+// an answer that counts the leap seconds between them. A uniform scale needs no
+// conversion and must stay on the cheap path — this is what pins that.
+func BenchmarkSub_SameScale_Uniform(b *testing.B) {
+	t1 := FromJD(2460001.0, TT)
+	t2 := FromJD(2460000.5, TT)
+
+	for b.Loop() {
+		_ = t1.Sub(t2)
+	}
+}

--- a/time/sub_elapsed_test.go
+++ b/time/sub_elapsed_test.go
@@ -1,0 +1,219 @@
+package time_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestSubBetweenTwoUTCEpochsIsElapsedSITime is the headline defect.
+//
+// UTC is not a uniform scale: it absorbs a leap second twice a decade, so the
+// difference of two UTC *labels* is short by every step between them. Across
+// 1972-2026 that is 27 s — 207 km of ISS track at 7.66 km/s, and about 16
+// arcsec of lunar motion.
+//
+// Sub used to unify scales only when they *differed*, so being careless gave
+// the right answer and being consistent gave the wrong one:
+//
+//	b.Sub(a)        // 1704153600 s — two UTC labels, 27 s short
+//	b.Sub(a.TAI())  // 1704153627 s — mixed, so unified via TT
+//
+// That is the opposite of the incentive the type system should create, and it
+// is invisible: both are plausible and neither errors.
+func TestSubBetweenTwoUTCEpochsIsElapsedSITime(t *testing.T) {
+	a := time.Date(1972, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+	b := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	// 27 leap seconds were inserted between these two dates: ΔAT went from 10
+	// to 37. The label difference is a whole number of 86400-second days.
+	const (
+		labelSeconds   = 1704153600.0
+		elapsedSeconds = labelSeconds + 27
+	)
+
+	if got := b.Sub(a).Seconds(); got != elapsedSeconds {
+		t.Errorf("UTC−UTC Sub = %.3f s, want %.3f s (a difference of %.0f s).\n"+
+			"  Two UTC labels differ by less than the time between them, by every "+
+			"leap second in the interval.", got, elapsedSeconds, elapsedSeconds-got)
+	}
+
+	// The three ways of asking must now agree. Before the fix the first
+	// disagreed with the other two.
+	for _, tc := range []struct {
+		name string
+		got  float64
+	}{
+		{"both UTC", b.Sub(a).Seconds()},
+		{"both TAI", b.TAI().Sub(a.TAI()).Seconds()},
+		{"both TT", b.TT().Sub(a.TT()).Seconds()},
+		{"mixed UTC and TAI", b.Sub(a.TAI()).Seconds()},
+		{"mixed TT and UTC", b.TT().Sub(a).Seconds()},
+	} {
+		if tc.got != elapsedSeconds {
+			t.Errorf("%s: %.3f s, want %.3f s", tc.name, tc.got, elapsedSeconds)
+		}
+	}
+}
+
+// TestSubAcrossASingleLeapSecondIs86401 pins the smallest visible case.
+//
+// One leap second was inserted at the end of 2016. A day spanning it contains
+// 86401 SI seconds, however the calendar labels its ends. One second is 7.66 km
+// of ISS track, so this is not a rounding concern.
+func TestSubAcrossASingleLeapSecondIs86401(t *testing.T) {
+	before := time.Date(2016, time.December, 31, 12, 0, 0, 0, time.LocationUTC)
+	after := time.Date(2017, time.January, 1, 12, 0, 0, 0, time.LocationUTC)
+
+	if got := after.Sub(before).Seconds(); got != 86401 {
+		t.Errorf("a UTC day spanning the 2016 leap second measured %.6f s, want 86401 s", got)
+	}
+
+	// And a day that spans no leap second is exactly 86400, so the test above
+	// is detecting the step rather than a constant offset.
+	q1 := time.Date(2020, time.June, 1, 12, 0, 0, 0, time.LocationUTC)
+	q2 := time.Date(2020, time.June, 2, 12, 0, 0, 0, time.LocationUTC)
+
+	if got := q2.Sub(q1).Seconds(); got != 86400 {
+		t.Errorf("an ordinary UTC day measured %.6f s, want 86400 s", got)
+	}
+}
+
+// TestSubInAUniformScaleIsUnchanged pins what this fix must *not* touch.
+//
+// TAI, TT and TDB run at a constant rate, so the difference of two labels is
+// already elapsed time and no conversion is needed. Routing them through TT
+// anyway would be wasted work for TAI and TT, and wrong for TDB: TDB and TT
+// differ by a periodic term of ±1.7 ms, so a TDB interval converted to TT and
+// back would move by up to a microsecond per hour — and an ephemeris
+// interpolating in TDB days wants the TDB interval it asked for.
+func TestSubInAUniformScaleIsUnchanged(t *testing.T) {
+	base := time.Date(2026, time.March, 15, 6, 0, 0, 0, time.LocationUTC)
+
+	for _, tc := range []struct {
+		name  string
+		start time.Time
+	}{
+		{"TAI", base.TAI()},
+		{"TT", base.TT()},
+		{"TDB", base.TDB()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Half a year, so a TDB round-trip through TT would show up: the
+			// periodic term is near its extremes at this separation.
+			const days = 182.5
+
+			end := tc.start.AddDays(days)
+
+			j1, j2 := tc.start.JDParts()
+			k1, k2 := end.JDParts()
+			label := ((k1 - j1) + (k2 - j2)) * 86400.0
+
+			if got := end.Sub(tc.start).Seconds(); math.Abs(got-label) > 1e-9 {
+				t.Errorf("Sub = %.9f s but the label difference is %.9f s.\n"+
+					"  %s is a uniform scale: the two must be identical, and no "+
+					"conversion should happen at all.", got, label, tc.name)
+			}
+		})
+	}
+}
+
+// TestSubSaturatesRatherThanWrapping covers a defect found while fixing the
+// one above, and arguably the worse of the two because it flips the sign.
+//
+// time.Duration is an int64 nanosecond count, so it runs out just past ±292
+// years — well inside the range this library supports, which reaches year 1.
+// The old conversion wrapped silently: year 1 to 2026 returned −9223372037 s,
+// a negative span for an interval that plainly runs forwards.
+//
+// Saturating is what time.Time.Sub does, and a pinned maximum is at least
+// recognisable as one.
+func TestSubSaturatesRatherThanWrapping(t *testing.T) {
+	year1 := time.Date(1, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+	modern := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	forward := modern.Sub(year1)
+	if forward != math.MaxInt64 {
+		t.Errorf("a 2025-year span returned %v, want the saturated maximum", forward)
+	}
+
+	if forward < 0 {
+		t.Errorf("a forward interval produced a negative duration (%v) — the int64 "+
+			"nanosecond count wrapped", forward)
+	}
+
+	if backward := year1.Sub(modern); backward != math.MinInt64 {
+		t.Errorf("the reversed span returned %v, want the saturated minimum", backward)
+	}
+
+	// SubDays is the API that survives the range, and must not saturate.
+	// 2025 years is a little over 739,000 days.
+	if got := modern.SubDays(year1); got < 739_000 || got > 740_000 {
+		t.Errorf("SubDays over the same span = %.1f days, want about 739,616 — "+
+			"it must not saturate", got)
+	}
+}
+
+// TestSubRoundsToTheNearestNanosecond pins the conversion from a float day
+// count to an integer nanosecond count.
+//
+// A scale round-trip adds and removes an offset of about 69 s, which lands the
+// result a part in 1e13 below a whole second. Truncating toward zero then
+// reports a ten-minute interval as 9m59.999999999s — and biases every duration
+// downward, never up.
+func TestSubRoundsToTheNearestNanosecond(t *testing.T) {
+	start := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	for _, want := range []time.Duration{
+		time.Duration(10) * time.Minute,
+		time.Duration(1) * time.Hour,
+		time.Duration(1) * time.Second,
+		time.Duration(24) * time.Hour,
+	} {
+		if got := start.Add(want).Sub(start); got != want {
+			t.Errorf("Add(%v) then Sub = %v, want exactly %v (off by %v)",
+				want, got, want, got-want)
+		}
+	}
+}
+
+// TestAddAdvancesTheLabelAndSubMeasuresTheClock pins the one asymmetry this
+// change deliberately leaves in place, so that it is a decision on the record
+// rather than something a later reader has to rediscover.
+//
+// Add is label arithmetic and Sub is physical, so across a leap second
+// t.Add(24h).Sub(t) is 86401 s rather than 86400 s. Both cannot be true at
+// once while UTC has no label for 23:59:60: physical addition into a leap
+// second has nowhere to land, aliases to its neighbour, and the trip back
+// arrives a second away — which is why Add stays reversible instead.
+//
+// Doing the arithmetic in a uniform scale gives the physical answer.
+func TestAddAdvancesTheLabelAndSubMeasuresTheClock(t *testing.T) {
+	start := time.Date(2016, time.December, 31, 12, 0, 0, 0, time.LocationUTC)
+
+	const day = time.Duration(24) * time.Hour
+
+	// The label lands on the same clock time the next day.
+	if got := start.Add(day).Format(time.RFC3339); got != "2017-01-01T12:00:00Z" {
+		t.Errorf("Add(24h) gave the label %s, want 2017-01-01T12:00:00Z", got)
+	}
+
+	// And 86401 SI seconds really did pass, which is what Sub reports.
+	if got := start.Add(day).Sub(start).Seconds(); got != 86401 {
+		t.Errorf("Add(24h) then Sub = %.6f s, want 86401 s across the leap second", got)
+	}
+
+	// Add remains exactly reversible, which physical addition could not be.
+	if back := start.Add(day).Add(-day); !back.Equal(start) {
+		t.Errorf("Add(24h) then Add(-24h) did not return to the start: %v vs %v",
+			back.Format(time.RFC3339), start.Format(time.RFC3339))
+	}
+
+	// Advancing by physical time is available by going through a uniform scale.
+	if got := start.TAI().Add(day).UTC().Format(time.RFC3339); got != "2017-01-01T11:59:59Z" {
+		t.Errorf("TAI().Add(24h).UTC() gave %s, want 2017-01-01T11:59:59Z — "+
+			"86400 SI seconds after the start lands one second short of the "+
+			"same clock time, because a leap second intervened", got)
+	}
+}

--- a/time/time.go
+++ b/time/time.go
@@ -228,6 +228,25 @@ func (s Scale) String() string {
 	}
 }
 
+// uniform reports whether one unit of s is one SI second, everywhere.
+//
+// TAI, TT and TDB are uniform: they run at a constant rate by construction, so
+// advancing a label by d and advancing the physical instant by d are the same
+// operation, and the difference of two labels is elapsed time. Duration
+// arithmetic in these scales needs no conversion at all — which is why the
+// hot paths that use them pay nothing for [Time.Sub] and [Time.AddDays].
+//
+// UTC and UT1 are not. UTC is a step function of TAI: it absorbs a leap second
+// twice a decade, so the difference of two UTC labels is short by every step
+// between them. UT1 tracks Earth's rotation, which is neither constant nor
+// predictable. For these two, duration arithmetic goes through TT.
+//
+// TDB is uniform in its own frame but not synchronous with TT — the periodic
+// term between them varies by ±1.7 ms, so a TDB interval and the TT interval
+// it spans differ by up to a microsecond per hour. Arithmetic in TDB stays in
+// TDB, which is what an ephemeris interpolating in TDB days wants.
+func (s Scale) uniform() bool { return s == TAI || s == TT || s == TDB }
+
 // Time represents a high-precision astronomical timestamp.
 //
 // Internal representation uses a two-part Julian Date (jd1 + jd2) to maintain
@@ -543,15 +562,39 @@ func (t Time) AddDate(years, months, days int) Time {
 	return result
 }
 
-// Add returns a new Time with the duration added.
-// It uses a simple conversion: 1 day = 86400.0 seconds.
+// Add returns a new Time with the duration added to its label.
 // The display location is preserved.
+//
+// See [Time.AddDays] for the one case where this is not the same as advancing
+// by d of physical time.
 func (t Time) Add(d time.Duration) Time {
 	return t.AddDays(d.Seconds() / 86400.0)
 }
 
-// AddDays returns a new Time with d days added.
+// AddDays returns a new Time with d days added to its label.
 // The display location is preserved.
+//
+// # This advances the label, and [Time.Sub] measures physical time
+//
+// In a uniform scale (TAI, TT, TDB) those are the same thing and the two are
+// exact inverses. In UTC they are not: adding 86400 s to a label that spans a
+// leap second advances the clock by 86401 SI seconds, so t.AddDays(1).Sub(t)
+// reports 86401 s — correctly, because that is how much time passed.
+//
+// The asymmetry is deliberate rather than an oversight, and it is bounded:
+//
+//   - Add stays label arithmetic because [Time.Add] must be reversible.
+//     t.Add(d).Add(-d) returns exactly t, which TestAddIsReversible pins.
+//     Physical addition cannot be, because UTC has no label for the leap
+//     second itself (see the 23:59:60 issue) — an instant added *into* a leap
+//     second has nowhere to land and aliases to its neighbour, so the trip
+//     back arrives one second away.
+//   - Sub is physical because it returns a [time.Duration], which is a count
+//     of SI seconds by type.
+//
+// Both cannot hold at once while UTC is not a total representation of the
+// instants it labels. To advance a UTC epoch by physical time, do the
+// arithmetic in a uniform scale: t.TAI().Add(d).UTC().
 func (t Time) AddDays(d float64) Time {
 	result := FromJDParts(t.jd1, t.jd2+d, t.scale)
 	result.loc = t.loc
@@ -751,17 +794,70 @@ func (t Time) IsZero() bool {
 	return t.jd1 == 0 && t.jd2 == 0
 }
 
-// Sub returns the duration t - other.
-// Cross-scale times are automatically unified via TT.
+// Sub returns the physical time elapsed from other to t, in SI seconds.
+//
+// # Not the difference of the calendar labels
+//
+// Both operands are converted to TT first, whatever scale they are in. For two
+// UTC epochs that is the whole point: UTC is not a uniform scale, so the
+// difference of two UTC labels is short by every leap second between them —
+// 27 s across 1972-2026, which is 207 km of ISS track and about 16 arcsec of
+// lunar motion.
+//
+// This used to unify only when the two scales *differed*, which meant mixing
+// scales gave the right answer and being consistent gave the wrong one:
+//
+//	b.Sub(a)             // 1704153600 s — two UTC labels
+//	b.Sub(a.TAI())       // 1704153627 s — mixed, so unified via TT
+//
+// A duration is a count of SI seconds by type, so the second reading was
+// always the one Sub promised.
+//
+// # Range
+//
+// [time.Duration] is an int64 nanosecond count, so it saturates just past ±292
+// years. Beyond that the maximum or minimum Duration is returned rather than a
+// silently wrapped value — the same choice [time.Time.Sub] makes, and it used
+// to wrap here: year 1 to 2026 returned −9223372037 s, a negative span for a
+// positive interval. Use [Time.SubDays] for intervals of astronomical length;
+// it is a float64 day count and does not saturate.
 func (t Time) Sub(other Time) time.Duration {
-	days := t.SubDays(other)
-	return time.Duration(days * 86400.0 * float64(time.Second))
+	const secondsPerDay = 86400.0
+
+	seconds := t.SubDays(other) * secondsPerDay
+
+	// Compare in seconds rather than nanoseconds: the nanosecond product
+	// overflows float64's exact-integer range long before it overflows int64,
+	// so the check has to happen before the multiplication.
+	const maxSeconds = float64(math.MaxInt64) / float64(time.Second)
+
+	switch {
+	case seconds >= maxSeconds:
+		return time.Duration(math.MaxInt64)
+	case seconds <= -maxSeconds:
+		return time.Duration(math.MinInt64)
+	default:
+		// Round rather than truncate. A conversion that lands a part in 1e13
+		// below a whole second — which a scale round-trip routinely does,
+		// since it adds and removes an offset of ~69 s — truncates to one
+		// nanosecond short, so an exactly-ten-minute interval reports
+		// 9m59.999999999s. Truncation also biases every result downward.
+		return time.Duration(math.Round(seconds * float64(time.Second)))
+	}
 }
 
-// SubDays returns the difference t - other in days.
-// Cross-scale times are automatically unified via TT.
+// SubDays returns the physical time elapsed from other to t, in days of 86400
+// SI seconds.
+//
+// See [Time.Sub], which is this in nanoseconds and carries the reasoning.
+// Unlike Sub this does not saturate, so it is the right call for intervals of
+// astronomical length.
 func (t Time) SubDays(other Time) float64 {
-	if t.scale != other.scale {
+	// Two epochs in one uniform scale need no conversion: their labels already
+	// differ by elapsed SI time. Anything else goes through TT — a mismatched
+	// pair because they must be made comparable, and a matched non-uniform
+	// pair (two UTC epochs, two UT1 epochs) because that is the whole bug.
+	if t.scale != other.scale || !t.scale.uniform() {
 		t, other = t.TT(), other.TT()
 	}
 


### PR DESCRIPTION
`Time.Sub` between two **UTC** epochs returned the difference of the calendar labels, not the physical time that elapsed — short by every leap second in the interval. Across 1972-2026 that is **27 s**: 207 km of ISS track at 7.66 km/s, and about 16 arcsec of lunar motion.

## The trap was the shape of the guard

`SubDays` unified via TT only when the two scales *differed*. So a caller careless about scales stumbled into correct physics, and a caller careful about them got a duration 27 s short:

```
b.Sub(a)             1704153600 s    two UTC labels
b.Sub(a.TAI())       1704153627 s    mixed, so unified via TT
b.TAI().Sub(a.TAI()) 1704153627 s
```

That is the opposite of the incentive the type system should create, and it is invisible: both readings are plausible and neither errors. `Sub` returns a `time.Duration` — a count of SI seconds by type — so the second was always the one it promised.

## The rule, and why it is not "always via TT"

Both operands go through TT **unless they already share a uniform scale**.

TAI, TT and TDB run at a constant rate, so their label difference already *is* elapsed time. That matters beyond saving work: routing TDB through TT would move a TDB interval by the ±1.7 ms periodic term between them — up to a microsecond per hour — and an ephemeris interpolating in TDB days wants the interval it asked for. `TestSubInAUniformScaleIsUnchanged` pins that nothing moved for TAI/TT/TDB.

UTC and UT1 are not uniform, and they are the whole bug.

## Two further defects, both in the same function

**`Sub` wrapped instead of saturating.** `time.Duration` is an int64 nanosecond count, so it runs out just past ±292 years — well inside the range this library supports, which reaches year 1. Measured: year 1 to 2026 returned **−9223372037 s**, a negative span for an interval that plainly runs forwards. It now saturates, which is what `time.Time.Sub` does, and the doc points at `SubDays` for astronomical spans.

**The float-to-`Duration` conversion truncated.** A scale round-trip adds and removes an offset of ~69 s, landing the result a part in 1e13 below a whole second, so an exactly-ten-minute interval reported `9m59.999999999s`. Truncation also biased every duration downward, never up.

## Where I stopped, and why

I tried making `Add` physical too, so `Add` and `Sub` would be inverses. An existing test caught it: `TestAddIsReversible` pins `t.Add(d).Add(-d) == t`.

Physical addition of 1 s to `2016-12-31T23:59:59Z` has nowhere to land — UTC has no label for 23:59:60 — so it aliases to its neighbour and the trip back arrives **1 s away**. Both invariants cannot hold while UTC is not a total representation of the instants it labels. That is **#144**, not something this change can fix.

So `Add` stays label arithmetic. The asymmetry is now documented on `AddDays` rather than left to be rediscovered: across a leap second `t.Add(24h).Sub(t)` is 86401 s (correctly), and `t.TAI().Add(d).UTC()` is the physical route. `TestAddAdvancesTheLabelAndSubMeasuresTheClock` pins all three, so the decision is on the record. Noted on #144 as the main thing resolving it would unlock.

## One thing I got wrong and backed out

Two `plan` tests based their windows on `time.ZeroTime()` — `FromJD(0, UTC)`, a zero-value sentinel at Julian Date 0 in the year **−4712**, where the Espenak & Meeus polynomial reads 135,943 s and drifts **0.144 s per hour**. They were reading that drift, not the scheduler.

My first attempt changed all eight uses of `ZeroTime` as a base. That made `TestSwapOptimizedStrategy` fail — a different epoch changed what the test *scored*, not how it measured. Reverted to the two that assert durations; the other six are untouched.

Separately, a Python `open(p, 'w')` silently rewrote three test files to CRLF. Caught by `gofmt -l`, fixed in binary mode.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Five mutations, each run against the final code:

| mutation | result |
| --- | --- |
| restore the old same-scale-skips guard | 3 tests fail |
| truncate instead of round | 1 fails |
| nothing is uniform (TDB forced via TT) | 1 fails — the TDB guard |
| everything is uniform (UTC not routed) | 3 fail |
| no positive saturation | 1 fails |

The first mutation run reported a **false pass**: the `||` in my sed patterns collided with its `|` delimiter, and the verification grep matched `Before`/`After`/`Equal`, which carry the same line. Redone with a different delimiter and an exact occurrence count.

### Performance, measured rather than assumed

| benchmark | before | after |
| --- | ---: | ---: |
| `Sub_SameScale` (two UTC) | 2.0 ns/op | 91.5 ns/op |
| `Sub_SameScale_Uniform` (two TT, new) | — | 3.9 ns/op |

The 46× on UTC is two scale conversions, in exchange for an answer that counts the leap seconds. It does not reach real workloads:

| plan benchmark | before | after |
| --- | ---: | ---: |
| `VisibleIntervals` | 22.6 ms | 22.6 ms |
| `EventSolver_Visibility` | 3.51 ms | 3.50 ms |
| `GreedyStrategy_100` | ~9.7 s | ~9.7 s |

All within noise — the conversions are invisible next to the ephemeris and `coord` work these do. The new uniform-scale benchmark exists so the fast path cannot silently regress.

Closes #149.
