### PR TITLE
docs: fix four places where the documentation contradicted the code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,13 +62,13 @@ linters:
       disabled-checks:
         - captLocal   # IAU photometric notation (H, G, R, M1, M2)
     gomoddirectives:
-      # remote/file is deliberately built against the user's own go-cloud
-      # fork (github.com/TuSKan/go-cloud), which carries SFTP/multipart
-      # upload/HTTP-driver work not yet merged upstream — this replace
-      # directive is the whole point of that architecture, not a
-      # workaround to remove.
-      replace-allow-list:
-        - gocloud.dev
+      # No replace directives, and none allowed. The go-cloud fork this used to
+      # permit was dropped when remote was rebuilt over gocloud-ext's published
+      # modules; go.mod has carried no replace since. Leaving gocloud.dev on the
+      # allow-list would quietly re-permit a fork the architecture no longer
+      # needs, so the list is empty rather than absent — an empty list still
+      # refuses everything, and says so on purpose.
+      replace-allow-list: []
     gomodguard_v2:
       local-replace-directives: true
 

--- a/atmosphere/dataset/cams/doc.go
+++ b/atmosphere/dataset/cams/doc.go
@@ -1,12 +1,13 @@
-// Package cams is a minimal, read-only NetCDF-4/HDF5 reader for CAMS
-// (Copernicus Atmosphere Monitoring Service) global analysis files —
-// the Sky Brightness V2 Phase 3/7 building block docs/skybrightness.md
-// §8's "CAMS aerosol data" notes describe, and the reader
-// atmosphere.Atmosphere's future live, geographically-resolved aerosol
-// tier is meant to sit on top of (the OPAC-sourced
-// atmosphere.RuralAerosol/UrbanAerosol/DesertAerosol/MaritimeAerosol
-// presets remain the offline, zero-dependency default; this package is
-// the operational counterpart, not a replacement).
+// Package cams is a minimal, read-only NetCDF-4/HDF5 reader for CAMS files.
+//
+// CAMS is the Copernicus Atmosphere Monitoring Service, and its global
+// analysis files are the Sky Brightness V2 Phase 3/7 building block that
+// docs/skybrightness.md §8's "CAMS aerosol data" notes describe — the reader
+// atmosphere.Atmosphere's future live, geographically-resolved aerosol tier is
+// meant to sit on top of. The OPAC-sourced
+// atmosphere.RuralAerosol/UrbanAerosol/DesertAerosol/MaritimeAerosol presets
+// remain the offline, zero-dependency default; this package is the operational
+// counterpart, not a replacement.
 //
 // # Access
 //

--- a/catalog/xmatch/xmatch.go
+++ b/catalog/xmatch/xmatch.go
@@ -1,7 +1,8 @@
-// Package xmatch cross-matches astronomical catalog entries — identifying
-// resolve.Target values from independently-obtained sources that describe
-// the same physical object — as a standalone, directly-testable primitive
-// operating on plain resolve.Target slices.
+// Package xmatch cross-matches astronomical catalog entries.
+//
+// It identifies resolve.Target values from independently-obtained sources that
+// describe the same physical object, as a standalone, directly-testable
+// primitive operating on plain resolve.Target slices.
 //
 // catalog.Resolver already has its own cross-match logic
 // (catalog/catalog.go's unionFind/unionByAlias/unionByPosition/mergeGroup),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,9 +146,12 @@ What ships now:
 - [x] Four named presets carrying their own radiative transfer, so a model cannot be
       silently evaluated under another's transport
 - [x] A dataset tier (`skybrightness/dataset`) that is the only part permitted to do I/O
-- [ ] **Limiting magnitude returns when Phases 2–3 make a defensible one possible.** It was
-      removed rather than kept, because a limiting magnitude derived from a wrong spectrum
-      is a confident number rather than a useful one
+- [x] **Limiting magnitude has returned, defensibly.** It was removed rather than kept,
+      because one derived from a wrong spectrum is a confident number rather than a useful
+      one. `skybrightness/plan.Imaging` now implements `plan.SkyDepth` over the spectral
+      engine, and needs no photometric zero point: the same estimate yields a surface
+      brightness and a detector background from the same stored spectrum through the same
+      instrument, and that pair *is* the calibration
 
 **Inspiration:** GAMBONS (Masana et al. 2021, 2024), Kocifaj's skyglow series,
 Kieffer & Stone (2005), Leinert et al. (1998), ESO SkyCalc.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -123,9 +123,14 @@ entirely wrong spectrum and every instrument projection would be wrong; it took 
 light-pollution floor as an input rather than propagating light from sources; and its Moon
 was a closed-form V-band fit with no spectrum to project at all.
 
-Nothing from the original checklist survives by name — `Floor`, `SQMGrid`,
-`FloorFromBortle`, `CompositeModel`, `VisualLimitingMag`, `ScoreObservableSky` and
-`LimitingMagnitudeConstraint` are all gone. See the CHANGELOG's `### Removed` entries.
+`Floor`, `SQMGrid`, `FloorFromBortle`, `CompositeModel`, `VisualLimitingMag` and
+`ScoreObservableSky` are gone. See the CHANGELOG's `### Removed` entries.
+
+One name came back, differently shaped: [`plan.LimitingMagnitudeConstraint`](../plan/skybrightness.go)
+exists today. The v0.2.0 version took a light-pollution floor as an input and gated on it;
+this one takes a `SkyDepth` — anything that can answer "how faint can I see at this
+pointing, at this instant" — and by default scores on a soft ramp rather than rejecting.
+The constraint is the same question asked of a real radiance model instead of a constant.
 
 What ships now:
 

--- a/docs/changelog.d/188-docs-contradict-code.md
+++ b/docs/changelog.d/188-docs-contradict-code.md
@@ -7,4 +7,4 @@ pr: 188
 `plan/events.go` credited SOFA for a rise/set threshold that hardcodes the conventional
 34′; `.golangci.yml` still described a go-cloud fork `replace` that `go.mod` has not
 carried since the remote rebuild; and the `cams`, `kepler` and `xmatch` package synopses
-were paragraphs, so pkg.go.dev rendered their directory listings as walls.
+were paragraphs, so pkg.go.dev rendered their directory listings as walls. The ROADMAP also still listed limiting magnitude as unbuilt while `skybrightness/plan.Imaging` implements it.

--- a/docs/changelog.d/188-docs-contradict-code.md
+++ b/docs/changelog.d/188-docs-contradict-code.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 188
+---
+**Four places where the documentation contradicted the code** (#119): the ROADMAP said
+`LimitingMagnitudeConstraint` was removed while a differently-shaped one exists;
+`plan/events.go` credited SOFA for a rise/set threshold that hardcodes the conventional
+34′; `.golangci.yml` still described a go-cloud fork `replace` that `go.mod` has not
+carried since the remote rebuild; and the `cams`, `kepler` and `xmatch` package synopses
+were paragraphs, so pkg.go.dev rendered their directory listings as walls.

--- a/ephemeris/kepler/doc.go
+++ b/ephemeris/kepler/doc.go
@@ -1,8 +1,10 @@
-// Package kepler provides a lightweight, network-free alternative to
-// SPK-kernel-backed ephemerides: propagating a position and velocity
-// directly from classical heliocentric osculating orbital elements
-// (semi-major axis, eccentricity, inclination, ascending node, argument
-// of periapsis, mean anomaly) via analytic two-body Keplerian motion.
+// Package kepler propagates a position and velocity from classical orbital
+// elements, with no kernel and no network.
+//
+// It is the lightweight alternative to SPK-kernel-backed ephemerides: analytic
+// two-body Keplerian motion from a body's own heliocentric osculating elements
+// (semi-major axis, eccentricity, inclination, ascending node, argument of
+// periapsis, mean anomaly).
 //
 // [Provider] satisfies [github.com/TuSKan/astrogo/ephemeris/core.Provider]
 // exactly like the SPK-kernel-backed providers in ephemeris/jpl, so a

--- a/plan/events.go
+++ b/plan/events.go
@@ -784,10 +784,17 @@ type TwilightEvent struct {
 
 // ── Sun/Moon/Twilight Helpers ──────────────────────────────────────────────────
 
-// NOTE: Horizon altitude constants were removed in favor of SOFA-native
-// refraction. Use Site.SunRiseSetThreshold(), Site.MoonRiseSetThreshold(),
-// and Site.RiseSetThreshold() which account for SOFA's rigorous refraction
-// model and only add body-specific corrections (semi-diameter, parallax).
+// Rise and set thresholds come from the Site: SunRiseSetThreshold,
+// MoonRiseSetThreshold and RiseSetThreshold.
+//
+// Each is the conventional sum of a standard refraction of 34', the body's
+// semi-diameter, and the geometric horizon dip for the site's elevation. The
+// 34' is a fixed convention, not a SOFA computation -- USNO and the Astronomical
+// Almanac define rise and set the same way, so that two implementations agree on
+// an instant that is otherwise sensitive to the air on the night. SOFA's
+// rigorous refraction is used where refraction is being modelled rather than
+// conventionally defined: coord.Context's apparent-place transform, and
+// atmosphere's refraction models.
 
 // SunEvents returns all rise, set, and transit events for the Sun in the given interval.
 // The threshold accounts for atmospheric refraction (34'), solar semi-diameter (16'),


### PR DESCRIPTION
#119 lists six. Two turned out to be already handled, which is worth recording so nobody
re-does them:

- **The "Implementation Status" table is gone** from `docs/ROADMAP.md`. The per-item
  `**Status:**` labels that remain are already guarded against their own checkboxes by
  `docsguard`'s `TestRoadmapStatusMatchesItsBoxes`.
- **`remote.WorldAtlas` already carries a `// Deprecated:` marker** with the full
  reasoning — a propagated model output rather than a measurement, so it can neither
  validate this module nor be served as its answer, plus the CC BY-NC licence — and is
  waiting out the two minor releases the policy requires before removal.

The other four are fixed here.

## 1. The ROADMAP said a type was gone that exists

> `LimitingMagnitudeConstraint` … **removed in its entirety** … `Floor`, `SQMGrid`, …
> and `LimitingMagnitudeConstraint` are all gone.

It is declared at `plan/skybrightness.go:46` today. Both statements were true of the
v0.2.0 type and neither is true of the *name*, which is the worst combination — a reader
checking the claim finds the symbol and stops believing the page.

The text now says what actually happened. The v0.2.0 version took a light-pollution
floor as an input and gated on it; the current one takes a `SkyDepth` — anything that
can answer *how faint can I see at this pointing, at this instant* — and scores on a soft
ramp rather than rejecting. Same question, asked of a real radiance model instead of a
constant.

## 2. `plan/events.go` credited SOFA for a hardcoded 34′

> Horizon altitude constants were removed in favor of SOFA-native refraction. Use
> Site.SunRiseSetThreshold() … which account for SOFA's rigorous refraction model

```go
func (s *Site) SunRiseSetThreshold() angle.Angle {
	const sunSemiDiameter   = 0.2667 // degrees, ~16 arcmin
	const standardRefraction = 0.5667 // degrees, ~34 arcmin
	return angle.Deg(-sunSemiDiameter - standardRefraction - s.HorizonDip().Degrees())
}
```

The convention is right — USNO and the Astronomical Almanac define rise and set with the
same fixed 34′, precisely so two implementations agree on an instant that is otherwise
sensitive to the night's air. So the comment now says *that*, and points at where SOFA's
rigorous refraction is actually used: `coord.Context`'s apparent-place transform and
`atmosphere`'s refraction models.

## 3. `.golangci.yml` described a `replace` that no longer exists

> remote/file is deliberately built against the user's own go-cloud fork … this replace
> directive is the whole point of that architecture

`go.mod` has carried no `replace` since the remote rebuild dropped it.

The allow-list is now **empty rather than absent**, which still refuses everything and
says so on purpose — leaving `gocloud.dev` on it would quietly re-permit a fork the
architecture no longer needs. Verified rather than assumed: adding a replace and running
the linter gives

```
go.mod:74:1: replacement are not allowed: gocloud.dev (gomoddirectives)
```

## 4. Three package synopses were paragraphs

`cams`, `kepler` and `xmatch` opened with first *sentences* five to nine lines long, so
pkg.go.dev rendered their directory listings as walls. Each now leads with one line.
Nothing was cut — only moved below the break.

## Not done: a guard for class 1

It would have to match prose — a backticked name near "gone" or "removed" — and the
CHANGELOG is full of statements that are historically true and must stay, including
about symbols later reintroduced under a different design. That is exactly this case, so
the guard would have to special-case the thing it exists to find. Fragile enough that
someone switches it off, which is the failure mode this repo's guards are written to
avoid.

## Verification

`gofmt` · `go build` · `go test ./...` · `go test -tags="integration,validation" ./internal/docsguard/` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

Refs #119.
