### PR TITLE
catalog: query providers concurrently

### DIFF
--- a/catalog/askall.go
+++ b/catalog/askall.go
@@ -1,0 +1,63 @@
+package catalog
+
+import (
+	"context"
+	"sync"
+)
+
+// answer is one provider's reply to one query, kept whether it succeeded or
+// failed. Both are load-bearing: a success is a candidate to reconcile, and a
+// failure is the difference between "no such object" and "nobody could say"
+// — see [Resolver.Resolve].
+type answer[R any] struct {
+	name string
+	val  R
+	err  error
+}
+
+// askAll puts one query to every provider at once and returns their replies in
+// provider-registration order.
+//
+// # Why concurrent
+//
+// This used to be a plain loop, so resolving a name cost the sum of every
+// provider's latency rather than the slowest one's. A resolver over SIMBAD and
+// OpenNGC paid a CDS round-trip on top of a local lookup for every query, and a
+// pipeline resolving ten thousand names paid it ten thousand times. See #138.
+//
+// Concurrency across providers is not concurrency across queries: each service
+// receives exactly the one request it would have received anyway, at the same
+// rate, so this adds nothing to anyone's load. Being polite to other people's
+// services is this project's stated policy and it is untouched here.
+//
+// # Why not internal/parallel.Map
+//
+// Map is an errgroup: the first error wins and the remaining work is
+// cancelled. That is the opposite of what a resolver needs. A provider being
+// unreachable must not cancel the ones that would have answered, and its
+// failure has to survive to be reported alongside the successes rather than
+// replacing them.
+//
+// # Why order is preserved
+//
+// Resolver.Resolve returns the first reconciled group, which is the
+// highest-priority provider's hit unless it merged with a later one. Writing
+// each reply into its own slot rather than appending as replies arrive keeps
+// that meaning exactly, so provider order stays a caller-visible guarantee
+// rather than a scheduling accident.
+func askAll[R any](ctx context.Context, providers []Provider, ask func(context.Context, Provider) (R, error)) []answer[R] {
+	answers := make([]answer[R], len(providers))
+
+	var wg sync.WaitGroup
+
+	for i, p := range providers {
+		wg.Go(func() {
+			val, err := ask(ctx, p)
+			answers[i] = answer[R]{name: p.Name(), val: val, err: err}
+		})
+	}
+
+	wg.Wait()
+
+	return answers
+}

--- a/catalog/askall_test.go
+++ b/catalog/askall_test.go
@@ -1,0 +1,186 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// barrier holds every provider in Resolve/Search until all of them have
+// arrived. Sequential querying therefore cannot satisfy it: the first provider
+// waits for a second that will not be called until the first returns.
+//
+// A barrier rather than a timing comparison, because "concurrent" is a
+// structural property and a wall-clock assertion would be a flake waiting for
+// a loaded CI machine. The wait is bounded so a sequential resolver reports a
+// clean failure instead of deadlocking the package.
+type barrier struct {
+	arrive   sync.WaitGroup
+	release  chan struct{}
+	timedOut atomic.Bool
+}
+
+// barrierWait is how long one provider will hold before concluding that the
+// others are never going to arrive. Never reached when the querying is
+// concurrent: the release fires as soon as the last goroutine checks in.
+const barrierWait = 2 * time.Second
+
+func (b *barrier) wait() {
+	b.arrive.Done()
+
+	select {
+	case <-b.release:
+	case <-time.After(barrierWait):
+		b.timedOut.Store(true)
+	}
+}
+
+type barrierProvider struct {
+	b      *barrier
+	name   string
+	target Target
+}
+
+func (p *barrierProvider) Name() string { return p.name }
+
+func (p *barrierProvider) Resolve(_ context.Context, _ string) (Target, error) {
+	p.b.wait()
+	return p.target, nil
+}
+
+func (p *barrierProvider) Search(_ context.Context, _ string) ([]Target, error) {
+	p.b.wait()
+	return []Target{p.target}, nil
+}
+
+// newBarrier builds n providers that must all be in flight at once.
+func newBarrier(t *testing.T, n int) (*barrier, []resolve.Provider) {
+	t.Helper()
+
+	b := &barrier{release: make(chan struct{})}
+	b.arrive.Add(n)
+
+	providers := make([]resolve.Provider, n)
+	for i := range n {
+		providers[i] = &barrierProvider{
+			b:      b,
+			name:   fmt.Sprintf("p%d", i),
+			target: Target{ID: fmt.Sprintf("ID%d", i), Name: fmt.Sprintf("N%d", i)},
+		}
+	}
+
+	go func() {
+		b.arrive.Wait()
+		close(b.release)
+	}()
+
+	return b, providers
+}
+
+// assertWasConcurrent fails with the reason rather than with a timeout.
+func assertWasConcurrent(t *testing.T, b *barrier) {
+	t.Helper()
+
+	if b.timedOut.Load() {
+		t.Error("a provider waited out the barrier: the resolver queried them sequentially, " +
+			"so each provider's latency adds to the next one's instead of overlapping it")
+	}
+}
+
+func TestResolveQueriesProvidersConcurrently(t *testing.T) {
+	b, providers := newBarrier(t, 4)
+	r := &Resolver{providers: providers}
+
+	if _, err := r.Resolve(context.Background(), "N0"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	assertWasConcurrent(t, b)
+}
+
+func TestSearchQueriesProvidersConcurrently(t *testing.T) {
+	b, providers := newBarrier(t, 4)
+	r := &Resolver{providers: providers, cfg: resolverConfig{cap: defaultCap}}
+
+	if _, err := r.Search(context.Background(), "N0"); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	assertWasConcurrent(t, b)
+}
+
+// TestAskAllPreservesProviderOrder is the guarantee Resolve's "the first group
+// is the highest-priority provider's hit" rests on. Replies are written into
+// their own slots, so a slow first provider does not lose its place to a fast
+// last one.
+func TestAskAllPreservesProviderOrder(t *testing.T) {
+	// Descending delays: without indexed slots the returned order would be the
+	// reverse of the registration order.
+	delays := []time.Duration{40 * time.Millisecond, 20 * time.Millisecond, 0}
+
+	providers := make([]resolve.Provider, len(delays))
+	for i, d := range delays {
+		providers[i] = &slowProvider{name: fmt.Sprintf("p%d", i), delay: d}
+	}
+
+	got := askAll(context.Background(), providers, func(ctx context.Context, p Provider) (Target, error) {
+		return p.Resolve(ctx, "anything")
+	})
+
+	for i, a := range got {
+		want := fmt.Sprintf("p%d", i)
+		if a.name != want {
+			t.Errorf("answers[%d].name = %q, want %q — provider order was lost", i, a.name, want)
+		}
+	}
+}
+
+// TestOneSlowProviderDoesNotCancelTheOthers: askAll is deliberately not
+// internal/parallel.Map, whose errgroup cancels the rest on the first error.
+// A failing provider must neither cancel nor suppress the ones that would have
+// answered.
+func TestOneSlowProviderDoesNotCancelTheOthers(t *testing.T) {
+	r := &Resolver{providers: []resolve.Provider{
+		&mockProvider{name: "broken", failWith: errProviderDown},
+		&mockProvider{name: "working", targets: map[string]Target{
+			"m42": {ID: "NGC1976", Name: "Orion Nebula"},
+		}},
+	}}
+
+	got, err := r.Resolve(context.Background(), "M42")
+	if err != nil {
+		t.Fatalf("a working provider was suppressed by a broken one: %v", err)
+	}
+
+	if got.ID != "NGC1976" {
+		t.Errorf("Resolve(M42).ID = %q, want NGC1976", got.ID)
+	}
+}
+
+// errProviderDown stands in for a transport failure — an outage, a rate limit,
+// a cancelled context — as opposed to a provider answering "no such object".
+var errProviderDown = errors.New("provider is down")
+
+// slowProvider answers after a fixed delay, resolving anything.
+type slowProvider struct {
+	name  string
+	delay time.Duration
+}
+
+func (p *slowProvider) Name() string { return p.name }
+
+func (p *slowProvider) Resolve(_ context.Context, _ string) (Target, error) {
+	time.Sleep(p.delay)
+	return Target{ID: p.name, Name: p.name}, nil
+}
+
+func (p *slowProvider) Search(_ context.Context, _ string) ([]Target, error) {
+	time.Sleep(p.delay)
+	return []Target{{ID: p.name, Name: p.name}}, nil
+}

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -240,6 +240,17 @@ type candidate struct {
 // A provider that succeeds wins outright: if any provider resolved the query,
 // the failures of the others are not reported, because the question was
 // answered.
+//
+// # Every provider is asked, all at once
+//
+// Merging is the point of this type, so there is no short-circuit: a hit from
+// a local catalogue does not mean SIMBAD has nothing to add to it, and
+// stopping early would quietly turn Resolve into "ask whichever provider was
+// registered first". The providers are queried concurrently instead, so the
+// cost is the slowest one rather than the sum — see askAll.
+//
+// The order they were registered in still decides which group comes back,
+// unchanged by the concurrency.
 func (r *Resolver) Resolve(ctx context.Context, query string) (Target, error) {
 	q := resolve.Normalize(query)
 	if q == "" {
@@ -257,17 +268,19 @@ func (r *Resolver) Resolve(ctx context.Context, query string) (Target, error) {
 		failures   []error
 	)
 
-	for _, p := range r.providers {
-		t, err := p.Resolve(ctx, query)
+	asked := askAll(ctx, r.providers, func(ctx context.Context, p Provider) (Target, error) {
+		return p.Resolve(ctx, query)
+	})
 
+	for _, a := range asked {
 		switch {
-		case err == nil:
-			candidates = append(candidates, candidate{t, p.Name()})
-		case errors.Is(err, resolve.ErrNotFound), errors.Is(err, resolve.ErrUnsupported):
+		case a.err == nil:
+			candidates = append(candidates, candidate{a.val, a.name})
+		case errors.Is(a.err, resolve.ErrNotFound), errors.Is(a.err, resolve.ErrUnsupported):
 			// Ordinary answers, not incidents. A cone-search-only provider
 			// declining to resolve a name is not a failure of the query.
 		default:
-			failures = append(failures, fmt.Errorf("%s: %w", p.Name(), err))
+			failures = append(failures, fmt.Errorf("%s: %w", a.name, a.err))
 		}
 	}
 
@@ -320,16 +333,19 @@ func (r *Resolver) Search(ctx context.Context, query string) ([]Target, error) {
 		failures   []error
 	)
 
-	for _, p := range r.providers {
-		found, err := p.Search(ctx, query)
-		if err != nil && !errors.Is(err, resolve.ErrNotFound) && !errors.Is(err, resolve.ErrUnsupported) {
-			failures = append(failures, fmt.Errorf("%s: %w", p.Name(), err))
+	asked := askAll(ctx, r.providers, func(ctx context.Context, p Provider) ([]Target, error) {
+		return p.Search(ctx, query)
+	})
+
+	for _, a := range asked {
+		if a.err != nil && !errors.Is(a.err, resolve.ErrNotFound) && !errors.Is(a.err, resolve.ErrUnsupported) {
+			failures = append(failures, fmt.Errorf("%s: %w", a.name, a.err))
 
 			continue
 		}
 
-		for _, t := range found {
-			candidates = append(candidates, candidate{t, p.Name()})
+		for _, t := range a.val {
+			candidates = append(candidates, candidate{t, a.name})
 		}
 	}
 

--- a/docs/changelog.d/202-concurrent-provider-queries.md
+++ b/docs/changelog.d/202-concurrent-provider-queries.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 202
+---
+**`catalog.Resolver` queries its providers concurrently.** `Resolve` and `Search`
+looped over them one at a time, so a resolver over SIMBAD and OpenNGC cost a CDS
+round-trip *plus* a local lookup per query instead of the slower of the two.
+Provider-registration order, merging and error reporting are unchanged.


### PR DESCRIPTION
Closes #138.

`Resolver.Resolve` and `Resolver.Search` looped over their providers one at a time, so a
resolver over SIMBAD and OpenNGC cost a CDS round-trip **plus** a local lookup for every
query rather than the slower of the two. A pipeline resolving ten thousand names paid that
ten thousand times.

## Why not the option the issue preferred

#138 proposed short-circuiting: try cache-backed providers first and stop on a hit. That
cannot be done without changing what `Resolve` means.

Merging is the point of the type — a hit from a local catalogue does not mean SIMBAD has
nothing to add to it, and `reconcile` exists precisely to fold them together. Stopping early
would quietly turn `Resolve` into "ask whichever provider was registered first". **The calls
are not avoidable; their latency is.**

The issue also worried that concurrency multiplies load on CDS. It does not. Concurrency
across *providers* is not concurrency across *queries*: each service receives exactly the
one request it would have received anyway, at the same rate. The politeness argument applies
to batching many queries, which this does not touch.

## Why not `internal/parallel.Map`

The issue suggested it. `Map` is an errgroup — the first error wins and the remaining work
is cancelled. A resolver needs the opposite: a provider being unreachable must not cancel
the ones that would have answered, and its failure has to *survive* to be reported alongside
the successes rather than replacing them. That distinction is the whole subject of #102 and
it would have been undone here.

Same mismatch `plan.VisibleTonight` hit in #180, for the same reason.

## What is preserved

Replies go into indexed slots rather than being appended as they arrive, so
provider-registration order stays a caller-visible guarantee and not a scheduling accident —
`Resolve` returning "the highest-priority provider's hit unless it merged with a later one"
still means that. Merging, ranking, the cap and the error model are untouched.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

Concurrency is asserted structurally, not by wall clock: four providers block until all four
have arrived, so sequential querying cannot satisfy the barrier. The wait is bounded, so a
regression reports *why* it failed instead of deadlocking the package — which is what the
first version of the test did when I ran the mutation.

| mutation | killed by |
| :--- | :--- |
| run the providers sequentially | `TestResolveQueriesProvidersConcurrently`, `TestSearchQueriesProvidersConcurrently` |
| append replies instead of slotting them | `TestAskAllPreservesProviderOrder` |
