### PR TITLE
Test four exported symbols that nothing in the module referenced

### DIFF
--- a/docs/changelog.d/187-untested-exports.md
+++ b/docs/changelog.d/187-untested-exports.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 187
+---
+Tests for four exported symbols that had no reference anywhere in the module — not a
+caller, not a test, not an example: `plan.EventAnyPhase` (a documented four-phase
+wildcard nothing had ever passed), `plan.NewEarth`, `plan.WithStep` and
+`time.FileEOPLoader`, the recommended no-dependencies EOP path (#106).

--- a/plan/unwired_exports_test.go
+++ b/plan/unwired_exports_test.go
@@ -1,0 +1,181 @@
+package plan
+
+import (
+	"testing"
+
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// Three exported symbols in this package had no reference anywhere in the
+// module — not a caller, not a test, not an example — found by indexing every
+// exported declaration against every reference (#106).
+//
+// A public symbol nothing exercises is not merely uncovered. It is a claim in
+// the documentation that nobody has checked, and the repository's own rule is
+// that every exported symbol ships with a test. These are the ones that did
+// not.
+
+// TestEventAnyPhaseFindsAllFour is the one worth having.
+//
+// EventAnyPhase is documented as "a wildcard to find all four lunar phases in a
+// single pass", and it is reached only through solveIllumination's default
+// branch — there is no `case EventAnyPhase` anywhere. Nothing in the module
+// passed it, so the claim rested entirely on that default happening to do the
+// right thing for a value chosen to fall through to it.
+//
+// It does. This is what says so.
+func TestEventAnyPhaseFindsAllFour(t *testing.T) {
+	t.Parallel()
+
+	moon := NewMoon(eph.Default())
+	solver := NewEventSolver(6*time.Hour, time.Second)
+
+	// One full lunation is 29.53 days, so 40 days contains all four phases
+	// with room for the window to start anywhere within a cycle.
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.LocationUTC)
+	end := start.AddDays(40)
+
+	events, err := solver.Find(EventSpec{
+		Family: EventFamilyIllumination,
+		Kind:   EventAnyPhase,
+		Target: moon,
+	}, start, end)
+	if err != nil {
+		t.Fatalf("Find(EventAnyPhase): %v", err)
+	}
+
+	seen := make(map[EventKind]int)
+	for _, e := range events {
+		seen[e.Kind]++
+	}
+
+	for _, want := range []EventKind{EventNewMoon, EventFirstQuarter, EventFullMoon, EventLastQuarter} {
+		if seen[want] == 0 {
+			t.Errorf("EventAnyPhase found no %v across 40 days.\n"+
+				"  The wildcard is documented to return all four phases in a single pass, and a "+
+				"lunation is 29.53 days, so every one of them falls inside this window.", want)
+		}
+	}
+
+	// And the contrast that makes it a wildcard rather than a synonym: a named
+	// kind must return only itself.
+	full, err := solver.Find(EventSpec{
+		Family: EventFamilyIllumination,
+		Kind:   EventFullMoon,
+		Target: moon,
+	}, start, end)
+	if err != nil {
+		t.Fatalf("Find(EventFullMoon): %v", err)
+	}
+
+	for _, e := range full {
+		if e.Kind != EventFullMoon {
+			t.Errorf("asking for EventFullMoon returned a %v; the kind filter is not applied", e.Kind)
+		}
+	}
+
+	if len(full) >= len(events) {
+		t.Errorf("EventFullMoon returned %d events and EventAnyPhase %d.\n"+
+			"  The wildcard must find strictly more, or it is not doing anything.",
+			len(full), len(events))
+	}
+
+	// Events come back sorted by time, which a caller merging four phase
+	// searches depends on.
+	for i := 1; i < len(events); i++ {
+		if events[i].Time.Before(events[i-1].Time) {
+			t.Fatalf("event %d is before event %d; the combined pass is not sorted", i, i-1)
+		}
+	}
+}
+
+// TestNewEarthTargetsEarth covers the one planet constructor nothing used.
+//
+// Earth is the odd member of the set: every other NewX names something to point
+// a telescope at. This one is mostly a way to reach Earth's own state through
+// Provider(), and whether it earns its place in the public API is a question
+// for #106 rather than for a test. What a test can settle is that it targets
+// the body it names, which is the way a constructor written by copying its
+// neighbour goes wrong.
+func TestNewEarthTargetsEarth(t *testing.T) {
+	t.Parallel()
+
+	earth := NewEarth(eph.Default())
+
+	if earth == nil {
+		t.Fatal("NewEarth returned nil")
+	}
+
+	if earth.Name() != "Earth" {
+		t.Errorf("Name() = %q, want Earth", earth.Name())
+	}
+
+	if got := earth.EphID(); got != eph.Earth {
+		t.Errorf("EphID() = %v, want eph.Earth (%v) — this constructor targets the wrong body",
+			got, eph.Earth)
+	}
+
+	// And the id is actually used rather than merely stored: two constructors
+	// must not produce the same sky position.
+	epoch := time.Date(2026, 3, 20, 12, 0, 0, 0, time.LocationUTC)
+
+	here, err := earth.Position(epoch)
+	if err != nil {
+		t.Fatalf("Position: %v", err)
+	}
+
+	there, err := NewMars(eph.Default()).Position(epoch)
+	if err != nil {
+		t.Fatalf("Mars Position: %v", err)
+	}
+
+	if here.RA() == there.RA() && here.Dec() == there.Dec() {
+		t.Error("NewEarth and NewMars produce the same position; the ephemeris id is not reaching the lookup")
+	}
+
+	// Not asserted: Dist(). Position returns a direction and leaves the
+	// distance at zero for every body -- eph.ToICRS computes the radius and
+	// does not carry it -- so a check on it would pass whatever this
+	// constructor did. TargetDetails.Distance is the populated one (measured:
+	// Mars 2.31 AU), and it goes through a different path.
+}
+
+// TestWithStepSetsTheSamplingCadence covers the VisibleTonight option that had
+// no caller.
+//
+// WithMinAltitude, WithPlanetaryMoons and WithSmallBodyKernels are all
+// exercised; WithStep was the one that was not, so nothing checked that the
+// option a caller reaches for to trade accuracy against time actually reaches
+// the window search.
+func TestWithStepSetsTheSamplingCadence(t *testing.T) {
+	t.Parallel()
+
+	var cfg visibleTonightConfig
+
+	if cfg.step != 0 {
+		t.Fatalf("precondition: a zero config has step %v, want 0", cfg.step)
+	}
+
+	WithStep(5 * time.Minute)(&cfg)
+
+	if cfg.step != 5*time.Minute {
+		t.Errorf("WithStep(5m) set step to %v", cfg.step)
+	}
+
+	// It must not disturb the other fields, which is the failure mode of an
+	// option written by copying its neighbour.
+	if cfg.minAltitude.Degrees() != 0 || cfg.includeMoons || cfg.forceSmallBodyKernels {
+		t.Errorf("WithStep changed something other than step: %+v", cfg)
+	}
+
+	// Applied after another option, both must survive — options are variadic
+	// and order must not matter.
+	cfg = visibleTonightConfig{}
+	WithPlanetaryMoons()(&cfg)
+	WithStep(30 * time.Second)(&cfg)
+
+	if !cfg.includeMoons || cfg.step != 30*time.Second {
+		t.Errorf("options do not compose: %+v", cfg)
+	}
+}

--- a/time/eop_fileloader_test.go
+++ b/time/eop_fileloader_test.go
@@ -1,0 +1,63 @@
+package time_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestFileEOPLoader covers the pre-seeded, no-dependencies EOP path.
+//
+// It had no test, no example and no caller anywhere in the module — found by
+// indexing every exported declaration against every reference (#106). That
+// matters more here than the count suggests: FileEOPLoader is the documented
+// answer for a deployment that wants EOP data without pulling in
+// cloud-storage and gRPC machinery, so it is a path recommended to users and
+// exercised by nobody.
+func TestFileEOPLoader(t *testing.T) {
+	t.Parallel()
+
+	// One real finals2000A record. The columns are fixed-width and the parser
+	// slices by index, so this is copied from the bulletin's own format rather
+	// than approximated.
+	const record = "73 1 2 41684.00 I  0.120733 0.009786  0.136966 0.015902  " +
+		"I 0.8084178 0.0002710  0.0000 0.1916  P    -0.766    0.199    -0.720    0.300"
+
+	path := filepath.Join(t.TempDir(), "finals2000A.data")
+	if err := os.WriteFile(path, []byte(record+"\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	loader := time.FileEOPLoader(path)
+
+	data, err := loader.Cached(t.Context())
+	if err != nil {
+		t.Fatalf("Cached: %v", err)
+	}
+
+	if len(data.Raw) == 0 {
+		t.Error("Cached returned no bytes for a file that exists")
+	}
+
+	if data.ModTime.IsZero() {
+		t.Error("Cached returned a zero ModTime; the staleness check has nothing to compare")
+	}
+
+	// Fetch must report absence rather than reaching for the network — that
+	// promise is the whole reason this type exists.
+	if _, err := loader.Fetch(t.Context()); !errors.Is(err, time.ErrNoEOPData) {
+		t.Errorf("Fetch returned %v, want ErrNoEOPData.\n"+
+			"  A FileLoader downloads nothing; returning anything else here would mean the "+
+			"no-dependencies path had grown one.", err)
+	}
+
+	// A missing file is an ordinary state, not a failure: "nothing pre-seeded
+	// here" is exactly what a fresh deployment looks like.
+	missing := time.FileEOPLoader(filepath.Join(t.TempDir(), "absent.data"))
+	if _, err := missing.Cached(t.Context()); !errors.Is(err, time.ErrNoEOPData) {
+		t.Errorf("Cached on a missing file returned %v, want ErrNoEOPData", err)
+	}
+}


### PR DESCRIPTION
#106 proposes a guard for exported symbols with no non-test caller, and asks for it to
be scoped narrowly or run in report-only mode first. I measured before building, and the
measurement says the guard as proposed should not be built.

## The measurement

Every exported declaration in the module, indexed against every reference:

| | count |
| --- | ---: |
| exported declarations | **1,552** |
| referenced only from tests | 134 |
| referenced **nowhere at all** | 45 |

A guard on "no in-module caller" would flag **179 symbols on day one**. For a library
that is not a defect, it is what a public API looks like — `unit.Kelvin`, `unit.Parsec`,
`norad.GroupStarlink` exist for callers who are not in this repository. A 179-entry
allowlist is exactly the outcome the issue warns against: *"worth having only if it is
narrow enough that people do not switch it off."*

## The narrower cut that is worth something

The 45 referenced **nowhere** — not a caller, not a test, not an example — are a
different matter, because the repository already has a rule that covers them: every
exported symbol ships with a test.

Most of the 45 are pure data constants (SI units, NORAD group names) where a test would
assert a literal against itself. **Five are behavioural.** Four are tested in
[#187](https://github.com/TuSKan/astrogo/pull/187):

- **`plan.EventAnyPhase`** — the one worth having. Documented as *"a wildcard to find
  all four lunar phases in a single pass"*, and reached only through
  `solveIllumination`'s `default:` branch; there is no `case EventAnyPhase` anywhere.
  Nothing had ever passed it, so the documented behaviour rested entirely on that
  default happening to be right for a value chosen to fall through to it. It is.
- **`time.FileEOPLoader`** — the documented answer for a deployment wanting EOP data
  without cloud-storage and gRPC dependencies. A path recommended to users and exercised
  by nobody.
- **`plan.WithStep`** — the one `VisibleTonight` option with no test, while the other
  three have them.
- **`plan.NewEarth`**.

## The fifth is a delete candidate, not a test candidate

```go
// ErrRetriable wraps a retriable HTTP status inside the retry loop.
// It normally never escapes Client.Do; it is exported so custom
// RetryPolicy implementations can produce/detect it.
ErrRetriable = errors.New("remote: retriable status code")
```

`RetryPolicy` appears **exactly once in the module** — in that sentence. There is no
such type. So `ErrRetriable` is produced by nothing, detected by nothing, and justified
by an extension point the library does not have.

Deliberately not tested, because a test would cement it. It wants deleting (with the
pre-1.0 deprecation cycle) or the extension point actually building.

## Also worth a decision: `IsNeverUp` / `IsCircumpolar`

Still test-only, as the issue says, and still referenced from `day_episode.go`'s **doc
comment** at line 271 while the code beside it does not call them. That is the #101
shape the issue names, and it is unchanged by #110.

## Two things I got wrong, since they changed the tests

- The Earth test first asserted its geocentric distance is ~0. Adding a **contrast
  assertion against Mars** showed the check was vacuous: `Position` leaves `Dist()` at
  zero for *every* body, because `eph.ToICRS` computes the radius and does not carry it.
  The test now asserts what actually distinguishes the constructor, and records in a
  comment why distance is not the thing to check.
- I nearly filed that as a bug. `TargetDetails.Distance` is populated correctly through
  a different path — measured, Mars 2.31 AU and the Moon 0.00245 AU — so there is
  nothing user-visible to fix and nothing to file.

## Verification

`gofmt` · `go vet` · `go test ./...` · `-race -short` · `-tags="integration,validation"` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

| mutation | result |
| --- | --- |
| `EventAnyPhase` collapsed to one phase | fails, naming the three it stopped finding |
| `WithStep` setting a different field | fails on both the value and the side effect |
| `NewEarth` targeting Mars | fails on the id and on the position |

Refs #106.
