### PR TITLE
Re-check open pull requests when main moves

### DIFF
--- a/.github/scripts/open-prs-still-build.sh
+++ b/.github/scripts/open-prs-still-build.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Trial-merge every open pull request into the commit that was just pushed to
+# main, and check the result still compiles.
+#
+# ── Why this exists ──────────────────────────────────────────────────────────
+#
+# GitHub tests a pull request against refs/pull/N/merge, which is the PR merged
+# into its base — so a PR's own checks already cover the merged result. What
+# they do not cover is main moving afterwards. Those checks are not re-run, so
+# a PR stays green while the branch it would merge into changes underneath it.
+#
+# PR #169 is the case. It edited a line in plan.LookAngle. PR #165 merged first
+# and rewrote that function, deleting the variable #169's line referred to. Git
+# merged the two without a single conflict marker, because they touched
+# different lines — and the result did not compile. It was caught only because
+# a later push to #169 happened to re-trigger its checks; left alone it would
+# have sat green and broken main on merge.
+#
+# A textual merge succeeding says nothing about whether the result builds. This
+# is the job that asks.
+#
+# ── Scope ────────────────────────────────────────────────────────────────────
+#
+# Build and vet, not the full test suite: this runs once per push to main and
+# multiplies by the number of open PRs, and a semantic conflict of this kind is
+# a compile error essentially every time. The PR's own checks remain the place
+# where behaviour is tested.
+#
+# A PR from a fork is skipped — its head is not a ref in this repository, and
+# a fork PR cannot be trial-merged without fetching untrusted code into a job
+# that holds a token.
+set -uo pipefail
+
+base_sha="$(git rev-parse HEAD)"
+broken=()
+checked=0
+skipped=0
+
+# --json/--jq keeps this to one API call regardless of how many PRs are open.
+prs="$(gh pr list --state open --base main --limit 100 \
+  --json number,headRefName,isCrossRepository \
+  --jq '.[] | [.number, .headRefName, (.isCrossRepository|tostring)] | @tsv')"
+
+if [ -z "$prs" ]; then
+  echo "No open pull requests targeting main."
+  exit 0
+fi
+
+while IFS=$'\t' read -r number head cross; do
+  [ -z "${number:-}" ] && continue
+
+  if [ "$cross" = "true" ]; then
+    echo "── #$number ($head): skipped, from a fork"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  echo "── #$number ($head)"
+
+  if ! git fetch --quiet origin "$head"; then
+    echo "   could not fetch the head ref; skipping"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if ! git -c user.name=ci -c user.email=ci@local merge --no-edit --quiet FETCH_HEAD >/dev/null 2>&1; then
+    # A textual conflict is the PR author's to resolve and GitHub already
+    # shows it, so it is reported but not counted as a break this job found.
+    echo "   textual conflict with main — GitHub already reports this"
+    git merge --abort >/dev/null 2>&1 || true
+    git reset --hard --quiet "$base_sha"
+    git clean -qfd
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  if out="$(go build ./... 2>&1 && go vet ./... 2>&1)"; then
+    echo "   builds against main"
+  else
+    echo "   DOES NOT BUILD against main:"
+    echo "$out" | sed 's/^/     /'
+    broken+=("#$number ($head)")
+  fi
+
+  git reset --hard --quiet "$base_sha"
+  git clean -qfd
+done <<< "$prs"
+
+echo
+echo "$checked pull request(s) trial-merged, $skipped skipped."
+
+if [ ${#broken[@]} -ne 0 ]; then
+  echo
+  echo "These open pull requests merge cleanly but no longer build against main:"
+  printf '  %s\n' "${broken[@]}"
+  echo
+  echo "Each needs a rebase onto main and a re-run of its own checks. Their"
+  echo "existing green checks were computed against an older main and no"
+  echo "longer mean anything."
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,38 @@ jobs:
           path: bench.txt
           retention-days: 90
 
+  # Runs on push to main, not on a pull request: it is the *base* moving that
+  # invalidates an already-green PR, and nothing re-runs those checks when it
+  # does. See the script for the case that motivated it (#169 merged cleanly
+  # and did not compile).
+  open-prs-still-build:
+    name: Open PRs still build against main
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # Full history: the job merges other branches into this commit.
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          # See the Setup Go step in the lint-and-test job for why this is a
+          # minor-version spec rather than go-version-file: go.mod (#109).
+          go-version: '1.25'
+          cache: true
+
+      - name: Trial-merge every open PR and build it
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash ./.github/scripts/open-prs-still-build.sh
+
   integration:
     name: Integration Tests (External APIs)
     runs-on: ubuntu-latest

--- a/docs/changelog.d/175-stale-pr-merge-check.md
+++ b/docs/changelog.d/175-stale-pr-merge-check.md
@@ -1,0 +1,11 @@
+---
+type: Added
+pr: 175
+---
+**CI now re-checks every open pull request when `main` moves.** A PR's own
+checks test it merged into its base, but nothing re-runs them when the base
+advances — so a PR can sit green while the branch it would merge into changes
+underneath it. #169 did exactly that: it merged with no textual conflict and
+did not compile, because #165 had meanwhile rewritten the function it touched.
+The new job trial-merges each open PR into the pushed commit and builds the
+result (#169).


### PR DESCRIPTION
A pull request's checks run against `refs/pull/N/merge` — the PR merged into its base — so the merged result *is* already covered. What is not covered is **main moving afterwards**. Those checks are not re-run, so a PR sits green while the branch it would merge into changes underneath it.

## #169 is the case, and it reached main

| | |
| --- | --- |
| #169 | edited one line in `plan.LookAngle` |
| #165 | merged first, rewrote that function and deleted the variable that line used |
| result | **no textual conflict**, and `plan/satellite.go:215:2: undefined: reduction` |

The two touched different lines, so git merged them without a single conflict marker. It was caught only because a later push to #169 happened to re-trigger its checks — left alone it would have stayed green and broken main on merge.

`git merge-tree` reporting "no conflict" is not evidence that the merge builds. This is the job that asks.

## What it does

On push to main: list the open PRs, trial-merge each into the commit just pushed, build the result.

- **Build and vet, not the full suite.** It runs once per push multiplied by the number of open PRs, and a semantic conflict of this kind is a compile error essentially every time. Behaviour stays the PR's own checks' job.
- **A textual conflict is reported, not failed.** GitHub already surfaces those and they are the author's to resolve; counting them here would just duplicate a signal.
- **Fork PRs are skipped.** Their head is not a ref in this repository, and fetching untrusted code into a job holding a token is not something a convenience check should do quietly.

## Verified both ways

**It catches the failure.** A branch built to reproduce #169's exact shape — compiles on the base it was branched from, merges into current main with no conflict, then does not build:

```
── #9999 (tmp/ci-selftest)
   DOES NOT BUILD against main:
     # github.com/TuSKan/astrogo/plan
     plan/zz_selftest.go:8:22: undefined: jpl.KMPerAU

These open pull requests merge cleanly but no longer build against main:
  #9999 (tmp/ci-selftest)
```

Exit 1. The fixture referenced `jpl.KMPerAU`, which #169 itself removed — so it is the same class of break, not a stand-in. Branch deleted after the run.

**It passes the real case.** Run against the live repository, it trial-merged the open PR, built it, reported clean, exit 0, and left the working tree untouched.

My first reproduction attempt was not faithful and I discarded it: merging the pre-rebase #169 commit into current main gives a *textual* conflict, because `git merge` and `git rebase` resolve against different merge bases and the branch had since been force-pushed. The synthetic fixture above reproduces the property that matters — clean merge, broken build — rather than trying to resurrect the original commit graph.

## The remaining gap

This closes the window between "main moved" and "someone pushed to the PR". It does **not** stop a merge — it reports after the fact, on the next push to main.

The complete fix is GitHub's own **"Require branches to be up to date before merging"** in branch protection for `main`, which forces an update before the merge button works. That is a repository setting rather than a file, so it is not in this PR. This job is the part that can live in the repo, and it is useful regardless: it names which open PRs went stale and why, instead of leaving it to whoever merges next.

Refs #169.
