### PR TITLE
Give Event two altitudes that mean what they are named

### DIFF
--- a/docs/changelog.d/167-event-altitude-convention.md
+++ b/docs/changelog.d/167-event-altitude-convention.md
@@ -1,0 +1,12 @@
+---
+type: Fixed
+pr: 167
+---
+**`Event.Altitude` was geometric at rise/set and refracted at transit**, with
+nothing in the type saying so, and `Event.GeometricAltitude` was assigned the
+identical value at both construction sites — so one field told a caller nothing
+the other did, and comparing a rise altitude against a transit altitude
+compared two different quantities. `Altitude` is now the refracted altitude at
+every event kind, matching `IsObservable` and `GetDetails`; `GeometricAltitude`
+is the unrefracted one. `Value` stays geometric at rise/set, so event times are
+unchanged (#156).

--- a/plan/events.go
+++ b/plan/events.go
@@ -399,38 +399,23 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 					return nil, err
 				}
 
-				// Calculate geometric altitude at the refined event time,
-				// using the same no-refraction atmosphere as the solver.
-				resCtx := coord.NewContext(resTime, spec.Observer.Location(), geomAtm)
-
-				var aa coord.AltAz
-
-				if mb, ok := spec.Target.(MovingBody); ok {
-					vec, err := mb.GeocentricVec(resTime)
-					if err != nil {
-						continue // Can't populate display fields reliably; skip this event
-					}
-
-					aa = resCtx.GeocentricToObserved(vec)
-				} else {
-					pos, err := spec.Target.Position(resTime)
-					if err != nil {
-						continue
-					}
-
-					aa, err = observedAltAz(spec.Target, resTime, resCtx, pos)
-					if err != nil {
-						continue
-					}
+				// Both altitudes, so the two fields mean what they are named.
+				// The solver works geometrically here — refraction is already
+				// baked into the threshold, per the USNO convention — so the
+				// geometric one is what Value is measured against, while
+				// Altitude reports what an observer would actually see.
+				geom, refr, ok := altitudesAt(spec, resTime, geomAtm)
+				if !ok {
+					continue // Can't populate display fields reliably; skip this event
 				}
 
 				events = append(events, Event{
 					Kind:              kind,
 					Time:              resTime,
-					Altitude:          aa.Alt(),
-					GeometricAltitude: aa.Alt(),
-					Azimuth:           aa.Az(),
-					Value:             aa.Alt().Degrees() - spec.Threshold.Degrees(),
+					Altitude:          refr.Alt(),
+					GeometricAltitude: geom.Alt(),
+					Azimuth:           geom.Az(),
+					Value:             geom.Alt().Degrees() - spec.Threshold.Degrees(),
 				})
 			}
 		}
@@ -487,25 +472,18 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 					continue // Skip if solver fails
 				}
 
-				resCtx := coord.NewContext(resTime, spec.Observer.Location(), spec.Observer.Refraction())
-
-				pos, err := spec.Target.Position(resTime)
-				if err != nil {
+				geom, refr, ok := altitudesAt(spec, resTime, geomAtm)
+				if !ok {
 					continue // Can't populate display fields reliably; skip this event
-				}
-
-				aa, err := observedAltAz(spec.Target, resTime, resCtx, pos)
-				if err != nil {
-					continue
 				}
 
 				events = append(events, Event{
 					Kind:              EventTransit,
 					Time:              resTime,
-					Altitude:          aa.Alt(),
-					GeometricAltitude: aa.Alt(),
-					Azimuth:           aa.Az(),
-					Value:             aa.Alt().Degrees(),
+					Altitude:          refr.Alt(),
+					GeometricAltitude: geom.Alt(),
+					Azimuth:           refr.Az(),
+					Value:             refr.Alt().Degrees(),
 				})
 			}
 		}
@@ -684,13 +662,37 @@ func (s EventSolver) solveGeometry(spec EventSpec, start, end time.Time) ([]Even
 
 // Event represents a specific occurrence of a celestial target in the coord.
 type Event struct {
-	Time              time.Time
-	Kind              EventKind
-	Altitude          angle.Angle
+	Time time.Time
+	Kind EventKind
+
+	// Altitude is the refracted altitude — what an observer would see — at
+	// every event kind. It agrees with [IsObservable] and [GetDetails] for the
+	// same instant, so altitudes may be compared across event kinds.
+	//
+	// It was geometric at rise and set and refracted at transit until #156,
+	// with nothing in the type saying so, which made a rise altitude and a
+	// transit altitude two different quantities under one name.
+	Altitude angle.Angle
+
+	// GeometricAltitude is the unrefracted altitude, at every event kind.
+	//
+	// This is the quantity rise and set are solved against: their thresholds
+	// already fold in a constant horizon allowance for refraction, the USNO
+	// convention, so applying refraction again would double-count it. Value
+	// carries the residual against that threshold and is geometric for the
+	// same reason.
 	GeometricAltitude angle.Angle
-	Azimuth           angle.Angle
-	Value             float64
-	Observable        bool
+
+	// Azimuth is the same under both conventions — refraction changes an
+	// object's altitude, not its bearing.
+	Azimuth angle.Angle
+
+	// Value is the quantity the solver drove to zero: the geometric altitude
+	// less the threshold for rise, set and twilight; the refracted altitude
+	// for a transit; a separation in degrees for geometry events.
+	Value float64
+
+	Observable bool
 }
 
 func (e Event) String() string {
@@ -1299,4 +1301,66 @@ func NextFullMoon(start time.Time, provider eph.Provider) (*Event, error) {
 	}
 
 	return &events[0], nil
+}
+
+// altitudesAt evaluates a target at t under both atmospheres, returning the
+// geometric altitude and the refracted one.
+//
+// # Why an Event carries both
+//
+// Event.Altitude and Event.GeometricAltitude used to be assigned the same
+// value at both construction sites, so one told a caller nothing the other
+// did. Worse, which quantity that shared value held depended on the event
+// kind: rise and set were evaluated under a no-refraction atmosphere, because
+// the solver works against a geometric threshold with refraction already baked
+// in per the USNO convention, while transit used the observer's real
+// refraction. Measured for the Moon, that made Event.Altitude 0.167 degrees
+// lower than IsObservable and GetDetails reported at rise and set, and exactly
+// equal at transit — so comparing a rise altitude against a transit altitude
+// was comparing two different quantities, with nothing in the type saying so.
+//
+// Computing both here costs a second coord.NewContext per event. Events are
+// refined candidates rather than samples — a handful per target per day, well
+// outside the solver loop — so the Apco13 solve is paid a few times, not per
+// bisection step.
+//
+// ok is false when the target cannot be evaluated at t, which the callers
+// treat as "skip this event" rather than failing the whole solve.
+func altitudesAt(spec EventSpec, t time.Time, geomAtm atmosphere.Refraction) (geom, refr coord.AltAz, ok bool) {
+	at := func(atm atmosphere.Refraction) (coord.AltAz, bool) {
+		ctx := coord.NewContext(t, spec.Observer.Location(), atm)
+
+		if mb, isMoving := spec.Target.(MovingBody); isMoving {
+			vec, err := mb.GeocentricVec(t)
+			if err != nil {
+				return coord.AltAz{}, false
+			}
+
+			return ctx.GeocentricToObserved(vec), true
+		}
+
+		pos, err := spec.Target.Position(t)
+		if err != nil {
+			return coord.AltAz{}, false
+		}
+
+		aa, err := observedAltAz(spec.Target, t, ctx, pos)
+		if err != nil {
+			return coord.AltAz{}, false
+		}
+
+		return aa, true
+	}
+
+	geom, ok = at(geomAtm)
+	if !ok {
+		return coord.AltAz{}, coord.AltAz{}, false
+	}
+
+	refr, ok = at(spec.Observer.Refraction())
+	if !ok {
+		return coord.AltAz{}, coord.AltAz{}, false
+	}
+
+	return geom, refr, true
 }

--- a/plan/events_altitudes_test.go
+++ b/plan/events_altitudes_test.go
@@ -1,0 +1,138 @@
+package plan
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+var errMovingBodyFails = errors.New("events_altitudes_test: geocentric vector always fails")
+
+// errMovingBody fails on GeocentricVec, covering the branch a fixed target
+// cannot reach.
+type errMovingBody struct{}
+
+func (errMovingBody) Name() string { return "ErrMovingBody" }
+
+func (errMovingBody) Position(time.Time) (coord.ICRS, error) {
+	return coord.ICRS{}, nil
+}
+
+func (errMovingBody) GetDetails(*coord.Context, ...string) (*TargetDetails, error) {
+	return nil, errMovingBodyFails
+}
+
+func (errMovingBody) GeocentricVec(time.Time) (vector.Vec3, error) {
+	return vector.Vec3{}, errMovingBodyFails
+}
+
+func (errMovingBody) Provider() eph.Provider { return nil }
+func (errMovingBody) EphID() eph.ID          { return 0 }
+
+// Compile-time proof this fixture reaches the MovingBody branch. Without it the
+// type falls through to the Position path and the test passes while covering
+// the wrong one, which is exactly what happened first time.
+var _ MovingBody = errMovingBody{}
+
+// TestAltitudesAtReportsFailureRatherThanAGuess covers the path an event takes
+// when a target cannot be evaluated at the refined time.
+//
+// altitudesAt returns ok=false and both callers skip the event. That matters
+// more than it looks: the alternative to skipping is appending an Event whose
+// altitude fields are the zero value, which would read as a target sitting
+// exactly on the horizon rather than as missing data.
+//
+// Both target shapes are covered because they reach the failure by different
+// routes — a MovingBody through GeocentricVec, everything else through
+// Position — and only one of them is reachable from a given fixture.
+func TestAltitudesAtReportsFailureRatherThanAGuess(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("altitudes", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	when := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+	geomAtm := atmosphere.Refraction{Pressure: 0}
+
+	for _, tc := range []struct {
+		name   string
+		target Observable
+	}{
+		{"a fixed target whose Position fails", errObservable{}},
+		{"a MovingBody whose GeocentricVec fails", errMovingBody{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := EventSpec{Target: tc.target, Observer: site}
+
+			geom, refr, ok := altitudesAt(spec, when, geomAtm)
+			if ok {
+				t.Fatalf("ok was true for a target that cannot be evaluated; "+
+					"got geom %v and refr %v", geom.Alt(), refr.Alt())
+			}
+
+			// Both altitudes must be the zero value, so a caller that ignores
+			// ok cannot mistake a stale reading for a fresh one.
+			if geom != (coord.AltAz{}) || refr != (coord.AltAz{}) {
+				t.Errorf("failure returned non-zero altitudes geom=%v refr=%v", geom, refr)
+			}
+		})
+	}
+}
+
+// TestAltitudesAtSeparatesTheTwoAtmospheres pins the reason the helper exists:
+// the two altitudes it returns must actually be different quantities.
+//
+// A refactor that passed the same atmosphere twice would leave every Event
+// with two identical fields again, which is the defect this replaced.
+func TestAltitudesAtSeparatesTheTwoAtmospheres(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(45), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("altitudes", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	// A star near the horizon, where refraction is largest and the two
+	// atmospheres disagree most.
+	star := NewStar("low", angle.Deg(0), angle.Deg(44))
+	when := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+
+	spec := EventSpec{Target: star, Observer: site}
+
+	geom, refr, ok := altitudesAt(spec, when, atmosphere.Refraction{Pressure: 0})
+	if !ok {
+		t.Fatal("altitudesAt failed on an ordinary star")
+	}
+
+	if refr.Alt() <= geom.Alt() {
+		t.Errorf("refracted altitude %v is not above geometric %v; refraction "+
+			"raises an object, so the two atmospheres are not being applied",
+			refr.Alt(), geom.Alt())
+	}
+
+	// Azimuth is unaffected by refraction, so it must match exactly.
+	if geom.Az() != refr.Az() {
+		t.Errorf("azimuth differs between the two atmospheres: %v vs %v",
+			geom.Az(), refr.Az())
+	}
+}

--- a/plan/pipelines_test.go
+++ b/plan/pipelines_test.go
@@ -71,40 +71,47 @@ func TestSatelliteAltitudePipelinesAgree(t *testing.T) {
 	}
 }
 
-// TestEventAltitudeConventionIsWhatItClaims pins the third pipeline against the
-// other two, and the answer is more interesting than "they agree".
+// TestEventAltitudesAreWhatTheyAreNamed pins the third pipeline against the
+// other two, and the answer was more interesting than "they agree".
+//
+// Named TestEventAltitudeConventionIsWhatItClaims until #156 — since renamed,
+// because it no longer records a convention that had to be discovered by
+// measurement; it checks the field names are true.
 //
 // # What comparing them found
 //
-// At transit, Event.Altitude matches IsObservable and GetDetails exactly. At
-// rise and set it differs by 0.1668°, at both ends, for the Moon:
+// At transit, Event.Altitude matched IsObservable and GetDetails exactly. At
+// rise and set it differed by 0.1668 degrees, at both ends, for the Moon:
 //
 //	Rise       Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
 //	Transit    Event= 54.2489  IsObservable= 54.2489  GetDetails= 54.2489
 //	Set        Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
 //
-// That 0.1668° is refraction — the same value coord's own refraction tests
-// measure at these altitudes. A constant offset at both ends, and none at
-// transit, rules out a timing difference and identifies the cause exactly.
+// That 0.1668 degrees is refraction. A constant offset at both ends and none
+// at transit ruled out a timing difference and identified the cause exactly:
+// the solver built the rise/set context with a no-refraction atmosphere,
+// because rise and set are solved against a geometric threshold with the
+// horizon allowance already folded in, the USNO convention. Transit was built
+// with the site's real refraction.
 //
-// It is deliberate. The solver builds the rise/set context with a
-// no-refraction atmosphere (events.go, "using the same no-refraction
-// atmosphere as the solver") because rise and set are solved against a
-// geometric threshold plus a constant horizon allowance, the USNO convention.
-// Transit is built with the site's real refraction.
+// So Event.Altitude meant different things for different event kinds, and
+// nothing said so. Event.GeometricAltitude was assigned the identical value at
+// both sites, so it distinguished nothing.
 //
-// So Event.Altitude means different things for different event kinds, and
-// nothing said so. Asserting a three-way equality would have been asserting
-// something false; this asserts the convention instead, which is the useful
-// thing to hold still.
+// # What this now asserts
 //
-// # Why this belongs with the others
+// Both fields are populated honestly at both construction sites, so the test
+// no longer records a convention — it checks the names are true:
 //
-// #100 and #101 were both two public APIs computing one quantity by different
-// routes and disagreeing, with no test looking. This is the third route. It
-// does not disagree — it answers a different question — but until something
-// compared them, nobody could tell those apart, which is the same gap.
-func TestEventAltitudeConventionIsWhatItClaims(t *testing.T) {
+//   - Altitude is the refracted altitude, at every event kind, which makes it
+//     equal to what IsObservable and GetDetails report. Comparing a rise
+//     altitude against a transit altitude is now sound.
+//   - GeometricAltitude is the geometric one, at every event kind.
+//   - The gap between them is the refraction at that altitude, not zero.
+//   - Value is still measured geometrically at rise and set, because that is
+//     what the threshold means. Changing the reported altitude must not move
+//     the event times, and this is what says so.
+func TestEventAltitudesAreWhatTheyAreNamed(t *testing.T) {
 	t.Parallel()
 
 	site, err := plan.NewSiteEarthLocation("pipelines", -23.5, -46.6, 800)
@@ -129,11 +136,9 @@ func TestEventAltitudeConventionIsWhatItClaims(t *testing.T) {
 
 	const toleranceArcsec = 1.0
 
-	var checked int
+	var checked, sawRiseOrSet, sawTransit int
 
 	for _, e := range events {
-		// The same instant through both conventions, so the comparison does
-		// not depend on which one the event happens to use.
 		refracted := coord.NewContext(e.Time, site.Location(), site.Refraction())
 		geometric := coord.NewContext(e.Time, site.Location(), atmosphere.Refraction{})
 
@@ -145,43 +150,61 @@ func TestEventAltitudeConventionIsWhatItClaims(t *testing.T) {
 		withRefraction := refracted.GeocentricToObserved(vec).Alt().Degrees()
 		withoutRefraction := geometric.GeocentricToObserved(vec).Alt().Degrees()
 
-		var (
-			want float64
-			why  string
-		)
-
-		if e.Kind == plan.EventTransit {
-			want, why = withRefraction, "transit is solved with the site's own refraction"
-		} else {
-			want, why = withoutRefraction, "rise and set are solved against a geometric "+
-				"threshold with a constant horizon allowance, so the reported altitude "+
-				"carries no refraction"
-		}
-
 		checked++
 
-		if d := math.Abs(e.Altitude.Degrees()-want) * 3600; d > toleranceArcsec {
-			t.Errorf("%s: Event.Altitude is %.4f°, expected %.4f° (%.1f arcsec out).\n"+
-				"  %s.\n  Refracted here is %.4f° and geometric %.4f°; if the event now "+
-				"matches the other one, the convention changed and this test is the "+
-				"record of what it used to be.",
-				e.Kind, e.Altitude.Degrees(), want, d, why, withRefraction, withoutRefraction)
+		if d := math.Abs(e.Altitude.Degrees()-withRefraction) * 3600; d > toleranceArcsec {
+			t.Errorf("%s: Altitude is %.4f deg, want the refracted %.4f deg "+
+				"(%.1f arcsec out). Altitude is what an observer sees, at every "+
+				"event kind, so it must agree with IsObservable and GetDetails.",
+				e.Kind, e.Altitude.Degrees(), withRefraction, d)
 		}
 
-		// Altitude and GeometricAltitude are assigned the same value at both
-		// construction sites, so they carry one quantity under two names. That
-		// is worth knowing about rather than relying on.
-		if e.Altitude != e.GeometricAltitude {
-			t.Errorf("%s: Altitude %v and GeometricAltitude %v differ; they have always "+
-				"been assigned the same value, so something now distinguishes them and "+
-				"the convention above needs revisiting",
-				e.Kind, e.Altitude, e.GeometricAltitude)
+		if d := math.Abs(e.GeometricAltitude.Degrees()-withoutRefraction) * 3600; d > toleranceArcsec {
+			t.Errorf("%s: GeometricAltitude is %.4f deg, want the unrefracted %.4f deg "+
+				"(%.1f arcsec out).", e.Kind, e.GeometricAltitude.Degrees(),
+				withoutRefraction, d)
+		}
+
+		// The two fields must actually differ, by the refraction at this
+		// altitude. Equal fields are the defect this test exists for: they
+		// were assigned the same value at both sites.
+		gap := (e.Altitude - e.GeometricAltitude).Arcseconds()
+		want := (withRefraction - withoutRefraction) * 3600
+
+		if math.Abs(gap-want) > toleranceArcsec {
+			t.Errorf("%s: Altitude and GeometricAltitude are %.2f arcsec apart, want "+
+				"%.2f — the refraction at %.2f deg.", e.Kind, gap, want,
+				e.GeometricAltitude.Degrees())
+		}
+
+		if gap <= 0 {
+			t.Errorf("%s: the two altitudes are %.2f arcsec apart; refraction raises "+
+				"an object, so the refracted one must be the higher", e.Kind, gap)
+		}
+
+		// Value keeps its geometric meaning at rise and set: it is the residual
+		// against the threshold the solver actually used. If this moved, the
+		// event times would have moved with it.
+		switch e.Kind { //nolint:exhaustive // MoonEvents yields only rise, transit and set
+		case plan.EventTransit:
+			sawTransit++
+		case plan.EventRise, plan.EventSet:
+			sawRiseOrSet++
+
+			residual := e.GeometricAltitude.Degrees() - site.MoonRiseSetThreshold().Degrees()
+			if d := math.Abs(e.Value-residual) * 3600; d > toleranceArcsec {
+				t.Errorf("%s: Value is %.6f but the geometric residual against the "+
+					"threshold is %.6f (%.1f arcsec out). Value must stay geometric, "+
+					"or the reported event times have shifted.", e.Kind, e.Value, residual, d)
+			}
+		default:
 		}
 	}
 
-	if checked < 3 {
-		t.Fatalf("only %d events checked", checked)
+	if sawRiseOrSet == 0 || sawTransit == 0 {
+		t.Fatalf("checked %d events but saw %d rise/set and %d transit; the test needs "+
+			"both kinds to compare them", checked, sawRiseOrSet, sawTransit)
 	}
 
-	t.Logf("%d events checked against their own altitude convention", checked)
+	t.Logf("%d events checked (%d rise/set, %d transit)", checked, sawRiseOrSet, sawTransit)
 }


### PR DESCRIPTION
`Event` carried two altitude fields, and both construction sites assigned them the same value:

```go
Altitude:          aa.Alt(),
GeometricAltitude: aa.Alt(),
```

So `GeometricAltitude` told a caller nothing `Altitude` did not. Worse, *which* quantity that shared value held depended on the event kind. Measured for the Moon over one day:

```
Rise       Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
Transit    Event= 54.2489  IsObservable= 54.2489  GetDetails= 54.2489
Set        Event= -1.6547  IsObservable= -1.4879  GetDetails= -1.4879
```

The 0.1668° at rise and set is refraction. The solver builds the rise/set context with a no-refraction atmosphere, because those events are solved against a geometric threshold with the horizon allowance already folded in — the USNO convention — while transit uses the site's real refraction. A constant offset at both ends and none at transit rules out a timing difference.

Not a wrong answer, but an undocumented convention a caller could only find by measuring, and one that made comparing a rise altitude against a transit altitude unsound.

## Both fields, honestly, at both sites

| field | now |
| --- | --- |
| `Altitude` | refracted, **every** event kind — what an observer sees, equal to `IsObservable` and `GetDetails` |
| `GeometricAltitude` | unrefracted, every event kind |
| `Azimuth` | unchanged — refraction moves altitude, not bearing |
| `Value` | **still geometric** at rise/set |

That last row is the one that matters for safety. `Value` is the residual against the threshold the solver actually used, so if it moved, the reported event times would have moved with it. The test asserts it directly against `site.MoonRiseSetThreshold()`, and a mutation that refracts it fails by 600 arcsec.

Cost is a second `coord.NewContext` per event. Events are refined candidates — a handful per target per day, well outside the solver loop — and the two context caches backing the sampling and bisection are untouched.

## The #157 guard did its job

That test was written to record the old convention, with the note *"if the event now matches the other one, the convention changed and this test is the record of what it used to be."* It failed the moment the change landed, naming both values:

```
Rise: Event.Altitude is -1.4879°, expected -1.6547° (600.5 arcsec out)
Rise: Altitude -1.4879° and GeometricAltitude -1.6547° differ
```

Rewritten rather than deleted, and now stronger. It no longer records a convention that had to be discovered by measurement — it checks the names are true:

- `Altitude` equals the refracted altitude at every kind
- `GeometricAltitude` equals the unrefracted one at every kind
- the gap between them equals the refraction at that altitude, rather than being zero
- the refracted one is the higher, since refraction raises an object
- `Value` is still the geometric residual

Renamed to `TestEventAltitudesAreWhatTheyAreNamed`, with the old name kept in the doc comment so the citation guard resolves.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Three mutations against the final code:

| mutation | result |
| --- | --- |
| `Altitude` back to geometric at rise/set | 3 assertions fire, naming the 600.45 arcsec gap |
| `GeometricAltitude` carries refraction | fails |
| `Value` refracted at rise/set | fails by 600.5 arcsec, "event times have shifted" |

The first two initially failed to compile (an unused variable), so they proved nothing; redone with the variable silenced so the mutation actually ran.

One process note: I built the rewritten test through a heredoc containing `\n`, and it mangled the escape into a real newline, breaking a string literal. That is the exact failure my own notes warn about; fixed with an editor rather than a script.

Closes #156.
