### PR TITLE
Make Refraction answer for its own nil model

### DIFF
--- a/atmosphere/refraction.go
+++ b/atmosphere/refraction.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/internal/gofaext"
 )
 
 // lowAltitudeCutoffDeg is the true/apparent altitude below which
@@ -64,6 +65,50 @@ type Refraction struct {
 	Wavelength  float64
 }
 
+// EffectiveModel returns the model this environment actually refracts with,
+// which is never nil.
+//
+// # Why a nil Model is not an error
+//
+// Refraction is a freely-literal-constructed value type, and the constructors
+// deliberately leave Model nil — [AtAltitude] says so in as many words. A nil
+// Model means "no opinion, use the default", not "no refraction": with a
+// pressure set it resolves to [RefractionSOFA], and only a zero pressure means
+// a vacuum.
+//
+// That convention used to live in coord, which read Model == nil and reached
+// for SOFA's constants itself. atmosphere had no such default, so the meaning
+// of a zero value depended on which package consumed it, and anyone following
+// the documented pluggable-model API into env.Model.RefractFromTrue got a nil
+// dereference. The convention belongs here, with the type it describes.
+func (r Refraction) EffectiveModel() RefractionModel {
+	switch {
+	case r.Model != nil:
+		return r.Model
+	case r.Pressure > 0:
+		return RefractionSOFA{}
+	default:
+		return RefractionNone{}
+	}
+}
+
+// RefractFromTrue is the refraction that carries a true geometric altitude to
+// the observed one, using [Refraction.EffectiveModel].
+//
+// Positive: refraction raises an object, so observed = true + this. Prefer it
+// over reaching into Model directly, which is nil under every constructor.
+func (r Refraction) RefractFromTrue(trueAlt angle.Angle) angle.Angle {
+	return r.EffectiveModel().RefractFromTrue(trueAlt, r)
+}
+
+// RefractFromApparent is the refraction to remove from an observed altitude to
+// recover the true geometric one, using [Refraction.EffectiveModel].
+//
+// Positive, like [Refraction.RefractFromTrue], so true = observed − this.
+func (r Refraction) RefractFromApparent(obsAlt angle.Angle) angle.Angle {
+	return r.EffectiveModel().RefractFromApparent(obsAlt, r)
+}
+
 // ── Models ────────────────────────────────────────────────────────────────────
 
 // RefractionNone entirely disables refraction.
@@ -109,6 +154,74 @@ func (RefractionApproximate) RefractFromApparent(obsAlt angle.Angle, env Refract
 	factor := (env.Pressure / 1010.0) * (283.0 / (273.15 + env.Temperature))
 
 	return angle.Deg((R * factor) / 60.0)
+}
+
+// RefractionSOFA is the refraction model SOFA itself uses: the two-term series
+// dz = A·tan z + B·tan³ z, with A and B derived from the pressure,
+// temperature, humidity and wavelength in the [Refraction] passed to it.
+//
+// This is the model a nil [Refraction.Model] resolves to when a pressure is
+// set — see [Refraction.EffectiveModel]. It exists so that "nil means SOFA"
+// is a statement atmosphere can act on, rather than a convention each consumer
+// has to reimplement.
+//
+// Unlike the Saemundsson and Bennett formulas beside it, the constants are not
+// a fixed empirical fit rescaled by a pressure ratio: gofa's Refco integrates
+// the refractive index of moist air for the specific conditions given, so the
+// wavelength dependence is real dispersion rather than the linear 0.005/µm
+// approximation [RefractionRigorous] applies.
+type RefractionSOFA struct{}
+
+// Refraction clamps, copied from SOFA's iauAtioq rather than chosen here.
+//
+// selMin bounds sin(altitude) at 0.05 — about 2.87° — so the tangent series is
+// never evaluated where it diverges. celMin bounds cos(altitude) away from
+// zero at the zenith, where the horizontal component vanishes.
+//
+// coord/context.go carries the same two constants for its own vector-form copy
+// of Atioq. They are duplicated rather than shared because they belong to the
+// algorithm, not to either package, and neither should import the other.
+const (
+	selMin = 0.05
+	celMin = 1e-6
+)
+
+// RefractFromTrue applies Atioq's Newton-corrected form of the series, which is
+// the direction SOFA uses when going from a true topocentric direction to the
+// observed one.
+func (RefractionSOFA) RefractFromTrue(trueAlt angle.Angle, env Refraction) angle.Angle {
+	if env.Pressure <= 0 {
+		return 0
+	}
+
+	refa, refb := gofaext.Refco(env.Pressure, env.Temperature, env.Humidity, env.Wavelength)
+
+	// In units of sine and cosine of altitude, as Atioq works on a unit vector.
+	z := math.Max(math.Sin(trueAlt.Radians()), selMin)
+	r := math.Max(math.Cos(trueAlt.Radians()), celMin)
+
+	tz := r / z
+	w := refb * tz * tz
+
+	return angle.Rad((refa + w) * tz / (1.0 + (refa+3.0*w)/(z*z)))
+}
+
+// RefractFromApparent applies the series in its defining form, where the
+// zenith distance is the observed one — which is how gofa's Refco documents A
+// and B, so no correction term belongs here.
+func (RefractionSOFA) RefractFromApparent(obsAlt angle.Angle, env Refraction) angle.Angle {
+	if env.Pressure <= 0 {
+		return 0
+	}
+
+	refa, refb := gofaext.Refco(env.Pressure, env.Temperature, env.Humidity, env.Wavelength)
+
+	z := math.Max(math.Sin(obsAlt.Radians()), selMin)
+	r := math.Max(math.Cos(obsAlt.Radians()), celMin)
+
+	tz := r / z
+
+	return angle.Rad(refa*tz + refb*tz*tz*tz)
 }
 
 // RefractionRigorous explicitly represents the analytical integration model derived from physical meteorological parameters.
@@ -252,7 +365,10 @@ func HorizonDip(h float64) angle.Angle {
 //   - M  = 0.0289644 kg/mol (molar mass of dry air)
 //   - R* = 8.31447 J/(mol·K) (universal gas constant)
 //
-// The refraction model and wavelength are inherited from [StandardRefraction].
+// Humidity and wavelength are inherited from [StandardRefraction]; the model
+// is deliberately left nil, which [Refraction.EffectiveModel] resolves to
+// [RefractionSOFA]. StandardRefraction's own RefractionRigorous is *not*
+// inherited, which this comment used to claim.
 func AtAltitude(h float64) Refraction {
 	if h <= 0 {
 		// Sea level: use standard ISA values but let SOFA handle refraction

--- a/atmosphere/refraction_nilmodel_test.go
+++ b/atmosphere/refraction_nilmodel_test.go
@@ -1,0 +1,198 @@
+package atmosphere_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+)
+
+// TestRefractionWorksWithTheNilModelEveryConstructorLeaves is the defect.
+//
+// Every constructor leaves Model nil — AtAltitude sets it so deliberately, and
+// a Refraction built as a literal (which its own doc comment invites) has no
+// model either. The package documented a pluggable RefractionModel, so anyone
+// following that into env.Model.RefractFromTrue got a nil pointer dereference.
+//
+// Refraction now answers for itself.
+func TestRefractionWorksWithTheNilModelEveryConstructorLeaves(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  atmosphere.Refraction
+	}{
+		{"AtAltitude at sea level", atmosphere.AtAltitude(0)},
+		{"AtAltitude at 2400 m", atmosphere.AtAltitude(2400)},
+		{"a bare literal, as the type invites", atmosphere.Refraction{
+			Pressure: 1013.25, Temperature: 15, Humidity: 0.5, Wavelength: 0.55,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env.Model != nil {
+				t.Fatalf("precondition: this constructor now sets a Model (%T); the "+
+					"test no longer covers the nil case it was written for", tc.env.Model)
+			}
+
+			// Would have panicked. Both directions, since both were reachable.
+			fromTrue := tc.env.RefractFromTrue(angle.Deg(45))
+			fromApparent := tc.env.RefractFromApparent(angle.Deg(45))
+
+			// At 45 degrees refraction is about one arcminute at sea level and
+			// less higher up, where there is less air. A wide bracket, because
+			// the point here is "a real number, not a panic".
+			for _, got := range []angle.Angle{fromTrue, fromApparent} {
+				if s := got.Arcseconds(); s < 20 || s > 90 {
+					t.Errorf("refraction at 45 deg = %.2f arcsec, want a plausible "+
+						"20-90 arcsec", s)
+				}
+			}
+		})
+	}
+}
+
+// TestEffectiveModelResolvesTheNilConvention pins the three-way resolution, and
+// in particular that nil does not mean "no refraction".
+//
+// A zero pressure is the only thing that means a vacuum. Reading nil as "no
+// atmosphere" is what made coord.Disperse report zero dispersion for an
+// environment coord.Reduce had just refracted through.
+func TestEffectiveModelResolvesTheNilConvention(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  atmosphere.Refraction
+		want atmosphere.RefractionModel
+	}{
+		{
+			"an explicit model wins",
+			atmosphere.Refraction{Model: atmosphere.RefractionApproximate{}, Pressure: 1013},
+			atmosphere.RefractionApproximate{},
+		},
+		{
+			"an explicit model wins even at zero pressure",
+			atmosphere.Refraction{Model: atmosphere.RefractionRigorous{}},
+			atmosphere.RefractionRigorous{},
+		},
+		{
+			"nil with a pressure means SOFA",
+			atmosphere.Refraction{Pressure: 1013.25, Temperature: 15},
+			atmosphere.RefractionSOFA{},
+		},
+		{
+			"nil without a pressure means a vacuum",
+			atmosphere.Refraction{},
+			atmosphere.RefractionNone{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.env.EffectiveModel()
+			if got == nil {
+				t.Fatal("EffectiveModel returned nil, which it never may")
+			}
+
+			if gotType, wantType := typeName(got), typeName(tc.want); gotType != wantType {
+				t.Errorf("EffectiveModel() = %s, want %s", gotType, wantType)
+			}
+		})
+	}
+}
+
+func typeName(m atmosphere.RefractionModel) string {
+	switch m.(type) {
+	case atmosphere.RefractionNone:
+		return "RefractionNone"
+	case atmosphere.RefractionApproximate:
+		return "RefractionApproximate"
+	case atmosphere.RefractionRigorous:
+		return "RefractionRigorous"
+	case atmosphere.RefractionSOFA:
+		return "RefractionSOFA"
+	default:
+		return "unknown"
+	}
+}
+
+// TestRefractionSOFAAgreesWithTheClassicTangentRule checks the new model
+// against something that is not SOFA, so this is a check on the physics rather
+// than on the plumbing.
+//
+// The textbook rule of thumb is R ≈ 58.3″ · tan z for zenith distances inside
+// about 75°, quoted at 1010 hPa and 10 °C. Scaling to this environment's
+// 1013.25 hPa and 15 °C by the usual density ratio gives 57.4″ at the zenith
+// distance where tan z = 1.
+//
+// The tolerance is 3%: the rule is itself a one-term approximation of the
+// two-term series, so agreeing much more closely than that would be suspicious
+// rather than reassuring.
+func TestRefractionSOFAAgreesWithTheClassicTangentRule(t *testing.T) {
+	env := atmosphere.Refraction{
+		Pressure: 1013.25, Temperature: 15.0, Humidity: 0.5, Wavelength: 0.55,
+	}
+
+	// 58.3" at 1010 hPa / 10 C, scaled to this environment.
+	const ruleAtUnitTangent = 58.3 * (1013.25 / 1010.0) * (283.15 / 288.15)
+
+	for _, altDeg := range []float64{60, 45, 30, 20} {
+		zenithDistance := 90.0 - altDeg
+		want := ruleAtUnitTangent * math.Tan(zenithDistance*math.Pi/180.0)
+
+		got := env.RefractFromTrue(angle.Deg(altDeg)).Arcseconds()
+
+		if rel := math.Abs(got-want) / want; rel > 0.03 {
+			t.Errorf("at %.0f deg altitude: %.2f arcsec, want about %.2f from the "+
+				"58.3\"·tan z rule (off by %.1f%%)", altDeg, got, want, rel*100)
+		}
+	}
+
+	// And it vanishes at the zenith, where the tangent rule gives zero too.
+	if got := env.RefractFromTrue(angle.Deg(90)).Arcseconds(); math.Abs(got) > 0.01 {
+		t.Errorf("refraction at the zenith = %.4f arcsec, want 0", got)
+	}
+}
+
+// TestRefractionSOFADispersesByWavelength pins the property that makes this
+// model worth having over the empirical formulas beside it.
+//
+// gofa's Refco integrates the refractive index of moist air at the wavelength
+// given, so blue light refracts measurably more than red. That difference is
+// atmospheric dispersion — the reason a low star shows a colour-fringed
+// image, and the quantity coord.Disperse exists to report.
+func TestRefractionSOFADispersesByWavelength(t *testing.T) {
+	base := atmosphere.Refraction{Pressure: 1013.25, Temperature: 15.0, Humidity: 0.5}
+
+	blue, red := base, base
+	blue.Wavelength, red.Wavelength = 0.40, 0.70
+
+	const alt = 30.0
+
+	b := blue.RefractFromTrue(angle.Deg(alt))
+	r := red.RefractFromTrue(angle.Deg(alt))
+
+	spread := (b - r).Arcseconds()
+
+	if spread <= 0 {
+		t.Fatalf("blue refracted %.3f arcsec and red %.3f — blue must refract more",
+			b.Arcseconds(), r.Arcseconds())
+	}
+
+	// Differential refraction between 0.40 and 0.70 um at 60 degrees zenith
+	// distance is a couple of arcseconds; it is a well-known observing problem
+	// at this scale, which is why atmospheric dispersion correctors exist.
+	if spread < 1.0 || spread > 5.0 {
+		t.Errorf("dispersion 0.40-0.70 um at %.0f deg = %.3f arcsec, want roughly "+
+			"1-5 arcsec", alt, spread)
+	}
+
+	// The empirical model's wavelength handling is a linear fudge, so it must
+	// not be mistaken for this. Pinned so that a later "simplification" that
+	// routes the default through RefractionRigorous is caught.
+	er, eb := base, base
+	er.Model, eb.Model = atmosphere.RefractionRigorous{}, atmosphere.RefractionRigorous{}
+	eb.Wavelength, er.Wavelength = 0.40, 0.70
+
+	if empirical := (eb.RefractFromTrue(angle.Deg(alt)) -
+		er.RefractFromTrue(angle.Deg(alt))).Arcseconds(); empirical >= spread {
+		t.Errorf("RefractionRigorous reported %.3f arcsec of dispersion against "+
+			"SOFA's %.3f; the linear 0.005/um approximation should be the smaller",
+			empirical, spread)
+	}
+}

--- a/coord/context.go
+++ b/coord/context.go
@@ -236,8 +236,14 @@ func (ctx *Context) AstrometricToObserved(c Astrometric) AltAz {
 //
 // Atmospheric refraction is applied using the Context's refraction model.
 // When no explicit model is set (Model == nil) but atmospheric pressure is
-// nonzero, the Saemundsson (1986) rigorous formula is used as a fallback,
-// matching the behaviour of SOFA's internal refraction in the stellar path.
+// nonzero, refractLikeAtioq applies SOFA's own two-term series from the Refa
+// and Refb constants Apco13 already cached — the same resolution
+// [atmosphere.Refraction.EffectiveModel] makes, reached by a faster route.
+//
+// atmosphere.RefractionSOFA is that model in portable form, recomputing the
+// constants per call rather than reusing the cache. The two are pinned against
+// each other by TestNilModelMatchesExplicitSOFAModel, which measures agreement
+// to 0.012 arcsec above 3 degrees and 0.7 milliarcsecond above 5 degrees.
 func (ctx *Context) GeocentricToObserved(v vector.Vec3) AltAz {
 	// Topocentric vector in ICRS frame.
 	topoVec := v.Sub(ctx.obsVec)

--- a/coord/reduction.go
+++ b/coord/reduction.go
@@ -85,29 +85,35 @@ func (r *Reducer) Reduce(v vector.Vec3) *Reduction {
 	}
 }
 
-// Disperse computes wavelength-dependent refraction for a set of target wavelengths,
-// returning the reduction evaluated differentially for each wavelength.
+// Disperse computes wavelength-dependent refraction for a set of target
+// wavelengths, returning the reduction evaluated differentially for each.
+//
+// # Why there is no nil-model shortcut here any more
+//
+// This used to return [Reduction.Observed] unchanged for every wavelength when
+// atmos.Model was nil — zero dispersion. But a nil Model does not mean no
+// refraction: with a pressure set it means SOFA's, which is exactly what
+// [Reducer.Reduce] applied a few lines earlier when it filled in Observed. So
+// the two halves of one reduction disagreed about whether there was an
+// atmosphere, and the half that said there wasn't is the one a caller asking
+// for dispersion cares about.
+//
+// Resolving through [atmosphere.Refraction.EffectiveModel] removes the
+// disagreement by construction: a zero-pressure environment still yields no
+// dispersion, because the model it resolves to returns zero.
 func (r *Reducer) Disperse(v vector.Vec3, wavelengths []float64) *Reduction {
 	res := r.Reduce(v)
-	res.Dispersion = make(map[float64]AltAz)
-
-	if r.atmos.Model == nil {
-		// No refraction model; dispersion is identical across all wavelengths
-		for _, wl := range wavelengths {
-			res.Dispersion[wl] = res.Observed
-		}
-
-		return res
-	}
+	res.Dispersion = make(map[float64]AltAz, len(wavelengths))
 
 	for _, wl := range wavelengths {
-		// Clone and substitute the specific environment wavelength dynamically
+		// Clone and substitute the specific environment wavelength dynamically.
+		// The clone is what makes this dispersion rather than one refraction
+		// repeated: SOFA's A and B are derived per wavelength.
 		wlAtmos := r.atmos
 		wlAtmos.Wavelength = wl
 
-		shift := wlAtmos.Model.RefractFromTrue(res.Geometric.Alt(), wlAtmos)
-		dispersedAltAz := NewAltAz(res.Geometric.Alt().Add(shift), res.Geometric.Az())
-		res.Dispersion[wl] = dispersedAltAz
+		shift := wlAtmos.RefractFromTrue(res.Geometric.Alt())
+		res.Dispersion[wl] = NewAltAz(res.Geometric.Alt().Add(shift), res.Geometric.Az())
 	}
 
 	return res

--- a/coord/refraction_default_test.go
+++ b/coord/refraction_default_test.go
@@ -1,0 +1,226 @@
+package coord_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// paranalSite is the reference observatory used by the tests in this file.
+func paranalSite(t *testing.T) *coord.Geodetic {
+	t.Helper()
+
+	site, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("site: %v", err)
+	}
+
+	return site
+}
+
+// seaLevelAir is a standard refraction environment with no model set.
+func seaLevelAir() atmosphere.Refraction {
+	return atmosphere.Refraction{
+		Pressure: 1013.25, Temperature: 15.0, Humidity: 0.5, Wavelength: 0.55,
+	}
+}
+
+// TestNilModelMatchesExplicitSOFAModel pins the one duplication this design
+// accepts on purpose.
+//
+// GeocentricToObserved does not call atmosphere at all when Model is nil: it
+// applies SOFA's series through refractLikeAtioq, using the Refa and Refb
+// constants Apco13 already cached for the epoch. That is a real performance
+// decision — recomputing them per call would cost a Refco on a path measured
+// in hundreds of nanoseconds.
+//
+// So the same model exists twice: once as cached constants inside coord, once
+// as atmosphere.RefractionSOFA, which recomputes them and is what a nil Model
+// resolves to everywhere else. Two copies of one model can drift, and nothing
+// would say so — which is what this test is for.
+//
+// Measured agreement over 2000 above-horizon directions: 0.012 arcsec above 3
+// degrees, 0.7 milliarcsecond above 5 degrees. The residual is the difference
+// between rotating a direction vector, as SOFA's Atioq does, and adding a
+// scalar correction to an altitude; it shrinks as refraction does. Below about
+// 3 degrees both are inside SOFA's own sin(altitude) clamp, where refraction is
+// not a trustworthy quantity in any case.
+func TestNilModelMatchesExplicitSOFAModel(t *testing.T) {
+	when := time.Date(2026, time.June, 15, 22, 0, 0, 0, time.LocationUTC)
+	site := paranalSite(t)
+
+	nilEnv := seaLevelAir()
+
+	explicit := nilEnv
+	explicit.Model = atmosphere.RefractionSOFA{}
+
+	ctxNil := coord.NewContext(when, site, nilEnv)
+	ctxExplicit := coord.NewContext(when, site, explicit)
+
+	// Contract per altitude floor, in arcseconds.
+	bounds := []struct {
+		floorDeg float64
+		maxDiff  float64
+	}{
+		{3, 0.05},
+		{5, 0.005},
+		{10, 0.001},
+	}
+
+	worst := make([]float64, len(bounds))
+	above := 0
+
+	// A deterministic spiral over the sphere, dense enough to find the worst case.
+	for i := range 4000 {
+		th := float64(i) * 0.7853981633974483
+		ph := float64(i) * 0.24
+
+		v := vector.Vec3{
+			X: math.Cos(ph) * math.Cos(th),
+			Y: math.Cos(ph) * math.Sin(th),
+			Z: math.Sin(ph),
+		}.MulScalar(1e10) // far enough that parallax is not in play
+
+		a := ctxNil.GeocentricToObserved(v)
+		b := ctxExplicit.GeocentricToObserved(v)
+
+		alt := a.Alt().Degrees()
+		if alt < 0 {
+			continue
+		}
+
+		above++
+
+		diff := math.Abs((a.Alt() - b.Alt()).Arcseconds())
+
+		for j, bound := range bounds {
+			if alt >= bound.floorDeg && diff > worst[j] {
+				worst[j] = diff
+			}
+		}
+
+		// Azimuth is untouched by refraction and must be bit-identical.
+		if az := math.Abs((a.Az() - b.Az()).Arcseconds()); az != 0 {
+			t.Fatalf("azimuth differs by %g arcsec at %.2f deg altitude; refraction "+
+				"must not move it", az, alt)
+		}
+	}
+
+	if above < 500 {
+		t.Fatalf("only %d of 4000 sample directions were above the horizon; the "+
+			"sampling no longer covers the range under test", above)
+	}
+
+	for j, bound := range bounds {
+		if worst[j] > bound.maxDiff {
+			t.Errorf("above %.0f deg: the cached-constant path and "+
+				"atmosphere.RefractionSOFA differ by %.6f arcsec, contract %.3f.\n"+
+				"  These are two copies of one model; they have drifted apart.",
+				bound.floorDeg, worst[j], bound.maxDiff)
+		}
+	}
+
+	t.Logf("%d above-horizon samples; worst difference %.6f arcsec above 3 deg, "+
+		"%.6f above 5 deg, %.6f above 10 deg", above, worst[0], worst[1], worst[2])
+}
+
+// TestDisperseReportsDispersionWhereReduceAppliedRefraction is the second half
+// of the nil-model defect.
+//
+// Disperse used to check Model == nil and, finding it, return the observed
+// position unchanged for every wavelength — zero dispersion. But Reduce, on
+// the very same Reducer, had just refracted through SOFA, because that is what
+// a nil model with a pressure means. One reduction, two answers about whether
+// there is an atmosphere.
+func TestDisperseReportsDispersionWhereReduceAppliedRefraction(t *testing.T) {
+	when := time.Date(2026, time.June, 15, 22, 0, 0, 0, time.LocationUTC)
+	site := paranalSite(t)
+
+	env := seaLevelAir()
+	if env.Model != nil {
+		t.Fatal("precondition: this test is about the nil-Model path")
+	}
+
+	r := coord.NewReducer(site, when, env)
+
+	// A direction well above the horizon, so refraction is real but modest.
+	var target vector.Vec3
+
+	for i := range 4000 {
+		th := float64(i) * 0.7853981633974483
+		ph := float64(i) * 0.24
+		v := vector.Vec3{
+			X: math.Cos(ph) * math.Cos(th),
+			Y: math.Cos(ph) * math.Sin(th),
+			Z: math.Sin(ph),
+		}.MulScalar(1e10)
+
+		if alt := r.Reduce(v).Observed.Alt().Degrees(); alt > 25 && alt < 50 {
+			target = v
+			break
+		}
+	}
+
+	if target.Norm() == 0 {
+		t.Fatal("no sample direction landed between 25 and 50 degrees altitude")
+	}
+
+	res := r.Disperse(target, []float64{0.40, 0.55, 0.70})
+
+	if len(res.Dispersion) != 3 {
+		t.Fatalf("got %d dispersion entries, want 3", len(res.Dispersion))
+	}
+
+	blue, red := res.Dispersion[0.40], res.Dispersion[0.70]
+
+	// Reduce refracted, so Disperse must too.
+	if lift := (res.Dispersion[0.55].Alt() - res.Geometric.Alt()).Arcseconds(); lift < 20 {
+		t.Errorf("the dispersed position at 0.55 um sits %.3f arcsec above the "+
+			"geometric one, but Reduce refracted this direction by a comparable "+
+			"amount. Disperse is reporting an atmosphere that is not there.", lift)
+	}
+
+	spread := (blue.Alt() - red.Alt()).Arcseconds()
+	if spread <= 0 {
+		t.Fatalf("blue sits %.4f arcsec below red; blue must refract more", -spread)
+	}
+
+	if spread < 0.5 || spread > 6 {
+		t.Errorf("dispersion between 0.40 and 0.70 um = %.3f arcsec, want roughly "+
+			"0.5-6 arcsec at this altitude", spread)
+	}
+
+	// Azimuth is unaffected by refraction, at any wavelength.
+	if d := (blue.Az() - red.Az()).Arcseconds(); math.Abs(d) > 1e-9 {
+		t.Errorf("azimuth varies with wavelength by %g arcsec", d)
+	}
+}
+
+// TestDisperseStillReportsNoDispersionInAVacuum pins the other half of the
+// resolution: with no pressure there is no atmosphere, so every wavelength
+// lands on the geometric position and agrees with what Reduce observed.
+func TestDisperseStillReportsNoDispersionInAVacuum(t *testing.T) {
+	when := time.Date(2026, time.June, 15, 22, 0, 0, 0, time.LocationUTC)
+	site := paranalSite(t)
+
+	r := coord.NewReducer(site, when, atmosphere.Refraction{})
+
+	v := vector.Vec3{X: 0.3, Y: 0.5, Z: 0.81}.MulScalar(1e10)
+	res := r.Disperse(v, []float64{0.40, 0.70})
+
+	for wl, got := range res.Dispersion {
+		if d := (got.Alt() - res.Geometric.Alt()).Arcseconds(); math.Abs(d) > 1e-9 {
+			t.Errorf("at %.2f um the dispersed altitude is %g arcsec from the "+
+				"geometric one, but there is no atmosphere", wl, d)
+		}
+
+		if d := (got.Alt() - res.Observed.Alt()).Arcseconds(); math.Abs(d) > 1e-9 {
+			t.Errorf("at %.2f um Disperse and Reduce disagree by %g arcsec", wl, d)
+		}
+	}
+}

--- a/docs/changelog.d/161-refraction-nil-model.md
+++ b/docs/changelog.d/161-refraction-nil-model.md
@@ -1,0 +1,12 @@
+---
+type: Fixed
+pr: 161
+---
+**Following the documented `RefractionModel` API panicked.** Every constructor
+leaves `Refraction.Model` nil, so `env.Model.RefractFromTrue(...)` was a nil
+dereference. `Refraction` now answers for itself via `RefractFromTrue`,
+`RefractFromApparent` and `EffectiveModel`, which resolve nil to the new
+`RefractionSOFA` when a pressure is set and to `RefractionNone` otherwise —
+moving the "nil means SOFA" convention out of `coord` and into the package that
+owns the type. `coord.Reducer.Disperse` consequently stops reporting zero
+dispersion for an environment `Reduce` had just refracted through (#118).


### PR DESCRIPTION
Every constructor leaves `Refraction.Model` nil. `AtAltitude` does it on purpose — *"let SOFA compute refraction"* — and the type's own doc comment invites literal construction, which leaves it nil too. But the package documents a pluggable `RefractionModel`, and the README advertises one, so anyone following that into `env.Model.RefractFromTrue(...)` got a nil pointer dereference. Confirmed by probe on `AtAltitude(2400)`.

## The convention was real, just homeless

`coord` read `Model == nil` and reached for SOFA's constants itself. `atmosphere` had no such default. So the meaning of a zero value depended on **which package consumed it**, and the package that owns the type could not act on its own convention.

`Refraction` now carries it:

```go
func (r Refraction) EffectiveModel() RefractionModel   // never nil
func (r Refraction) RefractFromTrue(trueAlt angle.Angle) angle.Angle
func (r Refraction) RefractFromApparent(obsAlt angle.Angle) angle.Angle
```

`EffectiveModel` resolves an explicit model first, then nil-with-pressure to the new `RefractionSOFA`, then nil-without-pressure to `RefractionNone`. **A nil Model means "no opinion", never "no atmosphere"** — only a zero pressure means a vacuum. That distinction is the whole bug.

## RefractionSOFA

The series SOFA itself uses, `dz = A·tan z + B·tan³ z`, with A and B from gofa's `Refco` for the conditions given.

Checked against something that is **not** SOFA, so the test is on the physics rather than the plumbing — the textbook `58.3″·tan z` rule, scaled to this environment's pressure and temperature, at 3% tolerance because the rule is itself a one-term approximation of a two-term series:

| altitude | RefractionSOFA | 58.3″·tan z rule |
| ---: | ---: | ---: |
| 60° | 32.98″ | 33.1″ |
| 45° | 57.07″ | 57.4″ |
| 30° | 98.58″ | 99.4″ |
| 90° | 0.00″ | 0″ |

Unlike the Saemundsson and Bennett formulas beside it, its wavelength dependence is real dispersion rather than a linear `0.005/µm` rescaling: **2.47 arcsec between 0.40 and 0.70 µm at 30°**, which is the scale at which atmospheric dispersion correctors exist.

## The same bug from the other side

`coord.Reducer.Disperse` checked `Model == nil` and returned the observed position unchanged for every wavelength — zero dispersion — while `Reduce`, on the *same* `Reducer`, had just refracted through SOFA because that is what a nil model with a pressure means.

Two halves of one reduction disagreeing about whether there is an atmosphere, and the half that said there wasn't is the one a caller asking for dispersion cares about. Resolving through `EffectiveModel` removes the disagreement by construction: a zero-pressure environment still yields no dispersion, because the model it resolves to returns zero.

## A duplication kept on purpose

`coord` keeps `refractLikeAtioq`, which uses the Refa and Refb `Apco13` already cached for the epoch. Recomputing them per call would put a `Refco` on a path measured in hundreds of nanoseconds.

So one model now exists twice, deliberately — and two copies of one model can drift with nothing to say so. `TestNilModelMatchesExplicitSOFAModel` pins them over 2000 above-horizon directions:

| altitude floor | worst difference | contract |
| ---: | ---: | ---: |
| 3° | 0.011922″ | 0.05″ |
| 5° | 0.000660″ | 0.005″ |
| 10° | 0.000119″ | 0.001″ |

The residual is the difference between rotating a direction vector, as Atioq does, and adding a scalar correction to an altitude; it shrinks as refraction does. Below ~3° both sit inside SOFA's own `sin(altitude)` clamp, where refraction is not a trustworthy quantity anyway.

## Two stale doc comments, found while reading

- `GeocentricToObserved` claimed the **Saemundsson (1986)** formula as its nil-model fallback. The code has applied SOFA's series via `refractLikeAtioq` since #153.
- `AtAltitude` claimed *"The refraction model and wavelength are inherited from StandardRefraction"* while explicitly setting `Model: nil`. `StandardRefraction`'s model is `RefractionRigorous`, so only the humidity and wavelength are in fact inherited.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` and `integration` tiers green.

Four mutations, each run against the final code:

| mutation | result |
| --- | --- |
| nil + pressure falls through to `RefractionNone` | 4 atmosphere tests fail |
| drop Atioq's Newton correction | **only** the coord cross-check fails |
| wavelength ignored in `Refco` | dispersion tests fail in both packages |
| `Disperse` back to zero dispersion | 1 fails |

The second is the informative one: it passes every `atmosphere` test — the tangent-rule tolerance is wider than the Newton term at moderate altitudes — and is caught only by the test that pins the two copies together. That is the test earning its keep.

### Performance

`coord/context.go`'s diff is **comments only**, so the hot paths are unchanged code. Measured rather than asserted:

| benchmark | before | after |
| --- | ---: | ---: |
| `Reducer_Cached` | 152–156 ns/op | 151–154 ns/op |
| `ICRSToAltAz_CachedContext` | ~310 ns/op | ~310 ns/op |
| `NewContext` | ~148 µs/op | ~147 µs/op |

The per-call `Refco` lands only in `Disperse`, where computing A and B per wavelength *is* the requested work.

My first attempt at that comparison produced an empty "before" set: stashing only the tracked files left the new tests referencing a type that no longer existed, so nothing built. Redone with `--include-untracked`.

## Noted, not fixed here

`RefractionRigorous.RefractFromTrue` returns **−0.11″ at the zenith** — negative refraction, because Saemundsson's tangent argument passes 90° there. Small but wrong-signed, and outside this PR's scope.

Closes #118.
