### PR TITLE
Answer Episode from culmination instead of a 366-day search

### DIFF
--- a/docs/changelog.d/168-episode-closed-form.md
+++ b/docs/changelog.d/168-episode-closed-form.md
@@ -1,0 +1,11 @@
+---
+type: Fixed
+pr: 168
+---
+**`plan.Episode` searched up to 366 days to discover a target never rises.**
+For a fixed target that answer is two arcsines — declination does not change,
+so upper and lower culmination bound the whole window — and `IsNeverUp` /
+`IsCircumpolar` already computed it while having no caller in the library.
+Measured: 2.84 s → 67 ns for the never-rises case, and the `plan` package
+18.6 s → 12.7 s. A one-degree margin keeps anything refraction or parallax
+could decide on the search path, and moving bodies always search (#110).

--- a/plan/day_episode.go
+++ b/plan/day_episode.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/time"
 )
@@ -203,6 +204,13 @@ func searchEvent(target Observable, site *Site, from time.Time, k EventKind, for
 // See DayEvents for the different question ("what happened on this
 // calendar day") this is deliberately not answering.
 func Episode(from, to time.Time, target Observable, site *Site) (rise, set *Event, err error) {
+	// A fixed target whose culminations put it clear of the horizon either way
+	// has no rise to find, and searching 366 days to discover that costs about
+	// 2.9 s. See culminationSkipsSearch.
+	if culminationSkipsSearch(target, site, from) {
+		return nil, nil, nil
+	}
+
 	up, err := isAboveHorizon(target, site, from)
 	if err != nil {
 		return nil, nil, err
@@ -228,4 +236,66 @@ func Episode(from, to time.Time, target Observable, site *Site) (rise, set *Even
 	}
 
 	return rise, set, nil
+}
+
+// episodeClosedFormMargin is how far outside the horizon threshold the
+// closed-form culmination bounds must place a target before [Episode] trusts
+// them and skips its search.
+//
+// One degree, chosen to clear every effect the closed form does not model. It
+// is pure spherical geometry from declination and latitude: no atmospheric
+// refraction (~34' at the horizon), no parallax, no proper motion over the
+// window. A target within that margin of the threshold is one where those
+// terms could decide the answer, so it goes to the search as before.
+//
+// The margin is what makes this an optimisation rather than a second, cruder
+// implementation of the same question. A target one degree clear is not a
+// borderline case: the never-rises test's star sits 75 degrees below its
+// site's horizon.
+const episodeClosedFormMargin = 1.0 // degrees
+
+// culminationSkipsSearch reports whether upper and lower culmination place a
+// fixed target unambiguously outside the range where a rise could be found, so
+// [Episode] can answer without searching.
+//
+// # Why this is worth doing
+//
+// Episode answers "does this ever rise?" by doubling a window out to 366 days,
+// evaluating positions at every step, each paying a coord.NewContext Apco13
+// solve plus an ephemeris lookup. For a target that never rises, every one of
+// those steps finds nothing, and the function only concludes by exhausting the
+// window. Measured at 2.9 s per call.
+//
+// For a fixed target the answer is two arcsine evaluations, because
+// declination does not change: upper culmination is the highest the target
+// ever gets and lower culmination the lowest. [IsNeverUp] and [IsCircumpolar]
+// already compute exactly this and, until now, had no caller in the library at
+// all.
+//
+// # Why only a fixed target
+//
+// A MovingBody's declination changes over the window, so a single pair of
+// culmination altitudes bounds nothing — the Moon moves 28 degrees of
+// declination in a fortnight, and a body below the horizon today may rise next
+// week. Those keep searching.
+func culminationSkipsSearch(target Observable, site *Site, at time.Time) bool {
+	if _, moving := target.(MovingBody); moving {
+		return false
+	}
+
+	pos, err := target.Position(at)
+	if err != nil {
+		// Let the search surface the error, as it did before.
+		return false
+	}
+
+	minAlt, maxAlt := circumpolarExtremes(pos.Dec(), site)
+
+	threshold := site.RiseSetThreshold().Radians()
+	margin := angle.Deg(episodeClosedFormMargin).Radians()
+
+	// Never rises: even at upper culmination it is clear of the threshold.
+	// Never sets: even at lower culmination it stays clear above it.
+	// Either way there is no rise to find, which is what Episode reports.
+	return maxAlt < threshold-margin || minAlt > threshold+margin
 }

--- a/plan/day_episode_closedform_test.go
+++ b/plan/day_episode_closedform_test.go
@@ -1,0 +1,264 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestCulminationSkipsSearchIsNeverAFalsePositive is the safety property.
+//
+// Episode now answers "does this ever rise?" from two arcsines instead of a
+// 366-day search, and a wrong "no" would be silent: the caller gets a nil rise
+// and a nil set, which is exactly what a genuine never-rises target returns.
+//
+// # Why a brute-force check is possible here
+//
+// For a target at fixed declination, one day covers every hour angle. So
+// sweeping a day at fine steps is not a sample — it is the whole domain, and
+// it settles the question exactly. That is what makes this an independent
+// check rather than the closed form compared against itself.
+//
+// The sweep deliberately uses the same refracted pipeline Episode's own
+// isAboveHorizon does, while the closed form is pure geometry with no
+// refraction. Those disagree near the horizon, which is exactly what
+// episodeClosedFormMargin exists to cover — and this test is what says the
+// margin is big enough.
+func TestCulminationSkipsSearchIsNeverAFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+
+	const (
+		sweepSteps = 96 // 15-minute steps across a day: every hour angle
+		dayMinutes = 24 * 60
+	)
+
+	checkedSkips := 0
+
+	for latDeg := -80.0; latDeg <= 80.0; latDeg += 10 {
+		loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(latDeg), 0)
+		if err != nil {
+			t.Fatalf("NewGeodetic(%g): %v", latDeg, err)
+		}
+
+		site, err := NewSite("sweep", loc)
+		if err != nil {
+			t.Fatalf("NewSite: %v", err)
+		}
+
+		// Contexts depend on time and site, never on the target, so build the
+		// day's worth once and reuse them across every declination. Without
+		// this the test would pay an Apco13 solve per (latitude, declination,
+		// step) and take minutes.
+		ctxs := make([]*coord.Context, sweepSteps)
+		times := make([]time.Time, sweepSteps)
+
+		for i := range ctxs {
+			times[i] = base.Add(time.Duration(i*dayMinutes/sweepSteps) * time.Minute)
+			ctxs[i] = coord.NewContext(times[i], site.Location(), site.Refraction())
+		}
+
+		for decDeg := -90.0; decDeg <= 90.0; decDeg += 5 {
+			star := NewStar("sweep", angle.Deg(0), angle.Deg(decDeg))
+
+			if !culminationSkipsSearch(star, site, base) {
+				continue
+			}
+
+			checkedSkips++
+
+			// It claims there is no rise. Over a full day of hour angles the
+			// altitude must therefore stay wholly on one side of the
+			// threshold — never crossing it.
+			pos, err := star.Position(base)
+			if err != nil {
+				t.Fatalf("Position: %v", err)
+			}
+
+			above, below := 0, 0
+
+			for i := range ctxs {
+				aa, err := observedAltAz(star, times[i], ctxs[i], pos)
+				if err != nil {
+					t.Fatalf("observedAltAz: %v", err)
+				}
+
+				if aa.Alt() > site.RiseSetThreshold() {
+					above++
+				} else {
+					below++
+				}
+			}
+
+			if above != 0 && below != 0 {
+				t.Errorf("lat %+.0f dec %+.0f: the closed form skipped the search, "+
+					"but over a full day the target is above the horizon at %d of %d "+
+					"steps and below at %d.\n"+
+					"  It does rise, so Episode would wrongly report no rise. "+
+					"episodeClosedFormMargin (%g deg) is too small.",
+					latDeg, decDeg, above, sweepSteps, below, episodeClosedFormMargin)
+			}
+		}
+	}
+
+	// A margin so large that nothing ever short-circuits would pass the loop
+	// above trivially, so check the optimisation still fires.
+	if checkedSkips < 50 {
+		t.Fatalf("the closed form short-circuited only %d times across the whole "+
+			"latitude/declination grid; it is no longer doing anything", checkedSkips)
+	}
+
+	t.Logf("%d short-circuits, each confirmed against a full day of hour angles",
+		checkedSkips)
+}
+
+// TestEpisodeStillSearchesNearTheHorizonBoundary pins the other direction: a
+// target close enough to the threshold that refraction or parallax could decide
+// the answer must go to the search, exactly as before.
+//
+// The dangerous change would be a short-circuit that creeps toward the
+// boundary and starts answering cases the geometry cannot settle.
+func TestEpisodeStillSearchesNearTheHorizonBoundary(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(50), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("boundary", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	base := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
+
+	// At latitude 50N the never-rises boundary is dec = -(90-50) = -40, and the
+	// circumpolar boundary is dec = +40. Declinations within the margin of
+	// either must not be answered from geometry alone.
+	for _, decDeg := range []float64{-40.5, -40.0, -39.5, 39.5, 40.0, 40.5} {
+		star := NewStar("edge", angle.Deg(0), angle.Deg(decDeg))
+
+		if culminationSkipsSearch(star, site, base) {
+			t.Errorf("dec %+.1f is within %g deg of a boundary at latitude 50, but "+
+				"the closed form answered without searching. Refraction alone is "+
+				"~34 arcmin here, so geometry cannot settle it.",
+				decDeg, episodeClosedFormMargin)
+		}
+	}
+}
+
+// TestEpisodeDoesNotShortCircuitAMovingBody pins the restriction that makes
+// the whole thing sound.
+//
+// The closed form reads one declination and treats it as fixed for the entire
+// search window. That holds for a star and not for anything in the solar
+// system: the Moon covers 28 degrees of declination in a fortnight, so a body
+// below the horizon today may well rise next week.
+//
+// # The fixture is chosen so the guard is load-bearing
+//
+// A first version of this test used an arbitrary epoch and passed even with
+// the MovingBody guard deleted — at that instant the Moon was near the horizon
+// boundary, so the margin declined to answer anyway and the guard was never
+// the reason. A mutation caught it.
+//
+// 2026-03-11 is picked instead because the Moon is then at declination -27.9,
+// putting upper culmination 17.9 degrees below this site's horizon — far
+// outside the margin, so a *fixed* target there would certainly be
+// short-circuited. Ten days later the Moon is at +13.5 and plainly rises. Only
+// the MovingBody check stops Episode answering "never rises" for a body that
+// rises within the week.
+func TestEpisodeDoesNotShortCircuitAMovingBody(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(80), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("arctic", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	base := time.Date(2026, time.March, 11, 0, 0, 0, 0, time.LocationUTC)
+	moon := NewMoon(eph.Default())
+
+	if _, isMoving := Observable(moon).(MovingBody); !isMoving {
+		t.Fatal("precondition: the Moon is no longer a MovingBody, so this test " +
+			"no longer covers the case it was written for")
+	}
+
+	// Confirm the fixture still puts the Moon clear of the margin, so that
+	// only the MovingBody check can be preventing the short-circuit.
+	pos, err := moon.Position(base)
+	if err != nil {
+		t.Fatalf("Position: %v", err)
+	}
+
+	_, maxAlt := circumpolarExtremes(pos.Dec(), site)
+
+	threshold := site.RiseSetThreshold().Radians()
+	margin := angle.Deg(episodeClosedFormMargin).Radians()
+
+	if maxAlt >= threshold-margin {
+		t.Fatalf("fixture drifted: the Moon's declination %.2f puts upper "+
+			"culmination at %.2f deg, inside the margin of the %.2f deg threshold. "+
+			"The margin would decline to answer regardless, so this test would "+
+			"pass with the MovingBody guard removed.",
+			pos.Dec().Degrees(), angle.Rad(maxAlt).Degrees(),
+			site.RiseSetThreshold().Degrees())
+	}
+
+	if culminationSkipsSearch(moon, site, base) {
+		t.Error("a MovingBody was answered from a single declination; its " +
+			"declination changes across the search window, so the culmination " +
+			"bounds do not hold")
+	}
+
+	// And the Moon really does rise, so short-circuiting here would be wrong
+	// rather than merely unjustified.
+	rise, _, err := Episode(base, base.AddDays(1), moon, site)
+	if err != nil {
+		t.Fatalf("Episode: %v", err)
+	}
+
+	if rise == nil {
+		t.Error("Episode found no moonrise within the search window, but the " +
+			"Moon reaches declination +13.5 ten days later and plainly rises")
+	}
+}
+
+// BenchmarkEpisodeNeverRises measures the case the closed form exists for.
+//
+// The search it replaces doubles a window out to 366 days and evaluates a
+// position at every step, finding nothing each time and concluding only by
+// exhaustion — measured at 2.84 s before this change.
+func BenchmarkEpisodeNeverRises(b *testing.B) {
+	loc, err := coord.NewGeodetic(angle.Deg(0), angle.Deg(80), 0)
+	if err != nil {
+		b.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("Arctic", loc)
+	if err != nil {
+		b.Fatalf("NewSite: %v", err)
+	}
+
+	star := NewStar("NeverUp", angle.Deg(0), angle.Deg(-85))
+	from := time.FromJD(2451544.5, time.UTC)
+	to := from.AddDays(1)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, _, err := Episode(from, to, star, site); err != nil {
+			b.Fatalf("Episode: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
`Episode` decided "does this ever rise?" by doubling a window out to 366 days and evaluating a position at every step, each paying a `coord.NewContext` Apco13 solve plus an ephemeris lookup. For a target that never rises, every step finds nothing and the function concludes only by exhausting the window.

For a **fixed** target that answer is two arcsines: declination does not change, so upper culmination is the highest it ever reaches and lower culmination the lowest. `IsNeverUp` and `IsCircumpolar` already computed exactly that — and had no caller anywhere in the library (#106).

| | before | after |
| --- | ---: | ---: |
| `TestEpisodeNeverRisesReturnsNilNil` | 2.84 s | **0.00 s** |
| `TestEpisodeCircumpolarReturnsNilNil` | 2.89 s | **0.00 s** |
| `BenchmarkEpisodeNeverRises` (new) | — | **67 ns/op** |
| `plan` package, whole suite | 18.6 s | **12.7 s** |

## What keeps this an optimisation rather than a cruder second implementation

**A one-degree margin.** The closed form is pure spherical geometry — no refraction (~34′ at the horizon), no parallax, no proper motion over the window. A target within a degree of the threshold is one where those terms could decide the answer, so it goes to the search exactly as before. A target a degree clear is not borderline: the never-rises test's star sits **75° below** its site's horizon.

**Moving bodies always search.** The closed form reads one declination and treats it as fixed across the window. That holds for a star and not for anything in the solar system — the Moon covers 28° of declination in a fortnight.

## The safety property is checked by brute force, not argued

A wrong "no" here would be silent: the caller gets a nil rise and a nil set, which is exactly what a genuine never-rises target returns.

For a target at fixed declination, **one day covers every hour angle** — so a 24-hour sweep is not a sample, it is the whole domain, and it settles the question exactly. `TestCulminationSkipsSearchIsNeverAFalsePositive` sweeps a latitude/declination grid and, for each of the **288** cases where the closed form skips the search, confirms across 96 steps that the altitude never crosses the threshold.

It sweeps through the same *refracted* pipeline `Episode`'s own `isAboveHorizon` uses, while the closed form has no refraction — so the margin is being measured, not restated. The test also fails if fewer than 50 short-circuits fire, so a margin widened until nothing optimises cannot pass it trivially.

## A vacuous test that a mutation caught

`TestEpisodeDoesNotShortCircuitAMovingBody` passed on its first fixture **even with the MovingBody guard deleted**. At that epoch the Moon happened to sit near the horizon boundary, so the margin declined to answer anyway and the guard was never the reason.

It now uses 2026-03-11, where the Moon is at declination −27.9° — putting upper culmination 17.9° below this site's horizon, far outside the margin, so a *fixed* target there would certainly be skipped. The test asserts the fixture still has that property (so it cannot go vacuous again silently), and that `Episode` still finds the moonrise, since the Moon reaches +13.5° ten days later.

With the guard removed it now fails decisively:

```
a MovingBody was answered from a single declination
Episode found no moonrise within the search window, but the Moon reaches
declination +13.5 ten days later and plainly rises
```

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Three mutations, each caught: margin removed (boundary test fires), MovingBody guard removed (see above), margin applied the wrong way so it widens the skip (boundary test fires on three declinations).

Closes #110.
