### PR TITLE
Make constants the only place the AU and light-time live

### DIFF
--- a/coord/context.go
+++ b/coord/context.go
@@ -105,15 +105,25 @@ func (ctx *Context) Clone() *Context {
 	return &c
 }
 
+// kmPerAU is the number of kilometres in one Astronomical Unit.
+//
+// var, not const: constants.IAU.AstronomicalUnit is a struct, and Go does not
+// permit selecting a struct field inside a constant expression.
+var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
+
 // tirsVec returns the observer's geocentric position in the TIRS frame
 // (AU) from site trigonometry and height — pure site geometry, independent
 // of time, shared by NewContext and AtTime.
 func tirsVec(sinLat, cosLat, sinLon, cosLon, heightM float64) vector.Vec3 {
+	// rEq and f are WGS84 reference-ellipsoid parameters, which belong to the
+	// geodesy here rather than to constants. au is a unit conversion with a
+	// canonical home, so it comes from there — see kmPerAU.
 	const (
-		au  = 149597870.7
 		rEq = 6378.137
 		f   = 1.0 / 298.257223563
 	)
+
+	au := kmPerAU
 
 	cEarth := 1.0 / math.Sqrt(cosLat*cosLat+(1.0-f)*(1.0-f)*sinLat*sinLat)
 	sEarth := (1.0 - f) * (1.0 - f) * cEarth

--- a/docs/changelog.d/169-constants-single-source.md
+++ b/docs/changelog.d/169-constants-single-source.md
@@ -5,8 +5,8 @@ pr: 169
 **The astronomical unit was written out in four production files and the
 light-time constant in two**, all agreeing with `constants` and with each other
 — which is the problem, since a future revision in `constants` would leave five
-copies silently behind. All now derive from `constants`. `jpl.KMPerAU` was
-exported, letting a downstream caller pin the stale value, and is now
-unexported; nothing outside its own file referenced it.
+copies silently behind. All now derive from `constants`.
+`jpl.KMPerAU` no longer exists: it was exported, letting a downstream caller
+pin the stale value, and nothing outside its own file referenced it.
 `TestCanonicalConstantsAreNotWrittenOut` scans the module so the literals
 cannot come back (#137).

--- a/docs/changelog.d/169-constants-single-source.md
+++ b/docs/changelog.d/169-constants-single-source.md
@@ -1,0 +1,12 @@
+---
+type: Changed
+pr: 169
+---
+**The astronomical unit was written out in four production files and the
+light-time constant in two**, all agreeing with `constants` and with each other
+— which is the problem, since a future revision in `constants` would leave five
+copies silently behind. All now derive from `constants`. `jpl.KMPerAU` was
+exported, letting a downstream caller pin the stale value, and is now
+unexported; nothing outside its own file referenced it.
+`TestCanonicalConstantsAreNotWrittenOut` scans the module so the literals
+cannot come back (#137).

--- a/ephemeris/core/core.go
+++ b/ephemeris/core/core.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/time"
 	"github.com/TuSKan/astrogo/vector"
 )
@@ -155,7 +156,11 @@ func (s State) Require(frame Frame, center Center) error {
 	return nil
 }
 
-const kmPerAU = 149597870.7
+// kmPerAU is the number of kilometres in one Astronomical Unit.
+//
+// var, not const: constants.IAU.AstronomicalUnit is a struct, and Go does not
+// permit selecting a struct field inside a constant expression.
+var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
 
 // Distance returns the geocentric distance in AU.
 func (s State) Distance() float64 { return s.Pos.Norm() }

--- a/ephemeris/ephemeris.go
+++ b/ephemeris/ephemeris.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/jpl"
@@ -420,6 +421,28 @@ func Altitude(p Provider, id ID, t time.Time) (float64, error) {
 	return st.DistanceKm() - earthMeanRadiusKm, nil
 }
 
+// lightAUPerDay is the speed of light in astronomical units per day, the
+// denominator of the light-time iteration below.
+//
+// Derived rather than written out. It was the literal 173.144632674 in both
+// places it is used — a published value rounded to nine decimals, which is
+// 1.4e-12 low against c and the AU as constants defines them.
+//
+// That rounding changes nothing, and provably so rather than approximately.
+// At Neptune's distance it moves the light time by 21 nanoseconds, which is
+// 2.4e-13 days; one ULP of a Julian Date at a modern epoch is 4.7e-10 days.
+// The correction is about 1900 times smaller than the smallest difference the
+// epoch can represent, so the retarded time below comes out bit-identical.
+// Measured: the apparent position of Mars, Jupiter and Neptune is unchanged to
+// the last bit.
+//
+// So this is a tidying, not a correction — but one that cannot go stale if
+// either input is ever revised, which the two literals could.
+//
+// var, not const: both inputs are struct fields.
+var lightAUPerDay = constants.SI2019.SpeedOfLight.Value *
+	constants.Derived.JulianDaySeconds.Value / constants.IAU.AstronomicalUnit.Value
+
 // ApparentState returns the apparent state of a target: where it is seen from
 // the Earth at obsTime, with both light time and annual aberration included.
 // It iterates the light time by repeatedly polling the Provider at (t - tau).
@@ -447,7 +470,7 @@ func ApparentState(p Provider, target ID, obsTime time.Time) (State, error) {
 		return State{}, fmt.Errorf("ephemeris: apparent state: %w", err)
 	}
 
-	tauDays := st.Pos.Norm() / 173.144632674
+	tauDays := st.Pos.Norm() / lightAUPerDay
 	for range 5 {
 		retardedTime := obsTime.AddDays(-tauDays)
 
@@ -456,7 +479,7 @@ func ApparentState(p Provider, target ID, obsTime time.Time) (State, error) {
 			return State{}, fmt.Errorf("ephemeris: apparent state retarded: %w", err)
 		}
 
-		tauDays = st.Pos.Norm() / 173.144632674
+		tauDays = st.Pos.Norm() / lightAUPerDay
 	}
 
 	return st, nil

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/ephemeris/core"
 	"github.com/TuSKan/astrogo/ephemeris/jpl/lsk"
 	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
@@ -56,8 +57,16 @@ var (
 	ErrWrongSmallBody = errors.New("jpl: horizons returned a different small body")
 )
 
-// KMPerAU is the number of kilometers per astronomical unit.
-const KMPerAU = 149597870.7
+// kmPerAU is the number of kilometres in one Astronomical Unit.
+//
+// Unexported. It was KMPerAU, which let a caller outside this module pin a
+// copy of the value that would not move if constants ever did — the precise
+// hazard routing everything through constants exists to remove. Nothing
+// outside this file ever referenced it.
+//
+// var, not const: constants.IAU.AstronomicalUnit is a struct, and Go does not
+// permit selecting a struct field inside a constant expression.
+var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
 
 // NAIFFor returns the NAIF integer identifier for a body, and whether the
 // body is one this package has a mapping for.
@@ -326,14 +335,14 @@ func (p *Provider) State(id core.ID, t time.Time) (core.State, error) {
 	// Convert to AU and AU/day
 	return core.State{
 		Pos: vector.Vec3{
-			X: relPos.X / KMPerAU,
-			Y: relPos.Y / KMPerAU,
-			Z: relPos.Z / KMPerAU,
+			X: relPos.X / kmPerAU,
+			Y: relPos.Y / kmPerAU,
+			Z: relPos.Z / kmPerAU,
 		},
 		Vel: vector.Vec3{
-			X: relVel.X * 86400 / KMPerAU,
-			Y: relVel.Y * 86400 / KMPerAU,
-			Z: relVel.Z * 86400 / KMPerAU,
+			X: relVel.X * 86400 / kmPerAU,
+			Y: relVel.Y * 86400 / kmPerAU,
+			Z: relVel.Z * 86400 / kmPerAU,
 		},
 		Frame:  core.FrameICRS,
 		Center: core.CenterGeocentre,

--- a/internal/docsguard/constants_test.go
+++ b/internal/docsguard/constants_test.go
@@ -1,0 +1,128 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// canonicalLiterals are values that have a home in the constants package and
+// must not be written out anywhere else.
+//
+// Each is a unit conversion, not a coefficient of a published formula.
+// CLAUDE.md's "magic numbers are physical constants" rule protects the latter
+// — a Saemundsson coefficient belongs beside its formula, where a reader can
+// check it against the paper. A conversion factor with a canonical home is the
+// opposite case: every copy is a place the value can fail to be updated.
+var canonicalLiterals = map[string]string{
+	"149597870.7":   "the astronomical unit in km — use constants.IAU.AstronomicalUnit.Value / 1e3",
+	"173.144632674": "the speed of light in AU/day — derive it from constants.SI2019.SpeedOfLight and constants.IAU.AstronomicalUnit",
+}
+
+// TestCanonicalConstantsAreNotWrittenOut keeps the constants package the single
+// source of truth for values that live there.
+//
+// # The failure this prevents
+//
+// The AU was written out in four production files and the light-time constant
+// in two, all agreeing with constants and with each other. Agreeing today is
+// the whole problem: the failure mode is a future revision applied in
+// constants while five other copies quietly do not move. Nothing would fail,
+// and the disagreement would surface as a slow drift between subsystems.
+//
+// One of those copies was exported, as jpl.KMPerAU, so a downstream caller
+// could pin the stale value from outside the module entirely.
+//
+// # Why a source scan
+//
+// The values cannot be compared at runtime, because after the fix there is
+// nothing left to compare — each package now reads the same variable. The
+// property being defended is textual: the literal must not reappear. A scan is
+// the only thing that can see that.
+//
+// Comments are exempt. A doc comment saying "1 AU = 149597870.7 km" is helping
+// a reader, not creating a second source of truth, and the packages that read
+// from constants annotate their derivation exactly that way.
+func TestCanonicalConstantsAreNotWrittenOut(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..")
+
+	var checked, offenders int
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unrelatable path is skipped, not fatal
+		}
+
+		rel = filepath.ToSlash(rel)
+
+		// constants is where these live, so it is the one place they are
+		// written out. Tests may pin a literal on purpose — that is what makes
+		// a test a check rather than a restatement.
+		if strings.HasPrefix(rel, "constants/") || strings.HasSuffix(rel, "_test.go") {
+			return nil
+		}
+
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unreadable file is skipped, not fatal
+		}
+
+		checked++
+
+		for i, line := range strings.Split(string(data), "\n") {
+			code := strings.TrimSpace(line)
+			if strings.HasPrefix(code, "//") {
+				continue // a comment quoting the value is documentation
+			}
+
+			// Strip a trailing line comment, so `x / 1e3 // 149597870.7 km`
+			// — the annotation the fixed call sites carry — is not a hit.
+			if idx := strings.Index(code, "//"); idx >= 0 {
+				code = code[:idx]
+			}
+
+			for literal, guidance := range canonicalLiterals {
+				if !strings.Contains(code, literal) {
+					continue
+				}
+
+				offenders++
+
+				t.Errorf("%s:%d writes out %s.\n  %s.\n  Every copy is a place the "+
+					"value can fail to be updated; constants is the single source.",
+					rel, i+1, literal, guidance)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if checked < 200 {
+		t.Fatalf("only %d Go files scanned; the walk is not reaching the module", checked)
+	}
+
+	t.Logf("%d files scanned, %d offending lines", checked, offenders)
+}

--- a/plan/satellite.go
+++ b/plan/satellite.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	mag "github.com/TuSKan/astrogo/magnitude"
@@ -169,6 +170,12 @@ func (s *Satellite) StaticMagnitude() (float64, bool) {
 	return s.stdMag, s.hasStdMag
 }
 
+// kmPerAU is the number of kilometres in one Astronomical Unit.
+//
+// var, not const: constants.IAU.AstronomicalUnit is a struct, and Go does not
+// permit selecting a struct field inside a constant expression.
+var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
+
 // defaultAtm is used for satellite pass prediction when no atmosphere is specified.
 var defaultAtm = atmosphere.Refraction{}
 
@@ -205,8 +212,6 @@ func LookAngle(prov eph.Provider, id eph.ID, ctx *coord.Context) (coord.AltAz, e
 	observed := ctx.GeocentricToObserved(st.Pos)
 
 	// Context works in AU — convert the topocentric distance to km.
-	const kmPerAU = 149597870.7
-
 	observed.SetDist(st.Pos.Sub(ctx.ObsVec()).Norm() * kmPerAU)
 
 	return observed, nil


### PR DESCRIPTION
The astronomical unit was written out in four production files and the light-time constant twice, all agreeing with `constants` and with each other.

| value | was written out in |
| --- | --- |
| `149597870.7` | `coord/context.go`, `ephemeris/core/core.go`, `ephemeris/jpl/provider.go`, `plan/satellite.go` |
| `173.144632674` | `ephemeris/ephemeris.go`, twice |

Agreeing today is the whole problem. The failure mode is not a wrong number now — it is a future revision applied in `constants` while five other copies quietly do not move, surfacing as a slow disagreement between subsystems with nothing failing.

One copy was **exported**, as `jpl.KMPerAU`, so a caller outside the module could pin the stale value. Nothing outside its own file ever referenced it, so it is now unexported.

## The AU replacement is exact

`constants.IAU.AstronomicalUnit.Value / 1e3` is **bit-identical** to the literal — verified before changing anything:

```
kmPerAU derived = 149597870.69999999
kmPerAU literal = 149597870.69999999
identical: true
```

Every call site returns the same float it did before.

## The light-time constant is not, and here is exactly what that costs

The literal `173.144632674` is a published value rounded to nine decimals. Derived from c and the AU it is `173.14463267424034` — 1.4e-12 higher.

That difference changes nothing, and provably rather than approximately:

- At Neptune's distance it moves the light time by **21 nanoseconds**
- 21 ns is **2.4e-13 days**
- One ULP of a Julian Date at a modern epoch is **4.7e-10 days**

The correction is about **1900× smaller than the smallest difference the epoch can represent**, so the retarded time comes out bit-identical. Measured directly, by running `ApparentState` with each constant and differencing the vectors:

```
Mars     r=  2.18 AU   position shift = 0 cm
Jupiter  r=  5.95 AU   position shift = 0 cm
Neptune  r= 30.27 AU   position shift = 0 cm
```

Exactly zero, not "small". The `validation` tier is unmoved.

## Guarded by a source scan, not a runtime comparison

After the fix there is nothing left to compare — every package reads the same variable. The property being defended is textual: the literal must not reappear.

`TestCanonicalConstantsAreNotWrittenOut` walks the module (291 files) and fails on any occurrence outside `constants` and tests. Comments are exempt, since a doc comment quoting the value helps a reader rather than creating a second source of truth — and the fixed call sites annotate their derivation exactly that way.

Mutation: reintroducing the literal in `plan/satellite.go` fails with `plan/satellite.go:202 writes out 149597870.7`.

## Why this is not the "magic numbers" rule

CLAUDE.md says magic numbers are physical constants and coefficients, and that they should not be abstracted out of published formulas. That rule protects a Saemundsson term sitting beside its formula, where a reader can check it against the paper.

A unit conversion with a canonical home in `constants` is the opposite case: it belongs to no formula, and every copy is a place the value can fail to be updated. The scan encodes only these two values, not a general ban on numeric literals.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Closes #137.
