### PR TITLE
Correct parseSpiceDate's comment: it computes midnight, not noon

### DIFF
--- a/ephemeris/jpl/lsk/reader.go
+++ b/ephemeris/jpl/lsk/reader.go
@@ -284,9 +284,19 @@ func parseSpiceDate(s string) (float64, error) {
 		return 0, fmt.Errorf("%w: %s", ErrInvalidMonth, monthStr)
 	}
 
-	// Simple JD calculation for 12:00:00 (standard for leapsecond dates in LSK)
-	// JD = 367*Y - (7*(Y + (M+9)/12))/4 + (275*M)/9 + D + 1721013.5
-	// This is valid for Gregorian calendar (post-1582).
+	// Julian Date at 00:00:00 UTC on the given calendar day, which is when a
+	// leap second takes effect and so what every DELTA_AT entry means.
+	//
+	// The trailing -32045.5 rather than -32045 is what does that: the standard
+	// formula yields the integer Julian Day Number, which is noon, and the
+	// half-day subtracts back to the preceding midnight. 1972-01-01 comes out
+	// 2441317.5, the canonical value naif0012.tls quotes in its own header.
+	//
+	// This comment used to say 12:00:00, which is what the formula gives
+	// *without* the half — the code has always computed midnight. leapTable
+	// depends on that, and TestLeapTableReadsMidnightAsTheDayItStarts pins it.
+	//
+	// Valid for the Gregorian calendar (post-1582).
 	a := (14 - month) / 12
 	y := year + 4800 - a
 	m := month + 12*a - 3


### PR DESCRIPTION
A comment that describes the code inaccurately, found while auditing what this session had deferred.

```go
// Simple JD calculation for 12:00:00 (standard for leapsecond dates in LSK)
```

The formula's trailing `-32045.5`, rather than `-32045`, subtracts the half-day back from the integer Julian Day Number. So it has always produced **00:00:00 UTC** — which is when a leap second takes effect and what every `DELTA_AT` entry means. 1972-01-01 comes out `2441317.5`, the value `naif0012.tls` quotes in its own header.

The code is right and always was; the comment described the formula without its own last term. `leapTable` (#159) depends on midnight, and `TestLeapTableReadsMidnightAsTheDayItStarts` pins it — including the ULP-either-side cases, since a value drifting an ULP low would read as 23:59:59.999… of the *previous* day and date a leap second one day early.

## Why it is a separate PR

It was committed to #176's branch after that PR had already been reviewed, and the merge took the branch as of the previous commit — so it was left behind rather than deliberately excluded. Rebased onto main unchanged.

## No changelog fragment

Labelled `no-changelog`: nothing a user can observe changes. That label is what `ci.yml`'s Changelog Fragment job already documents for this case, but it had never been created on the repository — it exists now.

## Verification

`gofmt` · `go build` · `go vet` · `golangci-lint` **0 issues** · `go test` on `ephemeris/jpl/lsk` and `internal/docsguard` (the citation guard resolves the test named above).
