### PR TITLE
time: re-export the standard library as functions and constants, not vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ Existing astronomy tools are powerful, but often:
 - **Astroplan-style observation workflows**
 - **Go-level performance and control**
 
-Designed from the ground up for Go: no dynamic magic, no hidden global state, zero-allocation hot paths.
+Designed from the ground up for Go: no dynamic magic, no *hidden* global state, zero-allocation hot paths.
+
+Process-wide state exists and is deliberate — download consent and offline mode (`remote.EnableDownloads`, `remote.SetOffline`), the logger (`logging.Set`), the EOP and leap-second registries (`time.RegisterModel`, `time.RegisterLeapSeconds`). All of it is set by an explicitly named call and none of it is established by an `init()` or by importing a package. Nothing else is reassignable: `time` exports no mutable function values, and its layout strings are constants.
 
 ---
 

--- a/docs/changelog.d/184-time-no-mutable-reexports.md
+++ b/docs/changelog.d/184-time-no-mutable-reexports.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 184
+---
+**`time` re-exported fifteen standard-library functions as reassignable package-level
+`var`s, and its six layout strings as a `var` block.** Any package in the import graph
+could reassign `time.Parse`, `time.Now` or `time.RFC3339` process-wide, in the package
+every epoch calculation goes through. They are functions and constants now — identical
+at every call site, so nothing outside had to change (#113).

--- a/docs/changelog.d/184-time-var-guard.md
+++ b/docs/changelog.d/184-time-var-guard.md
@@ -1,0 +1,7 @@
+---
+type: Added
+pr: 184
+---
+A guard holds `time`'s exported package-level vars to a documented inventory of eight,
+each recording why Go leaves no alternative — six error sentinels, `LocationUTC` (which
+wraps the standard library's own mutable `time.UTC`) and `J2000` (#113).

--- a/internal/docsguard/mutable_reexport_test.go
+++ b/internal/docsguard/mutable_reexport_test.go
@@ -1,0 +1,162 @@
+package docsguard_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// allowedTimeVars is the complete inventory of exported package-level vars the
+// `time` package may hold, each with the reason Go leaves no alternative.
+//
+// A var is reassignable by any importer, process-wide. In the package every
+// epoch calculation in the library passes through, that is worth spending a
+// line of justification on rather than letting one appear by habit.
+var allowedTimeVars = map[string]string{
+	// Sentinel errors re-exported from the unexported time/internal/iers, so
+	// callers can errors.Is against them. An error value cannot be const, and
+	// the sentinel-plus-%w idiom is what CLAUDE.md asks for.
+	"ErrOutOfRange":  "sentinel error; error values cannot be const",
+	"ErrNoRecords":   "sentinel error; error values cannot be const",
+	"ErrNoEOPLoader": "sentinel error; error values cannot be const",
+	"ErrNoEOPData":   "sentinel error; error values cannot be const",
+
+	// Sentinels the leap-second registry raises when a caller registers a
+	// table that contradicts the built-in one. Same reason.
+	"ErrLeapSecondConflict": "sentinel error; error values cannot be const",
+	"ErrLeapSecondOrder":    "sentinel error; error values cannot be const",
+
+	// The standard library declares `var UTC *Location = &utcLoc`, so a
+	// function would hand back the same reassignable pointer and remove
+	// nothing, at the cost of churning every call site.
+	"LocationUTC": "wraps the standard library's own mutable time.UTC",
+
+	// A struct value, which Go cannot declare immutable. Making it safe means
+	// turning it into a function and breaking every caller — a decision, not
+	// a cleanup, and left open on #113.
+	"J2000": "struct value; Go has no immutable struct, see #113",
+}
+
+// TestTimeExportsNoMutableFunctionValues keeps the package that underpins
+// every epoch in the library from re-exporting the standard library through
+// reassignable variables.
+//
+// # What was wrong
+//
+// Fifteen of `time`'s re-exports were declared `var Parse = time.Parse`,
+// `var Sleep = time.Sleep`, `var Now = time.Now` and so on, and the six layout
+// strings were a `var` block where the standard library has untyped constants.
+// Any package anywhere in the import graph could assign to any of them and
+// change the behaviour of every epoch calculation in the process — a
+// supply-chain footgun with no upside, since a plain function is identical at
+// every call site and a const is identical to a string literal.
+//
+// It also made README.md's "no hidden global state" straightforwardly untrue
+// in the one package where it mattered most.
+//
+// # Why a guard rather than just the fix
+//
+// `var X = pkg.X` is the shortest way to re-export something and reads as
+// entirely harmless, so the next one will be added the same way. The fix is
+// invisible once made; this is what keeps it made.
+//
+// The allow list is an inventory rather than an exclusion list: every entry
+// carries why Go offers no alternative, so adding one is a sentence somebody
+// has to write and a reviewer gets to disagree with.
+func TestTimeExportsNoMutableFunctionValues(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(repoRoot(t), "time")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read time/: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	seen := make(map[string]bool)
+	parsed := 0
+
+	// os.ReadDir plus ParseFile rather than parser.ParseDir, which Go 1.25
+	// deprecated for not considering build tags when grouping files into
+	// packages. Nothing here needs that grouping: every non-test .go file in
+	// the directory is scanned whatever its tags, which is what a guard wants.
+	for _, entry := range entries {
+		fileName := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(fileName, ".go") || strings.HasSuffix(fileName, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, filepath.Join(dir, fileName), nil, 0)
+		if err != nil {
+			t.Errorf("parse %s: %v", fileName, err)
+
+			continue
+		}
+
+		parsed++
+
+		for _, name := range exportedVarNames(file) {
+			seen[name.Name] = true
+
+			if _, allowed := allowedTimeVars[name.Name]; allowed {
+				continue
+			}
+
+			t.Errorf("%s:%d: exported var %s.\n"+
+				"  Any importer can reassign this, process-wide, in the package every epoch in "+
+				"the library goes through. Re-export a function AS a function — identical at "+
+				"every call site — and a constant value as a const. If it can be neither, add "+
+				"it to allowedTimeVars with the reason it cannot.",
+				fileName, fset.Position(name.Pos()).Line, name.Name)
+		}
+	}
+
+	// A source-scanning guard that walks nothing passes silently. Both counts
+	// close that: the files were read, and every allowed name was actually
+	// found rather than the list guarding an empty set.
+	if parsed == 0 {
+		t.Fatal("scanned no files in time/; the guard is guarding nothing")
+	}
+
+	for name, why := range allowedTimeVars {
+		if !seen[name] {
+			t.Errorf("allowedTimeVars lists %s (%s) but the scan did not find it.\n"+
+				"  Either it was removed — shorten the list — or the scan is not reaching time/.",
+				name, why)
+		}
+	}
+}
+
+// exportedVarNames returns every exported name declared by a top-level `var`
+// in file. Constants are not included, which is the point: a const cannot be
+// reassigned and needs no justification.
+func exportedVarNames(file *ast.File) []*ast.Ident {
+	var out []*ast.Ident
+
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+
+			for _, name := range vs.Names {
+				if name.IsExported() {
+					out = append(out, name)
+				}
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/docsguard/wallclock_test.go
+++ b/internal/docsguard/wallclock_test.go
@@ -30,6 +30,7 @@ var wallClockAllowed = map[string]string{
 	"skybrightness/gambons_allsky_test.go":                  "measures elapsed time for its own report",
 	"time/internal/iers/fetch_test.go":                      "the fetch cooldown is defined relative to now",
 	"time/time_test.go":                                     "TestNowUTC tests NowUTC",
+	"time/reexport_test.go":                                 "Since, Until and Sleep are defined relative to now; the present is the subject",
 }
 
 // TestNoUndeclaredWallClockTests keeps tests from quietly depending on when

--- a/time/reexport_test.go
+++ b/time/reexport_test.go
@@ -163,6 +163,7 @@ func TestDurationHelpersDelegate(t *testing.T) {
 	// Real but negligible: enough to prove the call reaches the standard
 	// library, short enough not to slow the suite.
 	start := time.Now()
+
 	time.Sleep(time.Millisecond)
 
 	if elapsed := time.Since(start); elapsed <= 0 {

--- a/time/reexport_test.go
+++ b/time/reexport_test.go
@@ -1,0 +1,216 @@
+package time_test
+
+import (
+	"errors"
+	"testing"
+
+	gotime "time"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The re-exports used to be `var Parse = time.Parse` — an alias, which cannot
+// be wrong. Rewriting them as functions to stop anyone reassigning them
+// (see #113) means each now has a hand-written signature and a hand-written
+// forwarding call, and a transposition compiles.
+//
+// GoDate is the one that would actually bite: eight parameters, five of them
+// `int`, so swapping day and hour type-checks and silently moves every
+// timestamp. These tests exist for that, not for coverage of a one-line body.
+
+// TestGoDateForwardsItsArgumentsInOrder pins the parameter order against the
+// standard library's own.
+func TestGoDateForwardsItsArgumentsInOrder(t *testing.T) {
+	t.Parallel()
+
+	// Every field distinct, so any transposition changes the result.
+	got := time.GoDate(2026, time.March, 4, 5, 6, 7, 8, time.LocationUTC)
+	want := gotime.Date(2026, gotime.March, 4, 5, 6, 7, 8, gotime.UTC)
+
+	if !got.Equal(want) {
+		t.Errorf("GoDate = %v, want %v — the arguments are not forwarded in order", got, want)
+	}
+
+	// Spelled out as well, because Equal would also pass if both sides were
+	// wrong in the same way.
+	if y, mo, d := got.Date(); y != 2026 || mo != gotime.March || d != 4 {
+		t.Errorf("date = %d-%v-%d, want 2026-March-4", y, mo, d)
+	}
+
+	if h, mi, s := got.Clock(); h != 5 || mi != 6 || s != 7 {
+		t.Errorf("clock = %d:%d:%d, want 5:6:7", h, mi, s)
+	}
+
+	if ns := got.Nanosecond(); ns != 8 {
+		t.Errorf("nanosecond = %d, want 8", ns)
+	}
+}
+
+// TestUnixForwardsSecondsThenNanoseconds catches the other order-sensitive
+// pair, where both parameters are int64 and swapping them type-checks.
+func TestUnixForwardsSecondsThenNanoseconds(t *testing.T) {
+	t.Parallel()
+
+	got := time.Unix(1_700_000_000, 123)
+	if want := gotime.Unix(1_700_000_000, 123); !got.Equal(want) {
+		t.Errorf("Unix = %v, want %v", got, want)
+	}
+
+	if sec := got.Unix(); sec != 1_700_000_000 {
+		t.Errorf("Unix().Unix() = %d, want 1700000000 — seconds and nanoseconds are swapped", sec)
+	}
+}
+
+// TestParseRoundTripsAndReportsFailure covers both outcomes, and confirms the
+// error is still the standard library's own type: the wrapper carries a scoped
+// //nolint:wrapcheck precisely so that a caller's type assertion keeps working.
+func TestParseRoundTripsAndReportsFailure(t *testing.T) {
+	t.Parallel()
+
+	got, err := time.Parse(time.RFC3339, "2026-03-04T05:06:07Z")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if want := gotime.Date(2026, gotime.March, 4, 5, 6, 7, 0, gotime.UTC); !got.Equal(want) {
+		t.Errorf("Parse = %v, want %v", got, want)
+	}
+
+	_, err = time.Parse(time.RFC3339, "not a time")
+	if err == nil {
+		t.Fatal("Parse accepted a value that is not a time")
+	}
+
+	var perr *gotime.ParseError
+	if !errors.As(err, &perr) {
+		t.Errorf("Parse returned %T; a caller can no longer type-assert *time.ParseError.\n"+
+			"  That is what the //nolint:wrapcheck on this re-export exists to preserve.", err)
+	}
+}
+
+// TestParseInLocationUsesTheGivenZone checks the third argument is actually
+// used, which a signature alone does not.
+func TestParseInLocationUsesTheGivenZone(t *testing.T) {
+	t.Parallel()
+
+	// +05:30, chosen because it is not a whole number of hours, so a dropped
+	// or defaulted location is unmistakable.
+	loc := time.FixedZone("test+0530", 5*3600+30*60)
+
+	got, err := time.ParseInLocation(time.DateTime, "2026-03-04 05:06:07", loc)
+	if err != nil {
+		t.Fatalf("ParseInLocation: %v", err)
+	}
+
+	if _, offset := got.Zone(); offset != 5*3600+30*60 {
+		t.Errorf("zone offset = %d s, want 19800 — the location argument was ignored", offset)
+	}
+
+	if utc := got.UTC(); utc.Hour() != 23 || utc.Minute() != 36 {
+		t.Errorf("in UTC the instant is %02d:%02d, want 23:36 the previous day", utc.Hour(), utc.Minute())
+	}
+}
+
+// TestLoadLocationAndMustLocation covers the pair, including MustLocation's
+// panic, which is its whole reason to exist over LoadLocation.
+func TestLoadLocationAndMustLocation(t *testing.T) {
+	t.Parallel()
+
+	// UTC resolves without the tzdata files, so this runs anywhere.
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("LoadLocation(UTC): %v", err)
+	}
+
+	if loc.String() != "UTC" {
+		t.Errorf("LoadLocation(UTC) = %q, want UTC", loc)
+	}
+
+	if _, err := time.LoadLocation("Not/AZone"); err == nil {
+		t.Error("LoadLocation accepted a zone that does not exist")
+	}
+
+	if got := time.MustLocation("UTC"); got.String() != "UTC" {
+		t.Errorf("MustLocation(UTC) = %q, want UTC", got)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("MustLocation did not panic on a zone that does not exist, which is the only " +
+				"thing distinguishing it from LoadLocation")
+		}
+	}()
+
+	_ = time.MustLocation("Not/AZone")
+}
+
+// TestDurationHelpersDelegate covers Since, Until, Sleep, After, NewTimer and
+// NewTicker together. Each is a one-line forward, so the useful assertion is
+// the direction of the sign and that the channel actually fires.
+func TestDurationHelpersDelegate(t *testing.T) {
+	t.Parallel()
+
+	past := time.Now().Add(-time.Hour)
+	if d := time.Since(past); d < time.Hour {
+		t.Errorf("Since(an hour ago) = %v, want at least an hour — the sign is inverted", d)
+	}
+
+	future := time.Now().Add(time.Hour)
+	if d := time.Until(future); d <= 0 || d > time.Hour {
+		t.Errorf("Until(an hour hence) = %v, want a positive duration under an hour", d)
+	}
+
+	// Real but negligible: enough to prove the call reaches the standard
+	// library, short enough not to slow the suite.
+	start := time.Now()
+	time.Sleep(time.Millisecond)
+
+	if elapsed := time.Since(start); elapsed <= 0 {
+		t.Errorf("Sleep returned after %v; time did not advance", elapsed)
+	}
+
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-time.After(5 * time.Second):
+		t.Error("After did not fire within 5s")
+	}
+
+	timer := time.NewTimer(time.Millisecond)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-time.After(5 * time.Second):
+		t.Error("NewTimer did not fire within 5s")
+	}
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	select {
+	case <-ticker.C:
+	case <-time.After(5 * time.Second):
+		t.Error("NewTicker did not fire within 5s")
+	}
+}
+
+// TestLayoutConstantsAreUntyped is the assertion that the layouts became
+// consts rather than merely stopped being reassignable.
+//
+// An untyped constant converts to any string type; a `var` of type string does
+// not. Passing them to a defined string type is the check, and it is a compile
+// -time one — if the layouts revert to var, this file stops building.
+func TestLayoutConstantsAreUntyped(t *testing.T) {
+	t.Parallel()
+
+	type layout string
+
+	for _, l := range []layout{
+		time.RFC1123, time.RFC3339, time.RFC3339Nano,
+		time.DateOnly, time.DateTime, time.TimeOnly,
+	} {
+		if l == "" {
+			t.Error("a layout constant is empty")
+		}
+	}
+}

--- a/time/time.go
+++ b/time/time.go
@@ -107,21 +107,31 @@ const (
 )
 
 // LoadLocation loads a location from the standard library.
-var LoadLocation = time.LoadLocation
+// caller already handles as the standard library's, for a function that adds nothing
+// of its own to fail at.
+//
+//nolint:wrapcheck // a transparent re-export: wrapping would change the error a
+func LoadLocation(name string) (*Location, error) { return time.LoadLocation(name) }
 
 // Parse parses a formatted time string, as the standard library does.
-var Parse = time.Parse
+//
+//nolint:wrapcheck // transparent re-export; callers type-assert *time.ParseError.
+func Parse(layout, value string) (GoTime, error) { return time.Parse(layout, value) }
 
 // ParseInLocation is Parse with a default location for a layout that carries
 // no zone.
-var ParseInLocation = time.ParseInLocation
+//
+//nolint:wrapcheck // transparent re-export; callers type-assert *time.ParseError.
+func ParseInLocation(layout, value string, loc *Location) (GoTime, error) {
+	return time.ParseInLocation(layout, value, loc)
+}
 
 // Since returns the duration since the given time.
-var Since = time.Since
+func Since(t GoTime) Duration { return time.Since(t) }
 
 // MustLocation loads a location from the standard library, panicking if the
 // location cannot be loaded.
-var MustLocation = func(name string) *time.Location {
+func MustLocation(name string) *Location {
 	loc, err := time.LoadLocation(name)
 	if err != nil {
 		panic(err)
@@ -134,20 +144,28 @@ var MustLocation = func(name string) *time.Location {
 //
 // Named for the location rather than aliased as UTC, because [UTC] is this
 // package's coordinated-universal *scale* and the two are different things.
+//
+// One of only two exported vars this package has left, and the one it cannot
+// improve on: the standard library declares `var UTC *Location = &utcLoc`, so
+// the mutability is Go's own. Hiding it behind a function would hand back the
+// same reassignable pointer and remove nothing, at the cost of churning every
+// call site. See TestTimeExportsNoMutableFunctionValues.
 var LocationUTC = time.UTC
 
 // FixedZone returns a location with a fixed offset from UTC.
-var FixedZone = time.FixedZone
+func FixedZone(name string, offset int) *Location { return time.FixedZone(name, offset) }
 
 // Unix converts a Unix timestamp to a [GoTime].
-var Unix = time.Unix
+func Unix(sec, nsec int64) GoTime { return time.Unix(sec, nsec) }
 
 // GoDate builds a [GoTime] from calendar fields.
 //
 // Named apart from [Date], which builds this package's own [Time]. Both are
 // needed: astronomy wants the scale-aware type, while ordinary calendar work
 // — a cache key, a filename stamp — wants the standard library's.
-var GoDate = time.Date
+func GoDate(year int, month Month, day, hour, minute, sec, nsec int, loc *Location) GoTime {
+	return time.Date(year, month, day, hour, minute, sec, nsec, loc)
+}
 
 // Now returns the current wall-clock instant as a [GoTime].
 //
@@ -156,31 +174,40 @@ var GoDate = time.Date
 // clock work — a cache timestamp, a rate limiter, a generated-at field —
 // that would otherwise be a reason to import the standard library's time
 // package alongside this one.
-var Now = time.Now
+func Now() GoTime { return time.Now() }
 
 // Until returns the duration until the given [GoTime].
-var Until = time.Until
+func Until(t GoTime) Duration { return time.Until(t) }
 
 // Sleep pauses the calling goroutine.
-var Sleep = time.Sleep
+func Sleep(d Duration) { time.Sleep(d) }
 
 // After returns a channel that receives after the given duration.
 //
 // Not to be confused with [Time.After], which compares two instants.
-var After = time.After
+func After(d Duration) <-chan GoTime { return time.After(d) }
 
 // NewTimer returns a timer that fires after the given duration.
-var NewTimer = time.NewTimer
+func NewTimer(d Duration) *time.Timer { return time.NewTimer(d) }
 
 // NewTicker returns a ticker that fires repeatedly.
-var NewTicker = time.NewTicker
+func NewTicker(d Duration) *time.Ticker { return time.NewTicker(d) }
 
 // J2000 is the standard epoch J2000.0 (JD 2451545.0 TT) — the reference
 // epoch most star catalogs (Gaia excepted, at J2016.0) and orbital-element
 // sources assume when they don't report their own epoch explicitly.
+//
+// The second and last exported var, and unlike [LocationUTC] this one is
+// astrogo's own: any importer can reassign the standard epoch process-wide.
+// Go offers no way to declare a struct value immutable, so making it safe
+// means turning it into a function and breaking every caller, which is a
+// decision rather than a cleanup. Recorded in #113 rather than done quietly.
 var J2000 = FromJD(2451545.0, TT)
 
-var (
+// Layout strings, const rather than var so that nothing can reassign a format
+// string process-wide -- and untyped, exactly as the standard library declares
+// them, so they still satisfy a parameter of any string type.
+const (
 	// RFC1123 is a time format that conforms to RFC 1123.
 	RFC1123 = time.RFC1123
 	// RFC3339 is a time format that conforms to RFC 3339.


### PR DESCRIPTION
Closes the mutability half of #113. The surface turned out to be larger than the issue
listed — **fifteen** function vars, not six — and one of them is worse than any it named.

## The fix

Every re-exported function becomes a function:

```go
-var Parse = time.Parse
+func Parse(layout, value string) (GoTime, error) { return time.Parse(layout, value) }
```

A function re-exported *as a function* is identical at every call site, so **nothing
outside this package changed**. No deprecation cycle, no migration, no call-site churn:
the whole library, its tests and its 20 examples build and pass unmodified.

The six layout strings become `const`, and untyped, exactly as the standard library
declares them — so they now satisfy a parameter of any string type rather than only
`string`.

| was | now |
| --- | --- |
| 15 function vars | 15 functions |
| 6 layout string vars | 6 untyped consts |
| `LocationUTC`, `J2000` | still vars — see below |

## The one the issue didn't list

```go
var J2000 = FromJD(2451545.0, TT)
```

Any importer could reassign **the standard epoch**, process-wide. That is a more
interesting footgun than `Sleep`, and it is astrogo's own rather than inherited.

It is still a var, because Go has no immutable struct value: making it safe means
turning it into a function and breaking every caller. That is a decision, not a
cleanup, so it is documented at the declaration and left open on #113 rather than done
quietly overnight.

`LocationUTC` stays a var for a better reason — the standard library declares

```go
var UTC *Location = &utcLoc
```

so a `LocationUTC()` function would hand back the same reassignable pointer and remove
nothing, at the cost of churning every call site. **The mutability there is Go's, not
ours.** Worth checking before wrapping it, which is why I did.

## The guard

`var X = pkg.X` is the shortest way to re-export something and reads as entirely
harmless, so the next one arrives the same way. A `docsguard` test holds `time`'s
exported vars to a documented inventory of eight — six error sentinels (an `error`
cannot be const, and the sentinel idiom is what CLAUDE.md requires), plus the two
above.

It is an **inventory, not an exclusion list**: each entry states why Go leaves no
alternative, so adding one is a sentence somebody has to write and a reviewer gets to
disagree with. It also asserts that every listed name was actually *found*, so the
scan cannot quietly stop reaching the package — the vacuous-guard failure mode.

## Two smaller things

`parser.ParseDir` is deprecated as of Go 1.25 (it ignores build tags when grouping
files); the guard uses `os.ReadDir` + `ParseFile`, which is what it wanted anyway.

The three functions returning a standard-library error carry a scoped
`//nolint:wrapcheck`. Wrapping is the right default and the wrong answer here: these
add nothing of their own to fail at, and callers type-assert `*time.ParseError`.

## README

> no dynamic magic, no hidden global state, zero-allocation hot paths

was untrue in the package where it mattered most. It now says what is actually
guaranteed — the process-wide state that *does* exist (download consent, offline mode,
the logger, the EOP and leap-second registries) is reached only through explicitly
named calls, never through an `init()` or an import.

## Deliberately not done: step 2 of the issue

> Drop `Sleep`, `After`, `NewTimer`, `NewTicker`, `Since`, `Until` — they have nothing
> to do with time scales, and callers can import stdlib `time` for them.

Priced it: **18 internal call sites** across `remote/api`, `remote/lock_resume`,
`skybrightness/dataset/starlight` and five test files. Removing them pushes astrogo's
own code into the `gotime "time"` dual-import pattern this package exists to avoid,
and CLAUDE.md's deprecation policy means two minor releases of `//nolint:staticcheck`
in the meantime.

That is a trade-off worth deciding rather than assuming, and it is independent of this
change — the footgun is gone either way. Left on the issue with the count.

## Verification

`gofmt` · `go vet` · `go test ./...` · `-race -short` · `-tags="integration,validation"` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

| mutation | result |
| --- | --- |
| a re-export returned to `var` form | fails, naming the line |
| the layout block returned to `var` | fails, six flagged |
| an allowed name removed but left on the list | fails on the inventory check |

Refs #113.
