### PR TITLE
test: make external tests say why they failed, and skip when it is not us

### DIFF
--- a/catalog/fink/fink_network_test.go
+++ b/catalog/fink/fink_network_test.go
@@ -27,8 +27,11 @@ func TestFINKProvider_SingleObjectJSON(t *testing.T) {
 
 	// Fast single-object JSON query.
 	tgt, err := p.Resolve(context.Background(), "8467")
+
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
-		t.Fatal("Resolve(8467) failed")
+		t.Fatalf("Resolve(8467): %v", err)
 	}
 
 	t.Logf("8467 %s:", tgt.Name)
@@ -82,8 +85,11 @@ func TestFINKProvider_SingleObjectJSON(t *testing.T) {
 
 	// Cross-check by name.
 	tgt2, err := p.Resolve(context.Background(), "Benoitcarry")
+
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
-		t.Fatal("Resolve by name failed")
+		t.Fatalf("Resolve(Benoitcarry): %v", err)
 	}
 
 	if tgt2.H != tgt.H {

--- a/catalog/norad/norad_network_test.go
+++ b/catalog/norad/norad_network_test.go
@@ -140,8 +140,16 @@ func TestResolve_Live(t *testing.T) {
 	p := New()
 
 	target, err := p.Resolve(context.Background(), "ISS")
+
+	// The health check in requireCelestrak is a sync.Once taken before this
+	// test ran, so it says nothing about a throttle arriving on this request.
+	// Checked here too, and the error is carried into the failure either way:
+	// "Failed to resolve ISS" on its own cannot distinguish a rate limit from
+	// CelesTrak genuinely not knowing what the ISS is.
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
-		t.Fatal("Failed to resolve ISS")
+		t.Fatalf("Resolve(ISS): %v", err)
 	}
 
 	t.Logf("Resolved: %s (ID=%s, Catalog=%s)", target.Name, target.ID, target.Catalog)

--- a/catalog/sbdb/sbdb_network_test.go
+++ b/catalog/sbdb/sbdb_network_test.go
@@ -72,8 +72,11 @@ func TestSBDBNetworkResolveOrbitalElements(t *testing.T) {
 	defer cancel()
 
 	tar, err := prov.Resolve(ctx, "1")
+
+	testutil.SkipOnUpstreamFailure(t, err)
+
 	if err != nil {
-		t.Fatal("failed to resolve 1 Ceres")
+		t.Fatalf("Resolve(1 Ceres): %v", err)
 	}
 
 	if !tar.HasElements {

--- a/catalog/simbad/resolution_network_test.go
+++ b/catalog/simbad/resolution_network_test.go
@@ -49,8 +49,15 @@ func TestResolveReturnsTheObjectAsked(t *testing.T) {
 			p := New()
 
 			tgt, err := p.Resolve(context.Background(), tc.query)
+
+			// "found nothing" was the whole message, which asserts the one
+			// reading the error may not support: SIMBAD being unreachable is
+			// not SIMBAD saying no. That inversion is #102's defect, here in
+			// the test rather than the library.
+			testutil.SkipOnUpstreamFailure(t, err)
+
 			if err != nil {
-				t.Fatalf("Resolve(%q) found nothing (%s)", tc.query, tc.why)
+				t.Fatalf("Resolve(%q) failed (%s): %v", tc.query, tc.why, err)
 			}
 
 			if !tgt.HasCoord {

--- a/docs/changelog.d/204-network-tests-report-why.md
+++ b/docs/changelog.d/204-network-tests-report-why.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 204
+---
+**Five network tests failed the build on somebody else's outage and discarded
+the error while doing it** — `Failed to resolve ISS` was the whole diagnostic
+when CI throttled. They now route through `testutil.SkipOnUpstreamFailure` and
+carry the error, and an `internal/docsguard` guard keeps the next one from
+reintroducing it.

--- a/internal/docsguard/upstreamskip_test.go
+++ b/internal/docsguard/upstreamskip_test.go
@@ -1,0 +1,133 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// externalTag matches the build tags that mark a test as talking to somebody
+// else's service.
+var externalTag = regexp.MustCompile(`(?m)^//go:build .*\b(network|integration)\b`)
+
+// errCheckFailure matches `if <err> != nil {` followed immediately by a
+// t.Fatal/t.Error call, capturing the error variable's name and the call line.
+//
+// Written against the shape rather than parsed, matching this package's other
+// guards. Whether the error is actually reported is decided in Go below: RE2
+// has no lookahead, and a format string may contain a parenthesis of its own —
+// t.Fatalf("Var(lnsp): %v", err) — so a pattern that tried to stop at the
+// closing parenthesis would misread the call and flag a test that does report.
+var errCheckFailure = regexp.MustCompile(
+	`(?m)^[ \t]*if ([a-zA-Z0-9_]*[eE]rr[a-zA-Z0-9_]*) != nil \{\n([ \t]*(?:t|b|tb)\.(?:Fatal|Fatalf|Error|Errorf)\([^\n]*)`)
+
+// TestExternalTestsReportWhyTheyFailed enforces, on the tests that reach
+// somebody else's service, that a failure says what went wrong.
+//
+// # Where the rule comes from
+//
+// CLAUDE.md states it plainly for the network tag: these tests skip when the
+// endpoint is unreachable and keep t.Fatal for wrong data from a reachable
+// one. internal/testutil.SkipOnUpstreamFailure is what draws that line — 429,
+// 5xx, 408, deadline-exceeded and network timeouts are "not verified", not
+// "wrong".
+//
+// # What this guard checks, and why it is the half worth checking
+//
+// Whether a test called SkipOnUpstreamFailure cannot be established from the
+// source without knowing which error reaches which check. Whether it reported
+// the error at all can. catalog/norad's TestResolve_Live failed a pull request
+// that touched only fits with:
+//
+//	norad_network_test.go:144: Failed to resolve ISS
+//
+// and that was the entire diagnostic, because the error was discarded. The
+// test one line below it resolved the ISS successfully 1.2 s later, so the
+// service was reachable — but nothing in the output could establish that, and
+// a throttle, an outage, and CelesTrak genuinely not knowing what the ISS is
+// all produce that same sentence.
+//
+// This is the error-versus-absence discipline the library holds itself to
+// (#102, #172, #177, #182), applied to its own tests: a failure that cannot be
+// told apart from a different failure is the thing being ruled out, and
+// carrying the error is what tells them apart. See #203.
+func TestExternalTestsReportWhyTheyFailed(t *testing.T) {
+	root := filepath.Join("..", "..")
+
+	var checked, offenders int
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // a file we cannot read is skipped, not fatal
+		}
+
+		body := string(src)
+		if !externalTag.MatchString(body) {
+			return nil
+		}
+
+		checked++
+
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unrelatable path is skipped, not fatal
+		}
+
+		for _, m := range errCheckFailure.FindAllStringSubmatchIndex(body, -1) {
+			name := body[m[2]:m[3]]
+			call := strings.TrimSpace(body[m[4]:m[5]])
+
+			// The error is reported. Nothing to say.
+			if strings.Contains(call, name) {
+				continue
+			}
+
+			// A call whose arguments run onto the next line cannot be read one
+			// line at a time. Left alone deliberately: a guard that guessed
+			// here would spend its credibility on false positives, and the
+			// case it exists for is the one-liner.
+			if strings.Count(call, "(") != strings.Count(call, ")") {
+				continue
+			}
+
+			offenders++
+
+			t.Errorf("%s:%d: fails on an error without reporting it.\n"+
+				"  %s\n"+
+				"  Pass %s into the message, and put\n"+
+				"  testutil.SkipOnUpstreamFailure(t, %s) before the check, so somebody\n"+
+				"  else's outage skips this test rather than failing the build.",
+				filepath.ToSlash(rel), lineOf(body, m[0]), call, name, name)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if checked == 0 {
+		t.Fatal("no externally-tagged test files examined; the walk root or the tag pattern is wrong")
+	}
+
+	t.Logf("%d externally-tagged test files checked, %d offenders", checked, offenders)
+}


### PR DESCRIPTION
Closes #203. Found by CI on #199, which failed a pull request that touches only `fits`.

```
--- FAIL: TestResolve_Live (1.81s)
    norad_network_test.go:144: Failed to resolve ISS
```

That sentence was the entire diagnostic. `TestResolveISSIsTheStation`, one test below it in
the same file, resolved the ISS successfully 1.2 s later — so CelesTrak was reachable and
this was almost certainly a throttle. Nothing in the output can establish that, because the
error was discarded:

```go
target, err := p.Resolve(context.Background(), "ISS")
if err != nil {
    t.Fatal("Failed to resolve ISS")   // err thrown away
}
```

## Two rules, both already stated

CLAUDE.md, on the `network` tag: these tests skip when the endpoint is unreachable (never
fail CI for external downtime) and keep `t.Fatal` for wrong data from a reachable one.

`requireCelestrak`'s health check is a `sync.Once` taken before the test ran, so it says
nothing about a throttle arriving on a later request in the same run — which is what
happened.

Five sites, now routed through `testutil.SkipOnUpstreamFailure` and carrying the error:

| file | was |
| :--- | :--- |
| `catalog/norad/norad_network_test.go` | `Failed to resolve ISS` |
| `catalog/fink/fink_network_test.go` | `Resolve(8467) failed` |
| `catalog/fink/fink_network_test.go` | `Resolve by name failed` |
| `catalog/sbdb/sbdb_network_test.go` | `failed to resolve 1 Ceres` |
| `catalog/simbad/resolution_network_test.go` | `Resolve(%q) found nothing (%s)` |

The simbad one is the worst of them: **"found nothing"** asserts the one reading the error
may not support, since SIMBAD being unreachable is not SIMBAD saying no. That is #102's
inversion, in the test rather than in the library.

## The guard is the point

`t.Fatal("...")` after an error check is the shortest thing to write and reads as entirely
harmless, so the next one goes in the same way. `TestExternalTestsReportWhyTheyFailed` scans
every `network`- or `integration`-tagged test file for a failure call that does not mention
the error it is reacting to.

It found the simbad site, which I had missed by grep.

Whether `SkipOnUpstreamFailure` was called cannot be established from the source without
knowing which error reaches which check. Whether the error was reported *can*, so that is
what the guard checks — and it declines calls whose arguments run onto the next line rather
than guessing at them, because a guard that spends its credibility on false positives gets
switched off.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues. The five tests were also run
live against their real services and pass.

Mutation: restoring the exact original line to `catalog/norad` makes the guard fail and name
it —

```
catalog/norad/norad_network_test.go:143: fails on an error without reporting it.
  t.Fatal("Failed to resolve ISS")
```

46 externally-tagged test files checked, 0 offenders on this branch.
