### PR TITLE
Remove the fits.Write stub that always failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ flowchart TD
 | `magnitude` | Apparent magnitude (planets, asteroids, comets, satellites, stars) | ✅ Stable |
 | `constellation` | IAU constellation lookup from an ICRS position (official 1930 boundaries), `List`/`Centroid` enumeration | ✅ Stable |
 | `optics` | Equipment-optics arithmetic (`Telescope`/`Eyepiece`/`Sensor`) — magnification, FOV, exit pupil, Dawes limit, pixel scale | ✅ Stable |
-| `fits` | FITS I/O, WCS (TAN projection), mmap, Arrow export | ✅ Stable |
+| `fits` | FITS **reading**, WCS (TAN projection), mmap, Arrow export | ✅ Stable (read-only — no writer yet, see [#127](https://github.com/TuSKan/astrogo/issues/127)) |
 | `fits/plan` | FITS↔plan bridge (`SiteFromFITS`, `TargetFromFITS`) | ✅ Stable |
 | `plan` | Observability, constraints, events, scheduling, satellite passes | ✅ Stable |
 | `skybrightness` | Spectral all-sky radiance engine (`Scene`/`Component`/`Model`/`Estimate`, all-sky ops, uncertainty, provenance) — seven components | ✅ Phases 0–5 (natural sky validated to 0.05 mag against GAMBONS) |

--- a/docs/changelog.d/171-fits-remove-write-stub.md
+++ b/docs/changelog.d/171-fits-remove-write-stub.md
@@ -1,0 +1,12 @@
+---
+type: Removed
+pr: 171
+---
+**`fits.Write` no longer exists — it always returned `ErrUnimplemented`.** An
+exported function that only ever fails, in a package the README marked Stable,
+is a runtime surprise for anyone who type-checks against it; an absent one is a
+compile error at the call site, which is the honest signal. Its signature could
+not have been implemented as written either — a filename and a flat
+`[]float64`, with no dimensions or header. `ErrUnimplemented` goes with it, and
+the README now labels `fits` read-only, pointing at #127 for the real writer.
+Nothing in the module called it (#135).

--- a/fits/fits.go
+++ b/fits/fits.go
@@ -23,8 +23,6 @@ var (
 	ErrInvalidBlock = errors.New("fits: block size is not 2880 bytes")
 	// ErrNoPrimaryHDU is returned when a primary HDU is not found.
 	ErrNoPrimaryHDU = errors.New("fits: missing primary HDU")
-	// ErrUnimplemented is returned when a feature is not yet implemented.
-	ErrUnimplemented = errors.New("fits: feature not yet implemented")
 )
 
 // File represents a full FITS dataset containing multiple HDUs.
@@ -283,11 +281,6 @@ func ReadBigEndian(r io.Reader, data any) error {
 	}
 
 	return nil
-}
-
-// Write scaffolds writing a basic HDU to a FITS file.
-func Write(_ string, _ []float64) error {
-	return ErrUnimplemented
 }
 
 // isImagePayload reports whether an HDU carries image pixels this package can

--- a/fits/fits_test.go
+++ b/fits/fits_test.go
@@ -2,7 +2,6 @@ package fits
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -162,11 +161,6 @@ func TestReadBigEndian(t *testing.T) {
 
 	if val != 42 {
 		t.Errorf("expected 42, got %d", val)
-	}
-
-	err = Write("dummy", nil)
-	if !errors.Is(err, ErrUnimplemented) {
-		t.Errorf("expected ErrUnimplemented, got %v", err)
 	}
 }
 

--- a/skybrightness/dataset/airglow/parse_fixture_test.go
+++ b/skybrightness/dataset/airglow/parse_fixture_test.go
@@ -14,11 +14,13 @@ import (
 
 // ── A minimal FITS binary table writer ───────────────────────────────────────
 //
-// Parse had no positive-path test, because fits.Write is unimplemented and
-// there is no fixture file in the tree — everything that exercised it needed
-// the network. Encoding a table is about forty lines, and having it means the
-// parser's screening can be tested against the malformed responses a service
-// actually returns rather than only against a string that is not FITS at all.
+// Parse had no positive-path test, because the fits package reads and does not
+// write — it carried a Write stub that always failed, since removed, and #127
+// tracks the real writer — and there is no fixture file in the tree, so
+// everything that exercised it needed the network. Encoding a table is about
+// forty lines, and having it means the parser's screening can be tested against
+// the malformed responses a service actually returns rather than only against a
+// string that is not FITS at all.
 
 const fitsBlock = 2880
 


### PR DESCRIPTION
```go
// fits/fits.go:289
func Write(_ string, _ []float64) error {
	return ErrUnimplemented
}
```

An exported function that only ever fails, in a package the README marked **Stable**. A caller who type-checks against it ships a binary that fails at runtime; an absent function is a compile error at the call site, which is the signal they actually want.

## It could not have been implemented as written

A filename and a flat `[]float64` carry no dimensions and no header, so this was not a placeholder for anything — a real writer (#127) needs a different signature entirely. The `path string` is also the second thing in the module to mean an OS filesystem path, which CLAUDE.md permits only for `fits.Open`.

So deleting it loses nothing that a future writer could have built on.

## What went with it

- `ErrUnimplemented`, which had no other user.
- The test assertion that only checked the stub returned its own error.
- A comment in `airglow`'s fixture explaining why its parser had no positive-path test, which cited `fits.Write is unimplemented`; it now says the package reads and does not write. Left uncorrected, docsguard's symbol check would have failed on a citation to a symbol this change removes.

**Nothing in the module called `Write`.**

## The README claim

```
- | `fits` | FITS I/O, WCS (TAN projection), mmap, Arrow export | ✅ Stable |
+ | `fits` | FITS **reading**, WCS (TAN projection), mmap, Arrow export | ✅ Stable (read-only — no writer yet, see #127) |
```

"FITS I/O" was the inaccurate half. The read path is not the problem and is not disparaged here — mmap, gzip, three HDU kinds, SIP/TPV distortions and the Arrow export all work, and the Arrow export is something nothing else in Go has. The row now says what the package does.

## Note on the API break

This removes an exported symbol without a deprecation cycle. CLAUDE.md's deprecation policy governs symbols that work and are being replaced; this one has never done anything but return an error, so no caller can depend on its behaviour except by handling the failure — and those callers get a compile error pointing at the exact line instead. The changelog entry is filed under `### Removed`.

The issue's other two observations — `GetCRVAL`/`SetCRVAL` Java-style accessors, and untyped `[]float64` for pixel-to-world — are real but are API design changes rather than a false claim, and belong with #130's typed-quantity work rather than here.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways.

Closes #135.
