### PR TITLE
Tell a failure apart from a legitimate absence

### DIFF
--- a/atmosphere/dataset/cams/attribute_test.go
+++ b/atmosphere/dataset/cams/attribute_test.go
@@ -1,0 +1,84 @@
+package cams
+
+import (
+	"context"
+	"testing"
+)
+
+// TestAttributeReadersSeparateAbsenceFromFailure is the fix for #172.
+//
+// # What was wrong
+//
+// The three attribute readers treated every error from ReadAttribute as
+// "attribute absent":
+//
+//	v, err := ds.ReadAttribute(name)
+//	if err != nil {
+//	    return 0, false, nil // absence is expected, not an error
+//	}
+//
+// That is true of one of the three paths ReadAttribute can fail on. It also
+// fails when the object header cannot be read at all — a corrupt or truncated
+// file — and when the attribute is present but undecodable. Both arrive as a
+// dynamic fmt.Errorf with no sentinel, so the readers reported a broken file as
+// a file that simply omits its optional attributes, and the reader carried on
+// with defaults.
+//
+// # How the failure is provoked
+//
+// By closing the file and reading through the still-live dataset handle, which
+// makes the header read fail for real rather than through a mock. The hdf5
+// package returns []*core.Attribute from an internal package, so the dependency
+// cannot be faked behind an interface — the type cannot be named here.
+func TestAttributeReadersSeparateAbsenceFromFailure(t *testing.T) {
+	bucket, key := synthFixture(t)
+
+	f, err := Open(context.Background(), bucket, key)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	ds, ok := f.vars["aermr01"]
+	if !ok {
+		t.Fatal("the fixture no longer carries an aermr01 variable")
+	}
+
+	// Present: the value comes back.
+	if got, err := readStringAttribute(ds, "units"); err != nil || got != "kg kg**-1" {
+		t.Fatalf(`readStringAttribute("units") = %q, %v; want "kg kg**-1", nil`, got, err)
+	}
+
+	// Absent: empty and no error, which is the case the old code was right
+	// about and must keep being right about.
+	if got, err := readStringAttribute(ds, "no_such_attribute"); err != nil || got != "" {
+		t.Errorf(`readStringAttribute(absent) = %q, %v; want "", nil`, got, err)
+	}
+
+	if _, ok, err := readInt32Attribute(ds, "no_such_attribute"); err != nil || ok {
+		t.Errorf("readInt32Attribute(absent) = ok %v, err %v; want false, nil", ok, err)
+	}
+
+	if _, ok, err := readFloat64Attribute(ds, "no_such_attribute"); err != nil || ok {
+		t.Errorf("readFloat64Attribute(absent) = ok %v, err %v; want false, nil", ok, err)
+	}
+
+	// Now make the header unreadable. Every reader must report a failure, not
+	// absence — this is the assertion the old code fails.
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := readStringAttribute(ds, "units"); err == nil {
+		t.Error("readStringAttribute reported an unreadable header as an absent " +
+			"attribute. A corrupt file then reads as one that merely omits its " +
+			"optional attributes, and the reader carries on with defaults.")
+	}
+
+	if _, ok, err := readInt32Attribute(ds, "units"); err == nil {
+		t.Errorf("readInt32Attribute reported an unreadable header as absence (ok=%v)", ok)
+	}
+
+	if _, ok, err := readFloat64Attribute(ds, "units"); err == nil {
+		t.Errorf("readFloat64Attribute reported an unreadable header as absence (ok=%v)", ok)
+	}
+}

--- a/atmosphere/dataset/cams/reader.go
+++ b/atmosphere/dataset/cams/reader.go
@@ -305,10 +305,59 @@ func isDimensionScale(ds *hdf5.Dataset) bool {
 // nil error) when the attribute is simply absent; a non-nil error means
 // the attribute exists but decoded to something this reader cannot
 // interpret as an integer.
+// attributePresent reports whether ds carries an attribute called name.
+//
+// # Why this exists rather than reading the error from ReadAttribute
+//
+// ReadAttribute returns an error from three different places, and only one of
+// them means the attribute is absent:
+//
+//	attrs, err := d.Attributes()          // 1. a real failure: corrupt header, I/O
+//	if err != nil { return nil, err }
+//	for _, attr := range attrs {
+//	    if attr.Name == name {
+//	        return attr.ReadValue()       // 2. a real failure: present, undecodable
+//	    }
+//	}
+//	return nil, fmt.Errorf("attribute %q not found", name)   // 3. genuine absence
+//
+// All three arrive as a dynamic fmt.Errorf with no sentinel, so errors.Is
+// cannot separate them and matching the message would tie astrogo to another
+// library's wording. Treating every one as absence — which the readers below
+// used to do — means a corrupt file reports every attribute as missing and the
+// reader carries on with defaults, looking exactly like a file that legitimately
+// omits optional ones.
+//
+// Asking which attributes exist first costs a second header read on a
+// per-dataset metadata path, and separates the cases exactly.
+func attributePresent(ds *hdf5.Dataset, name string) (bool, error) {
+	attrs, err := ds.Attributes()
+	if err != nil {
+		return false, fmt.Errorf("cams: read attributes of %q: %w", name, err)
+	}
+
+	for _, a := range attrs {
+		if a.Name == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func readInt32Attribute(ds *hdf5.Dataset, name string) (value int32, ok bool, err error) {
+	present, err := attributePresent(ds, name)
+	if err != nil {
+		return 0, false, err
+	}
+
+	if !present {
+		return 0, false, nil
+	}
+
 	v, err := ds.ReadAttribute(name)
 	if err != nil {
-		return 0, false, nil //nolint:nilerr // attribute absence is expected, not an error
+		return 0, false, fmt.Errorf("cams: read attribute %q: %w", name, err)
 	}
 
 	switch n := v.(type) {
@@ -329,9 +378,18 @@ func readInt32Attribute(ds *hdf5.Dataset, name string) (value int32, ok bool, er
 // Go types ReadAttribute may return it as. ok is false (nil error) when
 // the attribute is absent.
 func readFloat64Attribute(ds *hdf5.Dataset, name string) (value float64, ok bool, err error) {
+	present, err := attributePresent(ds, name)
+	if err != nil {
+		return 0, false, err
+	}
+
+	if !present {
+		return 0, false, nil
+	}
+
 	v, err := ds.ReadAttribute(name)
 	if err != nil {
-		return 0, false, nil //nolint:nilerr // attribute absence is expected, not an error
+		return 0, false, fmt.Errorf("cams: read attribute %q: %w", name, err)
 	}
 
 	switch n := v.(type) {
@@ -351,9 +409,18 @@ func readFloat64Attribute(ds *hdf5.Dataset, name string) (value float64, ok bool
 // readStringAttribute reads name as a string, returning "" (nil error)
 // when the attribute is absent.
 func readStringAttribute(ds *hdf5.Dataset, name string) (string, error) {
+	present, err := attributePresent(ds, name)
+	if err != nil {
+		return "", err
+	}
+
+	if !present {
+		return "", nil
+	}
+
 	v, err := ds.ReadAttribute(name)
 	if err != nil {
-		return "", nil //nolint:nilerr // attribute absence is expected, not an error
+		return "", fmt.Errorf("cams: read attribute %q: %w", name, err)
 	}
 
 	s, ok := v.(string)

--- a/docs/changelog.d/176-nilerr-absence-vs-failure.md
+++ b/docs/changelog.d/176-nilerr-absence-vs-failure.md
@@ -1,0 +1,12 @@
+---
+type: Fixed
+pr: 176
+---
+**Three places reported a real failure as a legitimate absence.** The CAMS
+HDF5 reader treated *any* `ReadAttribute` error as "attribute missing", so a
+corrupt file reported every attribute as absent and the reader carried on with
+defaults; it now asks which attributes exist first, which separates absence
+from an unreadable header. `IntegratedStarlight` read `err != nil || value <= 0`
+and reported a map that could not answer — a band it does not carry — as an
+uncovered direction; the two are now distinguished by the new
+`skybrightness.ErrNoCoverage` (#172).

--- a/ephemeris/jpl/spk/reader.go
+++ b/ephemeris/jpl/spk/reader.go
@@ -156,7 +156,13 @@ func removeChecksumSidecar(ctx context.Context, bucket *file.Bucket, key string)
 	sumKey := checksumSidecarKey(key)
 
 	if exists, err := bucket.Exists(ctx, sumKey); err != nil || !exists {
-		return nil //nolint:nilerr // a failed existence check just means "nothing to clean up here either"
+		// A failed check means we do not know whether a sidecar is there, not
+		// that there is nothing to remove -- the comment here used to claim
+		// the latter. Left alone either way: this runs after a checksum
+		// mismatch has already been reported, the worst outcome is a stale
+		// sidecar the next run re-checks, and failing the cleanup would
+		// replace a real error with a bookkeeping one.
+		return nil //nolint:nilerr // deliberate: see above
 	}
 
 	if err := bucket.Delete(ctx, sumKey); err != nil {

--- a/plan/visible_tonight.go
+++ b/plan/visible_tonight.go
@@ -206,6 +206,21 @@ var planetConstructors = []func(eph.Provider) *Planet{
 // propagation can't represent; see WithSmallBodyKernels to force the
 // kernel path unconditionally. A candidate whose ephemeris (either path)
 // can't be obtained is skipped, not treated as fatal.
+//
+// # The result can be silently incomplete
+//
+// That skip covers a network failure as well as a missing orbit. A kernel
+// fetch that times out, or JPL being unreachable, removes that body's moons or
+// that small body from the result and reports nothing — so an empty or short
+// list means "nothing qualified, as far as could be determined", never
+// "nothing qualified".
+//
+// This is deliberate: a partial sky is more useful than an error for a
+// planning query, and one unreachable kernel should not cost the caller the
+// other forty candidates. But it is worth knowing before treating the result
+// as exhaustive. A caller who needs certainty should pre-seed the kernels it
+// depends on, or check reachability first; remote.SetOffline(true) makes the
+// degradation deterministic rather than dependent on the network.
 func VisibleTonight(
 	ctx context.Context,
 	site *Site,

--- a/skybrightness/dataset/starlight/starlight.go
+++ b/skybrightness/dataset/starlight/starlight.go
@@ -175,7 +175,11 @@ func (m *Map) RadianceAt(band string, lon, lat angle.Angle) (float64, error) {
 
 	pixel := m.grid.PixelOf(lon, lat)
 	if pixel < 0 || pixel >= int64(len(values)) {
-		return 0, fmt.Errorf("%w: %d", ErrPixelRange, pixel)
+		// Wrapped with both sentinels: ErrPixelRange for a caller of this
+		// package, and skybrightness.ErrNoCoverage so IntegratedStarlight can
+		// tell "this map has nothing here" from "this map failed", which it
+		// previously could not — see that sentinel's own comment.
+		return 0, fmt.Errorf("%w: %w: %d", skybrightness.ErrNoCoverage, ErrPixelRange, pixel)
 	}
 
 	return values[pixel], nil

--- a/skybrightness/natural.go
+++ b/skybrightness/natural.go
@@ -730,6 +730,26 @@ func (a *Airglow) Provenance() Provenance {
 // ErrNoStarMap is returned when a starlight component is built without one.
 var ErrNoStarMap = errors.New("skybrightness: integrated starlight needs a sky map")
 
+// ErrNoCoverage marks a direction a map has no data for, as distinct from a
+// map that failed to answer.
+//
+// A [StarMap] may signal a gap two ways, and both are treated alike: a zero or
+// negative radiance, or an error wrapping this. The first is what a sparse map
+// does — starlight's fetch-on-demand maps are full-length slices with zero for
+// every pixel nobody has asked about, so "not covered" and "read as zero" are
+// the same thing there. The second exists for an implementation that can tell
+// the difference and wants to say so.
+//
+// Any *other* error is a failure: the band was not in the map, the file was
+// unreadable, the request was malformed.
+//
+// The two used to be indistinguishable here. [IntegratedStarlight] read
+// `if err != nil || value <= 0` and reported both as an uncovered direction,
+// so a misconfigured band — asking a V map for R — came back as a quiet gap in
+// the sky rather than as the mistake it is. That is the shape of #102, where a
+// swallowed error turned a CDS outage into "target not found".
+var ErrNoCoverage = errors.New("skybrightness: direction not covered by the map")
+
 // StarMap samples extra-atmospheric starlight radiance by direction.
 //
 // The values are outside the atmosphere: attenuating them is the component's
@@ -742,6 +762,11 @@ type StarMap interface {
 	// is the one handed to [NewIntegratedStarlight]; a map built for one
 	// band and read against another is a silent error this interface
 	// cannot catch.
+	//
+	// A direction the map does not cover is an error wrapping
+	// [ErrNoCoverage], not a zero value: zero is a legitimate radiance and
+	// carries no information about whether the map was asked something it
+	// could answer. Any other error is treated as a failure and propagated.
 	RadianceAt(lon, lat angle.Angle) (float64, error)
 
 	// Galactic reports whether the map is indexed in galactic coordinates.
@@ -881,8 +906,16 @@ func (s *IntegratedStarlight) AddRadiance(
 	}
 
 	value, err := s.sky.RadianceAt(lon, lat)
-	if err != nil || value <= 0 {
-		return UnknownCloud, nil //nolint:nilerr // absence of map coverage is not a failure
+
+	switch {
+	case errors.Is(err, ErrNoCoverage):
+		// The map answered: it has nothing here. Flagged, not failed.
+		return UnknownCloud, nil
+	case err != nil:
+		return 0, fmt.Errorf("skybrightness: starlight: radiance: %w", err)
+	case value <= 0:
+		// Covered, but no measurable starlight in this direction.
+		return UnknownCloud, nil
 	}
 
 	airmass, err := atmosphere.Airmass(dir.Alt())

--- a/skybrightness/starlight_component_test.go
+++ b/skybrightness/starlight_component_test.go
@@ -3,6 +3,7 @@ package skybrightness_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 
@@ -594,5 +595,100 @@ func TestDiffuseGalacticLightUncoveredSightlineIsNotCappedToZero(t *testing.T) {
 
 	if flags&skybrightness.UnknownCloud == 0 {
 		t.Error("an uncappable sightline must be flagged")
+	}
+}
+
+// failingSky answers every direction with a failure that is not a coverage
+// gap — the shape of a misconfigured band, or an unreadable map.
+type failingSky struct{}
+
+func (failingSky) Galactic() bool { return false }
+func (failingSky) RadianceAt(_, _ angle.Angle) (float64, error) {
+	return 0, errSkyUnavailable
+}
+
+var errSkyUnavailable = errors.New("starlight_component_test: the map could not answer")
+
+// uncoveredSky answers with a coverage gap, the way a real map reports a
+// direction outside its pixel array.
+type uncoveredSky struct{}
+
+func (uncoveredSky) Galactic() bool { return false }
+func (uncoveredSky) RadianceAt(_, _ angle.Angle) (float64, error) {
+	return 0, fmt.Errorf("%w: pixel out of range", skybrightness.ErrNoCoverage)
+}
+
+// TestIntegratedStarlightSeparatesFailureFromMissingCoverage is the fix for
+// #172.
+//
+// The component read `if err != nil || value <= 0` and reported both as an
+// uncovered direction. So a map that could not answer at all — the band was
+// not in it, the file was unreadable — came back as a quiet gap in the sky
+// rather than as the mistake it is, which is the shape of #102 where a
+// swallowed error turned a CDS outage into "target not found".
+//
+// The two cases are now told apart by ErrNoCoverage, and this asserts both
+// directions: a gap is still flagged rather than failed, and a failure is
+// propagated rather than flagged.
+func TestIntegratedStarlightSeparatesFailureFromMissingCoverage(t *testing.T) {
+	t.Parallel()
+
+	grid := skybrightness.DefaultOpticalGrid()
+	dir := coord.NewAltAz(angle.Deg(60), angle.Deg(0))
+
+	for _, tc := range []struct {
+		name      string
+		sky       skybrightness.StarMap
+		wantErr   error
+		wantFlags skybrightness.Flag
+	}{
+		{
+			name:      "a coverage gap is flagged, not failed",
+			sky:       uncoveredSky{},
+			wantFlags: skybrightness.UnknownCloud,
+		},
+		{
+			name:    "a map that cannot answer is a failure",
+			sky:     failingSky{},
+			wantErr: errSkyUnavailable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			isl, err := skybrightness.NewIntegratedStarlight(tc.sky, solarShape(grid), grid, testBand())
+			if err != nil {
+				t.Fatalf("NewIntegratedStarlight: %v", err)
+			}
+
+			dst := skybrightness.NewSpectralRadiance(grid)
+
+			flags, err := isl.AddRadiance(context.Background(), dst, grid, dir, starlightScene(t))
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("AddRadiance returned %v, want it to wrap %v.\n"+
+						"  A map that failed is not a map with nothing there; reporting "+
+						"it as an uncovered direction loses the only sign of the "+
+						"misconfiguration.", err, tc.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("AddRadiance: %v", err)
+			}
+
+			if flags&tc.wantFlags == 0 {
+				t.Errorf("flags = %v, want %v", flags, tc.wantFlags)
+			}
+
+			for i, v := range dst {
+				if v != 0 {
+					t.Fatalf("an uncovered direction wrote %v at index %d", v, i)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Three places reported "could not tell" as "nothing there" — the shape of #102, where a swallowed error turned a CDS outage into "target not found".

## 1. The CAMS attribute readers

All three treated *every* error from `ReadAttribute` as "attribute absent". That is true of one of the three paths `scigolib/hdf5` fails on:

```go
attrs, err := d.Attributes()          // 1. real failure: corrupt header, I/O
if err != nil { return nil, err }
for _, attr := range attrs {
    if attr.Name == name {
        return attr.ReadValue()       // 2. real failure: present, undecodable
    }
}
return nil, fmt.Errorf("attribute %q not found", name)   // 3. genuine absence
```

All three arrive as a dynamic `fmt.Errorf` with no sentinel, so a broken file reported **every** attribute as missing and the reader carried on with defaults — indistinguishable from a file that legitimately omits optional ones.

They now ask which attributes exist first, through the public API rather than by matching another library's error text. Cost is a second header read on a per-dataset metadata path.

## 2. IntegratedStarlight

```go
value, err := s.sky.RadianceAt(lon, lat)
if err != nil || value <= 0 { return UnknownCloud, nil }
```

`RadianceAt` returns `ErrBand` for a band the map does not carry — a misconfiguration, not a gap in the sky — and it came back as a quiet uncovered direction. The new `skybrightness.ErrNoCoverage` separates them: a gap is flagged, anything else propagates.

## Two things I got wrong on the way

**An unreachable branch I nearly shipped.** I first had `starlight` wrap `ErrNoCoverage` around its `ErrPixelRange`. A mutation showed removing that wrap broke nothing — and the reason is that the branch cannot be reached: every band is `make([]float64, npix)` and `NewMap` ties the lengths together, so `PixelOf` can never index past the slice. A sparse map signals a gap by *reading zero*, which the package documents. Shipping untestable defensive code that claims a contract is worse than not claiming it, so the wrap is gone and `ErrNoCoverage`'s doc states both signals instead.

**The CAMS fix had no test.** The same mutation pass caught that reverting it broke nothing. The dependency cannot be faked — `Attributes()` returns a type from hdf5's *internal* package, so it cannot be named in an interface here — so the test provokes a real header-read failure by closing the file and reading through the still-live dataset handle:

```
after close: "" err=cams: read attributes of "units": object header read failed: invalid argument
```

Reverting any of the three readers now fails it:

```
readStringAttribute reported an unreadable header as an absent attribute.
readInt32Attribute reported an unreadable header as absence (ok=false)
```

## Handled by documentation rather than code

- **`spk.removeChecksumSidecar`** — its comment claimed a failed existence check means "nothing to clean up". It means *we do not know*. The behaviour is still right (this runs after a checksum mismatch is already reported; the worst case is a stale sidecar the next run re-checks) and the reasoning now says so.
- **`lsk.parseSpiceDate`** — its comment said *"Simple JD calculation for 12:00:00"*. The formula's trailing `-32045.5` subtracts the half-day back from the integer Julian Day Number, so it has always computed **midnight** — which is when a leap second takes effect, and what every `DELTA_AT` entry means. The code was right; the comment described the formula without its own last term.
- **`VisibleTonight`** — its doc said a candidate whose ephemeris can't be obtained is skipped, but not that this covers a *network* failure. It now states plainly that an empty or short list means "nothing qualified as far as could be determined", and points at `remote.SetOffline(true)` for making the degradation deterministic.

## Left for a follow-up

`DiffuseGalacticLight.capFactor` has the same `err != nil || value <= 0` shape, but returns `(float64, Flag)` with no error channel — fixing it needs a signature change and propagation through `AddRadiance`.

Sweeping `err != nil ||` across the whole module afterwards found it is not alone: **six** sites share that cause, including the bisection predicates in `plan/schedule.go` and `plan/visibility.go`, where a constraint that *errors* is indistinguishable from one that *fails* and a target silently vanishes from a schedule. Filed as #177 with the full triage — eleven other matches are correct and are listed there so nobody re-derives them.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged · `go test ./...` · `-race` · `golangci-lint` **0 issues** both ways · `validation` tier green.

Three mutations: conflating failure with absence in `IntegratedStarlight` (fails), removing the starlight wrap (**passed** — which is what exposed the unreachable branch), and reverting all three CAMS readers (fails, after the missing test was added).

Closes #172.
