### PR TITLE
Delete the nolint directives that suppress a disabled linter

### DIFF
--- a/atmosphere/refraction.go
+++ b/atmosphere/refraction.go
@@ -330,8 +330,6 @@ func (RefractionRigorous) RefractFromApparent(obsAlt angle.Angle, env Refraction
 //
 // Renamed from StandardAtmosphere alongside the Atmosphere→Refraction
 // rename, for consistency between the type and its standard-value var.
-//
-//nolint:gochecknoglobals // ICAO ISA reference profile — immutable physical constant
 var StandardRefraction = Refraction{
 	Pressure:    1013.25,
 	Temperature: 15.0,

--- a/catalog/vizier/tables.go
+++ b/catalog/vizier/tables.go
@@ -44,8 +44,6 @@ var (
 // querying an unregistered table returns ErrUnknownTable rather than
 // assuming generic column names that may not exist for that table. Adding
 // a table here is a data change, not an API change.
-//
-//nolint:gochecknoglobals // read-only registry, populated once at init
 var tableSchemas = map[string]tableSchema{
 	// 2MASS Point Source Catalog — the package's original hardcoded table.
 	defaultTable: {RACol: "raj2000", DecCol: "dej2000", DesigCol: `"2MASS"`, Kind: resolve.KindStar, Epoch: epoch2MASS},

--- a/constants/de440.go
+++ b/constants/de440.go
@@ -114,8 +114,6 @@ const satSource = "JPL natural satellite ephemeris release forms " +
 // meaning is tied to the fit it came from, and the kernel publishes no
 // formal errors for them. They are not [Constant.Exact] either — nothing
 // here is exact by convention, unlike the IAU nominal values.
-//
-//nolint:gochecknoglobals // a published constant table, read-only
 var DE440 = EphemerisSet{
 	Vintage: "DE440",
 
@@ -217,6 +215,4 @@ var DE440 = EphemerisSet{
 // vintage — reference this, not [DE440] directly, unless a specific vintage
 // has to be pinned for reproducibility. When a newer ephemeris is adopted, a
 // new vintage set is added and this single assignment moves.
-//
-//nolint:gochecknoglobals // the current vintage alias, mirroring IAU
 var Ephemeris = DE440

--- a/coord/healpix.go
+++ b/coord/healpix.go
@@ -207,8 +207,6 @@ func (h HEALPix) equatorialPixel(tt, z float64) (face, ix, iy int64) {
 
 // faceRingOffset and facePhiOffset place each of the twelve base faces in
 // the ring/phi grid, per Górski et al. (2005) Fig. 4.
-//
-//nolint:gochecknoglobals // fixed geometry of the base tessellation
 var (
 	faceRingOffset = [12]int64{2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4}
 	facePhiOffset  = [12]int64{1, 3, 5, 7, 0, 2, 4, 6, 1, 3, 5, 7}

--- a/docs/changelog.d/172-dead-nolint-directives.md
+++ b/docs/changelog.d/172-dead-nolint-directives.md
@@ -1,0 +1,11 @@
+---
+type: Removed
+pr: 172
+---
+**42 `//nolint:gochecknoglobals` directives suppressed a linter `.golangci.yml`
+disables** — 29% of every suppression in the tree, each carrying a documented
+reason for silencing nothing, which is what made the live suppressions hard to
+pick out. All removed. `TestNoNolintForADisabledLinter` now cross-checks every
+directive against the config, since a dead one is invisible to golangci-lint
+itself: `nolintlint` reports an *unused* directive, but one naming a disabled
+linter is simply skipped (#136).

--- a/docs/changelog.d/173-dead-nolint-directives.md
+++ b/docs/changelog.d/173-dead-nolint-directives.md
@@ -1,6 +1,6 @@
 ---
 type: Removed
-pr: 172
+pr: 173
 ---
 **42 `//nolint:gochecknoglobals` directives suppressed a linter `.golangci.yml`
 disables** — 29% of every suppression in the tree, each carrying a documented

--- a/ephemeris/core/core.go
+++ b/ephemeris/core/core.go
@@ -347,8 +347,6 @@ type Body struct {
 }
 
 // Built-in major bodies.
-//
-//nolint:gochecknoglobals // IAU body registry — immutable catalog data
 var (
 	// SunBody is the Sun body.
 	SunBody = Body{ID: Sun, Name: "Sun", Kind: KindStar}
@@ -373,8 +371,6 @@ var (
 )
 
 // Bodies is a utility list of all major Solar System bodies as concrete structs.
-//
-//nolint:gochecknoglobals // IAU body registry — immutable catalog data
 var Bodies = []Body{
 	SunBody, MoonBody, MercuryBody, VenusBody, EarthBody,
 	MarsBody, JupiterBody, SaturnBody, UranusBody, NeptuneBody,

--- a/ephemeris/jpl/main_test.go
+++ b/ephemeris/jpl/main_test.go
@@ -91,7 +91,6 @@ func mustPlanetProvider(t *testing.T) *jpl.Provider {
 // answering, and a fifth of the budget.
 const kernelFetchTimeout = 3 * time.Minute
 
-//nolint:gochecknoglobals // one fetch attempt shared by every test in the package
 var warmOnce sync.Once
 
 // warmKernelCache makes at most one bounded attempt to obtain the kernel, and
@@ -128,5 +127,4 @@ func warmKernelCache(t *testing.T) {
 	}
 }
 
-//nolint:gochecknoglobals // written once under warmOnce, read after
 var errWarm error

--- a/ephemeris/jpl/validation/corpus_test.go
+++ b/ephemeris/jpl/validation/corpus_test.go
@@ -36,8 +36,6 @@ import (
 // Here rather than in main_test.go because the validation- and network-tagged
 // suites both need it and cannot see each other's files, and main_test.go has
 // to stay untagged so TestMain always compiles.
-//
-//nolint:gochecknoglobals // a derived constant, same convention as the rest of this repo's reference data
 var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
 
 // corpusSchemaVersion is the version of the document below.
@@ -48,7 +46,7 @@ var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
 const corpusSchemaVersion = 1
 
 // corpusPath is where the document lives, relative to this package.
-var corpusPath = filepath.Join("corpus", "horizons.json") //nolint:gochecknoglobals // a fixed path, same convention as the rest of this repository's reference data
+var corpusPath = filepath.Join("corpus", "horizons.json")
 
 // Errors from reading the corpus.
 var (

--- a/ephemeris/kepler/kepler.go
+++ b/ephemeris/kepler/kepler.go
@@ -77,8 +77,6 @@ type CentralBody struct {
 
 // sunCentre is the default central body: the Sun, with the IAU nominal mass
 // parameter the heliocentric path has always used.
-//
-//nolint:gochecknoglobals // the default central body, read-only
 var sunCentre = CentralBody{ID: core.Sun, GM: constants.IAU.SunGravitationalParameter.Value}
 
 // LaplacePlane is the reference plane a satellite's published mean elements

--- a/ephemeris/kepler/provider.go
+++ b/ephemeris/kepler/provider.go
@@ -163,8 +163,6 @@ func (p *Provider) Close() error { return nil }
 // SOFA has no analytical Pluto, and without one a satellite registered about
 // Pluto — Charon — cannot be placed at all, since the provider composes a
 // satellite through its parent.
-//
-//nolint:gochecknoglobals // a published element set, read-only
 var PlutoElements = func() Elements {
 	el, err := NewElements(time.J2000, 39.48211675, 0.24882730,
 		angle.Deg(17.14001206), angle.Deg(110.30393684),

--- a/internal/changelog/assemble_test.go
+++ b/internal/changelog/assemble_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/TuSKan/astrogo/time"
 )
 
-//nolint:gochecknoglobals // test flags must be package-level to register
 var (
 	update  = flag.Bool("update", false, "assemble docs/changelog.d into CHANGELOG.md and delete the consumed fragments")
 	version = flag.String("release-version", "", "version to assemble under, e.g. 0.17.0")

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -37,8 +37,6 @@ var (
 // SectionOrder is the order sections appear in a release, following Keep a
 // Changelog with this project's "Changed — BREAKING" variant kept alongside
 // plain Changed.
-//
-//nolint:gochecknoglobals // the canonical section order, read-only
 var SectionOrder = []string{
 	"Added",
 	"Changed — BREAKING",

--- a/internal/docsguard/index_test.go
+++ b/internal/docsguard/index_test.go
@@ -57,7 +57,6 @@ type symbolIndex struct {
 	varTypes map[string]map[string]string
 }
 
-//nolint:gochecknoglobals // a parse of the whole module, built once per test binary
 var (
 	indexOnce  sync.Once
 	indexValue *symbolIndex

--- a/internal/docsguard/nolint_test.go
+++ b/internal/docsguard/nolint_test.go
@@ -1,0 +1,175 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// nolintDirective matches a suppression and captures the linter list it names.
+var nolintDirective = regexp.MustCompile(`//nolint:([a-zA-Z0-9_,]+)`)
+
+// disabledLinter matches one entry of .golangci.yml's linters.disable block.
+var disabledLinter = regexp.MustCompile(`^\s*-\s+(\S+)`)
+
+// TestNoNolintForADisabledLinter checks that every //nolint directive names a
+// linter that actually runs.
+//
+// # Why this is worse than clutter
+//
+// .golangci.yml runs `default: all` with a documented disable list, so a
+// linter named in that list never fires — and a //nolint directive naming it
+// suppresses nothing. There were 42 such directives for gochecknoglobals
+// alone, 29% of every suppression in the tree.
+//
+// CLAUDE.md permits //nolint "only when locally scoped with a documented
+// reason", so each of those carried a written justification for silencing
+// nothing. That is the damaging part. A reader cannot tell the live
+// suppressions from the dead ones, and the rule that was supposed to make
+// each one deliberate instead made a wall of them look considered. Five were
+// added by an assistant following that rule without checking the config: the
+// process made the output look more rigorous, not less.
+//
+// # Why the check is against the disable list
+//
+// A dead directive is invisible to golangci-lint itself. nolintlint reports an
+// *unused* directive — one whose linter ran and had nothing to say — but a
+// directive for a disabled linter is simply skipped, so nothing complains. The
+// config is the only place the answer lives.
+//
+// This does not validate that a name is a real linter; a typo would still pass.
+// It catches the failure that actually happened, which is a directive that was
+// correct when written and became dead when the linter was disabled.
+func TestNoNolintForADisabledLinter(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..")
+
+	disabled := disabledLinters(t, filepath.Join(root, ".golangci.yml"))
+	if len(disabled) < 10 {
+		t.Fatalf("parsed only %d disabled linters from .golangci.yml; the disable "+
+			"block is no longer being found, so this test would pass vacuously",
+			len(disabled))
+	}
+
+	var checked, directives int
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unrelatable path is skipped, not fatal
+		}
+
+		rel = filepath.ToSlash(rel)
+
+		// This file writes the directives it is describing.
+		if strings.HasSuffix(rel, "internal/docsguard/nolint_test.go") {
+			return nil
+		}
+
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unreadable file is skipped, not fatal
+		}
+
+		checked++
+
+		n := 0
+
+		for line := range strings.SplitSeq(string(data), "\n") {
+			n++
+
+			for _, m := range nolintDirective.FindAllStringSubmatch(line, -1) {
+				for linter := range strings.SplitSeq(m[1], ",") {
+					directives++
+
+					if reason, dead := disabled[linter]; dead {
+						t.Errorf("%s:%d suppresses %q, which .golangci.yml disables"+
+							"%s.\n  The directive silences nothing, and its documented "+
+							"reason reads as a considered decision. Delete it.",
+							rel, n, linter, reason)
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if checked < 200 {
+		t.Fatalf("only %d Go files scanned; the walk is not reaching the module", checked)
+	}
+
+	t.Logf("%d files scanned, %d nolint directives, %d disabled linters in config",
+		checked, directives, len(disabled))
+}
+
+// disabledLinters reads the linters.disable block of .golangci.yml, mapping
+// each name to the trailing comment that justifies disabling it.
+func disabledLinters(t *testing.T, path string) map[string]string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	out := map[string]string{}
+	inBlock := false
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "disable:" {
+			inBlock = true
+			continue
+		}
+
+		if !inBlock {
+			continue
+		}
+
+		// A blank line or comment stays inside the block; anything else at or
+		// left of the block's own indentation ends it.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		m := disabledLinter.FindStringSubmatch(line)
+		if m == nil {
+			break
+		}
+
+		name := m[1]
+
+		reason := ""
+		if _, after, found := strings.Cut(line, "#"); found {
+			reason = " — " + strings.TrimSpace(after)
+		}
+
+		out[name] = reason
+	}
+
+	return out
+}

--- a/internal/docsguard/readme_compile_test.go
+++ b/internal/docsguard/readme_compile_test.go
@@ -21,8 +21,6 @@ var qualifier = regexp.MustCompile(`\b([a-z][a-z0-9]*)\.[A-Z]`)
 // import paths. Deliberately a short allowlist rather than a resolver: a
 // sample reaching for something outside it is a sample that has grown past
 // what a README should carry.
-//
-//nolint:gochecknoglobals // a lookup table, not state
 var stdlibForREADME = map[string]string{
 	"fmt":     "fmt",
 	"log":     "log",

--- a/internal/metrology/accuracy_doc_test.go
+++ b/internal/metrology/accuracy_doc_test.go
@@ -28,7 +28,7 @@ var updateAccuracy = flag.Bool("update-accuracy", false,
 // the untagged file would leave a symbol with no consumer in a build that
 // compiles neither tag, which is what "golangci-lint run" does and what it
 // reports as unused.
-var ambientOutDir = os.Getenv(metrology.OutDirEnv) //nolint:gochecknoglobals // captured at init because TestMain unsets the variable
+var ambientOutDir = os.Getenv(metrology.OutDirEnv)
 
 // accuracyDoc is the document whose marked region is generated.
 var accuracyDoc = filepath.Join("..", "..", "docs", "VALIDATION.md")

--- a/internal/metrology/report.go
+++ b/internal/metrology/report.go
@@ -67,7 +67,7 @@ type Result struct {
 
 // commitOnce caches the revision lookup: every suite in a run stamps the same
 // commit, and shelling out once per suite would be waste for a constant.
-var commitOnce = sync.OnceValue(resolveCommit) //nolint:gochecknoglobals // a memoised constant, not mutable state
+var commitOnce = sync.OnceValue(resolveCommit)
 
 // resolveCommit finds the astrogo revision a result was produced at.
 //

--- a/plan/angular_size.go
+++ b/plan/angular_size.go
@@ -22,8 +22,6 @@ import (
 // Earth's entry is the WGS 84 semi-major axis, not an IAU2015 member —
 // it is exact to the WGS84 standard and consistent with IAU 2015 B3's
 // own Earth value.
-//
-//nolint:gochecknoglobals // fixed reference data, same convention as plan.planetaryMoons/knownSites
 var bodyEquatorialRadiusM = map[eph.ID]float64{
 	eph.Sun:     constants.IAU.SunEquatorialRadius.Value,
 	eph.Moon:    constants.IAU.MoonEquatorialRadius.Value,

--- a/plan/meteor.go
+++ b/plan/meteor.go
@@ -114,8 +114,6 @@ func MeteorShowerNames() []string {
 // Deprecated: use [MeteorShowerNames] to enumerate and [NewMeteorShower] to
 // resolve. An exported map is process-wide mutable state; see
 // [KnownSiteNames].
-//
-//nolint:gochecknoglobals // fixed reference data, same convention as plan.PlanetaryMoons/KnownSites
 var MeteorShowers = map[string]MeteorShower{
 	"quadrantids": {
 		Name: "Quadrantids", Code: "QUA", ParentBody: "2003 EH1",

--- a/plan/usno_test.go
+++ b/plan/usno_test.go
@@ -132,7 +132,6 @@ var testLocations = []testLocation{
 // enforced independently of http.Client.Timeout (see usnoGet).
 const usnoRequestTimeout = 30 * time.Second
 
-//nolint:gochecknoglobals // once-per-process reachability cache, see requireUSNO
 var (
 	usnoReachableOnce sync.Once
 	usnoReachableOK   bool

--- a/plan/window_test.go
+++ b/plan/window_test.go
@@ -10,7 +10,7 @@ import (
 // t0 is an arbitrary fixed base instant every test below builds windows
 // relative to via hour offsets, so test cases read as plain integers
 // (h(0, 2) instead of two separately-constructed time.Time values).
-var t0 = time.FromJD(2451545.0, time.UTC) //nolint:gochecknoglobals // test fixture, not production state
+var t0 = time.FromJD(2451545.0, time.UTC)
 
 // h builds a Window [t0+startH, t0+endH] hours from the fixture base.
 func h(startH, endH float64) Window {

--- a/remote/file/file.go
+++ b/remote/file/file.go
@@ -35,7 +35,6 @@ import (
 	_ "github.com/TuSKan/gocloud-ext/blob/httpblob" // http://, https://
 )
 
-//nolint:gochecknoglobals // process-wide open-bucket cache; see Open
 var (
 	bucketsMu sync.Mutex
 	buckets   = map[string]*Bucket{}

--- a/remote/registry.go
+++ b/remote/registry.go
@@ -10,8 +10,6 @@ import (
 // registry holds the process-wide endpoint configuration. It is statically
 // initialized (no init() computation) and guarded by a single RWMutex; every
 // exported accessor below is safe for concurrent use.
-//
-//nolint:gochecknoglobals // process-wide endpoint configuration is this package's purpose
 var (
 	regMu     sync.RWMutex
 	endpoints = defaultEndpoints()

--- a/remote/storage.go
+++ b/remote/storage.go
@@ -17,8 +17,6 @@ const appName = "astrogo"
 
 // dataDirURL is the process-wide base location for everything astrogo
 // stores. Empty means "resolve the default lazily" — see DataDirURL.
-//
-//nolint:gochecknoglobals // process-wide data location is this package's purpose
 var (
 	dataMu     sync.RWMutex
 	dataDirURL string

--- a/skybrightness/dgl.go
+++ b/skybrightness/dgl.go
@@ -86,8 +86,6 @@ type dglCoefficient struct {
 // fitted range, exactly where a quadratic fitted to saturating data should
 // turn. TestDGLTurnoverMatchesTheFittedRange asserts this for every band, so
 // the evidence for the reading is executable rather than a comment.
-//
-//nolint:gochecknoglobals // published coefficient table
 var dglCoefficients = [8]dglCoefficient{
 	{225.0, 3.0, 0.1},
 	{274.0, 3.9, 0.3},

--- a/skybrightness/importgraph_test.go
+++ b/skybrightness/importgraph_test.go
@@ -10,8 +10,6 @@ const modulePath = "github.com/TuSKan/astrogo"
 
 // forbidden lists packages the sky-radiance core must not import directly,
 // with the reason, so a failure explains itself.
-//
-//nolint:gochecknoglobals // test fixture table
 var forbidden = map[string]string{
 	modulePath + "/remote":      "the core resolves no data; a provider layer hands it in already resolved",
 	modulePath + "/remote/file": "the core touches no storage",

--- a/skybrightness/quality.go
+++ b/skybrightness/quality.go
@@ -72,8 +72,6 @@ const (
 )
 
 // flagNames pairs each flag with its name, in declaration order.
-//
-//nolint:gochecknoglobals // lookup table for String
 var flagNames = []struct {
 	flag Flag
 	name string

--- a/skybrightness/zodiacal.go
+++ b/skybrightness/zodiacal.go
@@ -60,21 +60,15 @@ const (
 
 // zodiacalLongitudes are the differential ecliptic longitudes — the viewing
 // direction's minus the Sun's — indexing the rows of Leinert Table 17.
-//
-//nolint:gochecknoglobals // published table axis
 var zodiacalLongitudes = [19]float64{
 	0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 60, 75, 90, 105, 120, 135, 150, 165, 180,
 }
 
 // zodiacalLatitudes are the ecliptic latitudes indexing the columns.
-//
-//nolint:gochecknoglobals // published table axis
 var zodiacalLatitudes = [10]float64{0, 5, 10, 15, 20, 25, 30, 45, 60, 75}
 
 // zodiacalMissing marks the solar vicinity, within roughly 15 degrees
 // elongation, which Table 17 does not cover.
-//
-//nolint:gochecknoglobals // NaN is not a constant expression in Go
 var zodiacalMissing = math.NaN()
 
 // zodiacalBrightness is Leinert et al. (1998) Table 17: zodiacal light
@@ -83,8 +77,6 @@ var zodiacalMissing = math.NaN()
 // The blank entries are the solar vicinity. They are not zeroes and not
 // interpolable — the brightness there rises by another order of magnitude —
 // so a direction resolving to one is an error rather than a number.
-//
-//nolint:gochecknoglobals // published data table
 var zodiacalBrightness = [19][10]float64{
 	{zodiacalMissing, zodiacalMissing, zodiacalMissing, 3140, 1610, 985, 640, 275, 150, 100},
 	{zodiacalMissing, zodiacalMissing, zodiacalMissing, 2940, 1540, 945, 625, 271, 150, 100},

--- a/time/eop.go
+++ b/time/eop.go
@@ -123,7 +123,6 @@ func Coverage() (mjdMin, mjdMax float64, ok bool) { return iers.Coverage() }
 // Default: 5 minutes.
 func SetRetryCooldown(d Duration) { iers.SetRetryCooldown(d) }
 
-//nolint:gochecknoglobals // one-time-per-process warning guard
 var warnEOPUnavailableOnce sync.Once
 
 // warnEOPUnavailable logs, once per process, that no real EOP data could

--- a/time/internal/iers/eop.go
+++ b/time/internal/iers/eop.go
@@ -39,7 +39,6 @@ const (
 	SourceNetwork  = "network"
 )
 
-//nolint:gochecknoglobals // singleton EOP model with RWMutex guard
 var (
 	modelMu     sync.RWMutex
 	globalModel Model = ZeroModel{}

--- a/time/internal/iers/fetch.go
+++ b/time/internal/iers/fetch.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 
-//nolint:gochecknoglobals // fetch rate-limiter state — guarded by sync.Mutex
 var (
 	fetchMu       sync.Mutex
 	lastAttempt   time.Time         // wall-clock of last fetch attempt (success or failure)

--- a/time/internal/iers/loader.go
+++ b/time/internal/iers/loader.go
@@ -49,7 +49,6 @@ type Loader interface {
 	Fetch(ctx context.Context) (Data, error)
 }
 
-//nolint:gochecknoglobals // process-wide loader registration — guarded by loaderMu
 var (
 	loaderMu sync.RWMutex
 	loader   Loader

--- a/unit/dimension.go
+++ b/unit/dimension.go
@@ -67,8 +67,6 @@ func (d Dimension) PowInt(p int) Dimension {
 // ── Common Dimensions ────────────────────────────────────────────────────────
 
 // SI base and derived dimensions — immutable physical constants.
-//
-//nolint:gochecknoglobals // SI dimensions are inherently package-level constants
 var (
 	Dimensionless = Dimension{}
 	Length        = Dimension{L: 1}

--- a/unit/radiometric.go
+++ b/unit/radiometric.go
@@ -5,8 +5,6 @@ package unit
 // provenance serialization, and boundary parsing — never for the numeric
 // hot path, where skybrightness uses its own bespoke float64 types
 // instead. See the package doc's "Radiometric type safety" section for why.
-//
-//nolint:gochecknoglobals // package-level unit vars, matching units.go's own convention
 var (
 	// Watt is W = kg·m²·s⁻³ (power).
 	Watt = Unit{Dimension: Power, ScaleFactor: 1, Name: "watt", Symbol: "W"}
@@ -47,8 +45,6 @@ var (
 // composite unit in this codebase uses (see constants/units.go), so a
 // wrong exponent is a compile-time-visible composition error, not a
 // hand-typed literal.
-//
-//nolint:gochecknoglobals // composed from the vars above; same convention
 var (
 	// IrradianceUnit is W·m⁻².
 	IrradianceUnit = Watt.Div(Meter.PowInt(2))

--- a/unit/units.go
+++ b/unit/units.go
@@ -83,8 +83,6 @@ func (u Unit) String() string {
 // ── Built-in Units ─────────────────────────────────────────────────────────────
 
 // SI and astronomical measurement units — immutable physical constants.
-//
-//nolint:gochecknoglobals // SI/IAU units are inherently package-level constants
 var (
 	// Meter is the SI base unit of length.
 	Meter = Unit{Dimension: Length, ScaleFactor: 1.0, Name: "meter", Symbol: "m"}

--- a/vector/bench_test.go
+++ b/vector/bench_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/TuSKan/astrogo/vector"
 )
 
-//nolint:gochecknoglobals // benchmark sinks prevent dead-code elimination
 var (
 	sink    float64 // prevents dead-code elimination
 	vecSink vector.Vec3


### PR DESCRIPTION
`.golangci.yml` runs `default: all` and disables `gochecknoglobals`. There were **42** `//nolint:gochecknoglobals` directives — 29% of every suppression in the tree — silencing a linter that never fires.

## Why this is worse than clutter

CLAUDE.md permits `//nolint` "only when locally scoped with a documented reason". So each of these carried a written justification for suppressing nothing:

```go
//nolint:gochecknoglobals // ICAO ISA reference profile — immutable physical constant
//nolint:gochecknoglobals // fixed geometry of the base tessellation
//nolint:gochecknoglobals // IAU body registry — immutable catalog data
```

A reader cannot tell the live suppressions from the dead ones. The rule meant to make each one deliberate instead produced a wall of them that reads as considered — which is the state in which a real suppression gets added without scrutiny. Five were added by an assistant following that rule without checking the config.

38 were standalone lines at the end of a doc comment, with a bare `//` separator that went with them; 4 were trailing on a `var` line. **`gochecknoglobals` was the only dead name** — every other directive in the tree names a linter that runs:

| live | count | | live | count |
| --- | ---: | --- | --- | ---: |
| exhaustive | 22 | | noctx | 5 |
| nilerr | 14 | | gocognit | 4 |
| errcheck | 13 | | forcetypeassert | 3 |
| gosec | 12 | | staticcheck | 3 |
| wrapcheck | 7 | | unparam, nilnil | 2 each |
| dupl, revive, nolintlint | 6 each | | 5 others | 1 each |

## The guard

A dead directive is **invisible to golangci-lint itself**. `nolintlint` reports an *unused* directive — one whose linter ran and had nothing to say — but a directive naming a disabled linter is simply skipped, and nothing complains. The config is the only place the answer lives, so `TestNoNolintForADisabledLinter` reads it.

It also fails if it parses no disable block at all, so renaming the config key cannot make it pass vacuously:

| mutation | result |
| --- | --- |
| reintroduce a `gochecknoglobals` directive | fails, naming file and line |
| rename `disable:` in the config | fails — "would pass vacuously" |

670 files scanned, 110 directives, 38 disabled linters.

## The nilerr audit

The issue also asked for the 14 `//nolint:nilerr` to be justified individually rather than waved through, given #102 — where a swallowed error turned a CDS outage into "target not found". Done:

| sites | verdict |
| --- | --- |
| `internal/docsguard` × 10 | **fine** — skipping an unreadable path during a tree walk |
| `atmosphere/dataset/cams/reader.go` × 3 | **wrong** — corruption and decode failure both read as "attribute absent" |
| `skybrightness/natural.go:885` | **wrong** — a real `RadianceAt` failure reads as no map coverage |
| `plan/moons.go:174` | a stated convention, but a network outage silently drops that kernel's moons |
| `plan/constellation.go:40` | **fine** — documented, benign fallback |
| `ephemeris/jpl/spk/reader.go:159` | acceptable; comment overstates it |

The CAMS one is the clearest. `scigolib/hdf5`'s `ReadAttribute` returns an error from three places — `Attributes()` failing, `ReadValue()` failing, and genuine absence — as a dynamic `fmt.Errorf` with no sentinel, so only the third is what the comment claims. A corrupt file would report every attribute as missing and the reader would carry on with defaults.

**Filed as #172 rather than fixed here**, with the evidence and a suggested fix that distinguishes the cases through the public API without string-matching another library's error text. Mixing a behavioural change to a dataset reader into a directive cleanup would make both harder to review, and that fix wants its own corrupt-file fixture.

One thing checked and cleared: `natural.go` returning `UnknownCloud` from a *starlight* path looks like a copy-paste bug but is not — `fetch.go:47` documents the flag reuse and two tests assert it.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways.

Closes #136.
