### PR TITLE
time: add GPST, the scale a satellite user actually holds

### DIFF
--- a/docs/changelog.d/192-gps-time-scale.md
+++ b/docs/changelog.d/192-gps-time-scale.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 192
+---
+**`time.GPST` — GPS system time, the scale a satellite user most often actually holds.**
+A receiver timestamp had no way to say what it was; calling it UTC is 18 s wrong today,
+which is 138 km of ISS track. GPST is TAI − 19 s exactly, so the conversion is arithmetic
+and cannot fail. Galileo shares it; BeiDou and GLONASS do not (#145).

--- a/ephemeris/satellite/doc.go
+++ b/ephemeris/satellite/doc.go
@@ -8,6 +8,27 @@
 // position and velocity in the TEME (True Equator Mean Equinox) frame, then
 // converts to GCRS for consistency with astrogo's [eph.Provider] contract.
 //
+// # If your timestamp came from a receiver, say so
+//
+// [Satellite.State] takes an astrogo time.Time, which carries its own scale, and
+// a GNSS receiver does not hand out UTC. GPS and Galileo system time run 18
+// seconds ahead of it today, because they were synchronised once in 1980 and
+// told to ignore leap seconds since.
+//
+// Passing that timestamp as UTC puts the satellite that far along its track,
+// which for the ISS is 138 km. The offset is ΔAT − 19, so it is not a constant
+// a caller can subtract once and remember: it was 14 s in 2008 and stepped to 18
+// at the 2017 leap second. Build the instant with
+// [github.com/TuSKan/astrogo/time.GPST] as its scale and the arithmetic happens
+// for you, at whatever epoch:
+//
+//	t := time.FromJD(gpsJD, time.GPST)   // not time.UTC
+//	state, err := sat.State(0, t)
+//
+// BeiDou is a different offset again (TAI − 33 s) and is not expressible yet;
+// GLONASS is UTC plus three hours with leap seconds applied, so it needs no
+// scale of its own.
+//
 // # Accuracy, and where it does not hold
 //
 // Measured against Vallado's own verification suite (AIAA 2006-6753), 588

--- a/ephemeris/satellite/gpst_test.go
+++ b/ephemeris/satellite/gpst_test.go
@@ -1,0 +1,102 @@
+package satellite_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestGPSTimestampProducesTheSameStateAsItsUTC is the contract #145 asks for,
+// and the one that makes the new scale worth its API surface.
+//
+// A GNSS receiver hands out GPS system time, which is 18 seconds ahead of UTC
+// today. Before time.GPST existed a caller had no way to say so, and the only
+// expressible option — call it UTC — put the satellite 18 seconds along its
+// track. This asserts both halves: labelling it correctly gives the right
+// state, and labelling it UTC gives a measurably wrong one.
+//
+// It lives here rather than in time/ because the arithmetic is only half the
+// point. State converts to UTC internally, so this also proves the conversion
+// survives the trip through timeToComponents rather than falling through a
+// switch that never learned about the scale.
+func TestGPSTimestampProducesTheSameStateAsItsUTC(t *testing.T) {
+	t.Parallel()
+
+	sat, err := satellite.NewFromTLE("ISS", valladoLine1, valladoLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	// One physical instant, expressed two ways.
+	utc := time.Date(2008, time.September, 20, 12, 0, 0, 0, time.LocationUTC)
+	gps := utc.GPST()
+
+	if gps.Scale() != time.GPST {
+		t.Fatalf("precondition: converted instant is on scale %v", gps.Scale())
+	}
+
+	fromUTC, err := sat.State(0, utc)
+	if err != nil {
+		t.Fatalf("State(utc): %v", err)
+	}
+
+	fromGPS, err := sat.State(0, gps)
+	if err != nil {
+		t.Fatalf("State(gps): %v", err)
+	}
+
+	// Same instant, so the same state. The tolerance is a metre in AU, which
+	// is far below the sub-second interpolation residual and far above float
+	// noise.
+	const metreInAU = 1.0 / 1.495978707e11
+
+	if d := fromGPS.Pos.Sub(fromUTC.Pos).Norm(); d > metreInAU {
+		t.Errorf("the same instant on two scales gave states %.3f km apart",
+			d*1.495978707e8)
+	}
+
+	// Now the trap. Take the GPS label and assert it is UTC -- the only thing
+	// a caller could do before this scale existed.
+	misread := time.FromJD(gps.JD(), time.UTC)
+
+	// The offset is NOT a constant, and this epoch shows why the scale has to
+	// do the arithmetic rather than the caller. Vallado's element set is from
+	// 2008, when delta-AT was 33 s, so GPST - UTC is 33 - 19 = 14 s here. At a
+	// post-2017 epoch the same code gives 18. A caller subtracting a
+	// remembered number would be four seconds -- 31 km -- wrong.
+	gap := misread.Sub(utc).Seconds()
+	if math.Abs(gap-14) > 1e-3 {
+		t.Errorf("GPST - UTC = %.6f s at a 2008 epoch, want 14 (delta-AT 33 - 19)", gap)
+	}
+
+	fromMisread, err := sat.State(0, misread)
+	if err != nil {
+		t.Fatalf("State(misread): %v", err)
+	}
+
+	const kmPerAU = 1.495978707e8
+
+	offKm := fromMisread.Pos.Sub(fromUTC.Pos).Norm() * kmPerAU
+	speed := fromUTC.Vel.Norm() * kmPerAU / 86400
+
+	// The displacement must be the chord the satellite actually covers in that
+	// gap: slightly under gap*speed, since the orbit curves. Checking it
+	// against the measured speed rather than a remembered figure is what makes
+	// this an assertion instead of a transcription.
+	arc := gap * speed
+	if offKm > arc || offKm < 0.97*arc {
+		t.Errorf("mislabelling GPS time as UTC moved the ISS %.1f km; expected just under "+
+			"the %.1f km arc it covers in %.0f s at %.3f km/s", offKm, arc, gap, speed)
+	}
+
+	t.Logf("correctly labelled: %.6f km apart; mislabelled as UTC: %.1f km "+
+		"(%.0f s at %.3f km/s)", fromGPS.Pos.Sub(fromUTC.Pos).Norm()*kmPerAU, offKm, gap, speed)
+
+	// And the interval arithmetic that a scheduler would do on it: the two
+	// labels differ by 18 s, while the instants do not differ at all.
+	if d := math.Abs(gps.Sub(utc).Seconds()); d != 0 {
+		t.Errorf("gps.Sub(utc) = %v s, want 0", d)
+	}
+}

--- a/time/doc.go
+++ b/time/doc.go
@@ -22,11 +22,12 @@
 // The conversion graph is:
 //
 //	UTC ←→ TAI ←→ TT ←→ TDB
-//	 ↕
-//	UT1
+//	 ↕     ↕
+//	UT1   GPST
 //
 // Conversion status:
 //   - UTC ↔ TAI: Complete (via SOFA leap-second table)
+//   - TAI ↔ GPST: Complete (GPST = TAI − 19 s, exact by definition)
 //   - TAI ↔ TT:  Complete (TT = TAI + 32.184s, exact by definition)
 //   - TT  ↔ TDB: Complete (Fairhead & Bretagnon 1990 single-term, amplitude 1.657 ms)
 //   - UTC ↔ UT1: Complete when IERS EOP data is loaded; returns error when unavailable.

--- a/time/gpst_test.go
+++ b/time/gpst_test.go
@@ -1,0 +1,209 @@
+package time_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// epoch is the instant these tests work at: after the 2017 leap second, so
+// ΔAT is 37 s and GPST − UTC is 37 − 19 = 18 s, the figure Levine, Tavella &
+// Milton (2023) table 1 gives for GPS.
+func epoch() time.Time {
+	return time.Date(2026, time.March, 20, 12, 0, 0, 0, time.LocationUTC)
+}
+
+const secondsPerDay = 86400
+
+// labelSeconds is the difference between two instants' LABELS, in seconds.
+//
+// It subtracts the two-part Julian Dates componentwise rather than through
+// JD(). Collapsing jd1+jd2 into one float64 costs precision: at a modern epoch
+// one ULP is about 4.7e-10 days, which is 40 microseconds, and that is enough
+// to make an exactly-19-second offset read as 19.000018. The split exists
+// precisely so the fractional part keeps its resolution, and a test that
+// asserts an exact constant has to use it.
+//
+// Sub is not the answer here: it converts to a common scale first and would
+// correctly report zero, since these are one instant. The label gap is the
+// quantity under test.
+func labelSeconds(a, b time.Time) float64 {
+	a1, a2 := a.JDParts()
+	b1, b2 := b.JDParts()
+
+	return ((a1 - b1) + (a2 - b2)) * secondsPerDay
+}
+
+// TestGPSTOffsetFromTAIIsExactlyNineteenSeconds pins the definition.
+//
+// Everything else about this scale follows from it: GPS was set to UTC on
+// 1980-01-06, when TAI−UTC was 19 s, and has run at the TAI rate ignoring leap
+// seconds ever since. So TAI − GPST is 19 s at every epoch, not a table.
+func TestGPSTOffsetFromTAIIsExactlyNineteenSeconds(t *testing.T) {
+	t.Parallel()
+
+	for _, when := range []time.Time{
+		time.Date(1990, time.January, 1, 0, 0, 0, 0, time.LocationUTC),
+		time.Date(2005, time.July, 4, 6, 30, 0, 0, time.LocationUTC),
+		epoch(),
+		time.Date(2040, time.December, 31, 23, 0, 0, 0, time.LocationUTC),
+	} {
+		tai := when.TAI()
+		gps := when.GPST()
+
+		// The label difference, which is what the offset is about. Sub would
+		// be zero, since these are the same instant.
+		got := labelSeconds(tai, gps)
+		if math.Abs(got-19.0) > 1e-9 {
+			t.Errorf("at %v: TAI − GPST = %.9f s, want exactly 19", when.Format(time.DateOnly), got)
+		}
+	}
+}
+
+// TestGPSTIsEighteenSecondsAheadOfUTCToday is the figure a GNSS user recognises,
+// and the one that makes the scale worth having.
+//
+// Unlike the TAI offset it is not constant: it is ΔAT − 19, so it stepped to 18
+// at the 2017 leap second and will step again at the next one. That is exactly
+// why a caller cannot be asked to subtract a number themselves.
+func TestGPSTIsEighteenSecondsAheadOfUTCToday(t *testing.T) {
+	t.Parallel()
+
+	utc := epoch()
+	gps := utc.GPST()
+
+	got := labelSeconds(gps, utc)
+	if math.Abs(got-18.0) > 1e-9 {
+		t.Errorf("GPST − UTC = %.9f s, want 18 (ΔAT 37 − 19)", got)
+	}
+}
+
+// TestGPSTRoundTripsThroughEveryScale is the property a new scale most easily
+// breaks: the conversion graph routes GPST through TAI, and every method that
+// did not learn about it would either misread it as UT1 or recurse.
+func TestGPSTRoundTripsThroughEveryScale(t *testing.T) {
+	t.Parallel()
+
+	start := epoch().GPST()
+
+	// Tolerance is one microsecond of a day. The route through TDB carries the
+	// Fairhead periodic term and back, which is not bit-exact.
+	const tol = 1e-6 / secondsPerDay
+
+	for _, tc := range []struct {
+		name string
+		trip func(time.Time) time.Time
+	}{
+		{"UTC", func(x time.Time) time.Time { return x.UTC().GPST() }},
+		{"TAI", func(x time.Time) time.Time { return x.TAI().GPST() }},
+		{"TT", func(x time.Time) time.Time { return x.TT().GPST() }},
+		{"TDB", func(x time.Time) time.Time { return x.TDB().GPST() }},
+	} {
+		back := tc.trip(start)
+
+		if back.Scale() != time.GPST {
+			t.Errorf("via %s: came back on scale %v, want GPST", tc.name, back.Scale())
+		}
+
+		if d := math.Abs(back.JD() - start.JD()); d > tol {
+			t.Errorf("via %s: round trip moved the instant by %.9f s",
+				tc.name, d*secondsPerDay)
+		}
+	}
+}
+
+// TestGPSTNamesTheSameInstantAsItsUTC is the contract #145 asks for, and the
+// one that actually protects a satellite user.
+//
+// A GPS timestamp and the UTC timestamp of the same physical moment must be
+// equal as instants, however differently they are labelled. If they are not,
+// everything downstream — a look angle, a pass prediction — is computed for the
+// wrong moment.
+func TestGPSTNamesTheSameInstantAsItsUTC(t *testing.T) {
+	t.Parallel()
+
+	utc := epoch()
+	gps := utc.GPST()
+
+	if !gps.Equal(utc) {
+		t.Error("a GPST instant and the UTC instant it denotes compare unequal")
+	}
+
+	if d := gps.Sub(utc); d != 0 {
+		t.Errorf("gps.Sub(utc) = %v, want 0 — these are one moment on two scales", d)
+	}
+
+	// And the trap the scale exists to prevent: the same NUMBER read as UTC is
+	// a different moment, by the 18 s that would otherwise go unnoticed.
+	misread := time.FromJD(gps.JD(), time.UTC)
+	if d := misread.Sub(utc).Seconds(); math.Abs(d-18.0) > 1e-3 {
+		t.Errorf("mislabelling GPS time as UTC shifts the instant by %.3f s, want 18", d)
+	}
+}
+
+// TestGPSTLabelsAdvanceInSISecondsAcrossALeapSecond is the property that makes
+// this scale worth having for interval arithmetic, and the contrast with UTC is
+// the whole of it.
+//
+// GPS ignores leap seconds, so a GPST label never repeats or skips: the gap
+// between two labels IS the elapsed time. A UTC label does skip, so the same
+// two instants differ by two hours of label and 7201 seconds of clock.
+//
+// # What this does not test
+//
+// Scale.uniform() returns true for GPST, and nothing here can check that.
+// uniform() is consulted in exactly one place -- SubDays, to decide whether to
+// convert to TT before subtracting -- and for GPST both routes give the same
+// answer, because GPST-to-TT is a constant that cancels in a difference.
+// Dropping GPST from uniform() therefore changes no result, only two needless
+// conversions. Verified by mutation: removing it leaves every test here
+// passing.
+//
+// It is still the correct marking. UTC and UT1 are non-uniform because their
+// labels do not track SI seconds, and GPST's do; saying so keeps the predicate
+// meaning one thing rather than becoming a list of scales that happen to want
+// the fast path.
+func TestGPSTLabelsAdvanceInSISecondsAcrossALeapSecond(t *testing.T) {
+	t.Parallel()
+
+	// Two hours of UTC label spanning the 2017-01-01 leap second.
+	utcBefore := time.Date(2016, time.December, 31, 23, 0, 0, 0, time.LocationUTC)
+	utcAfter := time.Date(2017, time.January, 1, 1, 0, 0, 0, time.LocationUTC)
+
+	before, after := utcBefore.GPST(), utcAfter.GPST()
+
+	labels := labelSeconds(after, before)
+	elapsed := after.Sub(before).Seconds()
+
+	if math.Abs(labels-elapsed) > 1e-6 {
+		t.Errorf("GPST labels advanced %.6f s while %.6f s elapsed; on this scale they are the same thing",
+			labels, elapsed)
+	}
+
+	// 7201, not 7200: a second was inserted inside the interval.
+	if math.Abs(elapsed-7201) > 1e-6 {
+		t.Errorf("elapsed = %.6f s, want 7201", elapsed)
+	}
+
+	// The contrast. Same two instants, UTC labels, and the gap is 7200 --
+	// which is why subtracting UTC labels directly is a bug and subtracting
+	// GPST labels is not.
+	if utcLabels := labelSeconds(utcAfter, utcBefore); math.Abs(utcLabels-7200) > 1e-6 {
+		t.Errorf("UTC labels advanced %.6f s, want 7200 -- the leap second is missing from the label", utcLabels)
+	}
+}
+
+// TestGPSTStringIsItsName keeps the scale printable, which matters because a
+// mislabelled instant is most often noticed by reading one.
+func TestGPSTStringIsItsName(t *testing.T) {
+	t.Parallel()
+
+	if got := time.GPST.String(); got != "GPST" {
+		t.Errorf("GPST.String() = %q", got)
+	}
+
+	if got := epoch().GPST().Scale().String(); got != "GPST" {
+		t.Errorf("converted instant reports scale %q", got)
+	}
+}

--- a/time/time.go
+++ b/time/time.go
@@ -209,7 +209,44 @@ const (
 	UT1
 	// TDB is Barycentric Dynamical Time.
 	TDB
+
+	// GPST is GPS system time, and the scale a satellite user most often
+	// actually holds.
+	//
+	// # Why it is a scale rather than an offset a caller applies
+	//
+	// GNSS system times were synchronised to UTC once and then told to ignore
+	// leap seconds, so each has drifted from UTC by a whole number of seconds
+	// that grows at every leap event. GPS was set to UTC on 1980-01-06, when
+	// TAI−UTC was 19 s, and has run at the TAI rate since:
+	//
+	//	TAI − GPST = 19 s, exactly and for ever
+	//	GPST − UTC = ΔAT − 19 s, which is 18 s today
+	//
+	// A caller with a receiver timestamp previously had no way to say what it
+	// was. The only expressible option was to call it UTC, and that is wrong
+	// by 18 s — 138 km of ISS ground track, in the package that also fixed a
+	// 69.184 s scale error worth 530 km (#133). Satellite work is exactly the
+	// population holding GNSS timestamps, which is what made this the most
+	// likely remaining instance of that defect class.
+	//
+	// Galileo System Time shares this scale: it is also TAI − 19 s, and agrees
+	// with GPST to within nanoseconds by design. BeiDou does not — BDT is
+	// TAI − 33 s — and GLONASS needs no scale here at all, being UTC plus three
+	// hours with leap seconds applied. Neither is expressible today; see #145.
+	//
+	// Reference: Levine, Tavella & Milton (2023), "Towards a consensus on a
+	// continuous coordinated universal time", Metrologia 60 014001, table 1.
+	GPST
 )
+
+// gpstMinusTAI is the fixed offset that defines GPS time.
+//
+// Negative because GPST runs behind TAI: TAI = GPST + 19 s. It is the value of
+// TAI−UTC at the 1980-01-06 synchronisation, frozen, and it is a constant of
+// the system rather than a table lookup — which is what makes this scale cheap
+// to support correctly.
+const gpstMinusTAI = -19.0
 
 func (s Scale) String() string {
 	switch s {
@@ -223,6 +260,8 @@ func (s Scale) String() string {
 		return "UT1"
 	case TDB:
 		return "TDB"
+	case GPST:
+		return "GPST"
 	default:
 		return "UNKNOWN"
 	}
@@ -245,7 +284,7 @@ func (s Scale) String() string {
 // term between them varies by ±1.7 ms, so a TDB interval and the TT interval
 // it spans differ by up to a microsecond per hour. Arithmetic in TDB stays in
 // TDB, which is what an ephemeris interpolating in TDB days wants.
-func (s Scale) uniform() bool { return s == TAI || s == TT || s == TDB }
+func (s Scale) uniform() bool { return s == TAI || s == TT || s == TDB || s == GPST }
 
 // Time represents a high-precision astronomical timestamp.
 //
@@ -1025,6 +1064,11 @@ func (t Time) UTC() Time {
 		// UTC = UT1 − DUT1. Since |DUT1| < 0.9s, UT1 ≈ UTC for lookup.
 		dut1 := dut1OrFallback(t.jd1, t.jd2)
 		return fromPartsPreserveLoc(t, t.jd1, t.jd2-dut1/86400.0, UTC)
+	case GPST:
+		// GPST → TAI → UTC. The first step is a constant and the second is
+		// the leap-second table, which is where the 18 s a GNSS user is
+		// missing actually comes from.
+		return t.TAI().UTC()
 	}
 
 	return t // unreachable with current scales
@@ -1057,9 +1101,19 @@ func (t Time) TAI() Time {
 		// Delta-T at that epoch, applied on the way home and never on the way
 		// out. Measured by TestScaleRoundTripMatrix.
 		return t.TT().TAI()
+	case GPST:
+		// TAI = GPST + 19 s, exactly. No table, no epoch dependence: the
+		// offset was frozen at the 1980-01-06 synchronisation and GPS time
+		// has ignored leap seconds ever since.
+		return fromPartsPreserveLoc(t, t.jd1, t.jd2-gpstMinusTAI/86400.0, TAI)
 	default:
 		// UT1 → UTC → TAI. UT1 genuinely has to go this way: DUT1 is defined
 		// against UTC, so there is no arithmetic path.
+		//
+		// Only UT1 reaches here. Every other scale has a case above, and it
+		// must stay that way: a scale that falls through to this branch is
+		// converted as though it were UT1, and one that UTC() also does not
+		// know would recurse between the two.
 		return t.UTC().TAI()
 	}
 }
@@ -1116,9 +1170,35 @@ func (t Time) TT() Time {
 	case UT1:
 		// UT1 → UTC (with fallback) → TT
 		return t.UTC().TT()
+	case GPST:
+		// GPST → TAI → TT, both steps constant.
+		return t.TAI().TT()
 	}
 
 	return t // unreachable
+}
+
+// GPST returns a new Time converted to GPS system time.
+//
+// GPS time is TAI − 19 s exactly, so this conversion is arithmetic and cannot
+// fail: the offset was fixed at the 1980-01-06 synchronisation and GPS has
+// ignored leap seconds since. Against UTC the gap therefore grows at every leap
+// event, and is 18 s today.
+//
+// The direction that matters most is the other one. A receiver hands a caller
+// GPS time; building it with [FromJD] or [Date] and this scale, rather than
+// calling it UTC, is what stops those 18 seconds becoming 138 km of ISS track.
+//
+// Galileo System Time is the same scale to within nanoseconds. BeiDou is not
+// (BDT is TAI − 33 s) and is not expressible here — see [GPST]'s own note.
+func (t Time) GPST() Time {
+	if t.scale == GPST {
+		return t
+	}
+
+	tai := t.TAI()
+
+	return fromPartsPreserveLoc(t, tai.jd1, tai.jd2+gpstMinusTAI/86400.0, GPST)
 }
 
 // TDB returns a new Time converted to the Barycentric Dynamical Time scale.


### PR DESCRIPTION
#145, option 1 — the one the issue calls correct, and it is small because GPS time is a
constant rather than a table.

## The gap

`time.Scale` had UTC, TAI, TT, UT1 and TDB. A caller holding a GNSS receiver timestamp
could only call it UTC, and that is **18 seconds wrong today — 138 km of ISS track**.

Same defect class as the 69.184 s scale error worth 530 km in #133, except #134's
contract test could not catch this one: the scale could not be *expressed*.

## The arithmetic

```
TAI − GPST = 19 s,  exactly and for ever
GPST − UTC = ΔAT − 19,  which is 18 s today
```

GPS was set to UTC on 1980-01-06, when TAI−UTC was 19 s, and has ignored leap seconds
since. Galileo System Time is the same scale to within nanoseconds. BeiDou is not
(TAI − 33 s) and GLONASS needs no scale at all, being UTC + 3 h with leap seconds applied
— both noted where a reader will look for them.

## The care is in the graph, not the arithmetic

Every existing `switch t.scale` carries a `default:` that assumes UT1. A new scale falling
through it is not merely misconverted — `UTC()` returns a GPST value unchanged, `TAI()`'s
default calls `t.UTC().TAI()`, and the two recurse for ever.

So GPST is handled explicitly in `UTC()`, `TAI()` and `TT()`; `TDB` and `UT1` reach it
through those. **Confirmed by deleting the `TAI()` case**, which gives:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```

The `default:` in `TAI()` now says in a comment that only UT1 may reach it, and why.

## Two things the tests found rather than assumed

**An exact 19 s offset read as 19.000018.** Not a bug — collapsing the two-part Julian
Date through `JD()` costs about 40 µs at a modern epoch. The tests subtract `JDParts`
componentwise, which is what the split exists for, and then hold to a nanosecond.

**The end-to-end satellite test expected 138 km and measured 107.7.** Also not a bug:
Vallado's element set is from **2008**, when ΔAT was 33, so GPST − UTC is **14 s** there,
not 18. That is precisely the epoch dependence the scale exists to absorb — a caller
subtracting a remembered 18 would be 4 seconds and 31 km wrong. The test now asserts the
gap against ΔAT and the displacement against the satellite's **own measured speed**,
rather than against a number I typed:

```
correctly labelled: 0.000000 km apart; mislabelled as UTC: 107.7 km (14 s at 7.694 km/s)
```

## The contract the issue asked for

> a GPS-time instant must produce the same state as the UTC instant it denotes

Asserted end to end in `ephemeris/satellite`, both directions: labelling it correctly
gives an identical state (0.000000 km), and labelling it UTC gives a measurably wrong one.
It lives there rather than in `time/` because `State` converts internally, so it also
proves the conversion survives `timeToComponents` rather than falling through a switch
that never learned the scale.

## One thing no test covers, said out loud

`Scale.uniform()` returns true for GPST and **nothing can check it**. `uniform()` is
consulted in exactly one place — `SubDays`, to decide whether to convert to TT before
subtracting — and for GPST both routes give the same answer, because the offset cancels in
a difference. Verified by mutation: removing GPST from `uniform()` leaves every test
passing.

It is still the correct marking, and the test says why it is untestable rather than
implying coverage it does not have.

## Verification

`gofmt` · `go vet` · `go test ./...` · `-race -short` · `-tags="integration,validation"` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

| mutation | result |
| --- | --- |
| offset sign flipped | fails at every epoch |
| `TAI()` loses its GPST case | **stack overflow** |
| GPST dropped from `uniform()` | passes — correctly, see above |

Refs #145.
