### PR TITLE
plan: derive SatellitePasses' Contexts instead of rebuilding them

### DIFF
--- a/docs/changelog.d/201-satellite-passes-context-reuse.md
+++ b/docs/changelog.d/201-satellite-passes-context-reuse.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 201
+---
+**`plan.SatellitePasses` is about twice as fast** — 201 ms to 96 ms over a
+six-hour window at 30 s sampling. It rebuilt a full `coord.Context` per sample,
+which was 61% of each one; it now derives them with `Context.AtTime` from a base
+rebuilt hourly, costing ≲0.1″ against SGP4's own kilometre-scale error.

--- a/plan/contextcache.go
+++ b/plan/contextcache.go
@@ -1,0 +1,51 @@
+package plan
+
+import (
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// ctxRefresh is how far a derived [coord.Context] may sit from the
+// [coord.NewContext] it was derived from before that base is rebuilt.
+//
+// [coord.Context.AtTime] holds precession-nutation and aberration fixed, which
+// costs ≲0.1″ per hour of separation from the base epoch — dominated by
+// nutation's ~13.66-day term, with precession and the reused DUT1/polar-motion
+// an order of magnitude smaller. One hour therefore bounds the error at ≲0.1″,
+// which at the horizon's steepest crossing rate is under 0.01 s of rise/set
+// bias: a hundredfold margin against the 1 s tolerance the solvers refine to,
+// and against the minute-level USNO/NASA references this package is checked
+// against.
+//
+// What it buys is the ~91 µs Apco13 rebuild, once an hour instead of once per
+// sample and once per bisection iteration.
+const ctxRefresh = 1 * time.Hour
+
+// newContextCache returns a function handing out a [coord.Context] for any
+// instant, rebuilding the expensive base only when t has drifted more than
+// [ctxRefresh] from the last rebuild and deriving every other call with
+// [coord.Context.AtTime].
+//
+// A closure over one base rather than a keyed cache: callers here sweep a
+// window in order and then refine crossings inside it, so the useful hit rate
+// comes from locality alone, and nothing has to decide when an entry expires.
+// The drift test is absolute, so a solver stepping backwards inside a bracket
+// is served the same way a forward sample is.
+//
+// One cache per atmosphere. A Context carries the refraction inputs it was
+// built with, so deriving a refracted look angle from a geometric base would
+// silently answer with the wrong atmosphere — which is why solveVisibility
+// keeps separate caches for its geometric rise/set search and its refracted
+// hour-angle search rather than sharing one.
+func newContextCache(site *coord.Geodetic, atm atmosphere.Refraction) func(time.Time) *coord.Context {
+	var base *coord.Context
+
+	return func(t time.Time) *coord.Context {
+		if base == nil || t.Sub(base.Time()).Abs() > ctxRefresh {
+			base = coord.NewContext(t, site, atm)
+		}
+
+		return base.AtTime(t)
+	}
+}

--- a/plan/contextcache_test.go
+++ b/plan/contextcache_test.go
@@ -1,0 +1,235 @@
+package plan
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// testISS builds the provider and site the context-reuse tests share — the
+// same real ISS TLE and Paranal site the benchmarks use, so nothing here
+// touches the network.
+func testISS(t *testing.T) (*satellite.Satellite, *coord.Geodetic) {
+	t.Helper()
+
+	sat, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	if err != nil {
+		t.Fatalf("NewFromTLE: %v", err)
+	}
+
+	site, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	return sat, site
+}
+
+// TestContextCacheStaysInsideItsStatedBound measures what the reuse actually
+// costs, rather than trusting AtTime's ≲0.1″/hour on its own.
+//
+// Every 30-second sample across six hours is computed twice — once from the
+// cache, once from a full coord.NewContext — and compared as an angular
+// separation. The bound is what the cache's own doc comment claims for one
+// hour of drift; if a change to AtTime or to ctxRefresh made the reuse worse,
+// this is the test that has to be argued with.
+func TestContextCacheStaysInsideItsStatedBound(t *testing.T) {
+	sat, site := testISS(t)
+
+	start := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+	ctxAt := newContextCache(site, defaultAtm)
+
+	var (
+		worst   float64
+		worstAt time.Time
+		n       int
+	)
+
+	for i := range 6 * 60 * 2 { // six hours at 30 s
+		at := start.Add(time.Duration(i) * 30 * time.Second)
+
+		cached, err := LookAngle(sat, 0, ctxAt(at))
+		if err != nil {
+			continue // below the horizon geometry the provider rejects; not this test's subject
+		}
+
+		exact, err := LookAngle(sat, 0, coord.NewContext(at, site, defaultAtm))
+		if err != nil {
+			continue
+		}
+
+		n++
+
+		// coord.ICRS carries the pair here purely as a direction on a
+		// sphere: Separation is the angle between two unit vectors and does
+		// not care which frame labelled them.
+		sep := coord.Separation(
+			coord.NewICRS(cached.Az(), cached.Alt()),
+			coord.NewICRS(exact.Az(), exact.Alt()),
+		).Arcsec()
+
+		if math.Abs(sep) > worst {
+			worst, worstAt = math.Abs(sep), at
+		}
+	}
+
+	if n == 0 {
+		t.Fatal("no samples compared; the fixture produced no look angles")
+	}
+
+	t.Logf("compared %d samples, worst separation %.4f arcsec at %v", n, worst, worstAt)
+
+	// 0.1″ is the per-hour figure AtTime documents, and ctxRefresh holds the
+	// drift to one hour. Asserted at the documented bound rather than at the
+	// measured worst case, so the test cannot silently ratify a regression it
+	// merely happens to permit.
+	const boundArcsec = 0.1
+
+	if worst > boundArcsec {
+		t.Errorf("context reuse cost %.4f arcsec at %v, over the %.2f arcsec ctxRefresh is chosen to hold",
+			worst, worstAt, boundArcsec)
+	}
+}
+
+// TestSatellitePassEventsSurviveAFullRebuild is the end-to-end half: the pass
+// times SatellitePasses reports are re-evaluated against a freshly built
+// Context, and each rise and set must still sit on the elevation threshold it
+// was solved for.
+//
+// This is the property the reuse could actually break. A drifting Context
+// would move the crossing, and the reported time would then be a time at which
+// the satellite is not in fact at the minimum elevation.
+func TestSatellitePassEventsSurviveAFullRebuild(t *testing.T) {
+	sat, site := testISS(t)
+
+	start := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+	end := start.Add(6 * time.Hour)
+	minEl := angle.Deg(10)
+
+	passes, err := SatellitePasses(sat, "ISS", start, end, site, minEl)
+	if err != nil {
+		t.Fatalf("SatellitePasses: %v", err)
+	}
+
+	if len(passes) == 0 {
+		t.Fatal("no passes found; the fixture cannot exercise anything")
+	}
+
+	// The solver refines crossings to 1 s. The ISS crosses 10° at roughly
+	// 0.4°/s, so a residual of a few tenths of a degree is the refinement's
+	// own tolerance rather than context drift — and a residual from drift
+	// would be four orders of magnitude smaller than that. This catches a
+	// reuse window opened wide enough to move a crossing perceptibly.
+	const residualDeg = 0.5
+
+	for _, p := range passes {
+		for _, ev := range []struct {
+			what string
+			at   time.Time
+		}{{"rise", p.Rise.Time}, {"set", p.Set.Time}} {
+			got, err := LookAngle(sat, 0, coord.NewContext(ev.at, site, defaultAtm))
+			if err != nil {
+				t.Errorf("%s at %v: LookAngle: %v", ev.what, ev.at, err)
+				continue
+			}
+
+			off := got.Alt().Degrees() - minEl.Degrees()
+			if math.Abs(off) > residualDeg {
+				t.Errorf("%s reported at %v, but a full rebuild puts the ISS at %.4f° — %.4f° off the %.1f° threshold",
+					ev.what, ev.at, got.Alt().Degrees(), off, minEl.Degrees())
+			}
+		}
+	}
+}
+
+// TestContextCacheRebuildsPastItsWindow: the whole safety argument rests on
+// the base being rebuilt once the drift would exceed ctxRefresh. Nothing about
+// a returned Context says which base it came from, so the check is
+// differential — the same instant is asked of the cache and of a deliberately
+// stale base, and the two must disagree by about the drift AtTime documents.
+//
+// Without this, a cache that never rebuilt would pass every other test here:
+// six hours of ISS look angles stay inside 0.1" anyway, because the
+// geocentric-to-observed path rebuilds its rotation matrix exactly and only
+// the ASTROM precession-nutation goes stale. A fixed star is what exposes it.
+func TestContextCacheRebuildsPastItsWindow(t *testing.T) {
+	_, site := testISS(t)
+
+	start := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+	past := start.Add(ctxRefresh + time.Minute)
+
+	ctxAt := newContextCache(site, defaultAtm)
+
+	base := ctxAt(start)
+	rebuilt := ctxAt(past)
+	stale := base.AtTime(past)
+
+	// The Crab, as an ordinary catalogue position; any fixed direction does.
+	fixed := coord.NewAstrometric(angle.Deg(83.633), angle.Deg(22.014))
+
+	fresh := rebuilt.AstrometricToApparent(fixed)
+	drifted := stale.AstrometricToApparent(fixed)
+
+	sep := coord.Separation(
+		coord.NewICRS(fresh.RA(), fresh.Dec()),
+		coord.NewICRS(drifted.RA(), drifted.Dec()),
+	).Arcsec()
+
+	t.Logf("rebuilt vs stale derivation at ctxRefresh+1m: %.4f arcsec", sep)
+
+	// An order of magnitude below the ~0.1"/hour AtTime documents, so the
+	// assertion is that a rebuild happened at all rather than that it produced
+	// any particular number.
+	if sep < 0.01 {
+		t.Errorf("a Context past the reuse window agrees with the stale base to %.4f arcsec; "+
+			"it was derived rather than rebuilt", sep)
+	}
+}
+
+// TestContextCacheHandlesBackwardsSteps: the drift test is |t − base|, not
+// t − base, and this is the caller that needs it.
+//
+// SatellitePasses samples the whole window forward and only then refines its
+// crossings, so the first refinement asks for an instant hours *behind* the
+// base the sweep left behind. A signed comparison never trips on that and
+// serves a stale derivation instead — silently, since the answer is still
+// plausible. Found by mutation: dropping the .Abs() passes every other test
+// in this file.
+func TestContextCacheHandlesBackwardsSteps(t *testing.T) {
+	_, site := testISS(t)
+
+	start := time.Date(2026, time.April, 20, 0, 0, 0, 0, time.LocationUTC)
+	ctxAt := newContextCache(site, defaultAtm)
+
+	// Sweep forward far enough to move the base several windows on, the way a
+	// six-hour sample loop does.
+	for h := range 6 {
+		ctxAt(start.Add(time.Duration(h) * time.Hour))
+	}
+
+	// Now refine a crossing back near the beginning.
+	back := start.Add(10 * time.Minute)
+
+	fixed := coord.NewAstrometric(angle.Deg(83.633), angle.Deg(22.014))
+
+	got := ctxAt(back).AstrometricToApparent(fixed)
+	want := coord.NewContext(back, site, defaultAtm).AstrometricToApparent(fixed)
+
+	sep := coord.Separation(
+		coord.NewICRS(got.RA(), got.Dec()),
+		coord.NewICRS(want.RA(), want.Dec()),
+	).Arcsec()
+
+	t.Logf("backwards step of ~5h from the base: %.4f arcsec", sep)
+
+	const boundArcsec = 0.1
+
+	if sep > boundArcsec {
+		t.Errorf("a backwards step was served from a stale base: %.4f arcsec, over the %.2f arcsec bound",
+			sep, boundArcsec)
+	}
+}

--- a/plan/events.go
+++ b/plan/events.go
@@ -290,41 +290,18 @@ func (s EventSolver) solveVisibility(spec EventSpec, start, end time.Time) ([]Ev
 	// series would introduce in the root-finder.
 	geomAtm := atmosphere.Refraction{Pressure: 0} // zero pressure → no refraction
 
-	// eventCtxRefresh bounds how far a coord.Context.AtTime derivation may
-	// drift from its last full coord.NewContext rebuild. AtTime's documented
-	// accuracy is ≲0.1″/hour (holding precession-nutation and aberration
-	// fixed); at 1h that's <0.01s of rise/set-time bias — a >100x margin
-	// against the solver's ~1s Tolerance and this package's minute-level
-	// USNO/NASA reference tolerances, while still turning the large majority
-	// of per-sample and per-bisection-iteration NewContext calls (~91µs
-	// each) into O(1) AtTime derivations.
-	const eventCtxRefresh = 1 * time.Hour
-
-	// contextCache returns a closure that rebuilds a full coord.NewContext
-	// only when t has drifted more than eventCtxRefresh from the last
-	// rebuild, deriving every other call cheaply via AtTime. evalVal and
-	// evalHA use independent caches since they evaluate under different
-	// atmospheres (geomAtm vs. spec.Observer.Refraction()).
-	contextCache := func(atm atmosphere.Refraction) func(t time.Time) *coord.Context {
-		var base *coord.Context
-
-		return func(t time.Time) *coord.Context {
-			if base == nil || t.Sub(base.Time()).Abs() > eventCtxRefresh {
-				base = coord.NewContext(t, spec.Observer.Location(), atm)
-			}
-
-			return base.AtTime(t)
-		}
-	}
-
 	// evalCtx backs evalVal (rise/set/twilight, geometric no-refraction
 	// atmosphere); evalHACtx backs the transit search's evalHA closure
 	// (defined further below, inside the event loop, since it's only
 	// needed once a transit candidate is found) — both declared here so a
 	// single cache persists across every sample and bisection iteration,
 	// and across multiple transit candidates, within this solveVisibility call.
-	evalCtx := contextCache(geomAtm)
-	evalHACtx := contextCache(spec.Observer.Refraction())
+	//
+	// Two caches rather than one because they evaluate under different
+	// atmospheres, and a Context carries the one it was built with — see
+	// newContextCache.
+	evalCtx := newContextCache(spec.Observer.Location(), geomAtm)
+	evalHACtx := newContextCache(spec.Observer.Location(), spec.Observer.Refraction())
 
 	evalVal := func(t time.Time) (float64, error) {
 		ctx := evalCtx(t)

--- a/plan/satellite.go
+++ b/plan/satellite.go
@@ -246,15 +246,24 @@ func SatellitePasses(prov eph.Provider, name string, start, end time.Time,
 	step := 30 * time.Second // 30s steps for LEO
 	refineTol := 1 * time.Second
 
-	// lookAt creates a context and computes look angle at time t.
+	// lookAt computes the look angle at t.
+	//
+	// The Context comes from a cache rather than a fresh coord.NewContext per
+	// call. Decomposed on the ISS at Paranal, a rebuild is 145.5 µs against
+	// 94.8 µs for the SGP4 propagation and 24 ns for the transform itself, so
+	// 61% of every 30-second sample went on rebuilding state that barely
+	// changes. The reuse window's ≲0.1″ is three to four orders of magnitude
+	// inside SGP4's own kilometre-scale along-track error, which at a few
+	// hundred km of range is minutes of arc — see newContextCache and #166.
 	//
 	// Body id 0 is not a placeholder: satellite.Satellite carries one TLE and
 	// its State rejects any other id with ErrUnexpectedID, so 0 is the only
 	// one a satellite provider accepts. The name parameter is a label for the
 	// returned pass, not a lookup key.
+	ctxAt := newContextCache(observer, defaultAtm)
+
 	lookAt := func(t time.Time) (coord.AltAz, error) {
-		ctx := coord.NewContext(t, observer, defaultAtm)
-		return LookAngle(prov, 0, ctx)
+		return LookAngle(prov, 0, ctxAt(t))
 	}
 
 	// Elevation evaluation function.

--- a/plan/satellite_bench_test.go
+++ b/plan/satellite_bench_test.go
@@ -54,7 +54,10 @@ func BenchmarkLookAngle(b *testing.B) {
 // 30-second sampling across a six-hour window, which is 720 look angles plus
 // the root-finding refinement on each crossing.
 //
-// At one Apco13 solve per sample this is the floor; it used to be two.
+// It used to be two Apco13 solves per sample, then one (#111/#165), and is now
+// six for the whole window — one per hour of ctxRefresh. Measured on an
+// i9-11980HK: 201 ms before the Context cache, 96 ms after. What is left is
+// SGP4 propagation, which is the work this function exists to do.
 func BenchmarkSatellitePasses_6h(b *testing.B) {
 	sat, site := benchISS(b)
 


### PR DESCRIPTION
Closes #166.

`SatellitePasses` called `coord.NewContext` once per 30-second sample. Decomposed on the ISS
at Paranal, that is 145.5 µs against 94.8 µs for the SGP4 propagation and 24 ns for the
transform itself — **61% of every sample** spent rebuilding state that barely changes.

Measured on an i9-11980HK, six-hour window, `-benchtime=5x -count=5`:

```
before   201 ms/op
after     96 ms/op
```

What is left is SGP4, which is the work the function exists to do.

## Shared, not duplicated

`Context.AtTime` already existed for this, and `solveVisibility` has used it since #165
through a local closure. That closure moves to `plan.newContextCache` and both call sites
now share it — same policy, same accuracy argument, one place to argue with it.

## The accuracy argument, measured rather than asserted

`AtTime` holds precession-nutation and aberration fixed at ≲0.1″ per hour of drift;
`ctxRefresh` bounds the drift at one hour; 0.1″ at the horizon's steepest crossing rate is
under 0.01 s of rise/set bias against a solver refining to 1 s. For satellites it is free by
three to four orders of magnitude — SGP4's own along-track error is kilometres within a day
of epoch, which at a few hundred km of range is minutes of arc.

Two tests hold it:

- `TestContextCacheStaysInsideItsStatedBound` computes every 30-second sample across six
  hours **both ways** and compares them as an angular separation. Worst case **0.0302″**
  against the 0.1″ bound. The assertion is at the documented bound, not at the measured
  value, so it cannot silently ratify a regression it happens to permit.
- `TestSatellitePassEventsSurviveAFullRebuild` re-evaluates every reported rise and set
  against a freshly built Context and requires it to still sit on the elevation threshold
  it was solved for. That is the property the reuse could actually break.

## The mutation that found something

Four mutations. Never rebuilding the base, and widening `ctxRefresh` to 24 h (0.2200″), were
killed by the tests written for them.

**Dropping the `.Abs()` from the drift test was not.** It passes everything else in the
file. `SatellitePasses` sweeps the whole window forward and only *then* refines its
crossings, so the first refinement asks for an instant hours **behind** the base the sweep
left behind — and a signed `t - base > ctxRefresh` never trips on a negative. The answer
stays plausible, which is what makes it worth a test rather than a comment.

`TestContextCacheHandlesBackwardsSteps` exists for it, and measures 0.3188″ of stale drift
when the `.Abs()` is removed. (The `.Abs()` itself is inherited from #165, not new here —
it was simply never covered.)

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

`BenchmarkSatellitePasses_6h`'s doc comment carried a "this is the floor" claim that is no
longer true; it now records the before/after instead.
