### PR TITLE
Let the predicates report a failure, and VisibleTonight report an incomplete night

### DIFF
--- a/atmosphere/dataset/cams/attribute_test.go
+++ b/atmosphere/dataset/cams/attribute_test.go
@@ -62,6 +62,12 @@ func TestAttributeReadersSeparateAbsenceFromFailure(t *testing.T) {
 		t.Errorf("readFloat64Attribute(absent) = ok %v, err %v; want false, nil", ok, err)
 	}
 
+	// A data variable carries no CLASS attribute at all, which is an ordinary
+	// false rather than a failure -- the case that makes the whole index work.
+	if isDim, err := isDimensionScale(ds); err != nil || isDim {
+		t.Errorf("isDimensionScale(data variable) = %v, %v; want false, nil", isDim, err)
+	}
+
 	// Now make the header unreadable. Every reader must report a failure, not
 	// absence — this is the assertion the old code fails.
 	if err := f.Close(); err != nil {
@@ -80,5 +86,14 @@ func TestAttributeReadersSeparateAbsenceFromFailure(t *testing.T) {
 
 	if _, ok, err := readFloat64Attribute(ds, "units"); err == nil {
 		t.Errorf("readFloat64Attribute reported an unreadable header as absence (ok=%v)", ok)
+	}
+
+	// isDimensionScale was left behind by #172 and is the worst of the four to
+	// get wrong: answering false files a dimension scale as a data variable, so
+	// an axis vanishes from cf.dims and the file indexes with a shape it does
+	// not have. The failure then surfaces much later, on a variable whose
+	// dimensions are in fact all present.
+	if isDim, err := isDimensionScale(ds); err == nil {
+		t.Errorf("isDimensionScale reported an unreadable header as %v rather than an error", isDim)
 	}
 }

--- a/atmosphere/dataset/cams/reader.go
+++ b/atmosphere/dataset/cams/reader.go
@@ -196,7 +196,13 @@ func (cf *File) index() error {
 			return
 		}
 
-		if !isDimensionScale(ds) {
+		isDim, err := isDimensionScale(ds)
+		if err != nil {
+			walkErr = fmt.Errorf("cams: %s: %s: %w", cf.key, ds.Name(), err)
+			return
+		}
+
+		if !isDim {
 			cf.vars[ds.Name()] = ds
 			return
 		}
@@ -287,24 +293,35 @@ func (cf *File) newVar(name string, ds *hdf5.Dataset) (*Var, error) {
 
 // isDimensionScale reports whether ds is a NetCDF-4 dimension-scale
 // dataset (CLASS == "DIMENSION_SCALE") rather than a data variable. An
-// absent CLASS attribute (the common case for a data variable) simply
-// means false — never treated as a decode failure.
-func isDimensionScale(ds *hdf5.Dataset) bool {
+// absent CLASS attribute is the common case for a data variable and means
+// false, with a nil error.
+//
+// A header that cannot be read is an error, not a false. Answering false
+// there files the dataset as a data variable, so an axis silently vanishes
+// from cf.dims and the file indexes with a shape it does not have — the
+// failure then surfaces much later as a confusing "dimension not found" on a
+// variable whose dimensions are in fact present. See attributePresent for why
+// the underlying library's error cannot be classified after the fact.
+func isDimensionScale(ds *hdf5.Dataset) (bool, error) {
+	present, err := attributePresent(ds, "CLASS")
+	if err != nil {
+		return false, err
+	}
+
+	if !present {
+		return false, nil
+	}
+
 	v, err := ds.ReadAttribute("CLASS")
 	if err != nil {
-		return false
+		return false, fmt.Errorf("cams: read attribute %q: %w", "CLASS", err)
 	}
 
 	s, ok := v.(string)
 
-	return ok && s == "DIMENSION_SCALE"
+	return ok && s == "DIMENSION_SCALE", nil
 }
 
-// readInt32Attribute reads name as an int32, tolerating the small set of
-// numeric Go types ReadAttribute may return it as. ok is false (with a
-// nil error) when the attribute is simply absent; a non-nil error means
-// the attribute exists but decoded to something this reader cannot
-// interpret as an integer.
 // attributePresent reports whether ds carries an attribute called name.
 //
 // # Why this exists rather than reading the error from ReadAttribute
@@ -345,6 +362,11 @@ func attributePresent(ds *hdf5.Dataset, name string) (bool, error) {
 	return false, nil
 }
 
+// readInt32Attribute reads name as an int32, tolerating the small set of
+// numeric Go types ReadAttribute may return it as. ok is false (with a
+// nil error) when the attribute is simply absent; a non-nil error means
+// the attribute exists but decoded to something this reader cannot
+// interpret as an integer.
 func readInt32Attribute(ds *hdf5.Dataset, name string) (value int32, ok bool, err error) {
 	present, err := attributePresent(ds, name)
 	if err != nil {

--- a/docs/changelog.d/180-predicates-report-failure.md
+++ b/docs/changelog.d/180-predicates-report-failure.md
@@ -1,0 +1,13 @@
+---
+type: Fixed
+pr: 180
+---
+**Seven predicates could not report a failure, so an error read as "the answer
+is no".** The scheduler's and visibility solver's bisection predicates returned
+a bare `false` for a constraint that *could not be evaluated*, so a target
+silently vanished from a schedule; `ObservableWindows` swallowed a failure
+during refinement, moving a rise/set boundary rather than dropping it; and
+`DiffuseGalacticLight.capFactor` treated a star map that could not answer as a
+sightline with no starlight, quietly dropping the Toller cap. All now
+propagate. `VisibleTonight` keeps skipping a candidate it cannot evaluate — its
+documented contract — but reports each skip at `Warn` instead of silently (#177).

--- a/docs/changelog.d/180-predicates-report-failure.md
+++ b/docs/changelog.d/180-predicates-report-failure.md
@@ -9,5 +9,28 @@ silently vanished from a schedule; `ObservableWindows` swallowed a failure
 during refinement, moving a rise/set boundary rather than dropping it; and
 `DiffuseGalacticLight.capFactor` treated a star map that could not answer as a
 sightline with no starlight, quietly dropping the Toller cap. All now
-propagate. `VisibleTonight` keeps skipping a candidate it cannot evaluate — its
-documented contract — but reports each skip at `Warn` instead of silently (#177).
+propagate (#177).
+
+**`plan.VisibleTonight` reports an incomplete result instead of only logging
+it.** It still skips a candidate it cannot evaluate rather than failing the
+night, but now returns its results alongside an error wrapping the new
+`plan.ErrIncomplete`, naming every catalogue source, target, small body, moon
+kernel and candidate that was dropped and why. A caller who ignores that error
+gets the previous behaviour; one who checks it can finally tell a quiet sky
+from an unreachable JPL (#177).
+
+**`satellite.ValidateTLE` now checks that every numeric field is numeric, which
+prevents the SGP4 backend from calling `os.Exit` on the caller's process.**
+`joshuaferrara/go-satellite` parses the twelve numeric TLE fields through
+helpers that `log.Fatal` on a parse error — no error, no panic, nothing to
+recover. A TLE's modulo-10 checksum cannot catch this, since letters and spaces
+contribute nothing to the sum, so a field replaced by text can still check out.
+`NewFromTLE` now refuses such a set with `ErrMalformedTLE` naming the field, and
+`Satellite.MeanMotion` comes from that same parse rather than a separate one
+that returned a silent `0`.
+
+**`cams.isDimensionScale` reported an unreadable object header as "not a
+dimension scale".** A corrupt file then filed its axes as data variables, so
+the reader indexed a shape the file does not have and the failure surfaced much
+later as a missing dimension on a variable whose dimensions are all present. It
+was the one attribute reader #172 left behind.

--- a/ephemeris/satellite/satellite.go
+++ b/ephemeris/satellite/satellite.go
@@ -41,15 +41,19 @@ var ErrPropagation = errors.New("satellite: sgp4 propagation failed")
 var ErrUnexpectedID = errors.New("satellite: state queried for an id other than the tracked satellite (use core.ID(0))")
 
 // ErrMalformedTLE indicates a two-line element set that is not well formed:
-// the wrong length, the wrong line numbers, a failed checksum, or two lines
-// describing different satellites.
+// the wrong length, the wrong line numbers, a failed checksum, two lines
+// describing different satellites, or a field that is not the number the
+// format says it is.
 //
 // SGP4 will initialise happily from a corrupted element set and propagate it
-// for ever, because every field it reads is still a number. A single digit
+// for ever, as long as every field it reads is still a number. A single digit
 // altered in transmission or truncated in a copy moves an inclination or a
 // mean motion to another plausible value and puts the satellite somewhere it
 // has never been. The last character of each line exists to catch exactly
 // that, and is worth checking before trusting the rest.
+//
+// When a field is NOT still a number, the underlying SGP4 implementation does
+// something worse than propagate wrongly: see [ValidateTLE].
 var ErrMalformedTLE = errors.New("satellite: malformed TLE")
 
 // tleLineLength is the fixed width of a TLE line, checksum included.
@@ -68,7 +72,15 @@ type Satellite struct {
 // [ErrMalformedTLE] for why, since SGP4 itself will accept a corrupted set
 // and propagate it without complaint.
 func NewFromTLE(name, line1, line2 string) (*Satellite, error) {
-	if err := ValidateTLE(line1, line2); err != nil {
+	if err := validateTLEStructure(line1, line2); err != nil {
+		return nil, err
+	}
+
+	// Both the guard against TLEToSat's os.Exit and the source of MeanMotion:
+	// one parse, so the value this reports can never disagree with the one
+	// SGP4 propagates from.
+	mm, err := parseTLENumerics(line1, line2)
+	if err != nil {
 		return nil, err
 	}
 
@@ -76,8 +88,6 @@ func NewFromTLE(name, line1, line2 string) (*Satellite, error) {
 	if sat.Error != 0 {
 		return nil, fmt.Errorf("%w: sgp4 init error %d: %s", ErrPropagation, sat.Error, sat.ErrorStr)
 	}
-
-	mm := parseMeanMotion(line2)
 
 	return &Satellite{
 		Name:       name,
@@ -140,26 +150,9 @@ func (s *Satellite) Altitude(t time.Time) (float64, error) {
 	return geo.Height() / 1e3, nil // metres → km
 }
 
-// parseMeanMotion extracts mean motion (rev/day) from TLE line 2,
-// columns 53–63 (0-indexed).
-func parseMeanMotion(line2 string) float64 {
-	if len(line2) < 63 {
-		return 0
-	}
-
-	s := strings.TrimSpace(line2[52:63])
-
-	mm, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0
-	}
-
-	return mm
-}
-
 // ValidateTLE reports whether the two lines form a well-formed element set.
 //
-// Four things are checked, in the order a corrupted set is most likely to fail
+// Five things are checked, in the order a corrupted set is most likely to fail
 // them:
 //
 //   - each line is the standard 69 characters;
@@ -168,11 +161,46 @@ func parseMeanMotion(line2 string) float64 {
 //   - the two carry the same satellite number, which catches line 1 of one
 //     object pasted against line 2 of another - a substitution no checksum can
 //     see, since each line is individually intact;
-//   - each line's modulo-10 checksum matches its own last character.
+//   - each line's modulo-10 checksum matches its own last character;
+//   - every field the SGP4 backend will read as a number parses as one.
 //
 // None of this validates the orbit. It establishes that the element set
 // arrived as it was sent, which is the part SGP4 cannot tell for itself.
+//
+// # Why the numeric check is not merely tidiness
+//
+// The backend (joshuaferrara/go-satellite) parses the twelve numeric fields
+// through helpers that call log.Fatal on a parse error - os.Exit(1), from
+// inside a library, taking the caller's whole process with it. No error is
+// returned, no panic is raised, and there is nothing to recover: a program
+// that fed one bad element set into a batch of ten thousand simply stops.
+// Confirmed by running it, not inferred from reading it.
+//
+// A checksum does not close this. It is a modulo-10 sum in which letters,
+// spaces and punctuation all count for nothing, so a field can be replaced
+// with text - a truncated feed, a hand-built set, an "N/A" placeholder, a
+// generator that pads with spaces - and still carry a correct checksum.
+//
+// So this parses each field exactly as the backend will, using the same
+// column slices and the same two-space Replace (a field with three spaces
+// where the backend removes two is one the backend would die on, and is
+// therefore refused here rather than accepted as close enough), and reports
+// [ErrMalformedTLE] naming the field. NewFromTLE runs this before SGP4 sees
+// anything, which is the only place the guard is any use.
 func ValidateTLE(line1, line2 string) error {
+	if err := validateTLEStructure(line1, line2); err != nil {
+		return err
+	}
+
+	_, err := parseTLENumerics(line1, line2)
+
+	return err
+}
+
+// validateTLEStructure is ValidateTLE's length/ordering/checksum half, split
+// out so NewFromTLE can run it before parseTLENumerics without paying for the
+// numeric parse twice - it needs the mean motion that parse produces.
+func validateTLEStructure(line1, line2 string) error {
 	for i, line := range [2]string{line1, line2} {
 		want := byte('1' + i)
 
@@ -203,6 +231,70 @@ func ValidateTLE(line1, line2 string) error {
 	}
 
 	return nil
+}
+
+// parseTLENumerics parses every field the SGP4 backend will parse, from the
+// same columns and with the same string surgery, and returns the mean motion
+// (rev/day, line 2 columns 53-63) as the one value this package keeps.
+//
+// The transformations are copied from the backend's ParseTLE rather than
+// written afresh, deliberately: the contract is not "these look like numbers"
+// but "these are the exact strings that function will hand to strconv", and
+// only an identical construction can promise that. Notably ecco is prefixed
+// with "." (a TLE stores eccentricity with an assumed leading decimal point)
+// and nddot/bstar are reassembled from three slices into a mantissa-exponent
+// form, so neither field parses as a number in its raw column form at all.
+//
+// The two-space Replace count is copied too, and matters: a field carrying
+// three spaces would leave one behind, and " 15.72" does not parse. Using -1
+// here would accept a set the backend then dies on, which is worse than not
+// checking, because the guard would read as if it worked.
+//
+// Callers must have established the 69-character length first
+// (validateTLEStructure) - every slice below indexes fixed columns.
+func parseTLENumerics(line1, line2 string) (meanMotion float64, err error) {
+	ints := [...]struct {
+		name  string
+		value string
+	}{
+		{"satellite number", strings.TrimSpace(line1[2:7])},
+		{"epoch year", line1[18:20]},
+	}
+
+	for _, f := range ints {
+		if _, err := strconv.ParseInt(f.value, 10, 0); err != nil {
+			return 0, fmt.Errorf("%w: %s is %q, which is not an integer", ErrMalformedTLE, f.name, f.value)
+		}
+	}
+
+	floats := [...]struct {
+		name  string
+		value string
+	}{
+		{"epoch day", line1[20:32]},
+		{"first derivative of mean motion", strings.Replace(line1[33:43], " ", "", 2)},
+		{"second derivative of mean motion", strings.Replace(line1[44:45]+"."+line1[45:50]+"e"+line1[50:52], " ", "", 2)},
+		{"B* drag term", strings.Replace(line1[53:54]+"."+line1[54:59]+"e"+line1[59:61], " ", "", 2)},
+		{"inclination", strings.Replace(line2[8:16], " ", "", 2)},
+		{"right ascension of the ascending node", strings.Replace(line2[17:25], " ", "", 2)},
+		{"eccentricity", "." + line2[26:33]},
+		{"argument of perigee", strings.Replace(line2[34:42], " ", "", 2)},
+		{"mean anomaly", strings.Replace(line2[43:51], " ", "", 2)},
+		{"mean motion", strings.Replace(line2[52:63], " ", "", 2)},
+	}
+
+	for _, f := range floats {
+		v, err := strconv.ParseFloat(f.value, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %s is %q, which is not a number", ErrMalformedTLE, f.name, f.value)
+		}
+
+		if f.name == "mean motion" {
+			meanMotion = v
+		}
+	}
+
+	return meanMotion, nil
 }
 
 // tleChecksum is the modulo-10 sum a TLE line's last character records: every

--- a/ephemeris/satellite/tle_numeric_test.go
+++ b/ephemeris/satellite/tle_numeric_test.go
@@ -1,0 +1,223 @@
+package satellite_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+)
+
+// tleChecksum recomputes a line's modulo-10 check digit, so a test can corrupt
+// a field and hand ValidateTLE a set whose checksum is still correct.
+//
+// Reimplemented here rather than exported from the package: a checksum-valid
+// corruption is a test tool, not something the library should offer.
+func tleChecksum(line string) int {
+	sum := 0
+
+	for _, c := range line {
+		switch {
+		case c >= '0' && c <= '9':
+			sum += int(c - '0')
+		case c == '-':
+			sum++
+		}
+	}
+
+	return sum % 10
+}
+
+// rewriteField replaces line[start:end] with replacement and repairs the check
+// digit, so the result passes every structural test and differs from the
+// published set only in that field's contents.
+//
+// For the corruption tests that combination is the whole point: it is exactly
+// what a checksum cannot see. It also builds the padded-field fixture below,
+// which is a legal set rather than a corrupt one.
+func rewriteField(t *testing.T, line string, start, end int, replacement string) string {
+	t.Helper()
+
+	if len(replacement) != end-start {
+		t.Fatalf("replacement %q is %d chars, need %d — the corruption must not change the line length",
+			replacement, len(replacement), end-start)
+	}
+
+	out := line[:start] + replacement + line[end:]
+	out = out[:len(out)-1] + strconv.Itoa(tleChecksum(out[:len(out)-1]))
+
+	if len(out) != len(line) {
+		t.Fatalf("corrupted line is %d chars, want %d", len(out), len(line))
+	}
+
+	return out
+}
+
+// TestValidateTLERejectsANonNumericField covers every field the SGP4 backend
+// parses, because the consequence of missing one is not a wrong answer.
+//
+// joshuaferrara/go-satellite reads its twelve numeric fields through helpers
+// that call log.Fatal — os.Exit(1) — on a parse failure. There is no error and
+// no panic to recover: one bad element set ends the caller's process. A
+// modulo-10 checksum cannot prevent this, since letters and spaces contribute
+// nothing to the sum, so a field replaced by text can still check out.
+//
+// Each case below is checksum-valid and structurally perfect. If ValidateTLE
+// stops covering one, that case reaches strconv inside the backend.
+func TestValidateTLERejectsANonNumericField(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		line       int // 1, 2, or 0 for both — see "satellite number"
+		start, end int
+		replace    string
+	}{
+		// Both lines, not one: corrupting line 1's satellite number alone is
+		// caught by the earlier "these lines describe different satellites"
+		// check, so the case would pass without the numeric check existing at
+		// all. Corrupting both identically keeps that check satisfied and
+		// leaves this as the only thing that can refuse the set. Confirmed by
+		// deleting the numeric check and watching this case still pass.
+		{"satellite number", 0, 2, 7, "ABCDE"},
+		{"epoch year", 1, 18, 20, "XX"},
+		{"epoch day", 1, 20, 32, "  bad.51782 "},
+		{"first derivative", 1, 33, 43, " -.000x2182"[:10]},
+		{"second derivative", 1, 44, 52, "  000Q0-0"[:8]},
+		{"B* drag term", 1, 53, 61, "-116Z6-4"},
+		{"inclination", 2, 8, 16, " 5x.6416"},
+		{"raan", 2, 17, 25, "247.46Q7"},
+		{"eccentricity", 2, 26, 33, "00067z3"},
+		{"argument of perigee", 2, 34, 42, "130.53Y0"},
+		{"mean anomaly", 2, 43, 51, "325.0Z88"},
+		{"mean motion", 2, 52, 63, "1X.72125391"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			l1, l2 := valladoLine1, valladoLine2
+
+			if c.line == 1 || c.line == 0 {
+				l1 = rewriteField(t, l1, c.start, c.end, c.replace)
+			}
+
+			if c.line == 2 || c.line == 0 {
+				l2 = rewriteField(t, l2, c.start, c.end, c.replace)
+			}
+
+			err := satellite.ValidateTLE(l1, l2)
+			if !errors.Is(err, satellite.ErrMalformedTLE) {
+				t.Fatalf("ValidateTLE accepted a non-numeric %s (err = %v).\n"+
+					"  This set is checksum-valid, so nothing else will catch it, and the "+
+					"backend calls os.Exit when strconv fails on this field.", c.name, err)
+			}
+
+			// The message must name the field. "malformed TLE" alone leaves the
+			// caller to find which of twelve columns their feed mangled.
+			if !strings.Contains(err.Error(), c.name) && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(c.name)) {
+				t.Logf("note: error does not name %q verbatim: %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestValidateTLEAcceptsSpacePaddedFields guards the one way this check could
+// be too strict rather than too loose.
+//
+// The backend removes at most TWO spaces per field (strings.Replace with a
+// count of 2), and this validation copies that count so that it accepts
+// exactly what the backend accepts — no more, and no less. Getting the "no
+// less" half wrong would reject real element sets in order to guard against
+// corrupt ones.
+//
+// Two leading spaces is not a contrived case. Inclination, RAAN, argument of
+// perigee and mean anomaly are all written %8.4f, so any value below 10 —
+// every near-equatorial geostationary object, and any orbit whose node or
+// perigee happens to sit in the first ten degrees — pads to exactly two. It
+// cannot pad to three: three integer digits plus a point plus four decimals
+// already fill the eight columns.
+//
+// The fixture is the published ISS set with those four fields rewritten to
+// single-digit values and each checksum repaired — a legal element set, not a
+// real object's. A real satellite is not needed to test a padding rule, and
+// inventing one and calling it real would be worse than saying this.
+func TestValidateTLEAcceptsSpacePaddedFields(t *testing.T) {
+	t.Parallel()
+
+	l2 := rewriteField(t, valladoLine2, 8, 16, "  5.1234") // inclination 5.1234°
+	l2 = rewriteField(t, l2, 17, 25, "  8.7492")           // RAAN 8.7492°
+	l2 = rewriteField(t, l2, 34, 42, "  1.5360")           // argument of perigee
+	l2 = rewriteField(t, l2, 43, 51, "  5.0288")           // mean anomaly
+	l2 = rewriteField(t, l2, 52, 63, " 1.00269781")        // mean motion, one rev/day
+
+	for _, cols := range [][2]int{{8, 16}, {17, 25}, {34, 42}, {43, 51}} {
+		if field := l2[cols[0]:cols[1]]; !strings.HasPrefix(field, "  ") {
+			t.Fatalf("precondition: %q does not carry the two leading spaces this test exists for", field)
+		}
+	}
+
+	if err := satellite.ValidateTLE(valladoLine1, l2); err != nil {
+		t.Fatalf("a legal space-padded element set was rejected: %v\n"+
+			"  Every one of these fields is written %%8.4f, so a value below 10 pads to "+
+			"two spaces. Rejecting that refuses real data.", err)
+	}
+
+	sat, err := satellite.NewFromTLE("padded", valladoLine1, l2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	// MeanMotion comes from the same parse the validation performs, so this
+	// also confirms the field was read from the right columns and that the
+	// leading space did not survive into strconv.
+	if mm := sat.MeanMotion; mm < 1.0026 || mm > 1.0028 {
+		t.Errorf("MeanMotion = %v rev/day, want 1.00269781 as written in columns 53-63", mm)
+	}
+}
+
+// TestNewFromTLESurvivesANonNumericField is the assertion the test above
+// cannot make: that the process is still running afterward.
+//
+// A regression here does not fail an assertion — it calls os.Exit(1) from
+// inside the backend and takes the test binary with it, which would look like
+// an unrelated crash. Running the call in a subprocess turns "did not exit"
+// into something this test can actually observe and report.
+func TestNewFromTLESurvivesANonNumericField(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("ASTROGO_TLE_EXIT_PROBE") == "1" {
+		l2 := rewriteField(t, valladoLine2, 52, 63, "1X.72125391")
+
+		if _, err := satellite.NewFromTLE("probe", valladoLine1, l2); err != nil {
+			t.Logf("REFUSED: %v", err)
+
+			return
+		}
+
+		t.Log("ACCEPTED")
+
+		return
+	}
+
+	// The command is this test binary re-invoked on one of its own tests; no
+	// part of it comes from outside the process.
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run", "^"+t.Name()+"$", "-test.v")
+
+	cmd.Env = append(os.Environ(), "ASTROGO_TLE_EXIT_PROBE=1")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("the child process died on a non-numeric mean motion: %v\n"+
+			"  This is the failure mode the guard exists for — os.Exit(1) from inside "+
+			"the SGP4 backend, with no error and nothing to recover.\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "REFUSED:") {
+		t.Errorf("the child did not refuse the corrupted set:\n%s", out)
+	}
+}

--- a/examples/20_whats_visible_tonight/main.go
+++ b/examples/20_whats_visible_tonight/main.go
@@ -36,6 +36,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -140,8 +141,17 @@ func main() {
 	fmt.Println("does real network queries (SIMBAD/OpenNGC/SBDB) and, for any")
 	fmt.Println("qualifying minor body, a real JPL Horizons ephemeris fetch...")
 
+	// A partial answer is still an answer: VisibleTonight skips a candidate
+	// whose ephemeris it cannot fetch rather than failing the night, and
+	// reports what it skipped as an ErrIncomplete. Everything else it can
+	// return is fatal and comes with no results, so this example prints the
+	// warning and carries on with the sky it did get.
 	results, err := plan.VisibleTonight(ctx, site, night, magLimit, sources, planetProvider)
-	if err != nil {
+
+	switch {
+	case errors.Is(err, plan.ErrIncomplete):
+		fmt.Println("\n" + colorize(ansiYellow, fmt.Sprintf("Note: this list is not exhaustive — %v", err)))
+	case err != nil:
 		log.Fatalf("VisibleTonight: %v", err)
 	}
 

--- a/plan/incomplete.go
+++ b/plan/incomplete.go
@@ -1,0 +1,76 @@
+package plan
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrIncomplete marks a result that is usable but shorter than it should be.
+//
+// # Why a result and an error together
+//
+// [VisibleTonight] queries several catalogues and fetches an ephemeris per
+// candidate, and any of those can fail on its own. Failing the whole query
+// because one kernel could not be fetched would be worse than useless — a
+// night's plan is still a night's plan without one asteroid, and the caller
+// asked for what is visible, not for a transaction.
+//
+// So it keeps skipping, and returns what it found. What it no longer does is
+// keep quiet: a skip caused by a failure is collected, and the call returns a
+// non-nil error wrapping this sentinel alongside the results.
+//
+//	objects, err := plan.VisibleTonight(ctx, site, night, 6.0, sources, prov)
+//	if errors.Is(err, plan.ErrIncomplete) {
+//	    // objects is valid, and something was dropped. err says what.
+//	} else if err != nil {
+//	    // nothing usable came back
+//	}
+//
+// A caller who ignores the error gets exactly what they got before. A caller
+// who checks it can tell a sky with two visible planets from a sky with two
+// visible planets and an unreachable JPL — which reading the slice alone
+// cannot.
+//
+// This replaces reporting the skips only through the logger. A log line tells
+// a human something happened; it does not let the program decide, and deciding
+// is the caller's job. #177 fixed six predicates that answered "no" when they
+// meant "could not tell"; this is the same defect one layer up, where the
+// answer was a short list.
+var ErrIncomplete = errors.New("plan: result is incomplete")
+
+// skips collects the reasons a result came back short.
+//
+// Concurrency-safe: the gatherers run under parallel.Map, and each records its
+// own failures. parallel.Map's own error return cannot carry these — it is an
+// errgroup, so it keeps only the first error and cancels the rest, which is
+// the opposite of what a per-item skip needs.
+type skips struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+// add records one skip. A nil err is ignored, so callers need no guard.
+func (s *skips) add(stage, what string, err error) {
+	if err == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.errs = append(s.errs, fmt.Errorf("%s %q: %w", stage, what, err))
+}
+
+// err returns nil when nothing was skipped, or an error wrapping
+// [ErrIncomplete] and every reason collected.
+func (s *skips) err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.errs) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%w: %w", ErrIncomplete, errors.Join(s.errs...))
+}

--- a/plan/incomplete_test.go
+++ b/plan/incomplete_test.go
@@ -1,0 +1,182 @@
+package plan
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+)
+
+var (
+	errKernelUnreachable = errors.New("incomplete_test: kernel host unreachable")
+	errBadRow            = errors.New("incomplete_test: malformed catalog row")
+)
+
+// TestSkipsNilWhenNothingWasSkipped is the case that matters most, and the
+// easiest to get wrong: a complete result must return a nil error.
+//
+// If err() ever returned a non-nil ErrIncomplete for a clean run, every caller
+// following the documented `errors.Is(err, ErrIncomplete)` pattern would treat
+// every night as partial, and the signal would mean nothing.
+func TestSkipsNilWhenNothingWasSkipped(t *testing.T) {
+	t.Parallel()
+
+	var s skips
+
+	if err := s.err(); err != nil {
+		t.Fatalf("a fresh collector reported %v, want nil", err)
+	}
+
+	// A nil reason is not a skip. Callers pass the error unconditionally
+	// (dropped.add(stage, what, err) with no `if err != nil` guard), so this
+	// is the common path, not an edge case.
+	s.add("candidate", "Vega", nil)
+
+	if err := s.err(); err != nil {
+		t.Fatalf("a nil reason was recorded as a skip: %v", err)
+	}
+}
+
+// TestSkipsWrapsErrIncompleteAndKeepsEveryReason checks both halves of the
+// contract: the sentinel a caller branches on, and the individual causes
+// underneath it, which is what makes the error worth reading rather than
+// merely worth testing.
+func TestSkipsWrapsErrIncompleteAndKeepsEveryReason(t *testing.T) {
+	t.Parallel()
+
+	var s skips
+
+	s.add("small body", "433 Eros", errKernelUnreachable)
+	s.add("bright source", "*sbdb.Provider", errBadRow)
+
+	err := s.err()
+	if err == nil {
+		t.Fatal("two skips produced no error")
+	}
+
+	if !errors.Is(err, ErrIncomplete) {
+		t.Errorf("err does not wrap ErrIncomplete: %v", err)
+	}
+
+	// errors.Join preserves every cause, not just the first — the point of
+	// collecting rather than keeping errgroup's first-error-wins.
+	if !errors.Is(err, errKernelUnreachable) {
+		t.Errorf("the first skip's cause was lost: %v", err)
+	}
+
+	if !errors.Is(err, errBadRow) {
+		t.Errorf("the second skip's cause was lost: %v", err)
+	}
+
+	// The name is the operative part for a human: "something was dropped" is
+	// not actionable, "433 Eros was dropped" is.
+	msg := err.Error()
+	for _, want := range []string{"433 Eros", "*sbdb.Provider", "small body", "bright source"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error text does not name %q:\n%s", want, msg)
+		}
+	}
+}
+
+// TestSkipsIsConcurrencySafe runs add against the collector the way the
+// gatherers do — from inside parallel.Map callbacks, several at once.
+//
+// Worth an explicit test rather than trusting the mutex by inspection: this is
+// the one piece of shared mutable state VisibleTonight's concurrent stages
+// write to, and -race only catches what actually races during the run.
+func TestSkipsIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	const writers = 64
+
+	var (
+		s  skips
+		wg sync.WaitGroup
+	)
+
+	wg.Add(writers)
+
+	for range writers {
+		go func() {
+			defer wg.Done()
+
+			s.add("candidate", "concurrent", errKernelUnreachable)
+		}()
+	}
+
+	wg.Wait()
+
+	err := s.err()
+	if err == nil {
+		t.Fatal("64 concurrent skips produced no error")
+	}
+
+	if got := strings.Count(err.Error(), "concurrent"); got != writers {
+		t.Errorf("kept %d of %d skips — one was lost to a race", got, writers)
+	}
+}
+
+// photometryFailure is a target that HAS a magnitude but cannot compute it —
+// an asteroid whose SPK kernel went away between the window search and the
+// photometry call.
+//
+// The compile-time assertion below is the point of the declaration: a fixture
+// that misses the interface by one method would make the test vacuous rather
+// than failing, since rawMagnitude's type assertion would simply not match and
+// the object would fall through to "no published magnitude" — which is the
+// very distinction under test.
+var _ MagnitudeComputer = photometryFailure{}
+
+type photometryFailure struct{ unreachableTarget }
+
+func (photometryFailure) ApparentMagnitude(_ time.Time) (float64, error) {
+	return 0, errKernelUnreachable
+}
+
+func (photometryFailure) ApparentMagnitudeCtx(_ time.Time, _ *coord.Context) (float64, error) {
+	return 0, errKernelUnreachable
+}
+
+// noPublishedMagnitude implements neither magnitude interface — a real,
+// ordinary catalog row with no photometry.
+type noPublishedMagnitude struct{ unreachableTarget }
+
+// TestRawMagnitudeSeparatesFailureFromAbsence covers the third instance of
+// this defect inside VisibleTonight, and the least visible one.
+//
+// rawMagnitude fed a single bool into a magLimit comparison, so an object whose
+// photometry FAILED was dropped by exactly the same branch as one that is too
+// faint to make the cut. That is the #177 shape at its most deniable: the
+// result is not merely short, it is short in the one field the caller asked to
+// filter on.
+func TestRawMagnitudeSeparatesFailureFromAbsence(t *testing.T) {
+	t.Parallel()
+
+	epoch := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	// Photometry that failed: not a magnitude, and not an absence either.
+	_, ok, err := rawMagnitude(photometryFailure{}, epoch)
+	if ok {
+		t.Error("a failed photometry call reported a usable magnitude")
+	}
+
+	if !errors.Is(err, errKernelUnreachable) {
+		t.Errorf("rawMagnitude returned err = %v, want the underlying failure.\n"+
+			"  Reported as a bare false, this object is dropped exactly like one too faint to qualify.", err)
+	}
+
+	// No published magnitude: a legitimate negative, and must stay one. If
+	// this returned an error, every catalog row without photometry would
+	// make the night read as incomplete.
+	_, ok, err = rawMagnitude(noPublishedMagnitude{}, epoch)
+	if ok {
+		t.Error("an object with no published magnitude reported one")
+	}
+
+	if err != nil {
+		t.Errorf("an absent magnitude was reported as a failure: %v", err)
+	}
+}

--- a/plan/moons.go
+++ b/plan/moons.go
@@ -150,7 +150,7 @@ var moonSpecs = map[string]moonSpec{
 // moons finishes evaluating would break the others still using it. The
 // caller must Close every returned provider once ALL candidates (not just
 // these) have finished evaluating.
-func gatherPlanetaryMoons(ctx context.Context, at time.Time, magLimit float64) ([]visibleCandidate, []eph.Provider) {
+func gatherPlanetaryMoons(ctx context.Context, at time.Time, magLimit float64, dropped *skips) ([]visibleCandidate, []eph.Provider) {
 	byKernel := make(map[string][]moonSpec)
 
 	var kernels []string
@@ -167,11 +167,17 @@ func gatherPlanetaryMoons(ctx context.Context, at time.Time, magLimit float64) (
 	// kernel fetch yields a nil provider (kept in the slice, filtered
 	// below) rather than a hard error, matching gatherCandidates' own
 	// skip-on-fetch-failure convention -- this kernel's moons are simply
-	// unavailable tonight, not fatal to the others.
+	// unavailable tonight, not fatal to the others. The reason is not
+	// dropped, though: it goes to the caller's collector, so a night
+	// missing all eight Saturnian moons says why. It cannot travel as
+	// parallel.Map's error, which is errgroup's -- first one wins, rest
+	// cancelled -- exactly the wrong shape for a per-item skip.
 	providers, _ := parallel.Map(kernels, 0, func(_ int, kernel string) (eph.Provider, error) {
 		p, err := eph.NewProvider(ctx, eph.Moons, kernel)
 		if err != nil {
-			return nil, nil //nolint:nilerr,nilnil // see comment above: a failed kernel fetch is a documented skip, not an error
+			dropped.add("moon kernel", kernel, err)
+
+			return nil, nil //nolint:nilnil // see comment above: a failed kernel fetch is a recorded skip, not an error
 		}
 
 		return p, nil

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -545,13 +545,19 @@ func ObservableWindows(
 	}
 
 	// Observability check function for bisection refinement.
-	checkObs := func(t time.Time) bool {
+	// The sampling loop below propagates IsObservable's error directly. This
+	// closure exists for refineBisect, and used to swallow it — so a check
+	// that failed mid-bisection did not drop the window, it moved the refined
+	// boundary, and the caller got a rise or set time that was quietly wrong
+	// rather than absent.
+	checkObs := func(t time.Time) (bool, error) {
 		eval, err := IsObservable(obj, t, site, constraints...)
 		if err != nil {
-			return false
+			return false, fmt.Errorf("plan: observability at %s: %w",
+				t.Format(time.RFC3339), err)
 		}
 
-		return eval.Observable
+		return eval.Observable, nil
 	}
 
 	var windows []Window
@@ -575,14 +581,21 @@ func ObservableWindows(
 
 		if eval.Observable && !inWindow {
 			if hasPrev {
-				windowStart = refineBisect(prevT, t, prevOK, checkObs)
+				windowStart, err = refineBisect(prevT, t, prevOK, checkObs)
+				if err != nil {
+					return nil, err
+				}
 			} else {
 				windowStart = t
 			}
 
 			inWindow = true
 		} else if !eval.Observable && inWindow {
-			windowEnd := refineBisect(prevT, t, prevOK, checkObs)
+			windowEnd, err := refineBisect(prevT, t, prevOK, checkObs)
+			if err != nil {
+				return nil, err
+			}
+
 			windows = append(windows, Window{
 				Start: windowStart,
 				End:   windowEnd,

--- a/plan/predicate_errors_test.go
+++ b/plan/predicate_errors_test.go
@@ -23,6 +23,26 @@ func (failingConstraint) Check(_ Observable, _ time.Time, _ *Site) (Result, erro
 	return Result{}, errConstraintUnavailable
 }
 
+var errPositionUnavailable = errors.New("predicate_errors_test: position could not be computed")
+
+// unreachableTarget is an Observable whose position lookup always fails — a
+// target whose ephemeris provider is down.
+//
+// evaluateCandidate builds its own constraint (Altitude) internally rather
+// than taking the caller's, so failingConstraint cannot reach it; failing at
+// the Observable is the way in, and is the more realistic failure anyway.
+type unreachableTarget struct{}
+
+func (unreachableTarget) Name() string { return "Unreachable" }
+
+func (unreachableTarget) Position(_ time.Time) (coord.ICRS, error) {
+	return coord.ICRS{}, errPositionUnavailable
+}
+
+func (unreachableTarget) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+	return nil, errPositionUnavailable
+}
+
 // predicateSite builds the site these tests share.
 func predicateSite(t *testing.T) *Site {
 	t.Helper()
@@ -144,12 +164,13 @@ func TestObservableWindowsReportsAFailureDuringRefinement(t *testing.T) {
 //
 // VisibleTonight's contract is to skip a candidate it cannot evaluate rather
 // than fail the whole query — one unreachable kernel should not cost the caller
-// the other forty, and its doc comment says so. But every skip returned the
-// same bare false as "too faint" or "never rises", so a night's list could come
-// back short because a provider was down and nothing said which it was.
+// the other forty. But every skip returned the same bare false as "too faint"
+// or "never rises", so a night's list could come back short because a provider
+// was down and nothing said which it was.
 //
-// The skip stays; it is now reported at Warn, which is the level for a result
-// that is quietly less complete than it looks.
+// The skip stays. What changed is that the reason now leaves the function: a
+// Warn line for a human, and an error a program can test with errors.Is. A log
+// line is not a signal a caller can act on.
 func TestVisibleTonightReportsWhyACandidateWasSkipped(t *testing.T) {
 	// Not parallel: it installs the process-wide logger.
 	defer logging.Set(nil)
@@ -161,17 +182,24 @@ func TestVisibleTonightReportsWhyACandidateWasSkipped(t *testing.T) {
 	site := predicateSite(t)
 	start := fixedEpoch()
 
-	// A candidate whose constraint evaluation fails, driven through the same
-	// helper VisibleTonight uses per candidate.
-	cfg := visibleTonightConfig{step: 30 * time.Minute, minAltitude: angle.Deg(10)}
+	// A candidate whose position cannot be computed — the shape of a target
+	// backed by an ephemeris provider that could not be reached. The step is
+	// a legal one (ObservableWindows rejects anything over 15m outright), so
+	// the only thing that can fail here is the lookup itself.
+	cfg := visibleTonightConfig{step: 10 * time.Minute, minAltitude: angle.Deg(10)}
 
-	_, ok := evaluateCandidate(
+	_, ok, why := evaluateCandidate(
 		t.Context(),
-		visibleCandidate{obj: NewStar("Unreachable", angle.Zero(), angle.Zero())},
+		visibleCandidate{obj: unreachableTarget{}},
 		start, start.Add(2*time.Hour), site, nil, 6.0, cfg,
 	)
 	if ok {
 		t.Fatal("precondition: this candidate should not evaluate cleanly")
+	}
+
+	if !errors.Is(why, errPositionUnavailable) {
+		t.Errorf("evaluateCandidate returned reason %v, want it to wrap the lookup's error.\n"+
+			"  Without it the caller cannot tell an unreachable provider from a target that is simply not up.", why)
 	}
 
 	out := buf.String()

--- a/plan/predicate_errors_test.go
+++ b/plan/predicate_errors_test.go
@@ -1,0 +1,183 @@
+package plan
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/logging"
+	"github.com/TuSKan/astrogo/time"
+)
+
+var errConstraintUnavailable = errors.New("predicate_errors_test: constraint could not be evaluated")
+
+// failingConstraint cannot answer — the shape of an ephemeris lookup that
+// failed or a provider that could not be reached.
+type failingConstraint struct{}
+
+func (failingConstraint) Check(_ Observable, _ time.Time, _ *Site) (Result, error) {
+	return Result{}, errConstraintUnavailable
+}
+
+// predicateSite builds the site these tests share.
+func predicateSite(t *testing.T) *Site {
+	t.Helper()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("predicates", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	return site
+}
+
+// TestSchedulerReportsAConstraintThatCannotBeEvaluated is the fix for #177.
+//
+// # What was wrong
+//
+// checkConstraintsIntervalCtx read `if err != nil || !res.Pass` and returned a
+// bare false. So a constraint that could not be evaluated was indistinguishable
+// from one the target genuinely failed: the block was dropped, and the caller
+// received a schedule that looked complete.
+//
+// Constraint.Check returns an error precisely because a check can fail rather
+// than merely be false. Discarding that at the last step is the shape of #102,
+// where a swallowed error turned a CDS outage into "target not found".
+//
+// A schedule silently missing a block is the worst version of this, because
+// nothing about the result invites suspicion.
+func TestSchedulerReportsAConstraintThatCannotBeEvaluated(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+
+	planner, err := NewPlanner(site, []Constraint{failingConstraint{}})
+	if err != nil {
+		t.Fatalf("NewPlanner: %v", err)
+	}
+
+	start := fixedEpoch()
+	window := Window{Start: start, End: start.Add(1 * time.Hour)}
+	block := &Block{ID: "B1", Target: NewStar("T", angle.Zero(), angle.Zero()), Duration: 10 * time.Minute}
+
+	for _, tc := range []struct {
+		name     string
+		strategy Strategy
+	}{
+		{"greedy", &GreedyStrategy{}},
+		{"swap-optimized", &SwapOptimizedStrategy{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheduler := NewScheduler(planner, tc.strategy, &BasicTransitionModel{BaseSetup: 0})
+
+			sched, err := scheduler.BuildSchedule(window, []*Block{block})
+			if !errors.Is(err, errConstraintUnavailable) {
+				t.Fatalf("BuildSchedule returned %v (schedule %v), want it to wrap the "+
+					"constraint's error.\n  A constraint that cannot be evaluated is not "+
+					"a constraint the target failed; dropping the block leaves the "+
+					"caller a schedule that looks complete.", err, sched)
+			}
+		})
+	}
+}
+
+// TestFindReportsAConstraintThatCannotBeEvaluated covers the other bisection
+// predicate, in the visibility solver rather than the scheduler.
+//
+// Find's own signature already returned an error; only the closure driving the
+// interval search discarded one.
+func TestFindReportsAConstraintThatCannotBeEvaluated(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+	start := fixedEpoch()
+
+	_, err := Find(
+		mockObject{pos: coord.NewICRS(angle.Zero(), angle.Zero())},
+		site,
+		[]Constraint{failingConstraint{}},
+		start, start.Add(2*time.Hour), 10*time.Minute,
+	)
+
+	if !errors.Is(err, errConstraintUnavailable) {
+		t.Errorf("Find returned %v, want it to wrap the constraint's error", err)
+	}
+}
+
+// TestObservableWindowsReportsAFailureDuringRefinement covers the subtler half.
+//
+// ObservableWindows already propagated the error from its sampling loop. The
+// closure handed to refineBisect did not — so a check that failed *during*
+// bisection did not drop the window, it moved the refined boundary, and the
+// caller got a rise or set time that was quietly wrong rather than absent.
+func TestObservableWindowsReportsAFailureDuringRefinement(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+	start := fixedEpoch()
+
+	_, err := ObservableWindows(
+		NewStar("T", angle.Zero(), angle.Zero()),
+		start, start.Add(2*time.Hour), 10*time.Minute,
+		site,
+		failingConstraint{},
+	)
+
+	if !errors.Is(err, errConstraintUnavailable) {
+		t.Errorf("ObservableWindows returned %v, want it to wrap the constraint's error", err)
+	}
+}
+
+// TestVisibleTonightReportsWhyACandidateWasSkipped covers the one place that
+// deliberately keeps skipping.
+//
+// VisibleTonight's contract is to skip a candidate it cannot evaluate rather
+// than fail the whole query — one unreachable kernel should not cost the caller
+// the other forty, and its doc comment says so. But every skip returned the
+// same bare false as "too faint" or "never rises", so a night's list could come
+// back short because a provider was down and nothing said which it was.
+//
+// The skip stays; it is now reported at Warn, which is the level for a result
+// that is quietly less complete than it looks.
+func TestVisibleTonightReportsWhyACandidateWasSkipped(t *testing.T) {
+	// Not parallel: it installs the process-wide logger.
+	defer logging.Set(nil)
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	site := predicateSite(t)
+	start := fixedEpoch()
+
+	// A candidate whose constraint evaluation fails, driven through the same
+	// helper VisibleTonight uses per candidate.
+	cfg := visibleTonightConfig{step: 30 * time.Minute, minAltitude: angle.Deg(10)}
+
+	_, ok := evaluateCandidate(
+		t.Context(),
+		visibleCandidate{obj: NewStar("Unreachable", angle.Zero(), angle.Zero())},
+		start, start.Add(2*time.Hour), site, nil, 6.0, cfg,
+	)
+	if ok {
+		t.Fatal("precondition: this candidate should not evaluate cleanly")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "candidate skipped") {
+		t.Errorf("a skipped candidate produced no warning:\n%s\n"+
+			"  The skip is deliberate, but a silent one leaves the caller a "+
+			"short list with no way to tell why.", out)
+	}
+}

--- a/plan/predicate_errors_test.go
+++ b/plan/predicate_errors_test.go
@@ -181,3 +181,51 @@ func TestVisibleTonightReportsWhyACandidateWasSkipped(t *testing.T) {
 			"short list with no way to tell why.", out)
 	}
 }
+
+// TestSwapAndInsertPassesReportAConstraintFailure reaches the two passes
+// directly.
+//
+// Going through Schedule cannot: SwapOptimizedStrategy seeds with a greedy
+// pass, so a constraint that errors kills the seed before a swap is ever
+// attempted, and the forwarding branches inside swapPass and insertPass stay
+// unexecuted. Calling them with a schedule built by hand is the only way to
+// exercise the paths this change added, and they are unexported, so an
+// in-package test can.
+func TestSwapAndInsertPassesReportAConstraintFailure(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+
+	planner, err := NewPlanner(site, []Constraint{failingConstraint{}})
+	if err != nil {
+		t.Fatalf("NewPlanner: %v", err)
+	}
+
+	start := fixedEpoch()
+	window := Window{Start: start, End: start.Add(2 * time.Hour)}
+
+	b1 := &Block{ID: "B1", Target: NewStar("A", angle.Zero(), angle.Zero()), Duration: 10 * time.Minute}
+	b2 := &Block{ID: "B2", Target: NewStar("B", angle.Zero(), angle.Zero()), Duration: 10 * time.Minute}
+
+	strategy := &SwapOptimizedStrategy{}
+	transition := &BasicTransitionModel{BaseSetup: 0}
+
+	// Two adjacent scheduled blocks, so a swap is actually considered, plus one
+	// unscheduled so the insert pass has something to place.
+	sched := &Schedule{
+		Window: window,
+		Blocks: []ScheduledBlock{
+			{Block: b1, Window: Window{Start: start, End: start.Add(10 * time.Minute)}},
+			{Block: b2, Window: Window{Start: start.Add(10 * time.Minute), End: start.Add(20 * time.Minute)}},
+		},
+		Unscheduled: []UnscheduledBlock{{Block: b1}},
+	}
+
+	if _, err := strategy.swapPass(sched, planner, transition, time.Minute, newTabuList(2), 0); !errors.Is(err, errConstraintUnavailable) {
+		t.Errorf("swapPass returned %v, want it to wrap the constraint's error", err)
+	}
+
+	if _, err := strategy.insertPass(sched, planner, window, transition, time.Minute); !errors.Is(err, errConstraintUnavailable) {
+		t.Errorf("insertPass returned %v, want it to wrap the constraint's error", err)
+	}
+}

--- a/plan/predicate_errors_test.go
+++ b/plan/predicate_errors_test.go
@@ -229,3 +229,123 @@ func TestSwapAndInsertPassesReportAConstraintFailure(t *testing.T) {
 		t.Errorf("insertPass returned %v, want it to wrap the constraint's error", err)
 	}
 }
+
+// seedStrategy returns a canned schedule without evaluating any constraint,
+// standing in for SwapOptimizedStrategy's greedy seed.
+//
+// It exists because the seed and the passes share one constraint set: an
+// always-failing constraint kills the greedy seed before a swap is attempted,
+// so the error forwarding inside SwapOptimizedStrategy.Schedule is
+// unreachable through the public entry point. Replacing the seed reaches it.
+type seedStrategy struct{ sched *Schedule }
+
+func (s seedStrategy) Schedule(_ *Planner, _ Window, _ []*Block, _ TransitionModel) (*Schedule, error) {
+	return s.sched, nil
+}
+
+// TestSwapOptimizedScheduleForwardsAPassFailure covers the two error forwards
+// in SwapOptimizedStrategy.Schedule.
+//
+// Two cases, because the passes run in order and the first to fail hides the
+// second: with two adjacent blocks a swap is considered and swapPass fails;
+// with one block no swap is possible, swapPass returns cleanly, and insertPass
+// fails on the unscheduled block instead.
+func TestSwapOptimizedScheduleForwardsAPassFailure(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+
+	planner, err := NewPlanner(site, []Constraint{failingConstraint{}})
+	if err != nil {
+		t.Fatalf("NewPlanner: %v", err)
+	}
+
+	start := fixedEpoch()
+	window := Window{Start: start, End: start.Add(2 * time.Hour)}
+
+	b1 := &Block{ID: "B1", Target: NewStar("A", angle.Zero(), angle.Zero()), Duration: 10 * time.Minute}
+	b2 := &Block{ID: "B2", Target: NewStar("B", angle.Zero(), angle.Zero()), Duration: 10 * time.Minute}
+
+	placed := func(b *Block, offset time.Duration) ScheduledBlock {
+		return ScheduledBlock{
+			Block:  b,
+			Window: Window{Start: start.Add(offset), End: start.Add(offset + 10*time.Minute)},
+		}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		sched *Schedule
+	}{
+		{
+			name: "swapPass fails",
+			sched: &Schedule{
+				Window: window,
+				Blocks: []ScheduledBlock{placed(b1, 0), placed(b2, 10*time.Minute)},
+			},
+		},
+		{
+			name: "insertPass fails",
+			sched: &Schedule{
+				Window:      window,
+				Blocks:      []ScheduledBlock{placed(b1, 0)},
+				Unscheduled: []UnscheduledBlock{{Block: b2}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			strategy := &SwapOptimizedStrategy{Base: seedStrategy{sched: tc.sched}, Step: time.Minute}
+
+			_, err := strategy.Schedule(planner, window, []*Block{b1, b2}, &BasicTransitionModel{BaseSetup: 0})
+			if !errors.Is(err, errConstraintUnavailable) {
+				t.Errorf("Schedule returned %v, want it to wrap the constraint's error", err)
+			}
+		})
+	}
+}
+
+// endOnlyFailingConstraint fails at one exact instant and passes everywhere
+// else.
+type endOnlyFailingConstraint struct{ at time.Time }
+
+func (c endOnlyFailingConstraint) Check(_ Observable, t time.Time, _ *Site) (Result, error) {
+	if t.Equal(c.at) {
+		return Result{}, errConstraintUnavailable
+	}
+
+	return Result{Pass: true}, nil
+}
+
+// TestConstraintFailureAtTheExactEndIsReported covers the interval check's
+// last step.
+//
+// checkConstraintsIntervalCtx samples from start to end and then, if the two
+// differ, checks the exact end instant separately — because a step that does
+// not divide the interval leaves the endpoint unsampled, and a block whose
+// last moment violates a constraint is not schedulable.
+//
+// That extra check has its own error path, and only a constraint that fails
+// exactly there reaches it: an always-failing one returns from the loop's
+// first step instead.
+func TestConstraintFailureAtTheExactEndIsReported(t *testing.T) {
+	t.Parallel()
+
+	site := predicateSite(t)
+	start := fixedEpoch()
+
+	// A step that does not divide the interval, so the loop never lands on end.
+	end := start.Add(25 * time.Minute)
+
+	_, ok, err := checkConstraintsIntervalCtx(
+		NewStar("A", angle.Zero(), angle.Zero()),
+		start, end, 10*time.Minute, site,
+		endOnlyFailingConstraint{at: end},
+	)
+
+	if !errors.Is(err, errConstraintUnavailable) {
+		t.Errorf("returned ok=%v err=%v, want the constraint's error from the "+
+			"exact-end check", ok, err)
+	}
+}

--- a/plan/schedule.go
+++ b/plan/schedule.go
@@ -230,12 +230,26 @@ const defaultStep = 1 * time.Minute
 // Performance: creates a single coord.Context per time step and shares it
 // across all constraints that implement ConstraintCtx, avoiding redundant
 // SOFA matrix computations.
-func checkConstraintsIntervalCtx(target Observable, start, end time.Time, step time.Duration, site *Site, constraints ...Constraint) (*coord.Context, bool) {
+//
+// # A constraint that fails to evaluate is an error, not a "no"
+//
+// This used to read `if err != nil || !res.Pass { return false }`, so a
+// constraint that could not be evaluated — an ephemeris lookup that failed, a
+// provider that could not be reached — was indistinguishable from a constraint
+// the target genuinely failed. The block was then dropped and the caller got a
+// schedule that looked complete.
+//
+// Constraint.Check returns an error precisely because a check can fail rather
+// than merely be false, and discarding that at the last step is the shape of
+// #102, where a swallowed error turned a CDS outage into "target not found".
+// The error now propagates: a caller who cannot evaluate their constraints
+// should hear about it rather than receive a quietly shorter plan.
+func checkConstraintsIntervalCtx(target Observable, start, end time.Time, step time.Duration, site *Site, constraints ...Constraint) (*coord.Context, bool, error) {
 	mid := start.Add(end.Sub(start) / 2)
 
 	var midCtx *coord.Context
 
-	check := func(t time.Time) bool {
+	check := func(t time.Time) (bool, error) {
 		ctx := coord.NewContext(t, site.Location(), site.Refraction())
 		// Capture the context closest to the midpoint for reuse by scoring.
 		if midCtx == nil || absDur(t.Sub(mid)) <= absDur(midCtx.Time().Sub(mid)) {
@@ -253,18 +267,28 @@ func checkConstraintsIntervalCtx(target Observable, start, end time.Time, step t
 				res, err = c.Check(target, t, site)
 			}
 
-			if err != nil || !res.Pass {
-				return false
+			if err != nil {
+				return false, fmt.Errorf("plan: constraint at %s: %w",
+					t.Format(time.RFC3339), err)
+			}
+
+			if !res.Pass {
+				return false, nil
 			}
 		}
 
-		return true
+		return true, nil
 	}
 
 	t := start
 	for t.Before(end) || t.Equal(end) {
-		if !check(t) {
-			return nil, false
+		ok, err := check(t)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !ok {
+			return nil, false, nil
 		}
 
 		t = t.Add(step)
@@ -272,12 +296,17 @@ func checkConstraintsIntervalCtx(target Observable, start, end time.Time, step t
 
 	// Always check the exact end time as well.
 	if !start.Equal(end) {
-		if !check(end) {
-			return nil, false
+		ok, err := check(end)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !ok {
+			return nil, false, nil
 		}
 	}
 
-	return midCtx, true
+	return midCtx, true, nil
 }
 
 // absDur returns the absolute value of a time.Duration.
@@ -374,7 +403,12 @@ func (s *GreedyStrategy) Schedule(planner *Planner, window Window, blocks []*Blo
 			allConstraints = append(allConstraints, b.Constraints...)
 
 			// Check observability over the full duration
-			if midCtx, ok := checkConstraintsIntervalCtx(b.Target, startTime, endTime, step, planner.Site, allConstraints...); ok {
+			midCtx, ok, err := checkConstraintsIntervalCtx(b.Target, startTime, endTime, step, planner.Site, allConstraints...)
+			if err != nil {
+				return nil, fmt.Errorf("plan: greedy: block %s: %w", b.ID, err)
+			}
+
+			if ok {
 				score := scoreBlockPlacement(b, startTime, endTime, planner, midCtx)
 				sched.Blocks = append(sched.Blocks, ScheduledBlock{
 					Block:     b,

--- a/plan/strategy.go
+++ b/plan/strategy.go
@@ -84,9 +84,16 @@ func (s *SwapOptimizedStrategy) Schedule(
 	idlePasses := 0
 
 	for pass := range maxPasses {
-		swapped := s.swapPass(sched, planner, transition, step, tabu, pass)
+		swapped, err := s.swapPass(sched, planner, transition, step, tabu, pass)
+		if err != nil {
+			return nil, err
+		}
 
-		inserted := s.insertPass(sched, planner, window, transition, step)
+		inserted, err := s.insertPass(sched, planner, window, transition, step)
+		if err != nil {
+			return nil, err
+		}
+
 		if swapped || inserted {
 			idlePasses = 0
 		} else {
@@ -113,7 +120,7 @@ func (s *SwapOptimizedStrategy) swapPass(
 	step time.Duration,
 	tabu *tabuList,
 	passNum int,
-) bool {
+) (bool, error) {
 	improved := false
 	n := len(sched.Blocks)
 
@@ -134,7 +141,11 @@ func (s *SwapOptimizedStrategy) swapPass(
 		newJEnd := newJStart.Add(bj.Block.Duration)
 
 		// Validate bj's constraints at the new time.
-		midCtxJ, okJ := checkConstraintsIntervalCtx(bj.Block.Target, newJStart, newJEnd, step, planner.Site, mergedC[bj.Block.ID]...)
+		midCtxJ, okJ, err := checkConstraintsIntervalCtx(bj.Block.Target, newJStart, newJEnd, step, planner.Site, mergedC[bj.Block.ID]...)
+		if err != nil {
+			return false, fmt.Errorf("plan: swap: block %s: %w", bj.Block.ID, err)
+		}
+
 		if !okJ {
 			continue
 		}
@@ -172,7 +183,11 @@ func (s *SwapOptimizedStrategy) swapPass(
 		}
 
 		// Validate bi's constraints at the new time.
-		midCtxI, okI := checkConstraintsIntervalCtx(bi.Block.Target, newIStart, newIEnd, step, planner.Site, mergedC[bi.Block.ID]...)
+		midCtxI, okI, err := checkConstraintsIntervalCtx(bi.Block.Target, newIStart, newIEnd, step, planner.Site, mergedC[bi.Block.ID]...)
+		if err != nil {
+			return false, fmt.Errorf("plan: swap: block %s: %w", bi.Block.ID, err)
+		}
+
 		if !okI {
 			continue
 		}
@@ -210,7 +225,7 @@ func (s *SwapOptimizedStrategy) swapPass(
 		}
 	}
 
-	return improved
+	return improved, nil
 }
 
 // insertPass tries to insert each unscheduled block into a gap in the schedule.
@@ -226,9 +241,9 @@ func (s *SwapOptimizedStrategy) insertPass(
 	window Window,
 	transition TransitionModel,
 	step time.Duration,
-) bool {
+) (bool, error) {
 	if len(sched.Unscheduled) == 0 {
-		return false
+		return false, nil
 	}
 
 	improved := false
@@ -287,7 +302,12 @@ func (s *SwapOptimizedStrategy) insertPass(
 				continue
 			}
 
-			if midCtx, ok := checkConstraintsIntervalCtx(ub.Block.Target, startTime, endTime, step, planner.Site, mergedC[ub.Block.ID]...); ok {
+			midCtx, ok, err := checkConstraintsIntervalCtx(ub.Block.Target, startTime, endTime, step, planner.Site, mergedC[ub.Block.ID]...)
+			if err != nil {
+				return false, fmt.Errorf("plan: insert: block %s: %w", ub.Block.ID, err)
+			}
+
+			if ok {
 				score := scoreBlockPlacement(ub.Block, startTime, endTime, planner, midCtx)
 				sched.Blocks = append(sched.Blocks, ScheduledBlock{
 					Block:     ub.Block,
@@ -320,7 +340,7 @@ func (s *SwapOptimizedStrategy) insertPass(
 		return sched.Blocks[i].Window.Start.Before(sched.Blocks[j].Window.Start)
 	})
 
-	return improved
+	return improved, nil
 }
 
 // ── Scheduling Helpers ───────────────────────────────────────────────────────

--- a/plan/visibility.go
+++ b/plan/visibility.go
@@ -80,18 +80,25 @@ func refineVisibility(
 // This is used for constraint-based observability where the underlying
 // function may be discontinuous (unlike altitude, which is continuous
 // and uses Chandrupatla root-finding via refineVisibility).
-func refineBisect(a, b time.Time, aState bool, check func(time.Time) bool) time.Time {
+func refineBisect(a, b time.Time, aState bool, check func(time.Time) (bool, error)) (time.Time, error) {
 	const maxBisect = 20
+
 	for range maxBisect {
 		mid := a.Add(b.Sub(a) / 2)
-		if check(mid) == aState {
+
+		state, err := check(mid)
+		if err != nil {
+			return time.Time{}, err
+		}
+
+		if state == aState {
 			a = mid
 		} else {
 			b = mid
 		}
 	}
 
-	return a.Add(b.Sub(a) / 2)
+	return a.Add(b.Sub(a) / 2), nil
 }
 
 // ── Visibility Finders ───────────────────────────────────────────────────────
@@ -301,15 +308,20 @@ func Find(
 	}
 
 	// Constraint check function for bisection refinement.
-	checkObs := func(t time.Time) bool {
+	checkObs := func(t time.Time) (bool, error) {
 		for _, c := range constraints {
 			res, err := c.Check(obs, t, site)
-			if err != nil || !res.Pass {
-				return false
+			if err != nil {
+				return false, fmt.Errorf("plan: constraint at %s: %w",
+					t.Format(time.RFC3339), err)
+			}
+
+			if !res.Pass {
+				return false, nil
 			}
 		}
 
-		return true
+		return true, nil
 	}
 
 	intervals := make([]Interval, 0, 4)
@@ -325,18 +337,28 @@ func Find(
 
 	t := start
 	for t.Before(end) || t.Equal(end) {
-		allOK := checkObs(t)
+		allOK, err := checkObs(t)
+		if err != nil {
+			return nil, err
+		}
 
 		if allOK && !inWindow {
 			if hasPrev {
-				winStart = refineBisect(prevT, t, prevOK, checkObs)
+				winStart, err = refineBisect(prevT, t, prevOK, checkObs)
+				if err != nil {
+					return nil, err
+				}
 			} else {
 				winStart = t
 			}
 
 			inWindow = true
 		} else if !allOK && inWindow {
-			winEnd := refineBisect(prevT, t, prevOK, checkObs)
+			winEnd, err := refineBisect(prevT, t, prevOK, checkObs)
+			if err != nil {
+				return nil, err
+			}
+
 			intervals = append(intervals, Interval{
 				Object: obj,
 				Window: Window{Start: winStart, End: winEnd},

--- a/plan/visible_tonight.go
+++ b/plan/visible_tonight.go
@@ -13,6 +13,7 @@ import (
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/internal/parallel"
+	"github.com/TuSKan/astrogo/logging"
 	"github.com/TuSKan/astrogo/magnitude"
 	"github.com/TuSKan/astrogo/time"
 )
@@ -305,7 +306,7 @@ func VisibleTonight(
 	// evaluateCandidate reports failure via ok, not an error, so
 	// parallel.Map's own error return is never non-nil here.
 	evaluated, _ := parallel.Map(candidates, 0, func(_ int, c visibleCandidate) (evalResult, error) {
-		vo, ok := evaluateCandidate(c, start, end, site, planetProvider, magLimit, cfg)
+		vo, ok := evaluateCandidate(ctx, c, start, end, site, planetProvider, magLimit, cfg)
 
 		if c.closer != nil {
 			_ = c.closer.Close()
@@ -604,17 +605,39 @@ func (o observableObject) ICRS(t time.Time) (coord.ICRS, error) { return o.Posit
 // on purpose — see its doc comment), so this check, against the real
 // computed-and-extinguished magnitude, is the only place that bound is
 // enforced for real.
-func evaluateCandidate(c visibleCandidate, start, end time.Time, site *Site, planetProvider eph.Provider, magLimit float64, cfg visibleTonightConfig) (VisibleObject, bool) {
+func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.Time, site *Site, planetProvider eph.Provider, magLimit float64, cfg visibleTonightConfig) (VisibleObject, bool) {
 	obj := c.obj
 
-	windows, err := ObservableWindows(obj, start, end, cfg.step, site, Altitude{Threshold: cfg.minAltitude})
-	if err != nil || len(windows) == 0 {
+	// skipped reports a candidate dropped because it could not be evaluated,
+	// as distinct from one evaluated and found wanting.
+	//
+	// VisibleTonight's contract is to skip rather than fail — one unreachable
+	// kernel should not cost the caller the other forty candidates, and its
+	// doc comment says so. But every one of these used to return the same
+	// bare false as "too faint" or "never rises", so a night's list could come
+	// back short because JPL was down and nothing said which it was.
+	//
+	// Warn, not Info: the result is quietly less complete than it looks, which
+	// is exactly what that level is for. See the logging package.
+	skipped := func(stage string, err error) (VisibleObject, bool) {
+		logging.WarnContext(ctx, "candidate skipped: could not evaluate",
+			"target", obj.Name(), "stage", stage, "err", err)
+
 		return VisibleObject{}, false
+	}
+
+	windows, err := ObservableWindows(obj, start, end, cfg.step, site, Altitude{Threshold: cfg.minAltitude})
+	if err != nil {
+		return skipped("observable windows", err)
+	}
+
+	if len(windows) == 0 {
+		return VisibleObject{}, false // evaluated: never clears the horizon
 	}
 
 	events, err := VisibilityEvents(start, end, obj, site)
 	if err != nil {
-		return VisibleObject{}, false
+		return skipped("visibility events", err)
 	}
 
 	vo := VisibleObject{Target: c.target, Windows: windows}
@@ -646,20 +669,24 @@ func evaluateCandidate(c visibleCandidate, start, end time.Time, site *Site, pla
 	w := windows[0]
 
 	peakTime, _, err := TransitEstimate(observableObject{obj}, site, w.Start, w.End)
-	if err != nil || peakTime.IsZero() {
-		return VisibleObject{}, false
+	if err != nil {
+		return skipped("transit estimate", err)
+	}
+
+	if peakTime.IsZero() {
+		return VisibleObject{}, false // evaluated: no maximum inside the window
 	}
 
 	pos, err := obj.Position(peakTime)
 	if err != nil {
-		return VisibleObject{}, false
+		return skipped("position at peak", err)
 	}
 
 	astroCtx := coord.NewContext(peakTime, site.Location(), site.Refraction())
 
 	aa, err := observedAltAz(obj, peakTime, astroCtx, pos)
 	if err != nil {
-		return VisibleObject{}, false
+		return skipped("observed alt/az", err)
 	}
 
 	vo.PeakTime = peakTime
@@ -674,7 +701,7 @@ func evaluateCandidate(c visibleCandidate, start, end time.Time, site *Site, pla
 
 	airmass, err := atmosphere.Airmass(aa.Alt())
 	if err != nil {
-		return VisibleObject{}, false
+		return skipped("airmass", err)
 	}
 
 	vo.ApparentMag = magnitude.StarApparent(rawMag, airmass)

--- a/plan/visible_tonight.go
+++ b/plan/visible_tonight.go
@@ -208,20 +208,36 @@ var planetConstructors = []func(eph.Provider) *Planet{
 // kernel path unconditionally. A candidate whose ephemeris (either path)
 // can't be obtained is skipped, not treated as fatal.
 //
-// # The result can be silently incomplete
+// # The result can be incomplete, and says so
 //
 // That skip covers a network failure as well as a missing orbit. A kernel
 // fetch that times out, or JPL being unreachable, removes that body's moons or
-// that small body from the result and reports nothing — so an empty or short
-// list means "nothing qualified, as far as could be determined", never
-// "nothing qualified".
+// that small body from the result — so a short list can mean "nothing
+// qualified" or "not everything could be checked", and those are different
+// answers.
 //
-// This is deliberate: a partial sky is more useful than an error for a
+// Skipping is deliberate: a partial sky is more useful than an error for a
 // planning query, and one unreachable kernel should not cost the caller the
-// other forty candidates. But it is worth knowing before treating the result
-// as exhaustive. A caller who needs certainty should pre-seed the kernels it
-// depends on, or check reachability first; remote.SetOffline(true) makes the
-// degradation deterministic rather than dependent on the network.
+// other forty candidates. Staying quiet about it was not. So both values are
+// returned together: the candidates that did qualify, and an error wrapping
+// [ErrIncomplete] naming everything that could not be evaluated and why.
+//
+//	objects, err := plan.VisibleTonight(...)
+//	if errors.Is(err, plan.ErrIncomplete) {
+//		// objects is usable but not exhaustive; err says what is missing.
+//	} else if err != nil {
+//		return err
+//	}
+//
+// A caller who wants the old behaviour ignores an [ErrIncomplete] error; one
+// who needs certainty treats it as fatal. Both are now possible, which is the
+// point — a Warn log line, which is all this used to emit, is not something a
+// program can branch on. Every other error return is fatal and comes with no
+// results, so ignoring [ErrIncomplete] specifically is safe.
+//
+// To avoid the situation rather than detect it, pre-seed the kernels the query
+// depends on; remote.SetOffline(true) makes the degradation deterministic
+// rather than dependent on the network.
 func VisibleTonight(
 	ctx context.Context,
 	site *Site,
@@ -277,11 +293,15 @@ func VisibleTonight(
 	start, end := dusk.Time, dawn.Time
 	mid := start.Add(end.Sub(start) / 2)
 
-	candidates := gatherCandidates(ctx, gatherBrightTargets(ctx, brightSources, magLimit), start, end, cfg)
+	// Everything dropped because it could not be evaluated, rather than because
+	// it was evaluated and rejected. See ErrIncomplete.
+	var dropped skips
+
+	candidates := gatherCandidates(ctx, gatherBrightTargets(ctx, brightSources, magLimit, &dropped), start, end, cfg, &dropped)
 	candidates = append(candidates, gatherSolarSystemCandidates(planetProvider, mid, magLimit)...)
 
 	if cfg.includeMoons {
-		moonCandidates, moonProviders := gatherPlanetaryMoons(ctx, mid, magLimit)
+		moonCandidates, moonProviders := gatherPlanetaryMoons(ctx, mid, magLimit, &dropped)
 		candidates = append(candidates, moonCandidates...)
 
 		defer func() {
@@ -299,20 +319,23 @@ func VisibleTonight(
 	// considerate of here, so this uses every core rather than a small
 	// fixed bound.
 	type evalResult struct {
-		vo VisibleObject
-		ok bool
+		vo   VisibleObject
+		name string
+		ok   bool
+		err  error
 	}
 
-	// evaluateCandidate reports failure via ok, not an error, so
-	// parallel.Map's own error return is never non-nil here.
+	// The skip reason travels in the result rather than through parallel.Map's
+	// own error return: that is an errgroup, so it keeps only the first error
+	// and cancels the rest, and one candidate failing must not stop the others.
 	evaluated, _ := parallel.Map(candidates, 0, func(_ int, c visibleCandidate) (evalResult, error) {
-		vo, ok := evaluateCandidate(ctx, c, start, end, site, planetProvider, magLimit, cfg)
+		vo, ok, err := evaluateCandidate(ctx, c, start, end, site, planetProvider, magLimit, cfg)
 
 		if c.closer != nil {
 			_ = c.closer.Close()
 		}
 
-		return evalResult{vo: vo, ok: ok}, nil
+		return evalResult{vo: vo, name: c.obj.Name(), ok: ok, err: err}, nil
 	})
 
 	results := make([]VisibleObject, 0, len(candidates))
@@ -321,11 +344,13 @@ func VisibleTonight(
 		if r.ok {
 			results = append(results, r.vo)
 		}
+
+		dropped.add("candidate", r.name, r.err)
 	}
 
 	sort.Slice(results, func(i, j int) bool { return results[i].ApparentMag < results[j].ApparentMag })
 
-	return results, nil
+	return results, dropped.err()
 }
 
 // gatherBrightTargets calls SearchBright on every source concurrently and
@@ -335,7 +360,7 @@ func VisibleTonight(
 // caller registers) are otherwise independent network round trips with no
 // reason to wait on each other; each source writes into its own slice
 // index, so no mutex is needed to combine them afterward.
-func gatherBrightTargets(ctx context.Context, sources []resolve.BrightObjectSearcher, magLimit float64) []resolve.Target {
+func gatherBrightTargets(ctx context.Context, sources []resolve.BrightObjectSearcher, magLimit float64, dropped *skips) []resolve.Target {
 	// A source's own query error is handled per-item below (skipped, not
 	// propagated), so parallel.Map's own error return is never non-nil.
 	perSource, _ := parallel.Map(sources, 0, func(_ int, src resolve.BrightObjectSearcher) ([]resolve.Target, error) {
@@ -343,9 +368,15 @@ func gatherBrightTargets(ctx context.Context, sources []resolve.BrightObjectSear
 
 		iter := src.SearchBright(ctx, resolve.BrightRequest{MaxVMag: magLimit})
 		iter(func(tgt resolve.Target, err error) bool {
-			if err == nil {
-				targets = append(targets, tgt)
+			if err != nil {
+				// One bad row does not end the source, but the caller is told
+				// their list is short by however many of these there were.
+				dropped.add("bright source", fmt.Sprintf("%T", src), err)
+
+				return true
 			}
+
+			targets = append(targets, tgt)
 
 			return true
 		})
@@ -397,14 +428,17 @@ const coverageMargin = 24 * time.Hour
 // ("no coverage for target at requested epoch"), making the entire
 // category permanently absent from every result regardless of real
 // brightness.
-func gatherCandidates(ctx context.Context, targets []resolve.Target, start, end time.Time, cfg visibleTonightConfig) []visibleCandidate {
+func gatherCandidates(ctx context.Context, targets []resolve.Target, start, end time.Time, cfg visibleTonightConfig, dropped *skips) []visibleCandidate {
 	slots := make([]visibleCandidate, len(targets))
 
 	var smallBodyIdx []int
 
 	for i, tgt := range targets {
 		if !needsSmallBodyEphemeris(tgt.Kind) {
-			if obj, closer := candidateFromTarget(ctx, tgt, start, end, cfg); obj != nil {
+			obj, closer, err := candidateFromTarget(ctx, tgt, start, end, cfg)
+			dropped.add("target", tgt.Name, err)
+
+			if obj != nil {
 				slots[i] = visibleCandidate{obj: obj, target: tgt, closer: closer}
 			}
 
@@ -418,12 +452,15 @@ func gatherCandidates(ctx context.Context, targets []resolve.Target, start, end 
 	// maxConcurrentEphemerisFetches — the fast local candidates above need
 	// no such cap and stay fully synchronous, avoiding goroutine dispatch
 	// overhead for the common case. A candidate's own fetch failure is a
-	// skip, not a group-wide failure — candidateFromTarget already reports
-	// that by returning a nil Observable rather than an error, so Map's
-	// own error return is never non-nil here.
+	// skip, not a group-wide failure, so it goes to dropped rather than out
+	// through Map's error return — that is an errgroup's, which would cancel
+	// the other seven fetches over one unreachable body.
 	results, _ := parallel.Map(smallBodyIdx, maxConcurrentEphemerisFetches, func(_ int, idx int) (visibleCandidate, error) {
 		tgt := targets[idx]
-		if obj, closer := candidateFromTarget(ctx, tgt, start, end, cfg); obj != nil {
+		obj, closer, err := candidateFromTarget(ctx, tgt, start, end, cfg)
+		dropped.add("small body", tgt.Name, err)
+
+		if obj != nil {
 			return visibleCandidate{obj: obj, target: tgt, closer: closer}, nil
 		}
 
@@ -445,19 +482,6 @@ func gatherCandidates(ctx context.Context, targets []resolve.Target, start, end 
 	return candidates
 }
 
-// candidateFromTarget converts one bright-search result into an Observable.
-// Stars/deep-sky objects (FromCatalog's fixed-target path) need no
-// ephemeris and are always converted, with a nil closer. Asteroids/comets
-// need a real per-body SPK kernel fetched first — Stage 2 of the
-// two-stage minor-body design (see catalog/sbdb.SearchBright's doc
-// comment for Stage 1) — covering [start-coverageMargin, end+coverageMargin]
-// so the fetched kernel actually spans the night being evaluated; a
-// candidate whose kernel can't be fetched here returns a nil Observable,
-// skipped rather than failing the whole night's query. The returned
-// eph.Provider is the caller's to Close once this candidate has been
-// evaluated — FromCatalog's Comet/Asteroid wrapper holds it for the
-// lifetime of the evaluation, but the underlying SPK/LSK file handles must
-// not outlive that.
 // needsSmallBodyEphemeris reports whether kind requires a real per-body
 // Horizons-generated SPK ephemeris fetch (Stage 2) rather than the plain
 // FromCatalog(tgt, nil) path — asteroids, comets, dwarf planets, and
@@ -488,17 +512,36 @@ func isFixedTarget(obs Observable) bool {
 	}
 }
 
-func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end time.Time, cfg visibleTonightConfig) (Observable, eph.Provider) {
+// candidateFromTarget converts one bright-search result into an Observable.
+// Stars/deep-sky objects (FromCatalog's fixed-target path) need no
+// ephemeris and are always converted, with a nil closer. Asteroids/comets
+// need a real per-body SPK kernel fetched first — Stage 2 of the
+// two-stage minor-body design (see catalog/sbdb.SearchBright's doc
+// comment for Stage 1) — covering [start-coverageMargin, end+coverageMargin]
+// so the fetched kernel actually spans the night being evaluated; a
+// candidate whose kernel can't be fetched here returns a nil Observable,
+// skipped rather than failing the whole night's query. The returned
+// eph.Provider is the caller's to Close once this candidate has been
+// evaluated — FromCatalog's Comet/Asteroid wrapper holds it for the
+// lifetime of the evaluation, but the underlying SPK/LSK file handles must
+// not outlive that.
+//
+// The error says why no candidate came back, so a caller can tell a target
+// that could not be fetched from one that simply has no ephemeris to fetch.
+// A nil Observable with a nil error is the latter: FromCatalog produced a
+// fixed target where a small body was expected, which is a property of the
+// catalogue row, not a failure.
+func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end time.Time, cfg visibleTonightConfig) (Observable, eph.Provider, error) {
 	if !needsSmallBodyEphemeris(tgt.Kind) {
 		// A target the resolver returned with no position at all is
 		// dropped rather than placed at RA 0, Dec 0. Both callers already
 		// treat a nil Observable as "no candidate".
 		obj, err := FromCatalog(tgt, nil)
 		if err != nil {
-			return nil, nil
+			return nil, nil, err
 		}
 
-		return obj, nil
+		return obj, nil, nil
 	}
 
 	// Kepler first: try FromCatalog's own elements-based construction
@@ -509,24 +552,24 @@ func candidateFromTarget(ctx context.Context, tgt resolve.Target, start, end tim
 	// WithSmallBodyKernels.
 	if !cfg.forceSmallBodyKernels && tgt.HasElements {
 		if obj, err := FromCatalog(tgt, nil); err == nil && !isFixedTarget(obj) {
-			return obj, nil
+			return obj, nil, nil
 		}
 	}
 
 	minorProvider, err := eph.NewProvider(ctx, eph.SmallBody, tgt.SPKID,
 		eph.WithTimeInterval(start.Add(-coverageMargin), end.Add(coverageMargin)))
 	if err != nil {
-		return nil, nil
+		return nil, nil, fmt.Errorf("plan: small-body ephemeris for %q: %w", tgt.Name, err)
 	}
 
 	obj, err := FromCatalog(tgt, minorProvider)
 	if err != nil {
 		_ = minorProvider.Close()
 
-		return nil, nil
+		return nil, nil, err
 	}
 
-	return obj, minorProvider
+	return obj, minorProvider, nil
 }
 
 // gatherSolarSystemCandidates builds the Moon and every naked-eye planet,
@@ -605,7 +648,7 @@ func (o observableObject) ICRS(t time.Time) (coord.ICRS, error) { return o.Posit
 // on purpose — see its doc comment), so this check, against the real
 // computed-and-extinguished magnitude, is the only place that bound is
 // enforced for real.
-func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.Time, site *Site, planetProvider eph.Provider, magLimit float64, cfg visibleTonightConfig) (VisibleObject, bool) {
+func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.Time, site *Site, planetProvider eph.Provider, magLimit float64, cfg visibleTonightConfig) (VisibleObject, bool, error) {
 	obj := c.obj
 
 	// skipped reports a candidate dropped because it could not be evaluated,
@@ -619,11 +662,11 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 	//
 	// Warn, not Info: the result is quietly less complete than it looks, which
 	// is exactly what that level is for. See the logging package.
-	skipped := func(stage string, err error) (VisibleObject, bool) {
+	skipped := func(stage string, err error) (VisibleObject, bool, error) {
 		logging.WarnContext(ctx, "candidate skipped: could not evaluate",
 			"target", obj.Name(), "stage", stage, "err", err)
 
-		return VisibleObject{}, false
+		return VisibleObject{}, false, fmt.Errorf("%s: %w", stage, err)
 	}
 
 	windows, err := ObservableWindows(obj, start, end, cfg.step, site, Altitude{Threshold: cfg.minAltitude})
@@ -632,7 +675,7 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 	}
 
 	if len(windows) == 0 {
-		return VisibleObject{}, false // evaluated: never clears the horizon
+		return VisibleObject{}, false, nil // evaluated: never clears the horizon
 	}
 
 	events, err := VisibilityEvents(start, end, obj, site)
@@ -674,7 +717,7 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 	}
 
 	if peakTime.IsZero() {
-		return VisibleObject{}, false // evaluated: no maximum inside the window
+		return VisibleObject{}, false, nil // evaluated: no maximum inside the window
 	}
 
 	pos, err := obj.Position(peakTime)
@@ -694,9 +737,13 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 	vo.PeakAzimuth = aa.Az()
 	vo.Direction = coord.CompassDirection(aa.Az())
 
-	rawMag, ok := rawMagnitude(obj, peakTime)
+	rawMag, ok, err := rawMagnitude(obj, peakTime)
+	if err != nil {
+		return skipped("apparent magnitude", err)
+	}
+
 	if !ok {
-		return VisibleObject{}, false
+		return VisibleObject{}, false, nil // evaluated: no published magnitude
 	}
 
 	airmass, err := atmosphere.Airmass(aa.Alt())
@@ -706,7 +753,7 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 
 	vo.ApparentMag = magnitude.StarApparent(rawMag, airmass)
 	if vo.ApparentMag >= magLimit {
-		return VisibleObject{}, false
+		return VisibleObject{}, false, nil
 	}
 
 	if full, abbr, err := constellation.Lookup(pos); err == nil {
@@ -717,28 +764,36 @@ func evaluateCandidate(ctx context.Context, c visibleCandidate, start, end time.
 		vo.SkyNote = moonNote(planetProvider, peakTime, pos)
 	}
 
-	return vo, true
+	return vo, true, nil
 }
 
 // rawMagnitude returns obj's magnitude before atmospheric extinction —
 // via MagnitudeComputer (Planet/Asteroid/Comet, dynamic photometry) or
-// StaticMagnitude (Star/DeepSkyObject, fixed catalog VMag). ok is false if
-// obj exposes neither (no known magnitude).
-func rawMagnitude(obj Observable, t time.Time) (mag float64, ok bool) {
+// StaticMagnitude (Star/DeepSkyObject, fixed catalog VMag).
+//
+// The three outcomes are distinct and stay distinct: a magnitude; ok false
+// with a nil error, meaning obj publishes none (it exposes neither interface,
+// or its catalog row carried no VMag); and a non-nil error, meaning it has one
+// but the photometry could not be computed — an ephemeris lookup that failed
+// under it. Returning that last case as a bare false would drop the object
+// exactly like one too faint to make the cut, which is how it read before.
+func rawMagnitude(obj Observable, t time.Time) (mag float64, ok bool, err error) {
 	if mc, isMC := obj.(MagnitudeComputer); isMC {
 		m, err := mc.ApparentMagnitude(t)
 		if err != nil {
-			return 0, false
+			return 0, false, fmt.Errorf("plan: apparent magnitude of %q: %w", obj.Name(), err)
 		}
 
-		return m, true
+		return m, true, nil
 	}
 
 	if sm, isSM := obj.(StaticMagnitude); isSM {
-		return sm.StaticMagnitude()
+		m, has := sm.StaticMagnitude()
+
+		return m, has, nil
 	}
 
-	return 0, false
+	return 0, false, nil
 }
 
 // moonNote returns a Moon-proximity advisory when the Moon is a

--- a/plan/visible_tonight_incomplete_test.go
+++ b/plan/visible_tonight_incomplete_test.go
@@ -1,0 +1,103 @@
+package plan_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/plan"
+)
+
+var errSourceUnreachable = errors.New("visible_tonight_incomplete_test: catalog source unreachable")
+
+// failingBrightSource yields one good target and then fails, the shape of a
+// provider that goes away partway through a bulk listing — a paged query whose
+// second page times out, a connection dropped mid-stream.
+//
+// It yields the good row FIRST deliberately: a source that fails immediately
+// would be indistinguishable from one with nothing to say, and the interesting
+// case is precisely the one where a caller gets real results back and has no
+// way to know they are short.
+type failingBrightSource struct {
+	good resolve.Target
+}
+
+func (f *failingBrightSource) Capabilities() []resolve.Capability {
+	return []resolve.Capability{resolve.CapMagnitudeBrowse}
+}
+
+func (f *failingBrightSource) SearchBright(_ context.Context, _ resolve.BrightRequest) resolve.SeqIterator[resolve.Target] {
+	return func(yield func(resolve.Target, error) bool) {
+		if !yield(f.good, nil) {
+			return
+		}
+
+		yield(resolve.Target{}, errSourceUnreachable)
+	}
+}
+
+// TestVisibleTonightReportsAnIncompleteResult is the caller-facing half of the
+// #177 family, and the reason the skip logging alone was not enough.
+//
+// VisibleTonight is documented to skip what it cannot evaluate rather than fail
+// the night — that behaviour is right and does not change here. What changed is
+// that the skip stopped being invisible: it used to leave only a Warn line,
+// which a program cannot branch on, so a night's list came back short with the
+// same nil error as a night that was genuinely quiet.
+//
+// The test asserts both halves at once, because either alone is a different
+// bug: Sirius must still be in the results (skipping stayed a skip, not a
+// failure), AND the error must wrap ErrIncomplete (the shortfall is reported).
+func TestVisibleTonightReportsAnIncompleteResult(t *testing.T) {
+	sources := []resolve.BrightObjectSearcher{&failingBrightSource{good: sirius}}
+
+	results, err := plan.VisibleTonight(context.Background(), quintaCalixtoSite(t), testNight, 2, sources, ephemeris.Default())
+
+	if !errors.Is(err, plan.ErrIncomplete) {
+		t.Errorf("VisibleTonight returned err = %v, want it to wrap ErrIncomplete.\n"+
+			"  A source failed mid-listing, so this night's sky is short by an unknown number of objects "+
+			"and the caller has no way to tell that from a quiet sky.", err)
+	}
+
+	if !errors.Is(err, errSourceUnreachable) {
+		t.Errorf("the underlying cause was lost: %v", err)
+	}
+
+	if _, ok := findByName(results, "Sirius"); !ok {
+		t.Errorf("Sirius is missing from %+v.\n"+
+			"  The failure must degrade the result, not replace it — one bad source "+
+			"costs the caller that source, not the night.", results)
+	}
+}
+
+// TestVisibleTonightReturnsNilErrorWhenComplete is the other half, and the one
+// that gives the signal its meaning.
+//
+// If a clean run also returned ErrIncomplete, `errors.Is(err, ErrIncomplete)`
+// would be true always and would tell a caller nothing. This is the assertion
+// that would catch a future gatherer recording a skip for an ordinary
+// non-result — a target that is simply below the magnitude limit, say.
+func TestVisibleTonightReturnsNilErrorWhenComplete(t *testing.T) {
+	faint := sirius
+	faint.ID, faint.Name, faint.VMag = "faint", "Faint Star", 6.0
+
+	sources := []resolve.BrightObjectSearcher{&mockBrightSource{targets: []resolve.Target{sirius, faint}}}
+
+	results, err := plan.VisibleTonight(context.Background(), quintaCalixtoSite(t), testNight, 2, sources, ephemeris.Default())
+	if err != nil {
+		t.Fatalf("a run in which nothing failed returned %v, want nil.\n"+
+			"  A signal that is always on is not a signal.", err)
+	}
+
+	// Precondition: this run really did reject a candidate, so the nil error
+	// above means "rejections are not skips" rather than "nothing happened".
+	if _, ok := findByName(results, "Faint Star"); ok {
+		t.Fatal("precondition: Faint Star (VMag 6) should have been filtered out at magLimit 2")
+	}
+
+	if _, ok := findByName(results, "Sirius"); !ok {
+		t.Fatalf("precondition: expected Sirius in %+v", results)
+	}
+}

--- a/plan/visible_tonight_internal_test.go
+++ b/plan/visible_tonight_internal_test.go
@@ -51,7 +51,7 @@ func TestGatherPlanetaryMoonsSkipsWithoutDownloadConsent(t *testing.T) {
 	remote.DisableDownloads(remote.NAIFSPK)
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 
-	candidates, providers := gatherPlanetaryMoons(context.Background(), time.Date(2026, time.August, 1, 0, 0, 0, 0, time.LocationUTC), 30)
+	candidates, providers := gatherPlanetaryMoons(context.Background(), time.Date(2026, time.August, 1, 0, 0, 0, 0, time.LocationUTC), 30, &skips{})
 
 	if len(candidates) != 0 {
 		t.Errorf("expected no candidates without download consent, got %d", len(candidates))
@@ -129,7 +129,11 @@ func TestCandidateFromTarget_ElementsBearingTargetIsOffline(t *testing.T) {
 	start := tgt.Epoch
 	end := start.AddDays(1)
 
-	obj, closer := candidateFromTarget(context.Background(), tgt, start, end, visibleTonightConfig{})
+	obj, closer, err := candidateFromTarget(context.Background(), tgt, start, end, visibleTonightConfig{})
+	if err != nil {
+		t.Fatalf("candidateFromTarget: %v", err)
+	}
+
 	if obj == nil {
 		t.Fatal("expected a non-nil Observable from the offline Kepler path, got nil")
 	}
@@ -150,7 +154,11 @@ func TestCandidateFromTarget_ElementsBearingTargetIsOffline(t *testing.T) {
 	var forcedCfg visibleTonightConfig
 	WithSmallBodyKernels()(&forcedCfg)
 
-	obj2, _ := candidateFromTarget(context.Background(), tgt, start, end, forcedCfg)
+	obj2, _, err2 := candidateFromTarget(context.Background(), tgt, start, end, forcedCfg)
+	if err2 == nil {
+		t.Error("the forced kernel path failed offline but reported no reason")
+	}
+
 	if obj2 != nil {
 		t.Errorf("expected WithSmallBodyKernels to force the (here, offline-failing) kernel path, got a non-nil %T", obj2)
 	}
@@ -198,7 +206,7 @@ func TestGatherCandidates_SmallBodyPathOffline(t *testing.T) {
 	start := epoch
 	end := start.AddDays(1)
 
-	candidates := gatherCandidates(context.Background(), targets, start, end, visibleTonightConfig{})
+	candidates := gatherCandidates(context.Background(), targets, start, end, visibleTonightConfig{}, &skips{})
 
 	if len(candidates) != 2 {
 		t.Fatalf("len(candidates) = %d, want 2", len(candidates))

--- a/skybrightness/natural.go
+++ b/skybrightness/natural.go
@@ -285,7 +285,11 @@ func (d *DiffuseGalacticLight) AddRadiance(
 		// than there is starlight to scatter, which is what the flag says.
 		flags |= ExtrapolatedModel
 	} else {
-		capScale, capFlags := d.capFactor(scratch, grid, icrs, galactic)
+		capScale, capFlags, err := d.capFactor(scratch, grid, icrs, galactic)
+		if err != nil {
+			return flags, err
+		}
+
 		scale, flags = capScale, flags|capFlags
 	}
 
@@ -369,30 +373,43 @@ func (d *DiffuseGalacticLight) capFactor(
 	grid unit.SpectralGrid,
 	icrs coord.ICRS,
 	galactic coord.Galactic,
-) (scale float64, flags Flag) {
+) (scale float64, flags Flag, err error) {
 	lon, lat := icrs.RA(), icrs.Dec()
 	if d.sky.Galactic() {
 		lon, lat = galactic.L(), galactic.B()
 	}
 
 	starlight, err := d.sky.RadianceAt(lon, lat)
-	if err != nil || starlight <= 0 {
-		return 1, UnknownCloud
+
+	switch {
+	case errors.Is(err, ErrNoCoverage):
+		// The map answered: it has nothing here, so the cap cannot be applied.
+		return 1, UnknownCloud, nil
+	case err != nil:
+		return 0, 0, fmt.Errorf("skybrightness: diffuse galactic light: starlight cap: %w", err)
+	case starlight <= 0:
+		// Covered, but no starlight to scatter along this sightline.
+		return 1, UnknownCloud, nil
 	}
 
 	mean, err := magnitude.MeanFluxDensity(dgl, grid, d.band, 0)
-	if err != nil || mean <= 0 {
-		return 1, 0
+	if err != nil {
+		return 0, 0, fmt.Errorf("skybrightness: diffuse galactic light: mean flux density: %w", err)
+	}
+
+	if mean <= 0 {
+		// Nothing to cap: the component contributed no light in this band.
+		return 1, 0, nil
 	}
 
 	limit := MaxDGLToStarlightRatio * starlight
 	if mean <= limit {
-		return 1, 0
+		return 1, 0, nil
 	}
 
 	// Hitting the cap means the correlation was extrapolated past where it
 	// describes anything, so the result is bounded rather than trusted.
-	return limit / mean, ExtrapolatedModel
+	return limit / mean, ExtrapolatedModel, nil
 }
 
 // ── Zodiacal light ──────────────────────────────────────────────────────────

--- a/skybrightness/starlight_component_test.go
+++ b/skybrightness/starlight_component_test.go
@@ -692,3 +692,57 @@ func TestIntegratedStarlightSeparatesFailureFromMissingCoverage(t *testing.T) {
 		})
 	}
 }
+
+// TestDiffuseGalacticLightSeparatesFailureFromMissingCoverage is the DGL half
+// of #177, and the same defect the starlight component had in #172.
+//
+// capFactor read `if err != nil || starlight <= 0` and returned an uncapped
+// result with UnknownCloud. So a star map that could not answer — a band it
+// does not carry — read as a sightline with no starlight to scatter, and the
+// Toller cap was quietly not applied. The component then reported a diffuse
+// galactic light it had explicitly been given the means to bound.
+//
+// It was left out of #172 only because capFactor returned (float64, Flag) with
+// nowhere to put an error. It now returns one, and AddRadiance propagates it.
+func TestDiffuseGalacticLightSeparatesFailureFromMissingCoverage(t *testing.T) {
+	t.Parallel()
+
+	grid := skybrightness.DefaultOpticalGrid()
+	dir := coord.NewAltAz(angle.Deg(60), angle.Deg(0))
+
+	for _, tc := range []struct {
+		name    string
+		sky     skybrightness.StarMap
+		wantErr error
+	}{
+		{"a coverage gap leaves the cap unapplied, not failed", uncoveredSky{}, nil},
+		{"a map that cannot answer is a failure", failingSky{}, errSkyUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dgl, err := skybrightness.NewDiffuseGalacticLight(uniformDust(3.0), tc.sky, testBand())
+			if err != nil {
+				t.Fatalf("NewDiffuseGalacticLight: %v", err)
+			}
+
+			dst := skybrightness.NewSpectralRadiance(grid)
+
+			_, err = dgl.AddRadiance(context.Background(), dst, grid, dir, starlightScene(t))
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("AddRadiance returned %v, want it to wrap %v.\n"+
+						"  A star map that failed is not a sightline with no starlight; "+
+						"treating it as one silently drops the Toller cap.", err, tc.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("AddRadiance: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Seven places returned a bare `false` for something that had not been decided. #172 fixed three sites of this shape where an error channel already existed; these are the ones where the enclosing function had nowhere to put an error, which is why they were left.

## The scheduler is the worst of them

```go
if err != nil || !res.Pass {
    return false
}
```

A constraint that **could not be evaluated** — an ephemeris lookup that failed, a provider that could not be reached — was indistinguishable from one the target **genuinely failed**. The block was dropped and the caller got a schedule that looked complete. `Constraint.Check` returns an error precisely because a check can fail rather than merely be false.

`checkConstraintsIntervalCtx` now returns `(*coord.Context, bool, error)`, and both strategies propagate: `swapPass` and `insertPass` become `(bool, error)`, and each `Schedule` already returned an error. **All four call sites are unexported, so the public surface is unchanged.**

## The subtle one

`ObservableWindows` already propagated `IsObservable`'s error from its sampling loop. Only the closure handed to `refineBisect` swallowed — so a check that failed *mid-bisection* did not drop the window, it **moved the refined boundary**. The caller got a rise or set time that was quietly wrong rather than absent.

`refineBisect` now takes `func(time.Time) (bool, error)` and returns `(time.Time, error)`; `plan.Find` uses the same path.

## capFactor

Conflated a star map that cannot answer with a sightline that has no starlight, silently dropping the Toller cap on a result the caller had explicitly supplied a map to bound. It returns an error now and `AddRadiance` propagates it.

## VisibleTonight returns an incomplete result now, not just a log line

*Rewritten after review: "why not fix visibility skipping?"*

The first version of this PR left `VisibleTonight` skipping and added a `Warn`
line, arguing that its documented contract was to skip. That argument was
circular — I wrote that documentation in #176 and then cited it as the reason
not to change the behaviour — and a log line is not a signal a program can act
on. A caller still could not distinguish a quiet sky from an unreachable JPL.

Skipping stays; one unreachable kernel should not cost the caller the other
forty. What changed is that the reason now leaves the function. `VisibleTonight`
returns its results **and** an error wrapping the new `plan.ErrIncomplete`:

```go
objects, err := plan.VisibleTonight(...)
if errors.Is(err, plan.ErrIncomplete) {
    // objects is usable but not exhaustive; err names what is missing.
} else if err != nil {
    return err
}
```

Ignoring that error reproduces the previous behaviour exactly, so nothing
breaks. Every other error return is fatal and comes with no results, so
ignoring `ErrIncomplete` specifically is safe.

**Five layers were skipping silently, not one.** `parallel.Map`'s own error
return is an `errgroup`'s — first error wins, the rest are cancelled — which is
the opposite of what a per-item skip needs, so a small mutex-guarded collector
carries the reasons instead:

| layer | was |
| --- | --- |
| `evaluateCandidate` | bare `false` per candidate |
| `gatherBrightTargets` | a source's bad row dropped inside the iterator |
| `gatherCandidates` | `candidateFromTarget` returned `nil, nil` with no reason |
| `gatherPlanetaryMoons` | a failed kernel fetch dropped that planet's moons |
| `rawMagnitude` | **the least visible**: photometry that *failed* was dropped by the same branch as an object too faint to qualify — short in the one field the caller asked to filter on |

The two `return VisibleObject{}, false, nil` paths that are genuinely
evaluated-and-rejected — `len(windows) == 0` and `peakTime.IsZero()` — keep a
nil error and are commented as such, so a clean night still returns `nil`. A
signal that is always on is not a signal, and there is a test for exactly that.

`examples/20` now demonstrates the caller side rather than `log.Fatal`-ing on a
partial answer.

## The two recorded sites, and what one of them was hiding

Both are fixed here rather than deferred.

**`cams.isDimensionScale`** — the attribute reader #172 left behind. An
unreadable object header read as "not a dimension scale", so a corrupt file
filed its axes as *data variables*: `cf.dims` silently lost an axis and the
file indexed with a shape it does not have, surfacing much later as a
"dimension not found" on a variable whose dimensions are all present. It now
uses the `attributePresent` helper #172 already added for the other three.

**`satellite.parseMeanMotion`** — the recorded symptom was a silent `0`.
Probing it found something considerably worse underneath:

```
2026/09/05 23:19:58 strconv.ParseFloat: parsing "1X.72125391": invalid syntax
exit status 1
```

`joshuaferrara/go-satellite` parses its **twelve** numeric TLE fields through
helpers that call `log.Fatal` — `os.Exit(1)`, from inside a library. No error,
no panic, nothing to recover: a program feeding one bad element set into a
batch of ten thousand simply stops. Confirmed by running it, not inferred from
reading it.

A TLE checksum does not close this. It is a modulo-10 sum in which letters,
spaces and punctuation all count for nothing, so a field replaced by text — a
truncated feed, a hand-built set, an `N/A` placeholder — can carry a perfectly
correct check digit.

`ValidateTLE` now parses each field **exactly as the backend will**: the same
column slices, and the same `strings.Replace(..., " ", "", 2)` — the count of 2
is copied deliberately, since accepting a three-space field the backend then
dies on would be worse than not checking, because the guard would read as if it
worked. `NewFromTLE` runs it before SGP4 sees anything and takes `MeanMotion`
from that same parse, so the value reported can never disagree with the one
being propagated.

## Verification

Full §5 gate: `gofmt` · `go build` · `go vet` untagged **and** tagged ·
`go test ./...` · `-race -short` · `-tags="integration,validation"` ·
`golangci-lint run --build-tags="integration,network,validation"` — **0 issues**.

Nine new tests. Eight mutations, every one caught:

| mutation | result |
| --- | --- |
| scheduler back to conflating error with "did not pass" | fails, both strategies |
| `capFactor` back to conflating | fails |
| `skipped()` logs but returns a nil reason (the first version of this PR) | fails |
| `skips.err()` never reports | fails, 3 tests |
| `skips.add()` records a nil reason as a skip | fails — "a signal that is always on is not a signal" |
| the bright-source skip unwired | fails end-to-end |
| `rawMagnitude` swallows the photometry error | fails |
| `ValidateTLE` drops the numeric check | fails, all 12 fields |
| `NewFromTLE` ignores the parse error | **child process exits 1** — the failure mode itself |

Two of those are worth calling out because they changed the work:

- **A pre-existing test was passing on the wrong error.** The skip test drove
  `evaluateCandidate` with `step: 30m`, which trips `ObservableWindows`' own
  15-minute step validation, so the failing constraint it installed was never
  reached. Asserting on the specific error exposed it; it now fails at the
  ephemeris lookup, which is the shape being tested.
- **One of the twelve TLE cases was vacuous.** Corrupting line 1's satellite
  number alone is caught by the earlier "these lines describe different
  satellites" check, so it passed with the numeric check deleted. Both lines
  are now corrupted identically.

The `os.Exit` guard is tested by re-invoking the test binary as a subprocess:
a regression there does not fail an assertion, it terminates the runner, so
"the process is still alive" has to be observed from outside.

## Also

Two doc comments had drifted onto the following function — `candidateFromTarget`'s
sat above `needsSmallBodyEphemeris`, and `readInt32Attribute`'s above
`attributePresent`. Both reattached; unexported, so no pkg.go.dev impact, but
both were describing the wrong function to the next reader.

Closes #177.
