### PR TITLE
docs: an epoch read from a smeared host clock is not UTC

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -191,6 +191,15 @@ The following areas are not yet considered scientifically complete:
 - **Radial-velocity correction is now cross-checked against Astropy** (175 cases, 0.7 mm/s), which closes the gap this list previously recorded. What remains open is narrower: astrogo is a classical projection and does not implement the Wright & Eastman (2014) terms — gravitational redshift, light-travel time to the barycentre, and the effect of the target's own proper motion and parallax on the projection geometry. Measured, those amount to 4.66 m/s against Astropy's relativistic value, so sub-1-m/s precision-RV work needs the full treatment and this does not provide it.
 - **Artificial skyglow in clear air** is tested on the model's physical claims rather than against a measured sky. An absolute check needs a per-emitter inventory — flux, spectrum and upward emission function — and satellite radiance alone can determine only the first: the same VIIRS pixel is produced by many real installations differing in spectrum and in how much light they throw sideways rather than up.
 - **Cloud reaches only the artificial term.** A cloud deck in the scene's atmosphere changes artificial skyglow and nothing else; moonlight, integrated starlight, diffuse galactic light, zodiacal light and airglow are all evaluated as though the sky were clear. Three separate models are missing behind that one sentence, not one.
+- **Every figure on this page assumes the host clock is UTC.** Around a leap second it
+  may not be: NTP providers smear the step over as much as 24 hours, each differently and
+  without announcing which method they use, so a clock read during that window is off by
+  up to 0.5 s and says nothing about it (Levine, Tavella & Milton 2023, Metrologia 60
+  014001, table 2). That is 0.3″ of lunar motion, 7.5″ of Earth rotation and 3.8 km of ISS
+  track — above everything tabulated above and below anything that looks wrong. No library
+  can detect it. Work that must be reproducible passes an explicit epoch, which never
+  touches the clock; see the `time` package doc's "The clock you are given". Tracked as
+  [#146](https://github.com/TuSKan/astrogo/issues/146).
 - **The Illumina-v2 comparison at Observatorio del Teide** is a Level-3 target whose published numbers are already transcribed. It is blocked on Tenerife's lighting inventory rather than on the numbers.
 - **SGP4 is wrong by hundreds to thousands of kilometres for low-perigee, deep-space and decaying orbits.** Not a
   missing feature but a measured defect in the propagator astrogo depends on

--- a/docs/changelog.d/189-smeared-clock.md
+++ b/docs/changelog.d/189-smeared-clock.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 189
+---
+**The `time` package doc and `docs/VALIDATION.md` now record that an epoch read from a
+smeared host clock is not UTC.** Around a leap second, NTP providers spread the step over
+as much as 24 hours — each differently, none announcing which — so `NowUTC` can be off by
+0.5 s with nothing to detect it: 0.3″ of lunar motion, 3.8 km of ISS track (#146).

--- a/time/doc.go
+++ b/time/doc.go
@@ -74,4 +74,48 @@
 // changes for a caller that wants EOP data. A program that imports neither
 // degrades to zero EOP and links no storage backend at all, which is the
 // difference between a 2.5 MB binary and a 19.4 MB one.
+//
+// # The clock you are given
+//
+// [NowUTC] and [Now] read the host's clock, and around a leap second that clock
+// may be deliberately wrong by up to 0.5 s for up to 24 hours. Nothing in this
+// package, or in any library, can detect it.
+//
+// The cause is leap smearing: rather than repeat or skip a second, an NTP
+// provider spreads the step over hours by running the clock slightly fast or
+// slow. Every major provider does it differently (Levine, Tavella & Milton
+// 2023, Metrologia 60 014001, table 2):
+//
+//	Google      frequency adjustment for the 24 h before the leap second
+//	Facebook    frequency adjustment for the 18 h after
+//	Alibaba     symmetric, 12 h either side
+//	Microsoft   frequency halved for the second before
+//
+// All of them, in that paper's words, "have an error on the order of ±0.5 s
+// during the adjustment period", and providers "generally do not indicate which
+// method is being used". So a smeared timestamp is not merely offset — it is
+// offset by an amount that depends on whose NTP server the host happened to be
+// using, and the host cannot say which.
+//
+// For this library 0.5 s is not a rounding error. It is 0.3 arcsec of lunar
+// motion, 7.5 arcsec of Earth rotation, and 3.8 km of ISS ground track: far
+// above the accuracy the rest of this package works to, and far below the
+// threshold at which anything looks wrong. The result is a plausible epoch,
+// silently off, on the days around a leap second.
+//
+// What to do about it, in order of preference:
+//
+//   - Pass an explicit epoch. A [Time] built from [Date] or [FromJD] never
+//     touches the host clock and so is never smeared. Anything meant to be
+//     reproducible should be doing this regardless.
+//   - Take time from PTP (IEEE 1588) rather than NTP. PTP distributes TAI plus
+//     the current UTC offset, so there is no step to smear.
+//   - If neither is possible and the work spans a leap second, treat epochs
+//     from that window as good to 0.5 s rather than to the microsecond, and
+//     say so in whatever the results feed.
+//
+// This is not a defect this package can fix — the host clock is the host's —
+// and it is worth knowing rather than discovering. The window is also
+// shrinking: the most recent leap second was 2016-12-31, none is currently
+// scheduled, and the 2022 CGPM resolution abandons them by 2035.
 package time


### PR DESCRIPTION
#146 asks for two things. This is the first, and I am recommending against the second —
reasoning below and on the issue.

## The note

Around a leap second, NTP providers deliberately run the host clock fast or slow rather
than repeating or skipping a second, and **each does it differently** (Levine, Tavella &
Milton 2023, Metrologia 60 014001, table 2):

| provider | method |
| --- | --- |
| Google | frequency adjustment for the 24 h **before** |
| Facebook | frequency adjustment for the 18 h **after** |
| Alibaba | symmetric, 12 h either side |
| Microsoft | frequency halved for the second before |

All are *"on the order of ±0.5 s during the adjustment period"*, and providers
*"generally do not indicate which method is being used"* — so the offset depends on whose
server the host happened to be using, and the host cannot say which.

For this library 0.5 s is **0.3″ of lunar motion, 7.5″ of Earth rotation and 3.8 km of
ISS track**: above everything `docs/VALIDATION.md` tabulates, and below anything that
looks wrong. A plausible epoch, silently off.

It goes in two places, both where a reader meets the claim it undermines:

- **`time`'s package doc**, next to the existing *"Failure and degradation"* section,
  which already sets out how the EOP path degrades. This is the other thing that degrades
  silently.
- **`docs/VALIDATION.md`'s known limitations**, because every figure on that page assumes
  the clock is UTC.

The advice is ordered by what actually helps: pass an explicit epoch (never touches the
clock, and reproducible work should be doing it anyway); failing that take time from PTP,
which distributes TAI plus an offset and so has no step to smear; failing both, treat the
window as good to 0.5 s and say so downstream.

## Why not the helper

> Consider a helper that flags an epoch falling within ±24 h of a known leap second

**Smearing affects a clock *reading*, not a computed epoch.** An epoch built from `Date`
or `FromJD` for 2016-12-31 today is exact; nothing smeared it. So the helper can only
ever fire for a live `NowUTC()` call *during* a real leap-second window.

There has not been one since **2016-12-31**, none is scheduled, and the 2022 CGPM
resolution abandons them by 2035. A permanent public symbol that fires approximately
never, on a code path a caller would have to already suspect, is worth a decision rather
than an assumption — especially against this repo's minimal-API-surface rule.

Happy to add it if you want it; it is a few lines over the existing leap-second registry.
Flagged on the issue rather than shipped quietly either way.

## Verification

`gofmt` · `go vet` · `go build` · `go test ./...` · `go test -tags="integration,validation" ./internal/docsguard/` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**. `go doc ./time` renders.

Refs #146.
