### PR TITLE
fits: bound the cards ReadHeader keeps, not just the blocks it reads

### DIFF
--- a/docs/changelog.d/199-bound-header-cards.md
+++ b/docs/changelog.d/199-bound-header-cards.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 199
+---
+**`fits.ReadHeader` allocated about five times the file it was reading.** Its
+failsafe bounded blocks read, not cards retained, so 10,000 blocks of distinct
+keywords was 360,000 retained cards — measured at 144.1 MB from a 28.8 MB input.
+A second bound on retained cards holds it at 8.5 MB and, more to the point, flat
+as the input grows.

--- a/fits/errors.go
+++ b/fits/errors.go
@@ -16,8 +16,10 @@ var (
 	// ErrDatasumMismatch indicates a DATASUM verification failure.
 	ErrDatasumMismatch = errors.New("fits: DATASUM mismatch")
 
-	// ErrNoEndCard indicates the header exceeded maximum blocks without an END card.
-	ErrNoEndCard = errors.New("fits: header exceeded max blocks without END card")
+	// ErrNoEndCard indicates the header ran past one of ReadHeader's two
+	// failsafes without an END card — too many blocks read, or too many cards
+	// retained. The wrapped message says which.
+	ErrNoEndCard = errors.New("fits: header exceeded its size limit without an END card")
 	// ErrInvalidBitpix indicates an unsupported BITPIX value.
 	ErrInvalidBitpix = errors.New("fits: invalid BITPIX value")
 	// ErrEmptyHeader indicates a FITS file with an empty header.

--- a/fits/fits.go
+++ b/fits/fits.go
@@ -199,18 +199,50 @@ func payloadSize(h *Header) int64 {
 	return bytes
 }
 
-// ReadHeader reads a FITS header from a block reader.
-// It reads up to 10000 blocks (28MB) to find the END card.
-// This is a safety measure to prevent infinite loops in case of corrupted files.
+// Two failsafes bound [ReadHeader] against a file with no END card, or with an
+// END card an absurd distance in.
+//
+// They count different things on purpose. maxHeaderBlocks bounds what is read
+// and thrown away — blank padding is skipped, so a stream of it costs one
+// 2880-byte buffer no matter how long it runs. maxHeaderCards bounds what is
+// kept, and that is the quantity that actually grows: every non-blank card is
+// retained as three strings plus an entry in the header's keyword map.
+//
+// Bounding only the blocks, which is what this did, bounds the cheap thing.
+// 10,000 blocks is 360,000 cards, and 360,000 distinct cards — which is what
+// random or hostile bytes look like — was measured at 144 MB resident from a
+// 28.8 MB input, a fivefold amplification on a file astrogo did not produce.
+// See #185.
+const (
+	// maxHeaderBlocks caps the header at 28.8 MB of input.
+	maxHeaderBlocks = 10000
+
+	// maxHeaderCards caps the header at 20,000 retained cards, which is about
+	// 7 MB and 556 blocks of input.
+	//
+	// The number is a policy choice, so here is where it comes from: a
+	// conforming primary header is a few dozen cards, and the largest thing a
+	// real pipeline produces is a long HISTORY block, which this clears by
+	// orders of magnitude. It is eighteen times below the ceiling the block
+	// limit implies. If a legitimate file ever trips it, this constant is the
+	// thing to raise — the cost is linear and about 320 bytes a card.
+	maxHeaderCards = 20000
+)
+
+// ReadHeader reads a FITS header from a block reader, up to the END card.
+//
+// A header that reaches neither an END card nor the end of the stream within
+// [maxHeaderBlocks] of input or [maxHeaderCards] of retained cards fails with
+// [ErrNoEndCard], naming which of the two it exceeded. Both exist because this
+// is the one package in astrogo that opens a file astrogo did not write.
 func ReadHeader(br *BlockReader) (*Header, error) {
 	h := NewHeader()
 	buf := make([]byte, BlockSize)
-	maxBlocks := 10000 // 28MB max header size failsafe
 	blocksRead := 0
 
 	for {
-		if blocksRead > maxBlocks {
-			return nil, fmt.Errorf("%w: exceeded %d blocks", ErrNoEndCard, maxBlocks)
+		if blocksRead > maxHeaderBlocks {
+			return nil, fmt.Errorf("%w: exceeded %d blocks", ErrNoEndCard, maxHeaderBlocks)
 		}
 
 		err := br.ReadBlock(buf)
@@ -230,6 +262,12 @@ func ReadHeader(br *BlockReader) (*Header, error) {
 
 			// Exclude completely blank cards
 			if len(c.Keyword) > 0 || len(c.Value) > 0 || len(c.Comment) > 0 {
+				// Checked before the append rather than after, so the limit is
+				// the number of cards that can be held and not one more.
+				if len(h.Cards) >= maxHeaderCards {
+					return nil, fmt.Errorf("%w: exceeded %d cards", ErrNoEndCard, maxHeaderCards)
+				}
+
 				h.Append(c)
 			}
 		}

--- a/fits/readheader_limits_test.go
+++ b/fits/readheader_limits_test.go
@@ -133,3 +133,31 @@ func TestReadHeaderAllocationDoesNotScaleWithInput(t *testing.T) {
 		t.Errorf("ReadHeader allocated %.1f MB for a 28.8 MB hostile header; the card limit should hold it near 8 MB", large)
 	}
 }
+
+// blankStream is an endless source of blank cards — the corrupt file the block
+// failsafe exists for, where nothing is ever retained and nothing ever says
+// END. A generator rather than 28.8 MB of materialised spaces, since the point
+// is that the stream has no end for ReadHeader to reach.
+type blankStream struct{}
+
+func (blankStream) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = ' '
+	}
+
+	return len(p), nil
+}
+
+// TestBlockFailsafeStopsAnEndlessStream is the other failsafe, and the case
+// the card limit cannot cover: blank cards are skipped, so this stream retains
+// nothing and would otherwise be read for ever.
+func TestBlockFailsafeStopsAnEndlessStream(t *testing.T) {
+	_, err := ReadHeader(NewBlockReader(blankStream{}))
+	if !errors.Is(err, ErrNoEndCard) {
+		t.Fatalf("err = %v, want ErrNoEndCard", err)
+	}
+
+	if !strings.Contains(err.Error(), "blocks") {
+		t.Errorf("an endless blank stream should trip the block failsafe, not the card one: %v", err)
+	}
+}

--- a/fits/readheader_limits_test.go
+++ b/fits/readheader_limits_test.go
@@ -1,0 +1,135 @@
+package fits
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// distinctCards builds n well-formed cards with distinct keywords, padded to a
+// whole number of blocks. Distinct keywords are the point: they are what random
+// or hostile bytes look like to ParseCard, and what makes every card retained
+// rather than skipped.
+func distinctCards(t *testing.T, n int, trailer string) []byte {
+	t.Helper()
+
+	var b strings.Builder
+
+	for i := range n {
+		card := fmt.Sprintf("K%07d= %20d / filler", i, i)
+		b.WriteString(card + strings.Repeat(" ", CardSize-len(card)))
+	}
+
+	b.WriteString(trailer + strings.Repeat(" ", CardSize-len(trailer)))
+
+	out := b.String()
+	if pad := len(out) % BlockSize; pad != 0 {
+		out += strings.Repeat(" ", BlockSize-pad)
+	}
+
+	return []byte(out)
+}
+
+// TestReadHeaderAcceptsTheCardLimit: the limit is a ceiling, not a target. A
+// header holding exactly maxHeaderCards must still parse, or the constant means
+// one less than it says.
+func TestReadHeaderAcceptsTheCardLimit(t *testing.T) {
+	data := distinctCards(t, maxHeaderCards, "END")
+
+	h, err := ReadHeader(NewBlockReader(bytes.NewReader(data)))
+	if err != nil {
+		t.Fatalf("a header of exactly %d cards was rejected: %v", maxHeaderCards, err)
+	}
+
+	if len(h.Cards) != maxHeaderCards {
+		t.Errorf("kept %d cards, want %d", len(h.Cards), maxHeaderCards)
+	}
+}
+
+// TestReadHeaderRejectsOneCardTooMany is the other side of the boundary.
+func TestReadHeaderRejectsOneCardTooMany(t *testing.T) {
+	data := distinctCards(t, maxHeaderCards+1, "END")
+
+	_, err := ReadHeader(NewBlockReader(bytes.NewReader(data)))
+	if !errors.Is(err, ErrNoEndCard) {
+		t.Fatalf("err = %v, want ErrNoEndCard", err)
+	}
+
+	// The message has to name the limit that tripped, since the two failsafes
+	// mean different things: too many cards is a hostile or corrupt file, too
+	// many blocks is one with no END at all.
+	if !strings.Contains(err.Error(), "cards") {
+		t.Errorf("the error does not say which failsafe tripped: %v", err)
+	}
+}
+
+// TestBlankPaddingDoesNotCountAsCards keeps the two failsafes honest about
+// counting different things. Blank cards are skipped rather than retained, so a
+// long run of padding must be bounded by the block limit and not by the card
+// limit — a header legitimately padded to a block boundary is ordinary, and
+// charging it against the card budget would reject valid files.
+func TestBlankPaddingDoesNotCountAsCards(t *testing.T) {
+	// Far more blank cards than maxHeaderCards, then a real header.
+	blanks := (maxHeaderCards + 1000) * CardSize
+
+	var b strings.Builder
+
+	b.WriteString(strings.Repeat(" ", blanks))
+	b.WriteString("END" + strings.Repeat(" ", CardSize-3))
+
+	out := b.String()
+	if pad := len(out) % BlockSize; pad != 0 {
+		out += strings.Repeat(" ", BlockSize-pad)
+	}
+
+	h, err := ReadHeader(NewBlockReader(bytes.NewReader([]byte(out))))
+	if err != nil {
+		t.Fatalf("blank padding was charged against the card limit: %v", err)
+	}
+
+	if len(h.Cards) != 0 {
+		t.Errorf("kept %d cards from blank padding, want 0", len(h.Cards))
+	}
+}
+
+// TestReadHeaderAllocationDoesNotScaleWithInput is the property #185 is
+// actually about. Before the card bound, feeding ten times the input allocated
+// ten times the memory — 144 MB from a 28.8 MB file. The card limit is reached
+// at 556 blocks, so past that point the cost is flat and the caller's file size
+// stops choosing astrogo's memory use.
+func TestReadHeaderAllocationDoesNotScaleWithInput(t *testing.T) {
+	alloc := func(blocks int) float64 {
+		data := distinctCards(t, blocks*(BlockSize/CardSize), "END")
+
+		var m0, m1 runtime.MemStats
+
+		runtime.GC()
+		runtime.ReadMemStats(&m0)
+
+		_, _ = ReadHeader(NewBlockReader(bytes.NewReader(data)))
+
+		runtime.ReadMemStats(&m1)
+
+		return float64(m1.TotalAlloc-m0.TotalAlloc) / 1e6
+	}
+
+	small := alloc(1000)  // 2.9 MB of input
+	large := alloc(10000) // 28.8 MB of input
+
+	// Ten times the input, and the generous factor is for the read buffer and
+	// the cards up to the limit — not for a tenfold rise. Measured on the
+	// unbounded version: 14.9 MB and 144.1 MB, a ratio of 9.7.
+	if large > 2*small {
+		t.Errorf("allocation still scales with input: %.1f MB for 1000 blocks, %.1f MB for 10000 (ratio %.1f)",
+			small, large, large/small)
+	}
+
+	// An absolute bound too, so a future change that made both large would
+	// still be caught by something.
+	if large > 32 {
+		t.Errorf("ReadHeader allocated %.1f MB for a 28.8 MB hostile header; the card limit should hold it near 8 MB", large)
+	}
+}


### PR DESCRIPTION
Closes #185.

`ReadHeader`'s failsafe counted blocks. Blocks are the cheap thing — blank padding is
skipped, so a stream of it costs one 2880-byte buffer however long it runs. Cards are the
expensive thing, and 10,000 blocks is 360,000 of them, each retained as three strings plus
an entry in the header's keyword map.

Measured here, feeding well-formed cards with distinct keywords (what random or hostile
bytes look like to `ParseCard`):

| blocks | input | allocated before | allocated after |
| ---: | ---: | ---: | ---: |
| 1,000 | 2.9 MB | 14.9 MB | 8.5 MB |
| 10,000 | 28.8 MB | **144.1 MB** | **8.5 MB** |

Five times the file, and the multiplier was chosen by whoever wrote the file. `fits` is the
one package in astrogo that opens something astrogo did not produce.

## The fix

A second failsafe bounds retained cards at 20,000. The number that matters is not 8.5 vs
144 — it is that the second column is now **flat**: the card limit is reached at 556 blocks,
so past that the caller's file size stops choosing astrogo's memory use.

20,000 is a policy choice and the constant says so, along with where it comes from: a
conforming primary header is a few dozen cards, the largest thing a real pipeline writes is
a long HISTORY block, and this clears both by orders of magnitude while sitting eighteen
times below the ceiling the block limit implied. If a legitimate file ever trips it, that
constant is the thing to raise — the cost is linear, about 320 bytes a card.

The check sits **inside** the non-blank branch on purpose. Padding a header to a block
boundary is ordinary and correct, so it is charged against the block budget and not the card
budget; `TestBlankPaddingDoesNotCountAsCards` is what holds that.

`ErrNoEndCard` covers both bounds rather than gaining a sibling — both mean "reject this
file" and the distinction is not actionable. Its message no longer claims blocks were the
only limit, and the wrapped text names whichever tripped.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

Four mutations, each killed by the test written for it:

| mutation | killed by |
| :--- | :--- |
| no card limit at all | `TestReadHeaderAllocationDoesNotScaleWithInput` |
| limit checked with `>` (rejects exactly-the-limit) | `TestReadHeaderAcceptsTheCardLimit` |
| ...and accepts one over | `TestReadHeaderRejectsOneCardTooMany` |
| count every card slot, not the retained ones | `TestBlankPaddingDoesNotCountAsCards` |

## One thing deliberately not changed

CLAUDE.md's fuzzing section attributes `fits.Read`'s low throughput ("~4 exec/s") to this
amplification. I tried to re-measure it and could not do so honestly: `go test -fuzz`
accumulates a corpus in the build cache across runs, so consecutive runs are not comparable
— my before/after numbers moved in the wrong direction purely because the corpus had grown.
Attributing a throughput change without controlling the corpus would be guesswork, so the
CLAUDE.md figures are left alone. Filed separately as a note to re-measure them properly.
