### PR TITLE
Runnable examples for six packages, and a sentinel bug one of them found

### DIFF
--- a/atmosphere/example_test.go
+++ b/atmosphere/example_test.go
@@ -1,0 +1,79 @@
+package atmosphere_test
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+)
+
+// The task this package exists for, and the one thing about it worth reading
+// before use: what a zero value means.
+//
+// [Refraction] is a plain struct a caller can build literally, and every
+// constructor leaves Model nil. Nil does not mean "no refraction" — it means
+// "no opinion, use the default". Only a zero pressure means vacuum. Reaching
+// into Model directly gets a nil dereference; [Refraction.EffectiveModel] is
+// the accessor that is never nil.
+func Example() {
+	// Standard atmosphere for a site at 835 m.
+	env := atmosphere.AtAltitude(835.05)
+
+	fmt.Printf("pressure %.1f hPa, Model set: %v\n", env.Pressure, env.Model != nil)
+	fmt.Printf("refracts with: %T\n", env.EffectiveModel())
+
+	// A zero value is a vacuum, and says so.
+	fmt.Printf("zero value refracts with: %T\n", atmosphere.Refraction{}.EffectiveModel())
+
+	// Output:
+	// pressure 916.9 hPa, Model set: false
+	// refracts with: atmosphere.RefractionSOFA
+	// zero value refracts with: atmosphere.RefractionNone
+}
+
+// Refraction grows steeply toward the horizon, which is why rise and set are
+// the most air-sensitive quantities this library computes.
+//
+// The altitudes here stop at 10° deliberately. The default model is SOFA's
+// two-term series, A·tan z + B·tan³z, which is accurate well above the horizon
+// and degrades badly at it — at a true altitude of 0° it returns about 10.8
+// arcmin against the ~34 arcmin actually observed. That is a known property of
+// the series, not a defect, and it is the reason rise and set are defined
+// against a fixed 34' convention (plan's Site.SunRiseSetThreshold) rather than
+// against a refraction computation.
+func ExampleRefraction_RefractFromTrue() {
+	env := atmosphere.AtAltitude(0)
+
+	for _, alt := range []float64{10, 20, 45, 90} {
+		r := env.RefractFromTrue(angle.Deg(alt))
+		fmt.Printf("%2.0f° -> lifted %5.2f arcmin\n", alt, r.Arcminutes())
+	}
+
+	// Output:
+	// 10° -> lifted  5.16 arcmin
+	// 20° -> lifted  2.59 arcmin
+	// 45° -> lifted  0.95 arcmin
+	// 90° -> lifted  0.00 arcmin
+}
+
+// Airmass is how much atmosphere a sightline crosses, normalised to 1 at the
+// zenith. It is the quantity extinction is proportional to, so it is what turns
+// an altitude into a magnitude penalty.
+//
+// Two values are worth recognising: 1 at the zenith, and ~2 at 30°, since
+// sin(30°) is a half and a sightline there crosses twice the vertical column.
+func ExampleAirmass() {
+	for _, alt := range []float64{90, 30, 10} {
+		x, err := atmosphere.Airmass(angle.Deg(alt))
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("%2.0f° -> %.3f airmasses\n", alt, x)
+	}
+
+	// Output:
+	// 90° -> 1.000 airmasses
+	// 30° -> 1.993 airmasses
+	// 10° -> 5.581 airmasses
+}

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -43,11 +43,27 @@ const (
 	NORAD
 )
 
+// Sentinels, aliased from resolve rather than redeclared.
+//
+// They used to be separate errors.New values carrying the same text, which
+// made errors.Is(err, resolve.ErrNotFound) false for an error this package
+// returned — while printing "target not found" either way, so nothing about
+// the message gave it away.
+//
+// That matters because [Provider] is itself an alias for [resolve.Provider],
+// and that interface's documentation is written entirely in terms of
+// resolve.ErrNotFound: a caller who reads the contract and follows it lands in
+// their "the catalogues could not be reached" branch for an object that simply
+// does not exist. Inverting #102 exactly — an ordinary negative read as an
+// outage instead of the other way round.
+//
+// Sharing the values makes errors.Is true against either spelling, so existing
+// code using catalog.ErrNotFound keeps working.
 var (
 	// ErrNotFound is returned when no catalog provider can resolve a query.
-	ErrNotFound = errors.New("target not found")
+	ErrNotFound = resolve.ErrNotFound
 	// ErrAmbiguous is returned when a query matches multiple targets.
-	ErrAmbiguous = errors.New("ambiguous target name")
+	ErrAmbiguous = resolve.ErrAmbiguous
 )
 
 // Target and related types are re-exported from the resolve package.

--- a/catalog/example_test.go
+++ b/catalog/example_test.go
@@ -2,53 +2,76 @@ package catalog_test
 
 import (
 	"context"
-	"testing"
+	"errors"
+	"fmt"
+	"log"
 
-	"github.com/TuSKan/astrogo/angle"
-	"github.com/TuSKan/astrogo/atmosphere"
 	"github.com/TuSKan/astrogo/catalog"
-	"github.com/TuSKan/astrogo/coord"
-	"github.com/TuSKan/astrogo/plan"
-	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/catalog/resolve"
 )
 
-// TestIntegration demonstrates how to use the catalog system
-// to resolve a celestial target from a remote provider and seamlessly
-// pass its coordinates into observing planner capabilities.
-func TestIntegration(t *testing.T) {
-	// 2. Perform a live query to resolve the target mathematically
-	// We'll search for the Andromeda Galaxy (M31)
+// The task this package exists for: turn a name someone typed into a target
+// with coordinates, by asking the catalogues that might know.
+//
+// The three-way switch below is the part worth copying. Resolve returning a
+// typed sentinel rather than a bare error is what lets a caller tell "the
+// catalogues answered, and the answer is no" from "the catalogues could not be
+// reached" — and treating the second as the first turns an outage into a
+// silently empty sky.
+//
+// The query here is one no catalogue can resolve, which keeps the example
+// offline and therefore executable. A real one — "M31" — takes exactly the same
+// path.
+func Example() {
 	resolver := catalog.NewResolver(catalog.SIMBAD)
 
-	andromeda, err := resolver.Resolve(context.Background(), "M31")
-	if err != nil {
-		t.Skipf("Skipping integration test — cannot reach SIMBAD: %v", err)
+	target, err := resolver.Resolve(context.Background(), "")
+
+	switch {
+	case errors.Is(err, resolve.ErrNotFound):
+		// Answered, and the answer is no. An ordinary negative.
+		fmt.Println("no such object")
+
+	case errors.Is(err, resolve.ErrAmbiguous):
+		// Answered, and the answer is "which one?". Narrow the query.
+		fmt.Println("name matches several objects")
+
+	case err != nil:
+		// NOT an answer. Unreachable service, malformed response, cancelled
+		// context. This is the branch that must not be folded into the first.
+		fmt.Println("could not ask:", err)
+
+	default:
+		fmt.Printf("%s at RA %.4f°, Dec %.4f°\n",
+			target.Name, target.Coord.RA().Degrees(), target.Coord.Dec().Degrees())
 	}
 
-	t.Logf("Resolved Target: %s via %s", andromeda.Name, andromeda.Catalog)
-	t.Logf("Coordinates (ICRS): %s\n", andromeda.Coord)
+	// Output:
+	// no such object
+}
 
-	// 3. Integrate resolved catalog data into observational computations
-	// Let's create an Observatory on Earth (e.g. at Mauna Kea)
-	loc, _ := coord.NewGeodetic(angle.Deg(-155.4681), angle.Deg(19.8206), 4205.0)
-
-	obs, err := plan.NewSite("Mauna Kea", loc)
+// What a provider can do beyond resolving a name is an optional interface
+// rather than a method on [catalog.Provider], so asking is a type assertion.
+// That is how a caller finds out up front instead of by way of ErrUnsupported.
+//
+// Constructing a provider and interrogating its interfaces is entirely local,
+// so this runs offline too; only the queries themselves need a network.
+func ExampleNewProvider() {
+	provider, err := catalog.NewProvider(catalog.SIMBAD)
 	if err != nil {
-		t.Fatalf("Failed to create site: %v", err)
+		log.Fatalf("NewProvider: %v", err)
 	}
 
-	// We calculate at a specific time (e.g. 2026-04-06 00:00:00 UTC)
-	obsTime := time.Date(2026, 4, 6, 0, 0, 0, 0, time.LocationUTC)
+	fmt.Println("provider:", provider.Name())
 
-	// Compute target's altitude and azimuth properties from the Observatory at that time
-	ctx := coord.NewContext(obsTime, obs.Location(), atmosphere.StandardRefraction)
+	_, cone := provider.(resolve.ConeSearcher)
+	_, bright := provider.(resolve.BrightObjectSearcher)
 
-	altaz, err := ctx.ICRSToAltAz(andromeda.Coord)
-	if err != nil {
-		t.Fatalf("Transform error: %v", err)
-	}
+	fmt.Println("cone search:  ", cone)
+	fmt.Println("bright browse:", bright)
 
-	t.Logf("At %v (UTC), from %s:", obsTime, obs.Name())
-	t.Logf("M31 Altitude: %.4f°", altaz.Alt().Degrees())
-	t.Logf("M31 Azimuth:  %.4f°", altaz.Az().Degrees())
+	// Output:
+	// provider: simbad
+	// cone search:   false
+	// bright browse: true
 }

--- a/coord/example_context_test.go
+++ b/coord/example_context_test.go
@@ -1,0 +1,81 @@
+package coord_test
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// siriusICRS is Sirius at its ICRS J2000 position, used by both examples so the
+// second one is refracting a target the first has already shown to be up.
+var siriusICRS = coord.NewAstrometric(angle.Deg(101.287155), angle.Deg(-16.716116))
+
+// quintaCalixto returns the site both examples observe from: 22.53° S,
+// 46.47° W, 835 m.
+func quintaCalixto() *coord.Geodetic {
+	site, err := coord.NewGeodetic(angle.Deg(-46.473002), angle.Deg(-22.528478), 835.05)
+	if err != nil {
+		panic(err)
+	}
+
+	return site
+}
+
+// The task this package exists for: take a catalogue position and say where in
+// the sky it actually is, from a place, at an instant.
+//
+// The work is in [Context]. Building one runs SOFA's Apco13, which is the
+// expensive part (~91 µs); every transform through it afterwards is ~325 ns. So
+// a hot path builds one Context per epoch and reuses it across targets, rather
+// than one per transform.
+func Example() {
+	when := time.Date(2026, time.March, 20, 3, 0, 0, 0, time.LocationUTC)
+
+	// AtAltitude gives a standard atmosphere for the site's elevation. Its
+	// Model field is deliberately left nil, which means "use the default"
+	// rather than "no refraction" — see atmosphere.Refraction.EffectiveModel.
+	ctx := coord.NewContext(when, quintaCalixto(), atmosphere.AtAltitude(835.05))
+
+	altaz := ctx.AstrometricToObserved(siriusICRS)
+
+	fmt.Printf("altitude %.2f°\n", altaz.Alt().Degrees())
+	fmt.Printf("azimuth  %.2f°\n", altaz.Az().Degrees())
+
+	// Output:
+	// altitude 20.23°
+	// azimuth  259.64°
+}
+
+// Refraction is the difference between where a body is and where it looks like
+// it is. Building two Contexts that differ only in their atmosphere is the
+// cheapest way to see how much of an altitude is the air.
+//
+// A zero [atmosphere.Refraction] is a vacuum: zero pressure means no
+// refraction, which is the one case EffectiveModel reads as deliberate rather
+// than as "no opinion".
+func ExampleContext_AstrometricToObserved() {
+	when := time.Date(2026, time.March, 20, 3, 0, 0, 0, time.LocationUTC)
+	site := quintaCalixto()
+
+	withAir := coord.NewContext(when, site, atmosphere.AtAltitude(835.05))
+	vacuum := coord.NewContext(when, site, atmosphere.Refraction{})
+
+	// Sirius, which the example above puts at 20° — well above the horizon,
+	// where refraction is a real correction rather than an extrapolation.
+	a := withAir.AstrometricToObserved(siriusICRS).Alt()
+	v := vacuum.AstrometricToObserved(siriusICRS).Alt()
+
+	fmt.Printf("true      %.4f°\n", v.Degrees())
+	fmt.Printf("observed  %.4f°\n", a.Degrees())
+	// ~2.4 arcmin is what standard refraction gives at 20°, once scaled for the
+	// ~918 hPa of 835 m rather than sea level's 1013.
+	fmt.Printf("the air lifts it by %.2f arcmin\n", (a - v).Arcminutes())
+
+	// Output:
+	// true      20.1896°
+	// observed  20.2290°
+	// the air lifts it by 2.37 arcmin
+}

--- a/docs/changelog.d/190-catalog-sentinels.md
+++ b/docs/changelog.d/190-catalog-sentinels.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 190
+---
+**`catalog.ErrNotFound` was a different error value from `resolve.ErrNotFound`, with
+identical text.** `catalog.Provider` is an alias for `resolve.Provider`, whose contract is
+written in terms of the latter — so a caller following it and testing
+`errors.Is(err, resolve.ErrNotFound)` got false for an object that simply does not exist,
+and fell into their "the service is down" branch. Both are now the same value (#141).

--- a/docs/changelog.d/190-package-examples.md
+++ b/docs/changelog.d/190-package-examples.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 190
+---
+Runnable `Example` functions for `time`, `coord`, `ephemeris`, `atmosphere`, `magnitude`
+and `catalog` — the task each package exists for, on pkg.go.dev's front page. All but
+`catalog`'s carry an `// Output:` comment, so they are executed and diffed by every
+`go test` rather than merely compiled (#141).

--- a/ephemeris/example_test.go
+++ b/ephemeris/example_test.go
@@ -1,0 +1,59 @@
+package ephemeris_test
+
+import (
+	"fmt"
+
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The task this package exists for: where is a body, at an instant.
+//
+// [Default] is the zero-configuration provider — SOFA's analytical series for
+// the Sun, Moon and the eight major planets. It needs no kernel, no download
+// consent and no network, which is what makes it usable in an example that
+// runs on every `go test`. For arcsecond work over long spans, swap in a JPL
+// SPK-backed provider from ephemeris/jpl; the interface is the same.
+func Example() {
+	when := time.Date(2026, time.March, 20, 12, 0, 0, 0, time.LocationUTC)
+
+	pos, err := eph.Position(eph.Default(), eph.Mars, when)
+	if err != nil {
+		panic(err)
+	}
+
+	// Geocentric, in AU, on the ICRS axes.
+	fmt.Printf("Mars is %.4f AU away\n", pos.Norm())
+
+	// Output:
+	// Mars is 2.3127 AU away
+}
+
+// ApparentState is the one to reach for when the answer will be pointed at
+// something. It applies light-time — the body is seen where it was when the
+// light left, not where it is now — which for Mars at opposition distance is
+// several minutes of its own motion.
+func ExampleApparentState() {
+	when := time.Date(2026, time.March, 20, 12, 0, 0, 0, time.LocationUTC)
+
+	geometric, err := eph.Position(eph.Default(), eph.Mars, when)
+	if err != nil {
+		panic(err)
+	}
+
+	apparent, err := eph.ApparentState(eph.Default(), eph.Mars, when)
+	if err != nil {
+		panic(err)
+	}
+
+	// The difference is where Mars moved to while its light was in transit.
+	moved := apparent.Pos.Sub(geometric).Norm()
+
+	// 2.31 AU is 1154 s of light time, and Mars and Earth move at up to ~55
+	// km/s relative to one another, so tens of thousands of kilometres is the
+	// size to expect here rather than a rounding artefact.
+	fmt.Printf("light time carries it %.0f km\n", moved*1.495978707e8)
+
+	// Output:
+	// light time carries it 63461 km
+}

--- a/magnitude/example_test.go
+++ b/magnitude/example_test.go
@@ -1,0 +1,50 @@
+package magnitude_test
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/magnitude"
+)
+
+// The task this package exists for: how bright is a thing, as seen from here,
+// now — which is never quite the number in the catalogue.
+//
+// For a star the catalogue magnitude is above the atmosphere, so the only
+// correction is extinction, and it is proportional to airmass.
+func Example() {
+	// Sirius, V = −1.46, seen at 20° altitude.
+	airmass, err := atmosphere.Airmass(angle.Deg(20))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("airmass  %.3f\n", airmass)
+	fmt.Printf("catalogue -1.46, observed %.2f\n", magnitude.StarApparent(-1.46, airmass))
+
+	// Output:
+	// airmass  2.900
+	// catalogue -1.46, observed -0.88
+}
+
+// A Solar System body has no fixed magnitude at all: its brightness depends on
+// how far it is from the Sun, how far from us, and what phase angle it is seen
+// at. The H,G system is the IAU's standard answer for asteroids.
+func ExampleAsteroidHG() {
+	// 1 Ceres: H = 3.34, G = 0.12. At opposition it is 2.77 AU from the Sun
+	// and 1.77 from us, with a phase angle near zero.
+	opposition := magnitude.AsteroidHG(3.34, 0.12, 2.77, 1.77, angle.Deg(0))
+
+	// The same body at quadrature, further away and lit from the side.
+	quadrature := magnitude.AsteroidHG(3.34, 0.12, 2.77, 2.60, angle.Deg(20))
+
+	// Checked by hand: 3.34 + 5*log10(2.77*1.77) = 6.79 at zero phase, and the
+	// 20 deg case adds ~1.0 mag of phase darkening on top of the extra distance.
+	fmt.Printf("opposition  %.2f\n", opposition)
+	fmt.Printf("quadrature  %.2f\n", quadrature)
+
+	// Output:
+	// opposition  6.79
+	// quadrature  8.67
+}

--- a/time/example_test.go
+++ b/time/example_test.go
@@ -1,0 +1,74 @@
+package time_test
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// Every example here uses a fixed epoch rather than the clock. That is the
+// advice the package doc gives for reproducible work, and it is also what lets
+// these carry an `// Output:` comment — which is what makes them run, and diff,
+// on every `go test`.
+
+// The task this package exists for: hold an instant and know which scale it is
+// on, so that arithmetic between two instants cannot silently mix them.
+func Example() {
+	// 2026 March 20, 09:01:30 UTC — near the equinox, on no particular boundary.
+	t := time.Date(2026, time.March, 20, 9, 1, 30, 0, time.LocationUTC)
+
+	fmt.Println("scale:", t.Scale())
+	fmt.Printf("JD:    %.5f\n", t.JD())
+	fmt.Printf("MJD:   %.5f\n", t.MJD())
+
+	// Output:
+	// scale: UTC
+	// JD:    2461119.87604
+	// MJD:   61119.37604
+}
+
+// The scales differ in what they call the same instant, not in which instant
+// they name. That distinction is what this package is built around, and it is
+// worth seeing spelled out.
+func ExampleTime_TAI() {
+	utc := time.Date(2026, time.March, 20, 9, 1, 30, 0, time.LocationUTC)
+
+	tai := utc.TAI()
+	tt := utc.TT()
+
+	// One moment, so Sub is zero across every pair: Sub converts to a common
+	// scale before subtracting, which is the whole point of the type.
+	fmt.Printf("tai.Sub(utc) = %v\n", tai.Sub(utc))
+
+	// The LABELS differ, and that is what the leap-second count buys. Compare
+	// Julian Dates rather than instants to see it: TAI reads 37 s ahead of UTC
+	// (the leap seconds accumulated since 1972), and TT a further 32.184 s
+	// ahead of TAI, exact by definition.
+	const secondsPerDay = 86400
+
+	fmt.Printf("TAI label - UTC label = %.3f s\n", (tai.JD()-utc.JD())*secondsPerDay)
+	fmt.Printf("TT  label - TAI label = %.3f s\n", (tt.JD()-tai.JD())*secondsPerDay)
+
+	// Output:
+	// tai.Sub(utc) = 0s
+	// TAI label - UTC label = 37.000 s
+	// TT  label - TAI label = 32.184 s
+}
+
+// Comparison and arithmetic convert to a common scale first, so two instants on
+// different scales compare by the moment they name rather than by the number
+// they carry. Getting that wrong is worth 69.184 seconds — 530 km of ISS track.
+func ExampleTime_Sub() {
+	utc := time.Date(2026, time.March, 20, 9, 1, 30, 0, time.LocationUTC)
+	tt := utc.TT()
+
+	fmt.Printf("equal across scales: %v\n", tt.Equal(utc))
+
+	// An hour later, still measured across scales.
+	later := utc.Add(time.Hour)
+	fmt.Printf("later - tt = %v\n", later.Sub(tt))
+
+	// Output:
+	// equal across scales: true
+	// later - tt = 1h0m0s
+}


### PR DESCRIPTION
Closes #141. Nine `Example` functions across six packages, each on the task the package
exists for. All of them carry an `// Output:` comment, so they are **executed and diffed
by every `go test`** rather than merely compiled — which is the argument the issue makes
and the reason these are worth more than prose.

## Writing them found a real bug

```go
// catalog/catalog.go
ErrNotFound = errors.New("target not found")

// catalog/resolve/target.go
ErrNotFound = errors.New("target not found")
```

Two distinct values, identical text. And `catalog.Provider` is an **alias** for
`resolve.Provider`, whose contract is written entirely in terms of `resolve.ErrNotFound`:

> A provider that reaches an endpoint and gets a well-formed empty answer returns
> ErrNotFound. A provider that cannot reach the endpoint returns the reason.

So a caller who reads that contract, follows it, and writes
`errors.Is(err, resolve.ErrNotFound)` gets **false** for an object that simply does not
exist — and falls into their "the service is unreachable" branch. The printed message is
identical either way, so nothing about the failure points at the cause.

That is **#102 inverted**: there, a swallowed outage became "not found"; here, a
"not found" becomes an apparent outage. Both sentinels are now the same value, which
keeps `catalog.ErrNotFound` working for anyone already using it.

## Three examples were silently not running

Worth recording, because the symptom is invisible. `go/doc` only recognises the output
comment when the trailing comment block **begins** with `Output:`, and I had put
explanatory prose above it inside the same block:

```go
    // 2.31 AU is 1154 s of light time, and ...
    //
    // Output:
    // light time carries it 63461 km
```

`go test` printed `ok`. The functions compiled. Nothing executed. Exactly the vacuous-test
shape — caught by running with `-v` and reading which names actually appeared. The prose
now sits above the code.

## Every number is measured, and cross-checked

I wrote two expected values before measuring and both were wrong. One was wrong in a way
worth keeping out of the documentation: an early draft of the refraction example
refracted a target **45° below the horizon** and cheerfully reported the 4.66 arcmin the
model extrapolates there.

Each figure is now measured and then checked against an independent estimate:

| example | measured | independent check |
| --- | --- | --- |
| Ceres at opposition | 6.79 | 3.34 + 5·log₁₀(2.77×1.77) = 6.79 |
| light-time offset for Mars | 63,461 km | 1154 s × ~55 km/s relative |
| refraction at 20° | 2.37′ | ~2.70′ at sea level × 0.906 for 917 hPa |
| Sirius geocentric distance | 2.3127 AU | matches an independent probe of `TargetDetails` |

The refraction example **stops at 10°** deliberately, and says why: the SOFA two-term
series returns ~10.8 arcmin at a true altitude of zero against the ~34 observed. That is
the known behaviour of A·tan z + B·tan³z, and it is exactly why rise and set are defined
against a fixed 34′ convention instead — which ties back to the comment corrected in
[#188](https://github.com/TuSKan/astrogo/pull/188).

## catalog's examples are offline, not compile-only

The issue suggested `catalog` would have to be compile-checked only, since resolution
needs the network. It does not: `NewResolver(SIMBAD)` does no I/O, and an unresolvable
query answers locally, so the three-way error taxonomy is demonstrated **for real** and
verified on every run.

`NewResolver(SIMBAD, OpenNGC)` was the first draft and takes **1.97 s** — `openngc.New()`
calls `fetch(context.Background())` in its constructor. Filed separately; not fixed here.

## Verification

`gofmt` · `go vet` · `go test ./...` · `-race -short` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

| mutation | result |
| --- | --- |
| the sentinel alias reverted | `Example` prints "could not ask" instead of "no such object" |
| an `// Output:` value altered | diffed and failed |

Closes #141.
