### PR TITLE
Use the Context LookAngle is given

### DIFF
--- a/docs/changelog.d/165-lookangle-context-reuse.md
+++ b/docs/changelog.d/165-lookangle-context-reuse.md
@@ -1,0 +1,11 @@
+---
+type: Fixed
+pr: 165
+---
+**`plan.LookAngle` discarded the `coord.Context` it was handed** and had
+`coord.Reducer` build a second one, repeating the Apco13 solve the first
+already held. Measured: 242 → 95 µs per call, and `SatellitePasses` 318 → 200
+ms over a six-hour window, since it paid the solve twice per 30-second sample.
+Everything the Reducer computed is already on `Context`, so nothing is rebuilt.
+Using the given Context is also what the signature promised — one derived by
+`Context.AtTime` used to be silently replaced with a full rebuild (#111).

--- a/plan/lookangle_context_test.go
+++ b/plan/lookangle_context_test.go
@@ -1,0 +1,137 @@
+package plan
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestLookAngleUsesTheContextItIsGiven pins that the Context parameter is the
+// one used, rather than three fields copied out of it and a fresh Context built
+// behind the caller's back.
+//
+// # Why a derived Context is the fixture
+//
+// A Context built by Context.AtTime holds precession-nutation and aberration
+// from its *base* epoch, deliberately, because recomputing them is the 145 us
+// this exists to avoid. So it differs slightly from what NewContext would
+// produce at the same instant — measured here at 0.0005 arcsec after an hour
+// and 0.03 arcsec after twelve.
+//
+// That difference is the probe. The old implementation called
+// coord.NewReducer(ctx.Site(), ctx.Time(), ctx.Refraction()), which rebuilt a
+// Context from scratch and so returned the *direct* answer no matter which
+// Context it was handed. Handing it a derived one and demanding the derived
+// answer is what tells the two implementations apart.
+//
+// The assertion is exact equality rather than a tolerance, because there is
+// nothing approximate about it: the value must come from this Context.
+func TestLookAngleUsesTheContextItIsGiven(t *testing.T) {
+	sat, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	site, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	base := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+
+	for _, dt := range []time.Duration{time.Hour, 6 * time.Hour, 12 * time.Hour} {
+		at := base.Add(dt)
+		derived := coord.NewContext(base, site, defaultAtm).AtTime(at)
+
+		st, err := sat.State(0, at)
+		if err != nil {
+			t.Fatalf("State: %v", err)
+		}
+
+		want := derived.GeocentricToObserved(st.Pos)
+
+		got, err := LookAngle(sat, 0, derived)
+		if err != nil {
+			t.Fatalf("LookAngle: %v", err)
+		}
+
+		if got.Alt() != want.Alt() || got.Az() != want.Az() {
+			t.Errorf("dt=%v: LookAngle returned alt %v az %v, but the Context it "+
+				"was given gives alt %v az %v (%.4f and %.4f arcsec apart).\n"+
+				"  The Context is being rebuilt rather than used.",
+				dt, got.Alt(), got.Az(), want.Alt(), want.Az(),
+				(got.Alt() - want.Alt()).Arcseconds(),
+				(got.Az() - want.Az()).Arcseconds())
+		}
+
+		// The range must come from the same Context's observer vector.
+		const kmPerAU = 149597870.7
+
+		wantDist := st.Pos.Sub(derived.ObsVec()).Norm() * kmPerAU
+		if math.Abs(got.Dist()-wantDist) > 1e-9 {
+			t.Errorf("dt=%v: range %.6f km, want %.6f km from this Context's "+
+				"observer vector", dt, got.Dist(), wantDist)
+		}
+
+		// And it is a plausible ISS range, so the test is not comparing two
+		// identically-wrong numbers.
+		if got.Dist() < 300 || got.Dist() > 45000 {
+			t.Errorf("dt=%v: range %.1f km is not a plausible ISS topocentric "+
+				"distance", dt, got.Dist())
+		}
+	}
+}
+
+// TestLookAngleMatchesTheReducerItReplaced guards the other direction: the
+// change was meant to remove a redundant computation, not alter the result.
+//
+// Given a Context built the ordinary way, coord.Reducer's pipeline and this
+// function must agree exactly, since the Reducer's own Context is then
+// constructed from the same three values.
+func TestLookAngleMatchesTheReducerItReplaced(t *testing.T) {
+	sat, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	site, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	const kmPerAU = 149597870.7
+
+	for _, hour := range []int{0, 3, 9, 15, 21} {
+		at := time.Date(2026, time.April, 20, hour, 0, 0, 0, time.LocationUTC)
+		ctx := coord.NewContext(at, site, defaultAtm)
+
+		st, err := sat.State(0, at)
+		if err != nil {
+			t.Fatalf("State: %v", err)
+		}
+
+		reduction := coord.NewReducer(site, at, defaultAtm).Reduce(st.Pos)
+		reduction.Observed.SetDist(reduction.Topocentric.Norm() * kmPerAU)
+
+		got, err := LookAngle(sat, 0, ctx)
+		if err != nil {
+			t.Fatalf("LookAngle: %v", err)
+		}
+
+		if got.Alt() != reduction.Observed.Alt() || got.Az() != reduction.Observed.Az() {
+			t.Errorf("%02d:00 — alt/az drifted from the Reducer pipeline: "+
+				"%.6f\" alt, %.6f\" az", hour,
+				(got.Alt() - reduction.Observed.Alt()).Arcseconds(),
+				(got.Az() - reduction.Observed.Az()).Arcseconds())
+		}
+
+		if math.Abs(got.Dist()-reduction.Observed.Dist()) > 1e-9 {
+			t.Errorf("%02d:00 — range drifted: %.9f km", hour,
+				got.Dist()-reduction.Observed.Dist())
+		}
+	}
+}

--- a/plan/satellite.go
+++ b/plan/satellite.go
@@ -173,29 +173,43 @@ func (s *Satellite) StaticMagnitude() (float64, bool) {
 var defaultAtm = atmosphere.Refraction{}
 
 // LookAngle computes the topocentric look angle (altitude, azimuth, distance)
-// from an observer to any celestial body at time t.
+// from an observer to any celestial body at the Context's time.
 //
 // This works for both satellite and planetary providers — any Provider that
-// returns a valid State. Uses the coord.Reducer pipeline which correctly
-// handles both nearby objects (LEO satellites) and distant bodies (planets)
-// by computing the full topocentric vector (geocentric - observer).
+// returns a valid State. The observer's geocentric position is subtracted from
+// the body's, so the range is right for a LEO satellite as well as a planet.
+//
+// # It uses the Context it is given
+//
+// It used to build a coord.Reducer from ctx.Site(), ctx.Time() and
+// ctx.Refraction() and throw the Context itself away. The Reducer then
+// lazily constructed a second Context from those three values, repeating the
+// Apco13 precession-nutation solve — about 150 µs — that the one in hand
+// already held. SatellitePasses builds a Context per 30 s step and called
+// this once per step, so the expensive work happened twice for every sample.
+//
+// Everything the Reducer computed is already on Context: GeocentricToObserved
+// is the refracted alt/az, and ObsVec is the observer vector the topocentric
+// range needs. So there is nothing to rebuild.
+//
+// Using the given Context is also what the signature promises. A caller who
+// derived it with Context.AtTime — the cheap Earth-rotation-only update —
+// previously had that quietly discarded and a full rebuild substituted, which
+// is the opposite of what they asked for.
 func LookAngle(prov eph.Provider, id eph.ID, ctx *coord.Context) (coord.AltAz, error) {
 	st, err := prov.State(id, ctx.Time())
 	if err != nil {
 		return coord.AltAz{}, fmt.Errorf("satellite: look angle state: %w", err)
 	}
 
-	// Use the Reducer pipeline: computes observer GCRS position, subtracts it
-	// from the geocentric state, converts to ENU, then az/el. This gives the
-	// correct topocentric range for nearby objects (satellites).
-	reducer := coord.NewReducer(ctx.Site(), ctx.Time(), ctx.Refraction())
-	reduction := reducer.Reduce(st.Pos)
+	observed := ctx.GeocentricToObserved(st.Pos)
 
-	// The Reducer works in AU — convert topocentric distance to km.
+	// Context works in AU — convert the topocentric distance to km.
 	const kmPerAU = 149597870.7
-	reduction.Observed.SetDist(reduction.Topocentric.Norm() * kmPerAU)
 
-	return reduction.Observed, nil
+	observed.SetDist(st.Pos.Sub(ctx.ObsVec()).Norm() * kmPerAU)
+
+	return observed, nil
 }
 
 // SatellitePass represents a single pass of a satellite over an observer.
@@ -228,6 +242,11 @@ func SatellitePasses(prov eph.Provider, name string, start, end time.Time,
 	refineTol := 1 * time.Second
 
 	// lookAt creates a context and computes look angle at time t.
+	//
+	// Body id 0 is not a placeholder: satellite.Satellite carries one TLE and
+	// its State rejects any other id with ErrUnexpectedID, so 0 is the only
+	// one a satellite provider accepts. The name parameter is a label for the
+	// returned pass, not a lookup key.
 	lookAt := func(t time.Time) (coord.AltAz, error) {
 		ctx := coord.NewContext(t, observer, defaultAtm)
 		return LookAngle(prov, 0, ctx)

--- a/plan/satellite_bench_test.go
+++ b/plan/satellite_bench_test.go
@@ -1,0 +1,71 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// benchISS builds the provider and site the satellite benchmarks share.
+//
+// Same real ISS TLE the offline tests use, so nothing here touches the network.
+func benchISS(b *testing.B) (*satellite.Satellite, *coord.Geodetic) {
+	b.Helper()
+
+	sat, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	if err != nil {
+		b.Fatalf("NewFromTLE: %v", err)
+	}
+
+	site, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		b.Fatalf("NewGeodetic: %v", err)
+	}
+
+	return sat, site
+}
+
+// BenchmarkLookAngle measures one look-angle evaluation against a Context the
+// caller already holds.
+//
+// This is the call that used to discard that Context and have coord.Reducer
+// build a second one, repeating the Apco13 solve. The Context is constructed
+// outside the loop precisely because that is how a caller uses it — the point
+// of taking one is that the expensive part is already paid for.
+func BenchmarkLookAngle(b *testing.B) {
+	sat, site := benchISS(b)
+
+	when := time.Date(2026, time.April, 20, 3, 0, 0, 0, time.LocationUTC)
+	ctx := coord.NewContext(when, site, defaultAtm)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := LookAngle(sat, 0, ctx); err != nil {
+			b.Fatalf("LookAngle: %v", err)
+		}
+	}
+}
+
+// BenchmarkSatellitePasses_6h is the workload the cost actually lands in:
+// 30-second sampling across a six-hour window, which is 720 look angles plus
+// the root-finding refinement on each crossing.
+//
+// At one Apco13 solve per sample this is the floor; it used to be two.
+func BenchmarkSatellitePasses_6h(b *testing.B) {
+	sat, site := benchISS(b)
+
+	start := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+	end := start.Add(6 * time.Hour)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := SatellitePasses(sat, "ISS", start, end, site, angle.Deg(10)); err != nil {
+			b.Fatalf("SatellitePasses: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
`plan.LookAngle` took a `*coord.Context` and threw it away, keeping only `Site`, `Time` and `Refraction` to build a `coord.Reducer`. The Reducer then lazily constructed a **second** Context from those three values, repeating the Apco13 precession-nutation solve the first one already held.

Everything the Reducer computed is already on `Context`: `GeocentricToObserved` is the refracted alt/az, `ObsVec` is the observer vector the topocentric range needs. There is nothing to rebuild.

## Measured, and the arithmetic closes exactly

| component | cost |
| --- | ---: |
| `sat.State` (SGP4 + TEME→GCRS) | 94.8 µs |
| `coord.NewContext` (Apco13) | 145.5 µs |
| `ctx.GeocentricToObserved` | 24 ns |

| benchmark | before | after |
| --- | ---: | ---: |
| `LookAngle` | 242 µs | **95 µs** |
| `SatellitePasses` over 6 h | 318 ms | **200 ms** |

242 = 94.8 + 145.5, and 95 = 94.8 + 0.024. The fix removes exactly one Apco13 solve, and what remains is the SGP4 propagation `LookAngle` cannot avoid. `SatellitePasses` builds a Context per 30-second sample and calls this once per sample, so the solve happened twice for each of the 720 samples in that window; 318/200 = 1.59 against a predicted 386/240 = 1.61.

Both benchmarks are new — this path had none.

## It is a correctness point too, not only speed

A caller who derived their Context with `Context.AtTime` — the deliberate Earth-rotation-only update that exists to *avoid* the 145 µs — had it silently discarded and a full rebuild substituted. That is the opposite of what they asked for.

`TestLookAngleUsesTheContextItIsGiven` uses that as the probe: it hands in a derived Context and demands the derived answer, **exactly**. A derived Context differs from a directly-built one by 0.0005″ after an hour and 0.03″ after twelve — small, but it is the fingerprint that tells the two implementations apart. Reverting to the old code fails it at all three epochs, on angles and range.

`TestLookAngleMatchesTheReducerItReplaced` covers the other direction: given an ordinary Context, results are bit-identical to the pipeline that was removed.

## The hardcoded body id 0

The issue flagged this as "worth checking while here". Checked: it is in `SatellitePasses`, not `LookAngle`, and it is **correct rather than a bug**. `satellite.Satellite` carries one TLE and its `State` rejects any other id with `ErrUnexpectedID`, so 0 is the only id a satellite provider accepts. The `name` parameter is a label for the returned pass, not a lookup key. Recorded in a comment so the next reader does not re-investigate it.

## Left for a follow-up

`SatellitePasses` still spends 145 of its remaining 240 µs per sample building a Context that `Context.AtTime` could update instead — another ~2.5× on that workload. Not folded in here because it trades a documented accuracy bound (≲0.1″ per hour from the base epoch), which deserves its own review rather than riding along with a pure removal.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

The before/after benchmark needed two attempts: stashing the tracked change also removed the new (untracked) benchmark file, so the first "before" run measured nothing. Redone by keeping the benchmark file in place across the stash.

Closes #111.
