### PR TITLE
catalog/openngc: load the catalog on first query, not in New

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Any crasher Go writes to `testdata/fuzz/` should be committed — that's the one
 
 ## Embedded data
 
-There is no `go:generate` step in this codebase — it was removed deliberately. No package uses `go:embed` either — every data source is obtained at runtime through `remote.GetFile`, either explicitly (`catalog/openngc`, see [catalog/openngc/openngc.go](catalog/openngc/openngc.go)) or via a lazy, on-first-query load (`time`'s Earth Orientation Parameters, see [time/eop.go](time/eop.go) and the unexported `time/internal/iers`).
+There is no `go:generate` step in this codebase — it was removed deliberately. No package uses `go:embed` either — every data source is obtained at runtime through `remote.GetFile`, on a lazy, on-first-query load: `catalog/openngc`'s two CSVs (see [catalog/openngc/openngc.go](catalog/openngc/openngc.go)) and `time`'s Earth Orientation Parameters (see [time/eop.go](time/eop.go) and the unexported `time/internal/iers`). A constructor performs no I/O; the first query that needs the data fetches it under that caller's context.
 
 Never reintroduce a `go:generate`/download-tooling step, and never add `go:embed` to a new catalog provider — fetch through `remote` instead (see the caching primitives below).
 

--- a/catalog/openngc/fetch_test.go
+++ b/catalog/openngc/fetch_test.go
@@ -55,6 +55,19 @@ func fakeSources(t *testing.T) *file.Bucket {
 	return bucket
 }
 
+// loadNow builds a provider and drives its catalog load to completion.
+//
+// New performs no I/O — the fetch happens on the first query that needs the
+// catalog — so a test about fetch/cache behaviour has to ask a question to
+// provoke one.
+func loadNow(t *testing.T) {
+	t.Helper()
+
+	if _, err := New().Resolve(context.Background(), "M42"); err != nil {
+		t.Fatalf("Resolve(M42): %v", err)
+	}
+}
+
 func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 	t.Cleanup(remote.Capture().Restore)
 
@@ -82,7 +95,7 @@ func TestNewFetchesFromNetworkWhenDownloadsEnabled(t *testing.T) {
 	}
 }
 
-func TestNewSkipsBodyWhenUnchanged(t *testing.T) {
+func TestLoadSkipsBodyWhenUnchanged(t *testing.T) {
 	t.Cleanup(remote.Capture().Restore)
 
 	fakeSources(t)
@@ -90,7 +103,7 @@ func TestNewSkipsBodyWhenUnchanged(t *testing.T) {
 	remote.EnableDownloads(0, remote.OpenNGC)
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 
-	_ = New()
+	loadNow(t)
 
 	bucket, prefix, err := remote.CacheDir(context.Background(), remote.OpenNGC)
 	if err != nil {
@@ -107,11 +120,11 @@ func TestNewSkipsBodyWhenUnchanged(t *testing.T) {
 		t.Fatalf("Attributes(addendum.csv): %v", err)
 	}
 
-	// Second New() call: the source is untouched (same mtime/size, so the
-	// same fileblob-derived ETag), so both cache files must be reused
-	// untouched — proved by their own ModTime staying identical, which
-	// only happens if fetchInto's promote step never ran a second time.
-	_ = New()
+	// Second load: the source is untouched (same mtime/size, so the same
+	// fileblob-derived ETag), so both cache files must be reused untouched —
+	// proved by their own ModTime staying identical, which only happens if
+	// fetchInto's promote step never ran a second time.
+	loadNow(t)
 
 	ngcAttrsAfter, err := bucket.Attributes(context.Background(), prefix+"NGC.csv")
 	if err != nil {
@@ -152,14 +165,14 @@ func TestNewDefaultDenyIssuesNoRequest(t *testing.T) {
 
 	// A failed existence check is not "exists".
 	if exists, _ := bucket.Exists(context.Background(), prefix+"NGC.csv"); exists {
-		t.Error("New() must not create a cache file when downloads aren't enabled")
+		t.Error("a denied query must not create a cache file")
 	}
 }
 
-// TestNewDoesNotAccumulateCacheFiles is a regression test: repeated New()
-// calls must reuse a single cache file per source name, never leave stale
-// versions behind (the concern that originally motivated fetchSource).
-func TestNewDoesNotAccumulateCacheFiles(t *testing.T) {
+// TestLoadDoesNotAccumulateCacheFiles is a regression test: repeated loads
+// must reuse a single cache file per source name, never leave stale versions
+// behind (the concern that originally motivated fetchSource).
+func TestLoadDoesNotAccumulateCacheFiles(t *testing.T) {
 	t.Cleanup(remote.Capture().Restore)
 
 	fakeSources(t)
@@ -167,8 +180,10 @@ func TestNewDoesNotAccumulateCacheFiles(t *testing.T) {
 	remote.EnableDownloads(0, remote.OpenNGC)
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 
+	// Three separate providers, each loading for itself: the guard against
+	// accumulation has to be the cache, not one provider's own memo.
 	for range 3 {
-		_ = New()
+		loadNow(t)
 	}
 
 	bucket, prefix, err := remote.CacheDir(context.Background(), remote.OpenNGC)

--- a/catalog/openngc/lazyload_test.go
+++ b/catalog/openngc/lazyload_test.go
@@ -1,0 +1,166 @@
+package openngc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/remote"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+)
+
+// TestNewDoesNoIO is the whole point of the change: construction is pure, so
+// it cannot block, cannot fail, and cannot consume a deadline. Offline mode is
+// the strongest available statement of "no I/O happened" — under it any fetch
+// attempt fails, so a New that reached the network could not return here at all.
+func TestNewDoesNoIO(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.EnableDownloads(0, remote.OpenNGC)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+	remote.SetOffline(true)
+
+	if New() == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+// TestFailedLoadIsRetried is the second half of the change. A load failure used
+// to be recorded at construction and replayed for the life of the provider, so
+// a consent gate granted a moment later — or an endpoint that came back — never
+// took effect. The same provider must be able to answer once the reason for the
+// failure is gone.
+func TestFailedLoadIsRetried(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	// Downloads not enabled yet: the catalog is unreachable.
+	p := New()
+
+	if _, err := p.Resolve(context.Background(), "M42"); err == nil {
+		t.Fatal("Resolve without download consent: want an error, got none")
+	} else if errors.Is(err, resolve.ErrNotFound) {
+		t.Errorf("an unreachable catalog reported as a missing object: %v", err)
+	}
+
+	// Grant consent on the same provider and ask again.
+	remote.EnableDownloads(0, remote.OpenNGC)
+
+	got, err := p.Resolve(context.Background(), "M42")
+	if err != nil {
+		t.Fatalf("Resolve after consent was granted: %v", err)
+	}
+
+	if got.ID != "NGC1976" {
+		t.Errorf("Resolve(M42).ID = %q, want NGC1976", got.ID)
+	}
+}
+
+// TestLoadHappensOnce: the catalog is 7 MB and is kept for the life of the
+// provider. Going offline after a successful load and asking again is the
+// behavioural way to say so — a provider that re-fetched per query would fail
+// the second call.
+func TestLoadHappensOnce(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.EnableDownloads(0, remote.OpenNGC)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	p := New()
+
+	if _, err := p.Resolve(context.Background(), "M42"); err != nil {
+		t.Fatalf("first Resolve: %v", err)
+	}
+
+	remote.SetOffline(true)
+
+	if _, err := p.Resolve(context.Background(), "M31"); err != nil {
+		t.Errorf("second Resolve went back to the source: %v", err)
+	}
+}
+
+// TestLoadHonoursContext: the fetch now runs under the caller's context, which
+// is the reason for moving it out of New in the first place.
+func TestLoadHonoursContext(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.EnableDownloads(0, remote.OpenNGC)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := New().Resolve(ctx, "M42"); !errors.Is(err, context.Canceled) {
+		t.Errorf("Resolve with a cancelled context: err = %v, want context.Canceled", err)
+	}
+}
+
+// TestSearchBrightReportsLoadFailure guards the one query whose signature has
+// no error return. Before the load moved, a failure here was not reported at
+// all — SearchBright never consulted the recorded error, so an unreachable
+// catalog came back as a sky containing no bright objects.
+func TestSearchBrightReportsLoadFailure(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+	// Downloads deliberately left disabled.
+
+	var (
+		n      int
+		gotErr error
+	)
+
+	for _, err := range New().SearchBright(context.Background(), resolve.BrightRequest{MaxVMag: 6}) {
+		n++
+
+		if err != nil {
+			gotErr = err
+		}
+	}
+
+	if gotErr == nil {
+		t.Errorf("SearchBright over an unreachable catalog yielded %d targets and no error", n)
+	}
+}
+
+// TestConcurrentFirstQueriesLoadOnce: mu is held across the fetch, so the
+// second arrival waits rather than issuing its own request. Meaningful under
+// -race, which is where this package's concurrency is actually checked.
+func TestConcurrentFirstQueriesLoadOnce(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	fakeSources(t)
+	remote.EnableDownloads(0, remote.OpenNGC)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	p := New()
+
+	const goroutines = 8
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Go(func() {
+			_, errs[i] = p.Resolve(context.Background(), "M42")
+		})
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: Resolve(M42): %v", i, err)
+		}
+	}
+}

--- a/catalog/openngc/openngc.go
+++ b/catalog/openngc/openngc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
 )
@@ -21,55 +22,38 @@ type Record struct {
 
 // Provider implements the resolve.Provider interface for OpenNGC.
 type Provider struct {
+	// mu guards the load and everything it fills in. It is held across the
+	// fetch, so concurrent first queries make one request between them rather
+	// than one each.
+	mu      sync.Mutex
+	loaded  bool
 	byKey   map[string]int
 	targets []resolve.Target
-
-	// initErr records a failed catalog load so every query can report it.
-	//
-	// New used to log the failure and hand back an empty provider, which then
-	// answered every lookup with "not found" for the life of the process. A
-	// consent gate that was never granted, or one bad fetch at start-up, made
-	// the whole NGC/IC catalog silently absent while the provider looked
-	// healthy. Construction-time failure is worse than per-query failure for
-	// exactly that reason: it is permanent and it is invisible.
-	initErr error
 }
 
-// New creates a new OpenNGC catalog provider — like every other astrogo
-// catalog provider, it does its own network access rather than reading
-// build-time embedded data. It fetches and merges the two upstream source
-// CSVs if remote.EnableDownloads(..., remote.OpenNGC) has been called,
-// reusing a local cache untouched when a HEAD probe shows nothing changed
-// upstream. If downloads aren't enabled, or the fetch fails for any other
-// reason, New returns an empty, warning-logged provider — the same
-// degraded behavior as any other catalog provider whose backing source is
-// unreachable.
-func New() *Provider {
-	targets, err := fetch(context.Background())
-	if err != nil {
-		return &Provider{
-			byKey:   make(map[string]int),
-			initErr: fmt.Errorf("openngc: catalog unavailable: %w", err),
-		}
-	}
-
-	p := &Provider{
-		targets: targets,
-		byKey:   make(map[string]int),
-	}
-	for i, t := range targets {
-		p.byKey[resolve.Normalize(t.ID)] = i
-		if t.Name != "" {
-			p.byKey[resolve.Normalize(t.Name)] = i
-		}
-
-		for _, a := range t.Aliases {
-			p.byKey[resolve.Normalize(a)] = i
-		}
-	}
-
-	return p
-}
+// New creates an OpenNGC catalog provider. It performs no I/O.
+//
+// The catalog — two upstream CSVs, about 7 MB — is fetched on the first query
+// that needs it, using that caller's context, and kept for the life of the
+// provider.
+//
+// # Why not at construction
+//
+// It used to be. New called fetch with context.Background(), which meant a
+// constructor that looked pure blocked for as long as the endpoint took: two
+// seconds against a warm cache, and a full timeout against an unreachable one,
+// with no way for the caller to cancel it or set a deadline. catalog.NewResolver
+// takes no context either, so a request-scoped deadline above it had no effect
+// on the network call below it. Every other network entry point in astrogo takes
+// a ctx first, and this one took none.
+//
+// A failed load is also no longer permanent. It used to be recorded once and
+// replayed at every query for the life of the process, so a consent gate not yet
+// granted, or one bad fetch at start-up, made the whole NGC/IC catalog silently
+// absent while the provider looked healthy. That is worse than a per-query
+// failure precisely because it is invisible and cannot recover; a later query
+// now tries again.
+func New() *Provider { return &Provider{} }
 
 // Name returns the provider identifier.
 func (p *Provider) Name() string { return "openngc" }
@@ -80,10 +64,17 @@ func (p *Provider) Capabilities() []resolve.Capability {
 }
 
 // SearchBright returns every OpenNGC object brighter than req.MaxVMag,
-// brightest-first — a plain in-memory filter over the catalog already
-// loaded at New() time, since (unlike SIMBAD/SBDB) there's no remote query
-// to make.
-func (p *Provider) SearchBright(_ context.Context, req resolve.BrightRequest) resolve.SeqIterator[resolve.Target] {
+// brightest-first — a plain in-memory filter over the loaded catalog, since
+// (unlike SIMBAD/SBDB) there's no remote query to make. ctx carries the
+// catalog fetch if this is the first query to need it.
+func (p *Provider) SearchBright(ctx context.Context, req resolve.BrightRequest) resolve.SeqIterator[resolve.Target] {
+	if err := p.load(ctx); err != nil {
+		// The iterator is the only channel this signature has, so the failure
+		// goes down it. Yielding nothing instead would report an unreachable
+		// catalog as a sky with no bright objects in it.
+		return func(yield func(resolve.Target, error) bool) { yield(resolve.Target{}, err) }
+	}
+
 	var matches []resolve.Target
 
 	for _, t := range p.targets {
@@ -101,12 +92,14 @@ func (p *Provider) SearchBright(_ context.Context, req resolve.BrightRequest) re
 	return resolve.SliceSeq(matches)
 }
 
-// Resolve performs exact-match resolution for a query. ctx is accepted for
-// resolve.Provider conformance only — resolution runs over the in-memory
-// index built once at New(), with no I/O to cancel.
-func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, error) {
-	if p.initErr != nil {
-		return resolve.Target{}, p.initErr
+// Resolve performs exact-match resolution for a query.
+//
+// ctx is used: the first query to reach a provider fetches the catalog under
+// it. After that the lookup is an in-memory index and there is nothing left to
+// cancel.
+func (p *Provider) Resolve(ctx context.Context, query string) (resolve.Target, error) {
+	if err := p.load(ctx); err != nil {
+		return resolve.Target{}, err
 	}
 
 	q := resolve.Normalize(query)
@@ -117,11 +110,11 @@ func (p *Provider) Resolve(_ context.Context, query string) (resolve.Target, err
 	return resolve.Target{}, fmt.Errorf("%w: %q in OpenNGC", resolve.ErrNotFound, query)
 }
 
-// Search performs fuzzy search across all NGC/IC objects. ctx is accepted
-// for resolve.Provider conformance only — see Resolve.
-func (p *Provider) Search(_ context.Context, query string) ([]resolve.Target, error) {
-	if p.initErr != nil {
-		return nil, p.initErr
+// Search performs fuzzy search across all NGC/IC objects. ctx carries the
+// first query's catalog fetch — see Resolve.
+func (p *Provider) Search(ctx context.Context, query string) ([]resolve.Target, error) {
+	if err := p.load(ctx); err != nil {
+		return nil, err
 	}
 
 	q := resolve.Normalize(query)
@@ -147,4 +140,41 @@ func (p *Provider) Search(_ context.Context, query string) ([]resolve.Target, er
 	}
 
 	return results, nil
+}
+
+// load fetches and indexes the catalog once, under the caller's context.
+//
+// A failure is deliberately not cached: the next query retries. The cost of
+// that is a second attempt against an endpoint that is still down; the cost of
+// caching it is a provider that answers "not found" for ever because of one
+// cancelled context at start-up.
+func (p *Provider) load(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.loaded {
+		return nil
+	}
+
+	targets, err := fetch(ctx)
+	if err != nil {
+		return fmt.Errorf("openngc: catalog unavailable: %w", err)
+	}
+
+	byKey := make(map[string]int, len(targets)*2)
+
+	for i, t := range targets {
+		byKey[resolve.Normalize(t.ID)] = i
+		if t.Name != "" {
+			byKey[resolve.Normalize(t.Name)] = i
+		}
+
+		for _, a := range t.Aliases {
+			byKey[resolve.Normalize(a)] = i
+		}
+	}
+
+	p.targets, p.byKey, p.loaded = targets, byKey, true
+
+	return nil
 }

--- a/catalog/openngc/openngc_test.go
+++ b/catalog/openngc/openngc_test.go
@@ -17,7 +17,9 @@ func newTestProvider() *Provider {
 		{ID: "NGC9999", Name: "Faint Test Object", Kind: resolve.KindNebula, Catalog: "openngc"},
 	}
 
-	p := &Provider{targets: targets, byKey: make(map[string]int)}
+	// loaded: true stands in for a completed load — these tests exercise the
+	// index, not the fetch, and without it every query would try the network.
+	p := &Provider{loaded: true, targets: targets, byKey: make(map[string]int)}
 
 	for i, t := range targets {
 		p.byKey[resolve.Normalize(t.ID)] = i

--- a/docs/changelog.d/197-openngc-lazy-load.md
+++ b/docs/changelog.d/197-openngc-lazy-load.md
@@ -1,0 +1,9 @@
+---
+type: Changed
+pr: 197
+---
+**`openngc.New` no longer fetches the catalog.** It did about 7 MB of I/O under
+`context.Background()`, so `catalog.NewResolver(SIMBAD, OpenNGC)` blocked for two
+seconds against a warm cache with nothing above it able to cancel. The load now
+happens on the first query, under that caller's context, and a failed load is
+retried rather than replayed for the life of the provider.

--- a/docs/changelog.d/197-openngc-searchbright-error.md
+++ b/docs/changelog.d/197-openngc-searchbright-error.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 197
+---
+**`openngc.Provider.SearchBright` reported an unreachable catalog as an empty
+sky.** It was the one query that never consulted the recorded load failure, so a
+denied download or a dead endpoint came back as "no objects brighter than that"
+rather than as an error. It now yields the failure through the iterator.

--- a/time/internal/iers/fetch.go
+++ b/time/internal/iers/fetch.go
@@ -19,7 +19,7 @@ var (
 
 // EnsureLoaded makes a best-effort, at-most-one-attempt-per-cooldown-window
 // attempt to populate the global EOP model before a lookup for mjd —
-// mirroring the openngc.New()/jpl.NewProvider lazy-load contract used
+// mirroring the catalog/openngc first-query lazy-load contract used
 // elsewhere in this codebase. It never logs; callers (time.lookupEOP)
 // decide whether to warn-and-degrade or propagate the returned error.
 //


### PR DESCRIPTION
Closes #191.

`openngc.New` did about 7 MB of network I/O under `context.Background()`. The issue
measured what that costs a caller:

```
NewResolver(SIMBAD, OpenNGC): 1.9701798s
NewResolver(SIMBAD):          0s
Resolve(""):                  0s
```

All of it in construction, and neither `New` nor `catalog.NewResolver` above it takes a
`ctx`, so a request-scoped deadline had no effect on the network call underneath it.

## What changed

`New` performs no I/O. The first query that needs the catalog fetches it under that
caller's context, and the result is kept for the life of the provider. `Resolve`,
`Search` and `SearchBright` already took a `ctx` for interface conformance; they now use
it.

Concurrent first queries make one request between them — the mutex is held across the
fetch rather than around a check.

## A failed load is no longer permanent

This is the part that matters more than the two seconds. The failure used to be recorded
in `initErr` at construction and replayed at every subsequent query for the life of the
process, so a consent gate granted a moment later, or an endpoint that came back, never
took effect: the whole NGC/IC catalog stayed silently absent while the provider looked
healthy.

The issue suggested `sync.Once`, which preserves exactly that property. A plain mutex
retries instead. The cost is a second attempt against an endpoint that is still down; the
cost of the alternative is a provider that answers "not found" forever because of one
cancelled context at start-up.

## `SearchBright` never reported the failure at all

It was the one query that did not consult `initErr`, so an unreachable catalog came back
as a sky containing no bright objects — a failure indistinguishable from a legitimate
negative. It has no error return, so the failure now goes down the iterator, which is the
only channel the signature has.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

Six new tests in `catalog/openngc/lazyload_test.go`. Four mutations, each killed by the
test written for it:

| mutation | killed by |
| :--- | :--- |
| drop the load memo (`if p.loaded` → `if false`) | `TestLoadHappensOnce` |
| yield nothing instead of the error | `TestSearchBrightReportsLoadFailure` |
| set `loaded = true` on a failed fetch | `TestFailedLoadIsRetried` |
| `fetch(context.Background())` instead of `fetch(ctx)` | `TestLoadHonoursContext` |

`TestNewDoesNoIO` asserts construction is pure by running it under `remote.SetOffline(true)` —
a `New` that reached the network could not return there at all.

Two existing fetch tests asserted on cache state immediately after `New()`; they now drive
the load through a query (`TestLoadSkipsBodyWhenUnchanged`,
`TestLoadDoesNotAccumulateCacheFiles`). `newTestProvider` sets `loaded: true`, since those
tests exercise the index rather than the fetch.

CLAUDE.md's "Embedded data" paragraph described `catalog/openngc` as the explicit-fetch
counterexample to `time`'s lazy EOP load; both are now first-query loads, and the
`time/internal/iers` comment that cited `openngc.New()` as its model is updated to match.
