### PR TITLE
time: report the leap second Date cannot represent

### DIFF
--- a/docs/changelog.d/198-leap-second-aliasing-reported.md
+++ b/docs/changelog.d/198-leap-second-aliasing-reported.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 198
+---
+**A leap second passed to `time.Date` was aliased silently.** `23:59:60` has no
+representation in a two-part JD whose day is 86400 seconds long, so it collapsed
+onto the following midnight — one second away, and converted with the wrong ΔAT
+(37 rather than 36). It still does; it now says so through `logging` at WARN,
+distinguishing a real leap second from a second that never existed. See #144 for
+the representation question, which stays open.

--- a/time/doc.go
+++ b/time/doc.go
@@ -130,4 +130,32 @@
 // and it is worth knowing rather than discovering. The window is also
 // shrinking: the most recent leap second was 2016-12-31, none is currently
 // scheduled, and the 2022 CGPM resolution abandons them by 2035.
+//
+// # The second you cannot express
+//
+// [Date] is the escape from a smeared clock, and it has a boundary of its own.
+// A [Time] holds a two-part Julian Date whose day is 86400 seconds long, so
+// there is no room in it for the second UTC labels 23:59:60. Asked for one,
+// [Date] normalises it onto the following midnight:
+//
+//	Date(2016, 12, 31, 23, 59, 60, 0, UTC) == Date(2017, 1, 1, 0, 0, 0, 0, UTC)
+//
+// The inserted second is one second wide in reality and zero seconds wide in
+// this type. That is not only a labelling problem, because ΔAT differs across
+// the boundary — IERS and gofa both give the inserted second the *old* value,
+// 36 rather than 37 — so an aliased instant is converted with the wrong offset
+// and lands a full second away.
+//
+// Twenty-seven such seconds exist in all of history, and none since 2016. What
+// makes them worth a paragraph is not their number but that the loss used to
+// be silent: a plausible epoch, one second wrong, with nothing reported.
+// [Date] now emits a [logging] warning for any second of 60 or more, saying
+// whether the day in question carried a real leap second or whether the
+// timestamp names an instant that never existed at all.
+//
+// If you have data with real 23:59:60 timestamps in it, hold those instants in
+// TAI, which has no leap seconds to label and no ambiguity across the step.
+// SOFA's own answer is different — iauDtf2d lets the UTC day run to 86401
+// seconds — and adopting it here would touch every conversion in this package.
+// That has not been done; see https://github.com/TuSKan/astrogo/issues/144.
 package time

--- a/time/leapsecond_alias.go
+++ b/time/leapsecond_alias.go
@@ -1,0 +1,145 @@
+package time
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/TuSKan/astrogo/internal/gofaext"
+	"github.com/TuSKan/astrogo/logging"
+)
+
+// A leap second is one second wide in reality and zero seconds wide in this
+// type. UTC labels the inserted second 23:59:60, and [Time] holds a two-part
+// Julian Date whose day is 86400 seconds long, so that label has nowhere to
+// land: [Date] normalises it onto the following midnight, where it is
+// indistinguishable from an instant one second later.
+//
+// The consequence is measurable rather than theoretical. IERS and gofa agree
+// that the inserted second carries the *old* ΔAT:
+//
+//	2016-12-31 23:59:59 -> 36
+//	2016-12-31 23:59:60 -> 36     the leap second itself
+//	2017-01-01 00:00:00 -> 37     the step instant
+//
+// An aliased instant therefore gets 37 where the authority says 36 — a full
+// second of error, in the one place a time library is expected to be exact.
+//
+// SOFA does have a representation for this: iauDtf2d lets the UTC day run to
+// 86401 seconds, so 23:59:60 gets a two-part JD of its own. Adopting it is not
+// a local change — every conversion in this package divides by 86400 — so this
+// file does the next thing, which is to make the loss audible. See #144 for
+// the full argument and the options that were weighed.
+
+var warnLeapSecondAliasedOnce sync.Once
+
+// warnLeapSecondAliased reports, once per process, that a calendar instant
+// with second ≥ 60 was normalised away.
+//
+// Once per process rather than per call, matching [warnEOPUnavailable]: a
+// caller iterating a corpus that crosses a leap second would otherwise get one
+// line per row, and the attributes on the first line already name the instant
+// and the size of the error. The condition is a property of the type, not of
+// the particular timestamp, so the second report would add nothing.
+func warnLeapSecondAliased(year int, month time.Month, day, hour, minute, second int, loc *time.Location) {
+	warnLeapSecondAliasedOnce.Do(func() {
+		y, m, d, hh, mm := utcComponents(year, month, day, hour, minute, loc)
+		logLeapSecondAliased(y, int(m), d, hh, mm, second)
+	})
+}
+
+// utcComponents restates a wall-clock instant in UTC.
+//
+// Leap seconds are inserted at the end of a UTC day, so a caller in another
+// zone writes the same instant with a different date and a different hour:
+// classifying on the components as given would report the real 2016-12-31 leap
+// second as a second that never existed. The second is deliberately not passed
+// through the conversion — it is the value under discussion, and handing it to
+// time.Date is exactly what normalises it away.
+//
+// Deep-historical years are returned unchanged, because [Date] ignores loc for
+// them too.
+func utcComponents(year int, month time.Month, day, hour, minute int, loc *time.Location) (int, time.Month, int, int, int) {
+	if loc == nil || loc == time.UTC || year < 1 || year > 9999 {
+		return year, month, day, hour, minute
+	}
+
+	u := time.Date(year, month, day, hour, minute, 0, 0, loc).UTC()
+
+	return u.Year(), u.Month(), u.Day(), u.Hour(), u.Minute()
+}
+
+// logLeapSecondAliased writes the warning, separately from the [sync.Once]
+// that rations it — split out for the same reason as [logEOPUnavailable], so a
+// test can assert on the message and its level without depending on which test
+// happened to spend the Once first.
+func logLeapSecondAliased(y, m, d, hour, minute, second int) {
+	// Warn, not Info, and so still emitted by the default logger. Date has no
+	// error return, and this is the only notice a caller gets that the instant
+	// they asked for is not the instant they received.
+	if second == 60 && leapSecondEndsDay(y, m, d) {
+		logging.Warn("leap second not representable, instant moved to the following midnight",
+			"utc", isoSecond(y, m, d, hour, minute, second),
+			"error", "1 s",
+			"delta_at_applied", deltaAT(nextDay(y, m, d)),
+			// The inserted second carries the ΔAT in force throughout the day
+			// it ends, which is what a mid-day lookup returns. Asked at the
+			// day's own boundary the answer depends on which side gofa rounds
+			// to, and the boundary is the thing under discussion.
+			"delta_at_correct", deltaAT(y, m, d, 0.5),
+			"remedy", "hold instants inside a leap second in TAI; UTC cannot label them")
+
+		return
+	}
+
+	// Second 60 on a day with no leap second, or second > 60 anywhere, is not
+	// a representation limit — it is an instant that never existed. Go's
+	// time.Date rolls it into the next minute, which is documented but silent,
+	// and a wrong-by-a-second epoch looks exactly like a right one.
+	logging.Warn("second out of range, instant normalised into the following minute",
+		"utc", isoSecond(y, m, d, hour, minute, second),
+		"reason", "no leap second was inserted at the end of this UTC day",
+		"remedy", "pass a second in [0,59]; check the source that produced this timestamp")
+}
+
+// leapSecondEndsDay reports whether a leap second is inserted between the end
+// of the UTC day (y, m, d) and the start of the next one — that is, whether
+// 23:59:60 is a real instant on that date.
+//
+// Asked of the same ΔAT lookup every conversion in this package uses, so a
+// caller who registered their own leap-second table (see [RegisterLeapSeconds])
+// is answered from that table rather than from gofa's built-in one.
+//
+// The test is that ΔAT steps by exactly one second, not merely that it rises.
+// Before 1972 UTC tracked UT2 by rate offsets and fractional jumps, so ΔAT
+// there increases across *every* day by a few microseconds; a bare inequality
+// would report 23:59:60 as a real instant on any date in the 1960s, which it
+// never was. A whole second is what makes a leap second one, and it is the
+// same property validateLeapTable enforces on a registered table.
+func leapSecondEndsDay(y, m, d int) bool {
+	return math.Abs(deltaAT(nextDay(y, m, d))-deltaAT(y, m, d, 0.0)-1.0) < 1e-9
+}
+
+// nextDay returns the calendar date following (y, m, d), with a trailing 0.0
+// day fraction so the result feeds [deltaAT] directly.
+//
+// Via the Julian Date rather than by incrementing d, so month lengths, leap
+// years and the proleptic Gregorian calendar are gofa's problem and not this
+// file's — and leap seconds are only ever inserted at the end of a month, so
+// the carry is the case that matters.
+func nextDay(y, m, d int) (int, int, int, float64) {
+	jd1, jd2, _ := gofaext.Dtf2d("UTC", y, m, d, 0, 0, 0)
+
+	ny, nm, nd, _, _ := gofaext.JdToDate(jd1, jd2+1.0)
+
+	return ny, nm, nd, 0.0
+}
+
+// isoSecond formats a calendar instant for the warning's utc attribute. The
+// second is printed verbatim, 60 and above included: which value was rejected
+// is the whole point of the message, so this must not normalise it the way the
+// constructor being reported on just did.
+func isoSecond(y, m, d, hour, minute, second int) string {
+	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ", y, m, d, hour, minute, second)
+}

--- a/time/leapsecond_alias_test.go
+++ b/time/leapsecond_alias_test.go
@@ -1,0 +1,214 @@
+package time
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	stdtime "time"
+
+	"github.com/TuSKan/astrogo/logging"
+)
+
+// TestLeapSecondIsStillAliased pins the defect the warning exists to announce.
+//
+// This is deliberately an assertion that the wrong thing still happens. #144
+// weighs three options; this change takes the cheap two (report it, document
+// it) and leaves the expensive one — letting the UTC day run to 86401 seconds
+// the way iauDtf2d does — undecided. Should someone take it, this test fails,
+// and its failure is the signal to delete the warning rather than to restore
+// the aliasing.
+func TestLeapSecondIsStillAliased(t *testing.T) {
+	leap := Date(2016, 12, 31, 23, 59, 60, 0, stdtime.UTC)
+	next := Date(2017, 1, 1, 0, 0, 0, 0, stdtime.UTC)
+
+	leap1, leap2 := leap.JDParts()
+	next1, next2 := next.JDParts()
+
+	if leap1 != next1 || leap2 != next2 {
+		t.Fatalf("23:59:60 no longer aliases the following midnight: (%.1f, %.15f) vs (%.1f, %.15f)\n"+
+			"  If that is because the leap second is now representable, #144 is fixed:\n"+
+			"  delete the warning in leapsecond_alias.go along with this test.",
+			leap1, leap2, next1, next2)
+	}
+}
+
+// TestDateReportsTheAliasing is the wiring: everything else here exercises
+// logLeapSecondAliased directly, so without this a Date that never called it
+// would still pass the whole file.
+//
+// The sync.Once is reset rather than worked around, because the property under
+// test is "the first Date to alias a leap second reports it" and any test
+// running earlier would otherwise have spent it. Not parallel, for that reason
+// and because it swaps the process-wide logger.
+func TestDateReportsTheAliasing(t *testing.T) {
+	defer logging.Set(nil)
+
+	warnLeapSecondAliasedOnce = sync.Once{}
+	defer func() { warnLeapSecondAliasedOnce = sync.Once{} }()
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	Date(2016, 12, 31, 23, 59, 60, 0, stdtime.UTC)
+
+	if !strings.Contains(buf.String(), "leap second not representable") {
+		t.Errorf("Date aliased a leap second without reporting it; logger saw:\n%q", buf.String())
+	}
+
+	// An ordinary second must stay quiet, or the warning becomes noise a
+	// caller learns to filter out.
+	buf.Reset()
+
+	warnLeapSecondAliasedOnce = sync.Once{}
+
+	Date(2016, 12, 31, 23, 59, 59, 0, stdtime.UTC)
+
+	if buf.String() != "" {
+		t.Errorf("Date warned about an ordinary second:\n%q", buf.String())
+	}
+}
+
+// TestLeapSecondAliasWarningIsAWarningNotProgress: Date has no error return,
+// so this message is the only notice a caller gets that the instant they built
+// is one second away from the instant they asked for. Demoted to Info it would
+// vanish under the default logger and the loss would be silent again — which
+// #144 names as the worst property of the current behaviour.
+func TestLeapSecondAliasWarningIsAWarningNotProgress(t *testing.T) {
+	// Not parallel: it swaps the process-wide logger.
+	defer logging.Set(nil)
+
+	var buf bytes.Buffer
+
+	// Info-and-above, so a demotion to Info is caught by the level assertion
+	// below rather than by an empty buffer.
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+
+	// Called directly rather than through warnLeapSecondAliased, whose
+	// sync.Once would be spent by whichever test ran first.
+	logLeapSecondAliased(2016, 12, 31, 23, 59, 60)
+
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("the leap-second warning wrote nothing to the installed logger")
+	}
+
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("the leap-second message is not at WARN:\n%s\n"+
+			"  The default logger drops everything below WARN, so demoting this "+
+			"would make the aliasing silent again.", out)
+	}
+
+	for _, want := range []string{
+		`msg="leap second not representable, instant moved to the following midnight"`,
+		"utc=2016-12-31T23:59:60Z",
+		"delta_at_applied=37",
+		"delta_at_correct=36",
+		"remedy=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the message does not carry %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestSecondSixtyOnAnOrdinaryDayIsNotCalledALeapSecond: 2016-06-30 has no leap
+// second at its end, so 23:59:60 there is not an instant this type cannot hold
+// — it is an instant that never happened. Reporting the two the same way would
+// tell a caller their timestamp is a known limitation of the library when in
+// fact their data is wrong.
+func TestSecondSixtyOnAnOrdinaryDayIsNotCalledALeapSecond(t *testing.T) {
+	defer logging.Set(nil)
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+
+	logLeapSecondAliased(2016, 6, 30, 23, 59, 60)
+
+	out := buf.String()
+
+	if !strings.Contains(out, "second out of range") {
+		t.Errorf("23:59:60 on a day with no leap second was reported as a leap second:\n%s", out)
+	}
+
+	if strings.Contains(out, "delta_at_applied") {
+		t.Errorf("a non-existent second was given a ΔAT comparison, which implies it is real:\n%s", out)
+	}
+}
+
+// TestLeapSecondEndsDay checks the classifier against the published record
+// directly, since everything above depends on it telling the two cases apart.
+func TestLeapSecondEndsDay(t *testing.T) {
+	tests := []struct {
+		y, m, d int
+		want    bool
+		why     string
+	}{
+		{2016, 12, 31, true, "the most recent leap second"},
+		{2015, 6, 30, true, "a mid-year insertion"},
+		{2012, 6, 30, true, "a mid-year insertion"},
+		{2016, 6, 30, false, "June 2016 carried no leap second"},
+		{2016, 12, 30, false, "the day before the insertion, not the insertion"},
+		{2017, 1, 1, false, "the day after the step"},
+		{2020, 12, 31, false, "a year-end with no insertion"},
+		{1960, 12, 31, false, "before leap seconds existed at all"},
+	}
+
+	for _, tt := range tests {
+		if got := leapSecondEndsDay(tt.y, tt.m, tt.d); got != tt.want {
+			t.Errorf("leapSecondEndsDay(%d-%02d-%02d) = %v, want %v (%s)",
+				tt.y, tt.m, tt.d, got, tt.want, tt.why)
+		}
+	}
+}
+
+// TestNextDayCarries covers the case leapSecondEndsDay actually needs: leap
+// seconds are only ever inserted at the end of a month, so every real call
+// crosses a month boundary and most cross a year boundary too.
+func TestNextDayCarries(t *testing.T) {
+	tests := []struct {
+		y, m, d    int
+		wy, wm, wd int
+	}{
+		{2016, 12, 31, 2017, 1, 1},
+		{2015, 6, 30, 2015, 7, 1},
+		{2016, 2, 29, 2016, 3, 1}, // leap year
+		{1900, 2, 28, 1900, 3, 1}, // not a leap year in the Gregorian calendar
+		{2000, 2, 29, 2000, 3, 1}, // but 2000 is
+	}
+
+	for _, tt := range tests {
+		y, m, d, fd := nextDay(tt.y, tt.m, tt.d)
+		if y != tt.wy || m != tt.wm || d != tt.wd || fd != 0.0 {
+			t.Errorf("nextDay(%d-%02d-%02d) = %d-%02d-%02d+%v, want %d-%02d-%02d+0",
+				tt.y, tt.m, tt.d, y, m, d, fd, tt.wy, tt.wm, tt.wd)
+		}
+	}
+}
+
+// TestAliasWarningReportsTheUTCDate: a caller in a non-UTC zone writes the
+// 2016-12-31 leap second as a local time on a different date, and classifying
+// on the components as given would call the real leap second non-existent.
+func TestAliasWarningReportsTheUTCDate(t *testing.T) {
+	// UTC+13: 2016-12-31 23:59:60 UTC is 2017-01-01 12:59:60 there.
+	east := stdtime.FixedZone("UTC+13", 13*3600)
+
+	y, m, d, hh, mm := utcComponents(2017, stdtime.January, 1, 12, 59, east)
+
+	if y != 2016 || m != stdtime.December || d != 31 || hh != 23 || mm != 59 {
+		t.Fatalf("utcComponents(2017-01-01 12:59 UTC+13) = %d-%02d-%02d %02d:%02d, want 2016-12-31 23:59",
+			y, m, d, hh, mm)
+	}
+
+	if !leapSecondEndsDay(y, int(m), d) {
+		t.Error("the 2016-12-31 leap second was not recognised through a non-UTC zone")
+	}
+}

--- a/time/time.go
+++ b/time/time.go
@@ -673,7 +673,17 @@ func (t Time) AddDays(d float64) Time {
 // proleptic Gregorian calendar including negative (astronomical) years.
 // Year 0 = 1 BC, year -1 = 2 BC, etc.
 // The timezone location is preserved for display purposes.
+//
+// A second of 60 — the label UTC gives an inserted leap second — cannot be
+// represented and is normalised onto the following midnight, one second later
+// than the instant asked for. That is reported through [logging] rather than
+// returned, since this constructor has no error to return; see
+// leapsecond_alias.go for why the type cannot hold it.
 func Date(year int, month time.Month, day, hour, minute, second, nanosecond int, loc *time.Location) Time {
+	if second >= 60 {
+		warnLeapSecondAliased(year, month, day, hour, minute, second, loc)
+	}
+
 	// For years within Go's time.Time range, delegate to FromGo which
 	// handles timezone offsets exactly.
 	if year >= 1 && year <= 9999 {


### PR DESCRIPTION
Refs #144 — deliberately not `Closes`. See "What this does not do" below.

`Date(2016, 12, 31, 23, 59, 60, 0, UTC)` returns exactly the same instant as
`Date(2017, 1, 1, 0, 0, 0, 0, UTC)`:

```
23:59:59  jd1=2457754.0 jd2=0.499988425926
23:59:60  jd1=2457754.0 jd2=0.500000000000   <- identical
00:00:00  jd1=2457754.0 jd2=0.500000000000
```

The inserted second is one second wide in reality and zero seconds wide in a two-part JD
whose day is 86400 seconds long. And it is not only a labelling problem: IERS and gofa both
give the inserted second the *old* ΔAT — 36, not 37 — so an aliased instant is converted
with an offset a full second wrong.

## What this does

The issue's worst finding is that the loss is **silent**: a plausible epoch, one second
wrong, with nothing reported. `Date` now emits a `logging` warning for any second of 60 or
more.

```
level=WARN msg="leap second not representable, instant moved to the following midnight"
  utc=2016-12-31T23:59:60Z error="1 s" delta_at_applied=37 delta_at_correct=36
  remedy="hold instants inside a leap second in TAI; UTC cannot label them"
```

This follows the EOP-unavailable warning exactly, which exists for the same reason — a
constructor with no error return, degrading accuracy by a known amount. WARN so the default
logger still passes it; once per process so a corpus crossing a leap second does not produce
one line per row; split from its `sync.Once` so the message and its level can be tested
without depending on which test ran first.

The message distinguishes two cases a caller must not confuse:

- **23:59:60 on a day that really carried a leap second** is a limit of this type, and the
  warning names the ΔAT actually applied against the one the authority gives.
- **23:59:60 anywhere else** is an instant that never existed. Telling the caller it is a
  known library limitation would send them to the wrong place; the warning says to check
  whatever produced the timestamp.

`time/doc.go` gains a "The second you cannot express" section, placed directly after the
leap-smearing section it qualifies — that section recommends `Date` as the escape from a
smeared clock, so `Date`'s own boundary belongs next to it.

## What this does not do

The issue lists three options and says (3) "is a real project and should not be started
without deciding it is wanted". It is right. SOFA's `iauDtf2d` lets the UTC day run to 86401
seconds, which is the correct representation, and adopting it touches every conversion in
this package — all of which divide by 86400. **#144 stays open for that decision.**

`TestLeapSecondIsStillAliased` asserts the aliasing still happens, and says in its own
failure message that if it ever fails because the leap second became representable, the
right response is to delete the warning rather than restore the aliasing.

## One thing found along the way

The classifier tests for a **whole-second** step in ΔAT, not merely for ΔAT rising. Before
1972, UTC tracked UT2 by rate offsets and fractional jumps, so ΔAT increases across *every*
day of the 1960s by a few microseconds — a bare inequality reported 23:59:60 as a real
instant on any date in that era. Caught by `TestLeapSecondEndsDay`'s 1960-12-31 row, and
then again by the mutation that put the bug back.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

Five mutations, each killed by the test written for it:

| mutation | killed by |
| :--- | :--- |
| `Date` never calls the warner | `TestDateReportsTheAliasing` |
| classifier always returns true | `TestLeapSecondEndsDay` |
| classifier is a bare `>` inequality | `TestLeapSecondEndsDay` (1960-12-31) |
| `utcComponents` ignores the caller's zone | `TestAliasWarningReportsTheUTCDate` |
| `nextDay` does not advance | `TestNextDayCarries` |
