### PR TITLE
Stop refraction going negative at the zenith

### DIFF
--- a/atmosphere/refraction.go
+++ b/atmosphere/refraction.go
@@ -28,6 +28,30 @@ import (
 // extend further down than the two empirical tangent formulas here.
 const lowAltitudeCutoffDeg = -4.0
 
+// zenithArgumentLimit is the other end of the same problem, and the reason all
+// four empirical methods check their tangent argument against 90°.
+//
+// The additive term that keeps each fit stable near the horizon also carries
+// its argument *past* 90° near the zenith: Saemundsson's h + 10.3/(h+5.11) is
+// 90.108° at h = 90°, and Bennett's h + 7.31/(h+4.4) is 90.077°. tan is
+// negative just beyond its asymptote, so both formulas reported negative
+// refraction — measured at −0.114″ and −0.080″ at the zenith, turning negative
+// above 89.8916° and 89.9225° respectively.
+//
+// Refraction is never negative in a normal atmosphere: it raises an object, or
+// at the zenith does nothing, because light arriving along the normal is not
+// bent. Zero is the correct limit, and it is what SOFA returns there.
+//
+// Returning zero at and above the crossing discards at most 0.11″ — the value
+// the formula itself gives just below it — against a fit whose own quoted
+// accuracy is about 0.1 arcmin, i.e. 60 times larger. So this clamp costs
+// nothing measurable and removes a sign error.
+//
+// Expressed as a limit on the argument rather than on the altitude because the
+// two formulas cross at different altitudes, and because the argument is where
+// the problem actually is.
+const zenithArgumentLimit = 90.0
+
 // RefractionModel defines an algorithm that computes the angular refraction shift.
 // It explicitly parses the distinction between forward and reverse tracing.
 type RefractionModel interface {
@@ -135,8 +159,13 @@ func (RefractionApproximate) RefractFromTrue(trueAlt angle.Angle, env Refraction
 		return 0 // Avoid absurd refraction below horizon
 	}
 
+	inner := h + 10.3/(h+5.11)
+	if inner >= zenithArgumentLimit {
+		return 0 // see zenithArgumentLimit
+	}
+
 	// Refraction R in arcminutes
-	R := 1.02 / math.Tan((h+10.3/(h+5.11))*math.Pi/180.0)
+	R := 1.02 / math.Tan(inner*math.Pi/180.0)
 
 	factor := (env.Pressure / 1010.0) * (283.0 / (273.15 + env.Temperature))
 
@@ -150,7 +179,12 @@ func (RefractionApproximate) RefractFromApparent(obsAlt angle.Angle, env Refract
 		return 0
 	}
 
-	R := 1.0 / math.Tan((h+7.31/(h+4.4))*math.Pi/180.0)
+	inner := h + 7.31/(h+4.4)
+	if inner >= zenithArgumentLimit {
+		return 0 // see zenithArgumentLimit
+	}
+
+	R := 1.0 / math.Tan(inner*math.Pi/180.0)
 	factor := (env.Pressure / 1010.0) * (283.0 / (273.15 + env.Temperature))
 
 	return angle.Deg((R * factor) / 60.0)
@@ -241,7 +275,12 @@ func (RefractionRigorous) RefractFromTrue(trueAlt angle.Angle, env Refraction) a
 
 	// Saemundsson (1986) formula in arcminutes for true (geometric) altitude h
 	denom := h + 5.11
+
 	inner := h + (10.3 / denom)
+	if inner >= zenithArgumentLimit {
+		return 0 // see zenithArgumentLimit
+	}
+
 	r0 := 1.02 / math.Tan(inner*math.Pi/180.0)
 
 	correction := (env.Pressure / 1010.0) * (283.0 / (273.15 + env.Temperature))
@@ -268,7 +307,12 @@ func (RefractionRigorous) RefractFromApparent(obsAlt angle.Angle, env Refraction
 
 	// Bennett (1982) formula in arcminutes for observed (apparent) altitude h
 	denom := h + 4.4
+
 	inner := h + (7.31 / denom)
+	if inner >= zenithArgumentLimit {
+		return 0 // see zenithArgumentLimit
+	}
+
 	r0 := 1.0 / math.Tan(inner*math.Pi/180.0)
 
 	correction := (env.Pressure / 1010.0) * (283.0 / (273.15 + env.Temperature))

--- a/atmosphere/refraction_test.go
+++ b/atmosphere/refraction_test.go
@@ -33,7 +33,12 @@ func TestRefractionRigorous_KnownValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ref := model.RefractFromTrue(angle.Deg(tt.alt), env)
 
-			refArcmin := math.Abs(ref.Degrees() * 60.0)
+			// Signed, deliberately. This used to take math.Abs before
+			// comparing, which made the bracket blind to the sign of every
+			// row: -0.114 arcsec at the zenith passed the [0, 0.01] arcmin
+			// case below, and -34.6 arcsec would have passed the 60-degree
+			// one. Refraction is never negative, so let the bracket say so.
+			refArcmin := ref.Degrees() * 60.0
 			if refArcmin < tt.minRef || refArcmin > tt.maxRef {
 				t.Errorf("altitude=%g°: refraction=%.3f arcmin, want [%.1f, %.1f]",
 					tt.alt, refArcmin, tt.minRef, tt.maxRef)

--- a/atmosphere/refraction_zenith_test.go
+++ b/atmosphere/refraction_zenith_test.go
@@ -1,0 +1,204 @@
+package atmosphere
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+)
+
+// TestRefractionIsNeverNegative sweeps every empirical model over the whole
+// range it is evaluated on and asserts the one property refraction cannot
+// violate.
+//
+// # What went wrong
+//
+// The additive term that keeps each fit stable near the horizon carries its
+// tangent argument past 90° near the zenith — Saemundsson's h + 10.3/(h+5.11)
+// reaches 90.108° at h = 90°, Bennett's h + 7.31/(h+4.4) reaches 90.077°. tan
+// is negative just beyond its asymptote, so both formulas returned negative
+// refraction: −0.114″ and −0.080″ at the zenith, crossing zero at 89.8916° and
+// 89.9225°.
+//
+// Small, but wrong in a way a magnitude check cannot see. Refraction raises an
+// object or, at the zenith, does nothing; it never lowers one.
+//
+// # Why a sweep rather than a few points
+//
+// The defect lived in the last tenth of a degree of a 94° range. Picking
+// altitudes by hand is how it survived: the existing table has a zenith_90
+// case, and it passed. Stepping finely across the whole domain is what makes
+// the guard independent of guessing where the next one will be.
+func TestRefractionIsNeverNegative(t *testing.T) {
+	env := StandardRefraction
+
+	models := []struct {
+		name string
+		m    RefractionModel
+	}{
+		{"RefractionApproximate", RefractionApproximate{}},
+		{"RefractionRigorous", RefractionRigorous{}},
+		{"RefractionSOFA", RefractionSOFA{}},
+		{"RefractionNone", RefractionNone{}},
+	}
+
+	directions := []struct {
+		name string
+		f    func(RefractionModel, angle.Angle) angle.Angle
+	}{
+		{"RefractFromTrue", func(m RefractionModel, a angle.Angle) angle.Angle {
+			return m.RefractFromTrue(a, env)
+		}},
+		{"RefractFromApparent", func(m RefractionModel, a angle.Angle) angle.Angle {
+			return m.RefractFromApparent(a, env)
+		}},
+	}
+
+	for _, model := range models {
+		for _, dir := range directions {
+			t.Run(model.name+"/"+dir.name, func(t *testing.T) {
+				// 0.001° steps through the region where the sign flipped, and
+				// across the whole evaluated range besides.
+				for h := lowAltitudeCutoffDeg - 1.0; h <= 90.0; h += 0.001 {
+					got := dir.f(model.m, angle.Deg(h))
+					if got < 0 {
+						t.Fatalf("at %.4f deg altitude: %.6f arcsec.\n"+
+							"  Refraction is never negative — check the tangent "+
+							"argument against zenithArgumentLimit.",
+							h, got.Arcseconds())
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestRefractionVanishesAtTheZenith pins the physical limit.
+//
+// Light arriving along the normal is not bent, so refraction at the zenith is
+// zero. After clamping the tangent argument, both empirical models return a
+// literal zero there; RefractionSOFA returns 5.7e-5 arcsec, because iauAtioq
+// clamps cos(altitude) at celMin rather than letting it reach zero. Both are
+// correct — the distinction is carried by the exact field below rather than
+// papered over with one loose tolerance.
+func TestRefractionVanishesAtTheZenith(t *testing.T) {
+	env := StandardRefraction
+
+	for _, model := range []struct {
+		name string
+		m    RefractionModel
+		// exact is true for the models that return a literal zero. SOFA does
+		// not: iauAtioq clamps cos(altitude) away from zero at celMin = 1e-6,
+		// so the series evaluates to 5.7e-5 arcsec rather than nothing. That
+		// is SOFA's own behaviour, reproduced on purpose, and 57 microarcsec
+		// is eleven orders below anything this library claims.
+		exact bool
+	}{
+		{"RefractionApproximate", RefractionApproximate{}, true},
+		{"RefractionRigorous", RefractionRigorous{}, true},
+		{"RefractionSOFA", RefractionSOFA{}, false},
+	} {
+		t.Run(model.name, func(t *testing.T) {
+			const negligibleArcsec = 1e-3
+
+			for _, dir := range []struct {
+				name string
+				got  angle.Angle
+			}{
+				{"RefractFromTrue", model.m.RefractFromTrue(angle.Deg(90), env)},
+				{"RefractFromApparent", model.m.RefractFromApparent(angle.Deg(90), env)},
+			} {
+				switch {
+				case model.exact && dir.got != 0:
+					t.Errorf("%s(90 deg) = %.6f arcsec, want exactly 0",
+						dir.name, dir.got.Arcseconds())
+				case dir.got < 0:
+					t.Errorf("%s(90 deg) = %.9f arcsec, which is negative",
+						dir.name, dir.got.Arcseconds())
+				case dir.got.Arcseconds() > negligibleArcsec:
+					t.Errorf("%s(90 deg) = %.9f arcsec, want under %g",
+						dir.name, dir.got.Arcseconds(), negligibleArcsec)
+				}
+			}
+		})
+	}
+}
+
+// TestZenithClampCostsLessThanTheModelsOwnAccuracy bounds what the clamp
+// throws away, so "return zero up there" is a measured decision rather than an
+// assumption.
+//
+// The clamp takes effect exactly where each formula crosses zero, so the
+// largest value it discards is the one the formula gives immediately below the
+// crossing. Both fits quote about 0.1 arcmin (6 arcsec) of accuracy, so the
+// discarded amount has to be far under that to be free.
+func TestZenithClampCostsLessThanTheModelsOwnAccuracy(t *testing.T) {
+	env := StandardRefraction
+
+	// The quoted accuracy of the empirical fits, in arcseconds.
+	const quotedAccuracy = 0.1 * 60.0
+
+	for _, tc := range []struct {
+		name       string
+		f          func(angle.Angle) angle.Angle
+		crossingAt float64 // measured by bisection before the clamp existed
+	}{
+		{"Saemundsson (RefractFromTrue)", func(a angle.Angle) angle.Angle {
+			return RefractionRigorous{}.RefractFromTrue(a, env)
+		}, 89.8916},
+		{"Bennett (RefractFromApparent)", func(a angle.Angle) angle.Angle {
+			return RefractionRigorous{}.RefractFromApparent(a, env)
+		}, 89.9225},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Just inside the fitted range: the most this clamp can discard.
+			discarded := tc.f(angle.Deg(tc.crossingAt - 0.001)).Arcseconds()
+
+			if discarded < 0 {
+				t.Fatalf("the formula is already negative %.3f deg below the "+
+					"recorded crossing; the crossing has moved", 0.001)
+			}
+
+			if discarded > quotedAccuracy/10 {
+				t.Errorf("clamping discards %.4f arcsec, which is not negligible "+
+					"against the model's own %.1f arcsec accuracy", discarded, quotedAccuracy)
+			}
+
+			// And immediately above the crossing it is clamped, not evaluated.
+			if got := tc.f(angle.Deg(tc.crossingAt + 0.001)); got != 0 {
+				t.Errorf("above the crossing: %.6f arcsec, want exactly 0",
+					got.Arcseconds())
+			}
+
+			t.Logf("clamp discards at most %.4f arcsec, against %.1f arcsec quoted",
+				discarded, quotedAccuracy)
+		})
+	}
+}
+
+// TestZenithClampLeavesTheUsefulRangeUntouched checks the fix is local: every
+// altitude a real observation cares about must return what it did before.
+func TestZenithClampLeavesTheUsefulRangeUntouched(t *testing.T) {
+	env := StandardRefraction
+
+	// Values recorded on main before the clamp, in arcseconds.
+	for _, tc := range []struct {
+		altDeg float64
+		want   float64
+	}{
+		{89, 0.937318},
+		{88, 1.989153},
+		{85, 5.154335},
+		{80, 10.501172},
+		{60, 34.592363},
+		{45, 59.868502},
+		{30, 103.217851},
+		{10, 319.687275},
+	} {
+		got := RefractionRigorous{}.RefractFromTrue(angle.Deg(tc.altDeg), env).Arcseconds()
+		if math.Abs(got-tc.want) > 1e-5 {
+			t.Errorf("at %.0f deg: %.4f arcsec, want %.4f — the clamp reached "+
+				"below the zenith region", tc.altDeg, got, tc.want)
+		}
+	}
+}

--- a/docs/changelog.d/163-refraction-zenith-sign.md
+++ b/docs/changelog.d/163-refraction-zenith-sign.md
@@ -1,0 +1,11 @@
+---
+type: Fixed
+pr: 163
+---
+**`RefractionRigorous` and `RefractionApproximate` returned negative refraction
+near the zenith** — −0.114″ and −0.080″, crossing zero at 89.89° and 89.92°,
+because the term that stabilises each fit near the horizon carries its tangent
+argument past 90° at the top. Both now return zero above the crossing, which is
+the physical limit and costs at most 0.001″ against a fit quoting 6″. The
+known-values test also stops taking `math.Abs` before comparing, which had made
+its bracket blind to the sign of every row, not just the zenith one (#162).


### PR DESCRIPTION
`RefractionRigorous` and `RefractionApproximate` returned **negative** refraction near the zenith. Refraction cannot be negative in a normal atmosphere — it raises an object, or at the zenith does nothing.

Measured on `main` with `StandardRefraction`:

| altitude | `RefractFromTrue` (Saemundsson) | `RefractFromApparent` (Bennett) |
| ---: | ---: | ---: |
| **90.0°** | **−0.1140″** | **−0.0799″** |
| 89.0° | 0.9373″ | 0.9511″ |
| 85.0° | 5.1543″ | 5.0871″ |

Both models, both directions — the two share the same pair of formulas. Bisected sign crossings: **89.8916°** for Saemundsson, **89.9225°** for Bennett.

## Cause

The additive term that keeps each fit stable near the horizon carries its tangent argument past 90° at the other end:

```
Saemundsson  h + 10.3/(h+5.11)  ->  90.108 deg at h = 90
Bennett      h + 7.31/(h+4.4)   ->  90.077 deg at h = 90
```

`tan` is negative just beyond its asymptote. `lowAltitudeCutoffDeg` already guards the bottom of the range, where the same term diverges downward; nothing guarded the top.

All four methods now check the argument against a new `zenithArgumentLimit` and return zero above it. Zero is the physical limit rather than an approximation: light arriving along the normal is not bent, and it is what SOFA returns there.

The clamp is expressed as a limit on the *argument*, not on the altitude, because the two formulas cross at different altitudes and because the argument is where the problem is.

## What the clamp costs

At most **0.001″** — the value the formula itself gives immediately below the crossing — against fits whose quoted accuracy is about 0.1 arcmin, i.e. **6″**. `TestZenithClampCostsLessThanTheModelsOwnAccuracy` measures this rather than assuming it, and asserts the discarded amount stays under a tenth of the quoted accuracy.

Values from 10° to 89° are pinned unchanged to six decimals, confirming the clamp is local.

## The guard could not see signs at all

`TestRefractionRigorous_KnownValues` has a `zenith_90` case. It passed:

```go
refArcmin := math.Abs(ref.Degrees() * 60.0)
if refArcmin < tt.minRef || refArcmin > tt.maxRef {
```

`|−0.114″|` = 0.0019 arcmin sits inside its `[0.0, 0.01]` bracket. The blindness applied to **every row**, not just the zenith one — it would equally have accepted −34.6″ at 60°. The `math.Abs` is gone and the brackets are signed.

That half matters more than the clamp, so it is demonstrated rather than asserted. The two are separable, and mutation shows exactly what each does:

| state | `zenith_90` |
| --- | --- |
| no clamp + `math.Abs` (the state on main) | **passes** — blind |
| no clamp + signed bracket | **fails**: `refraction=-0.002 arcmin` |
| clamp + signed bracket (this PR) | passes |

So the test change alone would have caught the bug.

## New guards sweep rather than sample

The defect lived in the last tenth of a degree of a 94° range, and hand-picked altitudes are how it survived — the table already had a zenith case. `TestRefractionIsNeverNegative` steps 0.001° across the whole evaluated range, for every model in both directions, and asserts the one property refraction cannot violate.

`RefractionSOFA` is included, and is **not** exactly zero at the zenith: it reads 5.7e-5″ because `iauAtioq` clamps `cos(altitude)` at `celMin` rather than letting it reach zero. That is SOFA's own behaviour, reproduced on purpose, so it is carried by an explicit `exact` field rather than hidden under one loose tolerance that would weaken the assertion for the other two models.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Three mutations run against the final code: removing all four clamps, restoring the `math.Abs`, and setting the limit to 91° (too high to catch either crossing). Each fails the tests written for it; the table above is the isolated result.

One process note: I first wrote `59.8592″` as the 45° reference value, transcribed from a probe that had displayed only `59.86`. The real value is `59.868502″` — the extra digits were invented, and only a failing assertion surfaced it. All reference values were then re-measured and pinned to six decimals.

Closes #162.
