### PR TITLE
Address SIMBAD and VizieR over HTTPS

### DIFF
--- a/docs/changelog.d/164-cleartext-endpoints.md
+++ b/docs/changelog.d/164-cleartext-endpoints.md
@@ -1,0 +1,12 @@
+---
+type: Security
+pr: 164
+---
+**SIMBAD and VizieR are now addressed over HTTPS.** Both were registered as
+cleartext `http://`, shipping catalogue queries and the positions they return
+where anything on the path could read or rewrite them. Verified against the
+live services first: both answer HTTPS byte-identically to HTTP. `www.cvrl.org`
+stays HTTP because it runs no TLS listener at all — port 443 refuses the
+connection — and now says so in a new `Endpoint.InsecureReason`, which
+`TestNoUndeclaredCleartextEndpoints` requires of any cleartext URL in the
+registry (#107).

--- a/remote/endpoint.go
+++ b/remote/endpoint.go
@@ -386,6 +386,22 @@ type Endpoint struct {
 	// A token is an optimisation, never a requirement: every endpoint that
 	// declares one must still work without it.
 	TokenEnv string
+
+	// InsecureReason explains why this endpoint is addressed over cleartext
+	// http:// rather than https://, and must be non-empty whenever it is.
+	//
+	// Cleartext is a real exposure for a library like this one, in both
+	// directions: what is requested reveals what is being observed, and what
+	// comes back is a physical constant or a catalogue position that anything
+	// on the path can rewrite. So it is never a default and never an
+	// oversight — TestNoUndeclaredCleartextEndpoints refuses any http:// URL
+	// that does not record a reason here.
+	//
+	// The reason belongs in the registry rather than a comment because it is
+	// a property of the endpoint that a test can check, and because it should
+	// be re-examined: an upstream that gains TLS makes its exemption stale,
+	// and there is no way to notice that if the justification is prose.
+	InsecureReason string
 }
 
 // SizeVaries marks an endpoint whose per-fetch size cannot be usefully
@@ -516,7 +532,7 @@ func defaultEndpoints() map[EndpointID]Endpoint {
 		},
 		SIMBAD: {
 			ID:          SIMBAD,
-			URL:         "http://simbad.cds.unistra.fr/simbad/sim-tap/sync",
+			URL:         "https://simbad.cds.unistra.fr/simbad/sim-tap/sync",
 			Kind:        KindAPI,
 			Subsystem:   "catalog/simbad",
 			Description: "CDS SIMBAD TAP service",
@@ -526,7 +542,7 @@ func defaultEndpoints() map[EndpointID]Endpoint {
 		},
 		VizieR: {
 			ID:          VizieR,
-			URL:         "http://tapvizier.u-strasbg.fr/TAPVizieR/tap/sync",
+			URL:         "https://tapvizier.u-strasbg.fr/TAPVizieR/tap/sync",
 			Kind:        KindAPI,
 			Subsystem:   "catalog/vizier",
 			Description: "CDS VizieR TAP service",
@@ -674,8 +690,15 @@ func defaultEndpoints() map[EndpointID]Endpoint {
 		},
 
 		CVRLLuminosity: {
-			ID:        CVRLLuminosity,
-			URL:       "http://www.cvrl.org/database/data/lum/",
+			ID:  CVRLLuminosity,
+			URL: "http://www.cvrl.org/database/data/lum/",
+			InsecureReason: "www.cvrl.org serves no TLS at all: port 443 refuses " +
+				"the connection while port 80 answers, and the bare cvrl.org name " +
+				"does not resolve. Verified 2026-09-05. Not a certificate problem " +
+				"that could be waved through — there is no listener. Re-check when " +
+				"UCL modernises the host; the two CSVs here are CIE luminous " +
+				"efficiency functions, fixed published tables, so the exposure is " +
+				"tampering rather than disclosure.",
 			Kind:      KindFile,
 			Subsystem: "skybrightness/dataset/luminosity",
 			Description: "CVRL (UCL Institute of Ophthalmology) CIE luminous efficiency " +

--- a/remote/endpoint_scheme_test.go
+++ b/remote/endpoint_scheme_test.go
@@ -1,0 +1,98 @@
+package remote_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// TestNoUndeclaredCleartextEndpoints is the registry guard that keeps a
+// cleartext URL from being added without anyone saying why.
+//
+// # Why every endpoint, not only KindAPI
+//
+// The obvious reading is that an API request is the sensitive one, because the
+// query says what is being observed. But a KindFile fetch over cleartext is at
+// least as bad and arguably worse: the bytes coming back are a physical
+// constant, a catalogue, or an ephemeris kernel, and anything on the path can
+// rewrite them. A tampered luminous-efficiency table does not look like an
+// attack, it looks like a slightly different answer. So the rule covers the
+// whole registry.
+//
+// # Why a declared reason rather than a whitelist
+//
+// A list of exempt IDs rots silently: the entry stays after the upstream gains
+// TLS, and nobody re-reads it. A reason recorded on the endpoint has to be
+// written by whoever adds the URL, sits next to it, and can be re-checked
+// against the service.
+func TestNoUndeclaredCleartextEndpoints(t *testing.T) {
+	t.Parallel()
+
+	checked := 0
+
+	for _, ep := range remote.Endpoints() {
+		id := ep.ID
+
+		u, err := url.Parse(ep.URL)
+		if err != nil {
+			t.Errorf("%s: URL %q does not parse: %v", id, ep.URL, err)
+			continue
+		}
+
+		checked++
+
+		if u.Scheme != "http" {
+			// https, file, s3 and anything else a blob driver understands are
+			// outside this test's remit; only cleartext http is.
+			if ep.InsecureReason != "" {
+				t.Errorf("%s: scheme is %q but it records an InsecureReason.\n"+
+					"  The reason is stale — remove it, or the next reader will "+
+					"believe this endpoint is still cleartext.", id, u.Scheme)
+			}
+
+			continue
+		}
+
+		if strings.TrimSpace(ep.InsecureReason) == "" {
+			t.Errorf("%s: %q is cleartext http and records no InsecureReason.\n"+
+				"  Switch it to https, or set InsecureReason saying what was "+
+				"checked and when. Verify with a real request, not a HEAD: "+
+				"SIMBAD and VizieR both answered https identically to http, "+
+				"while www.cvrl.org refuses port 443 outright.", id, ep.URL)
+		}
+	}
+
+	if checked < 20 {
+		t.Fatalf("only %d endpoints checked; the registry has shrunk or "+
+			"Endpoints() is no longer enumerating it", checked)
+	}
+
+	t.Logf("%d endpoints checked", checked)
+}
+
+// TestCVRLIsTheOnlyDeclaredCleartextEndpoint pins the current exemption set, so
+// adding a second one is a deliberate act that shows up in a diff rather than
+// a quiet addition to a growing list.
+//
+// If an endpoint legitimately needs to join it, extend this test in the same
+// change and say why in the commit.
+func TestCVRLIsTheOnlyDeclaredCleartextEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var exempt []remote.EndpointID
+
+	for _, ep := range remote.Endpoints() {
+		if ep.InsecureReason != "" {
+			exempt = append(exempt, ep.ID)
+		}
+	}
+
+	if len(exempt) != 1 || exempt[0] != remote.CVRLLuminosity {
+		t.Errorf("cleartext exemptions are %v, want exactly [%v].\n"+
+			"  Every addition here ships astrogo's traffic in the clear for "+
+			"another service; it needs to be visible in review.",
+			exempt, remote.CVRLLuminosity)
+	}
+}


### PR DESCRIPTION
SIMBAD and VizieR were registered as cleartext `http://`. For a library whose job is catalogue positions that is exposure in both directions: the query says what is being observed, and the coordinates coming back can be rewritten by anything on the path.

## Verified before switching, not assumed

| service | HTTPS result |
| --- | --- |
| SIMBAD | 200, valid chain, real ADQL result for `M 31` |
| VizieR | 200, valid chain, body **byte-identical** to HTTP (10,503 bytes) |

## The 403 the issue could not explain

#107 recorded an earlier VizieR probe returning 403 and noted it "proves nothing either way". It is not about TLS. Running the same query over both schemes:

| query | http | https |
| --- | ---: | ---: |
| `SELECT TOP 1 * FROM "I/239/hip_main"` | 200 | 200 |
| same, with `WHERE HIP=32349` | **403** | **403** |

VizieR's filter dislikes something in the clause, identically on both schemes. Unrelated to the switch.

## Confirmed through astrogo's own client

curl proves the service works; it does not prove the library does. The `network` tier runs and passes against both, genuinely executing rather than skipping:

```
--- PASS: TestSimbadNetworkResolve (2.40s)
--- PASS: TestSimbadNetworkSearchBright (0.92s)
--- PASS: TestVizierNetworkConeSearch (2.01s)
--- PASS: TestVizierNetworkConeSearch_RegisteredTable (1.00s)
```

## www.cvrl.org has no TLS at all

Not a certificate problem that could be waved through — **there is no listener**:

- port 443 refuses the connection (`curl: (28) Failed to connect ... after 21072 ms`)
- port 80 answers 200
- the bare `cvrl.org` name does not resolve

So it stays HTTP, and the exemption becomes **data rather than prose**. `Endpoint` gains `InsecureReason`, and `TestNoUndeclaredCleartextEndpoints` refuses any `http://` URL in the registry that does not carry one.

A whitelist of exempt IDs would rot silently: the entry survives the upstream gaining TLS and nobody re-reads it. A reason recorded on the endpoint has to be written by whoever adds the URL, sits beside it, and can be re-checked against the service. The test also fails a reason left behind on an endpoint that has *since* moved to HTTPS, so the exemption cannot go stale in the other direction either.

`TestCVRLIsTheOnlyDeclaredCleartextEndpoint` pins the exemption set at exactly one, so a second one has to appear in a diff.

## Scope: every endpoint, not only KindAPI

The issue suggested asserting HTTPS for `KindAPI`. The rule here covers the whole registry, because a cleartext `KindFile` fetch is at least as bad — the bytes are a physical constant, a catalogue or an ephemeris kernel, and a tampered luminous-efficiency table does not look like an attack, it looks like a slightly different answer. `CVRLLuminosity` is `KindFile`, so the narrower rule would not have covered the one endpoint that actually needed documenting.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways. 32 endpoints checked by the new guard.

Three mutations, each caught with the right message:

| mutation | result |
| --- | --- |
| SIMBAD back to cleartext, no reason | fails, naming `cds.simbad` |
| CVRL exemption removed | both tests fail, naming `cvrl.lum` |
| stale reason added to an HTTPS endpoint | both tests fail, naming `jpl.sbdb` |

Closes #107.
