### PR TITLE
Guard: keep the CI Go pins on go.mod's minor version

### DIFF
--- a/docs/changelog.d/183-go-version-pin-guard.md
+++ b/docs/changelog.d/183-go-version-pin-guard.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 183
+---
+A guard keeps the six hand-written `go-version` pins in the CI workflows on the same
+minor version as `go.mod`. They are deliberately decoupled from `go-version-file`
+(#109), which is safe but invisible: the day `go.mod` moves past 1.25, every job would
+silently start downloading a toolchain again while CI stayed green.

--- a/internal/docsguard/gomod_ci_test.go
+++ b/internal/docsguard/gomod_ci_test.go
@@ -1,0 +1,112 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// workflows are the CI definitions that pin a Go toolchain, relative to the
+// repository root.
+var workflows = []string{
+	filepath.Join(".github", "workflows", "ci.yml"),
+	filepath.Join(".github", "workflows", "pre-release.yml"),
+}
+
+var (
+	// goDirective matches go.mod's own version line: "go 1.25.8".
+	goDirective = regexp.MustCompile(`(?m)^go (\d+)\.(\d+)(?:\.\d+)?\s*$`)
+
+	// workflowGoVersion matches a setup-go pin: "go-version: '1.25'".
+	workflowGoVersion = regexp.MustCompile(`(?m)^\s*go-version:\s*'?"?(\d+)\.(\d+)`)
+)
+
+// TestWorkflowGoVersionTracksTheModuleDirective keeps the six hand-written
+// toolchain pins in the workflows on the same minor version as go.mod.
+//
+// # Why these are hand-written at all
+//
+// The obvious spelling is `go-version-file: go.mod`, and this repository used
+// it until it caused an outage. go.mod declares a *patch-level* minimum —
+// `go 1.25.8`, inherited from gocloud.dev via gocloud-ext and not something
+// astrogo asks for — so setup-go demanded that exact patch, could not use the
+// runner's preinstalled toolchain, and downloaded one before every job on
+// every run. On PR #151 that download hung for 25 minutes without a single
+// test running. A minor-version spec resolves to whatever 1.25.x the runner
+// already has. See #109 for why the patch level cannot simply be lowered: the
+// API gocloud-ext's drivers implement only exists after gocloud.dev's newest
+// tag, so the pseudo-version that carries the directive is load-bearing.
+//
+// # What this guards
+//
+// Decoupling the two is safe in the direction that matters — Go refuses to
+// build below go.mod's directive and fetches the toolchain it needs, so a
+// mismatch degrades to a download rather than to a wrong result. What it is
+// not is *visible*: the day go.mod moves to 1.26.x, all six pins silently
+// reintroduce the exact download #109 exists to remove, and CI stays green
+// while doing it. Nothing about a slow job says which line to change.
+//
+// So this fails instead, and names the lines.
+func TestWorkflowGoVersionTracksTheModuleDirective(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	modBytes, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+
+	m := goDirective.FindStringSubmatch(string(modBytes))
+	if m == nil {
+		t.Fatal("go.mod has no `go` directive this guard can read; if its spelling changed, so must goDirective")
+	}
+
+	wantMajor, wantMinor := m[1], m[2]
+	want := wantMajor + "." + wantMinor
+
+	found := 0
+
+	for _, wf := range workflows {
+		path := filepath.Join(root, wf)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", wf, err)
+
+			continue
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			pin := workflowGoVersion.FindStringSubmatch(line)
+			if pin == nil {
+				continue
+			}
+
+			found++
+
+			if got := pin[1] + "." + pin[2]; got != want {
+				t.Errorf("%s:%d pins Go %s, but go.mod declares %s.\n"+
+					"  These are deliberately separate (see this test's doc comment and #109), but they "+
+					"must stay on the same minor version: a stale pin makes every CI job download a "+
+					"toolchain again, silently, which is the outage that separated them in the first place.",
+					wf, i+1, got, want)
+			}
+		}
+	}
+
+	// A pin that stops matching is worse than a mismatched one: the guard
+	// keeps passing while guarding nothing. Six is the count today, and a
+	// seventh workflow step should arrive with this number updated.
+	const wantPins = 6
+
+	if found != wantPins {
+		t.Errorf("found %d Go version pins across %v, want %d.\n"+
+			"  Either a workflow step was added or removed — update this count — or the "+
+			"pins are no longer written in a form workflowGoVersion recognises, in which "+
+			"case this test has been passing without checking anything.", found, workflows, wantPins)
+	}
+}


### PR DESCRIPTION
Small follow-on from investigating #109, which turned out not to be fixable — see
[the comment there](https://github.com/TuSKan/astrogo/issues/109#issuecomment-5556629838). Short version: the patch-level `go 1.25.8` originates in
`gocloud.dev`, not `gocloud-ext`, and its newest **tag** (v0.46.0) predates the
`driver.DeleteOptions` interface method that both of gocloud-ext's drivers implement,
so the pseudo-version carrying the directive is load-bearing. Nothing here can lower it.

What *is* already in place is the workaround: six `setup-go` steps pin
`go-version: '1.25'` by hand instead of reading `go-version-file: go.mod`, so no job
downloads a toolchain.

## The gap that leaves

`ci.yml`'s own comment argues, correctly, that decoupling is safe in the direction that
matters — Go refuses to build below `go.mod`'s directive and fetches what it needs, so
a mismatch degrades to a download rather than to a wrong result.

Safe, but invisible. The day `go.mod` moves to 1.26.x, all six pins silently
reintroduce **exactly the download #109 exists to remove**, CI stays green, and nothing
about a slow job points at which of six lines to change. That is the same failure shape
this repo has been fixing all week: a degradation that looks identical to success.

So a guard fails instead, and names the lines:

```
gomod_ci_test.go:92: .github/workflows/ci.yml:53 pins Go 1.25, but go.mod declares 1.26.
gomod_ci_test.go:92: .github/workflows/ci.yml:173 pins Go 1.25, but go.mod declares 1.26.
...
```

It also **counts** the pins. A guard whose pattern stops matching is worse than one
that mismatches, because it keeps passing while checking nothing — the vacuous-test
problem that has bitten twice in the last two PRs. Six is the count today.

## Mutations

| mutation | result |
| --- | --- |
| `go.mod` moves to 1.26 | fails, naming all six lines |
| a `setup-go` step removed | fails on the count (5, want 6) |
| a step reverted to `go-version-file: go.mod` | fails on the count — which is the outage returning |
| the YAML value unquoted (`go-version: 1.25`) | **passes, correctly** — same pin, written differently |

The fourth is listed because it is the one that should *not* fail, and I checked that
it doesn't rather than assuming.

`gofmt` · `go vet` · `go test ./...` · `golangci-lint --build-tags="integration,network,validation"` — 0 issues.

Refs #109.
