### PR TITLE
satellite: report which SGP4 regime an element set is in

### DIFF
--- a/docs/changelog.d/196-sgp4-regime-signal.md
+++ b/docs/changelog.d/196-sgp4-regime-signal.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 196
+---
+**`satellite.Satellite.Verified`** reports whether an element set sits inside the regime
+astrogo's SGP4 verification covers, and says why when it does not — so a position that may
+be 3440 km out no longer looks exactly like one for the ISS. It tests perigee against
+SGP4's own 220 km simplified-drag branch; deep space is deliberately excluded, because the
+measurement says it would raise fifteen false alarms and catch nothing new (#182).

--- a/ephemeris/satellite/doc.go
+++ b/ephemeris/satellite/doc.go
@@ -48,11 +48,30 @@
 // and none of the eight that fail, which is how an implementation with this
 // defect passes its own verification.
 //
-// Nothing here reports which regime a given element set falls in — a position
-// for a decaying rocket body comes back looking exactly like one for the ISS.
-// Until that changes, treat a result for a low-perigee, deep-space or decaying
-// object as unvalidated. See ephemeris/satellite/sgp4_vallado_validation_test.go,
-// which measures all of the above on every run of the validation tier, and
+// [Satellite.Verified] reports which side of that a given element set falls on,
+// so a position for a decaying rocket body no longer comes back looking exactly
+// like one for the ISS:
+//
+//	if ok, why := sat.Verified(); !ok {
+//		log.Printf("%s: %s", sat.Name, why)
+//	}
+//
+// It tests one thing — whether perigee is below the 220 km at which SGP4
+// switches to its simplified drag model — because that is what the measurement
+// supports. Every large divergence in the suite lives there. Deep space, the
+// obvious second condition, is deliberately absent: of roughly eighteen
+// deep-space cases only four diverge and all four already have a low perigee,
+// so adding it would raise fifteen false alarms for nothing. Both claims are
+// asserted against the fixtures, so neither can rot quietly.
+//
+// Measured over the thirty readable cases, it flags ten, seven of which
+// diverge, and misses one — a decaying object with a 282 km perigee that is out
+// by 0.62 km, the smallest divergence in the set. So it is conservative near
+// the boundary and silent about slow decay; see [Satellite.Verified] for the
+// full shape of that.
+//
+// See ephemeris/satellite/sgp4_vallado_validation_test.go, which measures all
+// of the above on every run of the validation tier, and
 // https://github.com/TuSKan/astrogo/issues/120.
 //
 // # Usage

--- a/ephemeris/satellite/regime.go
+++ b/ephemeris/satellite/regime.go
@@ -1,0 +1,122 @@
+package satellite
+
+import (
+	"fmt"
+	"math"
+)
+
+// WGS84 constants, matching the gravity model NewFromTLE hands the propagator.
+//
+// Copied from the backend's own getGravConst rather than from a table, because
+// the point of the arithmetic below is to reproduce a branch that code takes,
+// and a constant that differs in the last digit reproduces a different branch.
+const (
+	earthRadiusKM = 6378.137
+	muKM3S2       = 398600.5
+	j2            = 0.00108262998905
+)
+
+// xke is sqrt(GM) in earth radii^1.5 per minute — SGP4's time and length units.
+var xke = 60.0 / math.Sqrt(earthRadiusKM*earthRadiusKM*earthRadiusKM/muKM3S2)
+
+// simplifiedDragPerigeeKM is where SGP4 switches to its simplified drag model.
+//
+// Not a threshold chosen here. It is the backend's own branch, spelled in its
+// own units as `rp < 220.0/radiusearthkm + 1.0`, which is a perigee altitude of
+// 220 km. Everything in Vallado's verification suite that astrogo could not
+// reproduce lives below it — see [Satellite.Verified].
+const simplifiedDragPerigeeKM = 220.0
+
+// perigeeAltitudeKM returns the perigee altitude SGP4 itself computes, in km.
+//
+// # Why this is not (mu/n^2)^(1/3) * (1-e) - R
+//
+// Because that is the two-body value and SGP4 does not use it. A TLE's mean
+// motion is a Kozai mean element, and initl converts it to the Brouwer form
+// before deriving a semi-major axis — a correction worth about 1.4 km of
+// perigee for a low orbit, which is the difference between reproducing the
+// backend's branch and merely being near it. The sequence below is initl's,
+// term for term.
+//
+// Confirmed against the figures Vallado wrote into his own test file: it
+// returns 127.20 km where he says "perigee = 127.20", 135.75 where he says
+// 135.75, and a negative perigee for the case he annotates "(perigee = -51km)".
+func perigeeAltitudeKM(meanMotionRevPerDay, ecc, inclRad float64) float64 {
+	// no: mean motion in radians per minute, the unit SGP4 works in.
+	no := meanMotionRevPerDay * 2 * math.Pi / 1440
+
+	eccsq := ecc * ecc
+	omeosq := 1.0 - eccsq
+	rteosq := math.Sqrt(omeosq)
+	cosio := math.Cos(inclRad)
+	cosio2 := cosio * cosio
+
+	const twoThirds = 2.0 / 3.0
+
+	ak := math.Pow(xke/no, twoThirds)
+	d1 := 0.75 * j2 * (3.0*cosio2 - 1.0) / (rteosq * omeosq)
+	del := d1 / (ak * ak)
+	adel := ak * (1.0 - del*del - del*(1.0/3.0+134.0*del*del/81.0))
+	del = d1 / (adel * adel)
+
+	// The un-Kozai'd mean motion, and the semi-major axis that follows.
+	ao := math.Pow(xke/(no/(1.0+del)), twoThirds)
+
+	// rp is in earth radii; 1.0 is the surface.
+	return (ao*(1.0-ecc) - 1.0) * earthRadiusKM
+}
+
+// Verified reports whether this element set sits inside the regime astrogo's
+// SGP4 verification actually covers, and says why when it does not.
+//
+// # What the answer means
+//
+// astrogo measures its propagation against Vallado's reference suite (AIAA
+// 2006-6753) on every run of the validation tier. Twenty-two of the thirty
+// cases it can read agree to a median of 35 m; eight do not, by 0.6 km to
+// 3440 km. This reports which side of that a given element set is likely to
+// fall on, so a caller is not left reading a number that looks like every
+// other number.
+//
+// False is not "this result is wrong". It is "nothing here has been shown to
+// be right", which is a different and more honest claim.
+//
+// # Why perigee, and only perigee
+//
+// Because that is what the measurement says. Below 220 km SGP4 switches to a
+// simplified drag model — the backend's own `isimp` branch — and every large
+// divergence in the suite lives there: the five cases that miss by more than
+// 100 km have perigees of 80 to 152 km.
+//
+// The obvious second condition, deep space, is deliberately absent. It looked
+// right and the data refuted it: of roughly eighteen deep-space cases in the
+// suite only four diverge, and all four ALSO have a perigee under 220 km, so
+// they are already caught. Flagging deep space would add about fourteen false
+// alarms — every geostationary and Molniya case, all of which agree to metres
+// — for nothing, and a signal that cries wolf is one people switch off.
+//
+// # What it costs and misses, measured
+//
+// Against the thirty cases: it flags ten, of which seven diverge. The three it
+// flags wrongly have perigees of 180, 201 and 212 km, at the top of the band,
+// and they agree to 9 m, 52 m and 75 m. It misses one, satellite 29141, a
+// decaying object with a 282 km perigee that diverges by 0.62 km — the
+// smallest divergence in the set.
+//
+// So it is conservative near the boundary and silent about slow decay. Both are
+// stated because a caller deciding what to trust needs the shape of the error,
+// not a bare boolean. TestVerifiedMatchesTheMeasuredDivergence asserts every
+// number in this comment against the checked-in fixtures.
+func (s *Satellite) Verified() (bool, string) {
+	perigee := perigeeAltitudeKM(s.MeanMotion, s.ecc, s.inclRad)
+
+	if perigee >= simplifiedDragPerigeeKM {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf(
+		"perigee %.0f km is below %.0f km, where SGP4 uses its simplified drag model; "+
+			"astrogo's verification could not reproduce Vallado's reference vectors in that "+
+			"regime, by as much as 3440 km",
+		perigee, simplifiedDragPerigeeKM)
+}

--- a/ephemeris/satellite/regime_test.go
+++ b/ephemeris/satellite/regime_test.go
@@ -1,0 +1,66 @@
+package satellite_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+)
+
+// The measured behaviour of Satellite.Verified is asserted against Vallado's
+// suite under the validation tag. These are the ordinary-tier tests, so the
+// predicate has coverage in a plain `go test ./...` too — a signal about
+// trustworthiness should not itself be untested outside a tagged run.
+
+// TestVerifiedClearsAnOrdinaryOrbit uses the ISS: a 400 km perigee, nowhere
+// near SGP4's simplified-drag branch, and the case the library is most often
+// pointed at.
+func TestVerifiedClearsAnOrdinaryOrbit(t *testing.T) {
+	t.Parallel()
+
+	sat, err := satellite.NewFromTLE("ISS", valladoLine1, valladoLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	ok, reason := sat.Verified()
+	if !ok {
+		t.Errorf("the ISS was flagged as unverified: %s", reason)
+	}
+
+	if reason != "" {
+		t.Errorf("a cleared satellite carried a reason: %q", reason)
+	}
+}
+
+// TestVerifiedFlagsALowPerigeeOrbit is the other half, on the worst case in
+// Vallado's suite: COSMOS 2405, perigee 127 km, which astrogo misses by
+// 3440 km.
+func TestVerifiedFlagsALowPerigeeOrbit(t *testing.T) {
+	t.Parallel()
+
+	// Vallado's own annotation: "Near Earth, perigee = 127.20 (< 156) s4 mod".
+	const (
+		line1 = "1 28350U 04020A   06167.21788666  .16154492  76267-5  18678-3 0  8894"
+		line2 = "2 28350  64.9977 345.6130 0024870 260.7578  99.9590 16.47856722116490"
+	)
+
+	sat, err := satellite.NewFromTLE("COSMOS 2405", line1, line2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	ok, reason := sat.Verified()
+	if ok {
+		t.Fatal("a 127 km perigee was reported as verified; that is the case astrogo " +
+			"misses by 3440 km")
+	}
+
+	// The reason has to be usable: a caller logging it needs to know what was
+	// wrong and roughly how much it matters, not just that something was.
+	for _, want := range []string{"perigee", "220", "3440"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("reason %q does not mention %q", reason, want)
+		}
+	}
+}

--- a/ephemeris/satellite/regime_validation_test.go
+++ b/ephemeris/satellite/regime_validation_test.go
@@ -1,0 +1,251 @@
+//go:build validation
+
+package satellite
+
+import (
+	"math"
+	"sort"
+	"testing"
+)
+
+// Satellite.Verified makes a claim about which element sets astrogo can be
+// trusted on, and the claim is only worth anything if it is measured against
+// the data that established the regimes in the first place. These run against
+// the checked-in Vallado suite for exactly that reason.
+
+// divergence is the maximum position error #181 measured per satellite, in km,
+// for the eight cases astrogo could not reproduce.
+var divergence = map[string]float64{
+	"28350": 3440.27,
+	"22312": 1830.30,
+	"16925": 1329.38,
+	"11801": 782.18,
+	"28623": 486.20,
+	"28872": 7.73,
+	"23333": 3.11,
+	"29141": 0.62,
+}
+
+// TestPerigeeReproducesValladosOwnFigures is the check that the arithmetic is
+// SGP4's rather than merely near it.
+//
+// Vallado wrote perigee altitudes into the comments of his own test file for
+// three cases. A two-body semi-major axis gets within about 1.4 km of them; the
+// Kozai-to-Brouwer correction in initl is what closes the gap. Matching his
+// numbers to a tenth of a kilometre is how this says the correction is right,
+// rather than asserting the code against itself.
+func TestPerigeeReproducesValladosOwnFigures(t *testing.T) {
+	t.Parallel()
+
+	tles := loadValladoTLEs(t)
+
+	// The tolerance is the precision Vallado quoted, not one number for all
+	// three: two of his figures carry two decimals and the third is written
+	// "-51km", so holding that one to a tenth would be asserting precision the
+	// source does not have.
+	for _, tc := range []struct {
+		satnum string
+		want   float64 // km, from Vallado's own comment in SGP4-VER.TLE
+		tol    float64
+		note   string
+	}{
+		{"28350", 127.20, 0.05, `"Near Earth, perigee = 127.20 (< 156) s4 mod"`},
+		{"28623", 135.75, 0.05, `"Deep space, perigee = 135.75 (<156) s4 mod"`},
+		{"28872", -51.00, 1.00, `"(perigee = -51km), lost in 50 minutes" — quoted to the km`},
+	} {
+		sets, ok := tles[tc.satnum]
+		if !ok || len(sets) == 0 {
+			t.Fatalf("fixture no longer carries satellite %s", tc.satnum)
+		}
+
+		el, err := parseTLENumerics(sets[0][0][:tleLineLength], sets[0][1][:tleLineLength])
+		if err != nil {
+			t.Fatalf("%s: %v", tc.satnum, err)
+		}
+
+		got := perigeeAltitudeKM(el.meanMotion, el.ecc, el.inclRad)
+
+		if math.Abs(got-tc.want) > tc.tol {
+			t.Errorf("satellite %s: perigee %.2f km, Vallado says %.2f — %s.\n"+
+				"  A gap near 1.4 km means the Kozai correction is missing and this is the "+
+				"two-body value, which is not the number SGP4 branches on.",
+				tc.satnum, got, tc.want, tc.note)
+		}
+	}
+}
+
+// TestVerifiedMatchesTheMeasuredDivergence asserts every figure in
+// Satellite.Verified's doc comment against the fixtures.
+//
+// A predicate about trustworthiness that nobody checks is worse than none, and
+// the numbers in that comment — flags ten, seven of them divergent, misses one
+// — are exactly the kind of claim that rots. This recomputes them.
+func TestVerifiedMatchesTheMeasuredDivergence(t *testing.T) {
+	t.Parallel()
+
+	tles := loadValladoTLEs(t)
+
+	var (
+		flagged      []string
+		flaggedBad   int
+		missed       []string
+		verifiedGood int
+	)
+
+	for satnum, sets := range tles {
+		// The three checksum-invalid cases never reach a Satellite at all.
+		if checksumInvalid[satnum] {
+			continue
+		}
+
+		sat, err := NewFromTLE(satnum, sets[0][0][:tleLineLength], sets[0][1][:tleLineLength])
+		if err != nil {
+			t.Errorf("%s: NewFromTLE: %v", satnum, err)
+
+			continue
+		}
+
+		ok, reason := sat.Verified()
+		_, diverges := divergence[satnum]
+
+		switch {
+		case !ok && diverges:
+			flagged = append(flagged, satnum)
+			flaggedBad++
+		case !ok && !diverges:
+			flagged = append(flagged, satnum)
+		case ok && diverges:
+			missed = append(missed, satnum)
+		default:
+			verifiedGood++
+		}
+
+		if ok && reason != "" {
+			t.Errorf("%s: Verified reported true with a reason attached: %q", satnum, reason)
+		}
+
+		if !ok && reason == "" {
+			t.Errorf("%s: Verified reported false with no reason", satnum)
+		}
+	}
+
+	sort.Strings(flagged)
+	sort.Strings(missed)
+
+	t.Logf("flagged %d (%d of them divergent); missed %d; cleared %d",
+		len(flagged), flaggedBad, len(missed), verifiedGood)
+
+	if len(flagged) != 10 {
+		t.Errorf("flagged %d cases %v, want 10 — the doc comment says ten", len(flagged), flagged)
+	}
+
+	if flaggedBad != 7 {
+		t.Errorf("%d of the flagged cases actually diverge, want 7", flaggedBad)
+	}
+
+	// The one it misses, named, so that a change in either direction is loud.
+	if len(missed) != 1 || missed[0] != "29141" {
+		t.Errorf("missed %v, want exactly [29141] — the decaying case with a 282 km perigee", missed)
+	}
+}
+
+// TestEveryLargeDivergenceIsFlagged is the property that actually matters, and
+// it is stronger than the counts above.
+//
+// A caller can live with a conservative flag on an orbit that turns out fine.
+// What they cannot live with is a 3440 km error reported as trustworthy. Every
+// case in the suite that misses by more than 100 km must be flagged, and that
+// is asserted separately so it cannot be traded away by tuning the threshold.
+func TestEveryLargeDivergenceIsFlagged(t *testing.T) {
+	t.Parallel()
+
+	tles := loadValladoTLEs(t)
+
+	const seriousKM = 100
+
+	serious := 0
+
+	for satnum, maxErr := range divergence {
+		if maxErr < seriousKM {
+			continue
+		}
+
+		serious++
+
+		sets := tles[satnum]
+
+		sat, err := NewFromTLE(satnum, sets[0][0][:tleLineLength], sets[0][1][:tleLineLength])
+		if err != nil {
+			t.Fatalf("%s: %v", satnum, err)
+		}
+
+		if ok, _ := sat.Verified(); ok {
+			t.Errorf("satellite %s misses Vallado by %.0f km and Verified reports it as trustworthy.\n"+
+				"  A silent kilometre-scale error is the whole reason this predicate exists.",
+				satnum, maxErr)
+		}
+	}
+
+	if serious != 5 {
+		t.Errorf("the suite has %d divergences over %d km, want 5", serious, seriousKM)
+	}
+}
+
+// TestDeepSpaceIsDeliberatelyNotACondition makes the negative decision checkable.
+//
+// Flagging deep space looks obviously right and the measurement refutes it: the
+// deep-space cases in this suite that agree outnumber the ones that do not by
+// about three to one, and every divergent one is already caught by its perigee.
+// If somebody adds the condition later, this fails and says why.
+func TestDeepSpaceIsDeliberatelyNotACondition(t *testing.T) {
+	t.Parallel()
+
+	tles := loadValladoTLEs(t)
+
+	// SGP4's own deep-space branch: a period of 225 minutes or more.
+	const deepSpaceMinutes = 225
+
+	deepAndFine := 0
+
+	for satnum, sets := range tles {
+		if checksumInvalid[satnum] {
+			continue
+		}
+
+		sat, err := NewFromTLE(satnum, sets[0][0][:tleLineLength], sets[0][1][:tleLineLength])
+		if err != nil {
+			continue
+		}
+
+		if sat.OrbitalPeriod() < deepSpaceMinutes {
+			continue
+		}
+
+		if _, diverges := divergence[satnum]; diverges {
+			continue
+		}
+
+		// A deep-space case can still be flagged, for its perigee — 23599 is
+		// deep space with a 180 km perigee and is one of the three known
+		// conservative flags. What must not happen is a case being flagged for
+		// being deep space, so only those clear of the perigee band are
+		// asserted on.
+		if perigeeAltitudeKM(sat.MeanMotion, sat.ecc, sat.inclRad) < simplifiedDragPerigeeKM {
+			continue
+		}
+
+		if ok, reason := sat.Verified(); !ok {
+			t.Errorf("satellite %s is deep space, has a perigee above the band, agrees with "+
+				"Vallado, and is flagged anyway: %s", satnum, reason)
+		}
+
+		deepAndFine++
+	}
+
+	if deepAndFine < 10 {
+		t.Errorf("only %d deep-space cases both agree and are cleared; the argument for leaving "+
+			"deep space out of the predicate rests on there being many", deepAndFine)
+	}
+
+	t.Logf("%d deep-space cases agree with Vallado and are correctly not flagged", deepAndFine)
+}

--- a/ephemeris/satellite/satellite.go
+++ b/ephemeris/satellite/satellite.go
@@ -71,6 +71,13 @@ type Satellite struct {
 	// sub-second correction from this rather than from zero -- see there.
 	epoch        time.Time
 	epochFracSec float64
+
+	// ecc and inclRad are kept for [Satellite.Verified], which reproduces
+	// SGP4's own perigee to decide which side of its simplified-drag branch
+	// this element set falls on. They come from the same parse as MeanMotion,
+	// so the three cannot disagree about the orbit they describe.
+	ecc     float64
+	inclRad float64
 }
 
 // NewFromTLE creates a Satellite from raw TLE lines.
@@ -86,7 +93,7 @@ func NewFromTLE(name, line1, line2 string) (*Satellite, error) {
 	// Both the guard against TLEToSat's os.Exit and the source of MeanMotion:
 	// one parse, so the value this reports can never disagree with the one
 	// SGP4 propagates from.
-	mm, epoch, err := parseTLENumerics(line1, line2)
+	el, err := parseTLENumerics(line1, line2)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +101,7 @@ func NewFromTLE(name, line1, line2 string) (*Satellite, error) {
 	// The same conversion propagateECI applies to a query time, so the two
 	// fractional seconds are on identical footing and cancel exactly when the
 	// query lands a whole number of seconds after the epoch.
-	_, _, _, _, _, _, epochFracSec := timeToComponents(epoch)
+	_, _, _, _, _, _, epochFracSec := timeToComponents(el.epoch)
 
 	sat := gosatellite.TLEToSat(line1, line2, gosatellite.GravityWGS84)
 	if sat.Error != 0 {
@@ -103,10 +110,12 @@ func NewFromTLE(name, line1, line2 string) (*Satellite, error) {
 
 	return &Satellite{
 		Name:         name,
-		MeanMotion:   mm,
+		MeanMotion:   el.meanMotion,
 		sat:          sat,
-		epoch:        epoch,
+		epoch:        el.epoch,
 		epochFracSec: epochFracSec,
+		ecc:          el.ecc,
+		inclRad:      el.inclRad,
 	}, nil
 }
 
@@ -206,7 +215,7 @@ func ValidateTLE(line1, line2 string) error {
 		return err
 	}
 
-	_, _, err := parseTLENumerics(line1, line2)
+	_, err := parseTLENumerics(line1, line2)
 
 	return err
 }
@@ -247,6 +256,19 @@ func validateTLEStructure(line1, line2 string) error {
 	return nil
 }
 
+// elements are the orbital values this package keeps from a TLE, parsed once.
+//
+// Kept together rather than returned as four values because they describe one
+// orbit: MeanMotion, the epoch propagateECI measures from, and the pair
+// [Satellite.Verified] needs to reproduce SGP4's own perigee. Parsing them in
+// one pass is what stops any of them disagreeing about the element set.
+type elements struct {
+	meanMotion float64 // revolutions per day
+	ecc        float64
+	inclRad    float64
+	epoch      time.Time
+}
+
 // parseTLENumerics parses every field the SGP4 backend will parse, from the
 // same columns and with the same string surgery, and returns the mean motion
 // (rev/day, line 2 columns 53-63) as the one value this package keeps.
@@ -266,7 +288,9 @@ func validateTLEStructure(line1, line2 string) error {
 //
 // Callers must have established the 69-character length first
 // (validateTLEStructure) - every slice below indexes fixed columns.
-func parseTLENumerics(line1, line2 string) (meanMotion float64, epoch time.Time, err error) {
+func parseTLENumerics(line1, line2 string) (elements, error) {
+	var el elements
+
 	ints := [...]struct {
 		name  string
 		value string
@@ -277,7 +301,7 @@ func parseTLENumerics(line1, line2 string) (meanMotion float64, epoch time.Time,
 
 	for _, f := range ints {
 		if _, err := strconv.ParseInt(f.value, 10, 0); err != nil {
-			return 0, time.Time{}, fmt.Errorf("%w: %s is %q, which is not an integer", ErrMalformedTLE, f.name, f.value)
+			return elements{}, fmt.Errorf("%w: %s is %q, which is not an integer", ErrMalformedTLE, f.name, f.value)
 		}
 	}
 
@@ -300,20 +324,26 @@ func parseTLENumerics(line1, line2 string) (meanMotion float64, epoch time.Time,
 	for _, f := range floats {
 		v, err := strconv.ParseFloat(f.value, 64)
 		if err != nil {
-			return 0, time.Time{}, fmt.Errorf("%w: %s is %q, which is not a number", ErrMalformedTLE, f.name, f.value)
+			return elements{}, fmt.Errorf("%w: %s is %q, which is not a number", ErrMalformedTLE, f.name, f.value)
 		}
 
 		switch f.name {
 		case "mean motion":
-			meanMotion = v
+			el.meanMotion = v
+		case "eccentricity":
+			el.ecc = v
+		case "inclination":
+			el.inclRad = v * math.Pi / 180
 		case "epoch day":
 			if err := checkEpochDay(line1, v); err != nil {
-				return 0, time.Time{}, err
+				return elements{}, err
 			}
 		}
 	}
 
-	return meanMotion, tleEpoch(line1), nil
+	el.epoch = tleEpoch(line1)
+
+	return el, nil
 }
 
 // checkEpochDay refuses a day-of-year the backend would walk off the end of.


### PR DESCRIPTION
Closes #182. #181 measured that astrogo reproduces Vallado's vectors for 22 of 30 cases and
misses eight by 0.6–3440 km — and nothing told a caller which they had.

```go
if ok, why := sat.Verified(); !ok {
    log.Printf("%s: %s", sat.Name, why)
}
// COSMOS 2405: perigee 127 km is below 220 km, where SGP4 uses its simplified
// drag model; astrogo's verification could not reproduce Vallado's reference
// vectors in that regime, by as much as 3440 km
```

## The design came out of the data, and the data refuted half my own issue

I proposed flagging **low perigee, deep space, and decay**. Measuring all 33 cases against
the checked-in fixtures says: perigee, and only perigee.

| condition | flags | of which diverge |
| --- | ---: | ---: |
| perigee < 220 km | 10 | **7** |
| + deep space | **25** | 7 |

Of ~18 deep-space cases only four diverge, and **all four already have a perigee under
220 km**, so they are caught anyway. Adding the condition raises fifteen false alarms —
every GEO and Molniya orbit in the set, all agreeing to metres — and catches nothing new.
A signal that cries wolf is one people switch off.

`TestDeepSpaceIsDeliberatelyNotACondition` fails if somebody adds it later, so the
negative decision is as checkable as the positive one.

## 220 km is SGP4's number, not mine

It is the backend's own `isimp` branch, spelled in its units as
`rp < 220.0/radiusearthkm + 1.0`. Every large divergence lives below it: the five cases
missing by more than 100 km have perigees of 80–152 km.

And the perigee is SGP4's own too. A TLE's mean motion is a **Kozai** mean element, and
`initl` converts it to the Brouwer form before deriving a semi-major axis. Skipping that is
worth 1.3–2.4 km of perigee — the difference between reproducing the branch and being near
it. Verified against the figures Vallado wrote into his own test file:

| case | Verified computes | Vallado's comment |
| --- | ---: | --- |
| 28350 | 127.20 | *"perigee = 127.20 (< 156) s4 mod"* |
| 28623 | 135.75 | *"Deep space, perigee = 135.75 (<156)"* |
| 28872 | −51.7 | *"(perigee = -51km), lost in 50 minutes"* |

Dropping the Kozai correction misses all three.

## What it costs, stated rather than hidden

Flags **10** of 30; **7** diverge. The three it flags wrongly sit at 180, 201 and 212 km —
the top of the band — and agree to 9 m, 52 m and 75 m. It **misses one**: 29141, a decaying
object at 282 km, out by 0.62 km, the smallest divergence in the set.

So: conservative near the boundary, silent about slow decay. Both are in the doc comment
and both are asserted, because a caller deciding what to trust needs the shape of the error
rather than a bare boolean. `TestEveryLargeDivergenceIsFlagged` separately pins the property
that matters most — nothing over 100 km may ever be reported as trustworthy — so it cannot
be traded away by tuning the threshold.

## A doc I wrote four PRs ago was already wrong

`doc.go` said *"nothing here reports which regime a given element set falls in"* and advised
treating **deep-space** results as unvalidated. The first is obsoleted by this change; the
second the measurement never supported. Both rewritten — the #188 class of defect, arriving
in my own recent work.

## Verification

`gofmt` · `go vet` · `go test ./...` · `-race` · `-tags="integration,validation"` ·
`golangci-lint --build-tags="integration,network,validation"` — **0 issues**.

| mutation | result |
| --- | --- |
| Kozai correction dropped | all three Vallado perigees fail |
| threshold moved to a fitted 160 km | flags drop to 6, misses 2 |
| deep space added as a condition | flags jump to 25, named |

Closes #182.
