### PR TITLE
skybrightness/dataset/dust: test the I/O paths, 37.5% to 96.5%

### DIFF
--- a/docs/changelog.d/205-dust-io-coverage.md
+++ b/docs/changelog.d/205-dust-io-coverage.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 205
+---
+Offline tests for `skybrightness/dataset/dust`'s I/O paths, taking it from 37.5%
+to 96.5% — the IRSA fetch and its cache (a second session asks nothing, a cell is
+asked once, a run cut off keeps what it paid for, a corrupt line costs one
+sightline) and every reason `SFD.Open` refuses a hemisphere, against synthetic
+SFD-shaped FITS built in the test (#122).

--- a/skybrightness/dataset/dust/fetch_test.go
+++ b/skybrightness/dataset/dust/fetch_test.go
@@ -1,0 +1,375 @@
+package dust
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/remote/file"
+)
+
+// response renders a service document carrying one 100 micron intensity,
+// wrapped in the two blocks that share its element names — the shape the real
+// service answers with, and the reason parse looks for the block by
+// description rather than taking the first refPixelValue.
+func response(mjySr float64) string {
+	return fmt.Sprintf(`<?xml version="1.0"?>
+<results status="ok">
+  <result><desc>E(B-V) Reddening</desc>
+    <statistics><refPixelValue>0.0231 (mag)</refPixelValue></statistics></result>
+  <result><desc>100 Micron Emission</desc>
+    <statistics><refPixelValue>%.4f (MJy/sr)</refPixelValue></statistics></result>
+  <result><desc>Dust Temperature</desc>
+    <statistics><refPixelValue>21.1993 (K)</refPixelValue></statistics></result>
+</results>`, mjySr)
+}
+
+// fakeIRSA stands the service up locally and points remote.IRSADust at it,
+// with a fresh cache directory per test. Returns the request counter, which is
+// what most of these tests are actually about: this package exists because it
+// once spent twenty-five minutes of a shared facility's time re-asking
+// questions it had already answered.
+//
+// handler is called per request and returns the intensity to serve, or an
+// error status to send instead.
+func fakeIRSA(t *testing.T, handler func(n int) (mjySr float64, status int)) *atomic.Int64 {
+	t.Helper()
+
+	t.Cleanup(remote.Capture().Restore)
+
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := int(calls.Add(1))
+
+		v, status := handler(n)
+		if status != 0 {
+			w.WriteHeader(status)
+
+			return
+		}
+
+		_, _ = w.Write([]byte(response(v)))
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := remote.SetURL(remote.IRSADust, srv.URL); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	return &calls
+}
+
+// serve is the ordinary handler: every request succeeds, with a distinct value
+// per call so a test can tell which answer landed where.
+func serve(n int) (float64, int) { return 1000 * float64(n), 0 }
+
+// TestFetchServesASecondSessionFromDisk is the property the cache exists for.
+//
+// A sightline's 100 micron intensity does not change, so a value fetched once
+// is a value fetched for good. The assertion is not that the second call is
+// fast but that it issues no request at all — the client is built lazily, on
+// the first sightline that actually needs asking, so a fully cached call must
+// open no connection.
+func TestFetchServesASecondSessionFromDisk(t *testing.T) {
+	calls := fakeIRSA(t, serve)
+
+	dirs := []Direction{
+		{L: angle.Deg(10), B: angle.Deg(20)},
+		{L: angle.Deg(30), B: angle.Deg(-40)},
+	}
+
+	first, err := Fetch(context.Background(), nil, dirs...)
+	if err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("first Fetch made %d requests, want one per direction", got)
+	}
+
+	// A new session: nothing in memory, everything on disk.
+	second, err := Fetch(context.Background(), nil, dirs...)
+	if err != nil {
+		t.Fatalf("second Fetch: %v", err)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("a fully cached Fetch asked the service %d more times, want 0", got-2)
+	}
+
+	for _, d := range dirs {
+		want, err := first.IntensityAt(d.L, d.B)
+		if err != nil {
+			t.Fatalf("first map is missing l=%v b=%v: %v", d.L, d.B, err)
+		}
+
+		got, err := second.IntensityAt(d.L, d.B)
+		if err != nil {
+			t.Errorf("second map is missing l=%v b=%v: %v", d.L, d.B, err)
+			continue
+		}
+
+		if math.Abs(got-want) > 1e-6 {
+			t.Errorf("l=%v b=%v: cached %v, fetched %v", d.L, d.B, got, want)
+		}
+	}
+}
+
+// TestFetchQueriesACellOnce: the cache is keyed by cell, not by direction, so
+// directions that round to the same cell are one question.
+func TestFetchQueriesACellOnce(t *testing.T) {
+	calls := fakeIRSA(t, serve)
+
+	// Three directions inside one 0.1 degree cell.
+	_, err := Fetch(context.Background(), nil,
+		Direction{L: angle.Deg(10.00), B: angle.Deg(20.00)},
+		Direction{L: angle.Deg(10.01), B: angle.Deg(20.01)},
+		Direction{L: angle.Deg(9.99), B: angle.Deg(19.99)},
+	)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("three directions in one cell cost %d requests, want 1", got)
+	}
+}
+
+// TestFetchKeepsWhatItLearnedWhenCutOff: being cut off part way through a long
+// list should cost the remaining sightlines, not the ones already paid for.
+// Without this the next run re-asks for everything, which is the behaviour the
+// cache was added to stop.
+func TestFetchKeepsWhatItLearnedWhenCutOff(t *testing.T) {
+	calls := fakeIRSA(t, func(n int) (float64, int) {
+		if n == 1 {
+			return 4242, 0
+		}
+
+		return 0, http.StatusInternalServerError
+	})
+
+	good := Direction{L: angle.Deg(10), B: angle.Deg(20)}
+
+	_, err := Fetch(context.Background(), nil,
+		good,
+		Direction{L: angle.Deg(30), B: angle.Deg(-40)},
+	)
+	if err == nil {
+		t.Fatal("Fetch returned no error although the service failed")
+	}
+
+	if calls.Load() < 2 {
+		t.Fatalf("the service was asked %d times; the failure did not come from the second sightline", calls.Load())
+	}
+
+	held, err := CachedDirections(context.Background())
+	if err != nil {
+		t.Fatalf("CachedDirections: %v", err)
+	}
+
+	if len(held) != 1 {
+		t.Fatalf("cache holds %d directions after a partial run, want the 1 that succeeded: %v", len(held), held)
+	}
+
+	if math.Abs(held[0].Intensity-4242) > 1e-6 {
+		t.Errorf("cached intensity = %v, want 4242", held[0].Intensity)
+	}
+
+	if math.Abs(held[0].L.Degrees()-good.L.Degrees()) > cellSizeDeg ||
+		math.Abs(held[0].B.Degrees()-good.B.Degrees()) > cellSizeDeg {
+		t.Errorf("cached direction = l %v b %v, want l %v b %v",
+			held[0].L, held[0].B, good.L, good.B)
+	}
+}
+
+// TestCachedDirectionsIsOrdered: the ordering is what lets the all-sky
+// validation report the same worst case twice running. Go randomises map
+// iteration, so without the sort the same cache reads back differently on
+// consecutive runs and no comparison against it is reproducible.
+//
+// Seeded through writeCache rather than through Fetch: the subject is the
+// round trip, and going via Fetch would spend six seconds of the default test
+// run on the two-second pacing the service is owed.
+func TestCachedDirectionsIsOrdered(t *testing.T) {
+	fakeIRSA(t, serve)
+
+	ctx := context.Background()
+
+	bucket, prefix, err := remote.CacheDir(ctx, remote.IRSADust)
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+
+	// Deliberately not in sorted order.
+	err = writeCache(ctx, bucket, path.Join(prefix, cacheFile), map[cell]float64{
+		{l: 300, b: 100}: 3,
+		{l: 100, b: 100}: 1,
+		{l: 200, b: -50}: 2,
+	})
+	if err != nil {
+		t.Fatalf("writeCache: %v", err)
+	}
+
+	held, err := CachedDirections(ctx)
+	if err != nil {
+		t.Fatalf("CachedDirections: %v", err)
+	}
+
+	if len(held) != 3 {
+		t.Fatalf("cache holds %d directions, want 3", len(held))
+	}
+
+	for i := 1; i < len(held); i++ {
+		prev, cur := held[i-1], held[i]
+		if cur.B < prev.B || (cur.B == prev.B && cur.L < prev.L) {
+			t.Errorf("entry %d (l %v b %v) sorts before entry %d (l %v b %v)",
+				i, cur.L, cur.B, i-1, prev.L, prev.B)
+		}
+	}
+}
+
+// TestCachedDirectionsOnAColdCache: a cache that has never been written is a
+// normal state, so an empty result rather than an error. Reporting a failure
+// here would make a first run look broken.
+func TestCachedDirectionsOnAColdCache(t *testing.T) {
+	fakeIRSA(t, serve)
+
+	held, err := CachedDirections(context.Background())
+	if err != nil {
+		t.Fatalf("a cold cache reported an error: %v", err)
+	}
+
+	if len(held) != 0 {
+		t.Errorf("a cold cache produced %d directions", len(held))
+	}
+}
+
+// TestReadCacheSkipsUnusableLines: a truncated or corrupt line costs the
+// sightline on it, not the whole file — the worst case is asking IRSA again
+// for that one direction, and discarding every other answer to avoid it would
+// be the more expensive mistake.
+func TestReadCacheSkipsUnusableLines(t *testing.T) {
+	fakeIRSA(t, serve)
+
+	ctx := context.Background()
+
+	bucket, prefix, err := remote.CacheDir(ctx, remote.IRSADust)
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+
+	key := path.Join(prefix, cacheFile)
+
+	body := strings.Join([]string{
+		"100 200 1.5e+03", // good
+		"100 200",         // truncated
+		"x 200 1.0",       // l not a number
+		"100 y 1.0",       // b not a number
+		"100 201 abc",     // value not a number
+		"100 202 -1.0",    // negative intensity
+		"100 203 NaN",     // not a number
+		"100 204 +Inf",    // unbounded
+		"",                // blank
+		"101 200 2.5e+03", // good
+	}, "\n") + "\n"
+
+	if err := file.Save(ctx, bucket, key, strings.NewReader(body)); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	got := readCache(ctx, bucket, key)
+
+	want := map[cell]float64{
+		{l: 100, b: 200}: 1500,
+		{l: 101, b: 200}: 2500,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("readCache kept %d entries, want %d: %v", len(got), len(want), got)
+	}
+
+	for c, v := range want {
+		if math.Abs(got[c]-v) > 1e-6 {
+			t.Errorf("cell %+v = %v, want %v", c, got[c], v)
+		}
+	}
+}
+
+// TestReadCacheOnAMissingFile: no file yet is a cold cache, which readCache
+// reports as an empty map rather than by failing — Fetch has no way to act on
+// the difference and would only be able to give up.
+func TestReadCacheOnAMissingFile(t *testing.T) {
+	fakeIRSA(t, serve)
+
+	ctx := context.Background()
+
+	bucket, prefix, err := remote.CacheDir(ctx, remote.IRSADust)
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+
+	if got := readCache(ctx, bucket, path.Join(prefix, "nothing-here.txt")); len(got) != 0 {
+		t.Errorf("a missing cache file produced %d entries", len(got))
+	}
+}
+
+// TestFetchWithNoDirectionsAsksNothing: the early return, which is what keeps a
+// caller with an empty target list from opening a cache or a connection.
+func TestFetchWithNoDirectionsAsksNothing(t *testing.T) {
+	calls := fakeIRSA(t, serve)
+
+	m, err := Fetch(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if m == nil {
+		t.Fatal("Fetch returned a nil map for an empty direction list")
+	}
+
+	if got := calls.Load(); got != 0 {
+		t.Errorf("an empty direction list made %d requests", got)
+	}
+}
+
+// TestFetchAddsToAnExistingMap: passing a map in accumulates rather than
+// starting over, and a direction already held in memory is not re-asked.
+func TestFetchAddsToAnExistingMap(t *testing.T) {
+	calls := fakeIRSA(t, serve)
+
+	first := Direction{L: angle.Deg(10), B: angle.Deg(20)}
+	second := Direction{L: angle.Deg(30), B: angle.Deg(-40)}
+
+	m, err := Fetch(context.Background(), nil, first)
+	if err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+
+	if _, err := Fetch(context.Background(), m, first, second); err != nil {
+		t.Fatalf("second Fetch: %v", err)
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("%d requests in total, want 2: the direction already in the map was re-asked", got)
+	}
+
+	if m.Len() != 2 {
+		t.Errorf("map holds %d directions, want 2 — the second Fetch started over instead of adding", m.Len())
+	}
+
+	if _, err := m.IntensityAt(first.L, first.B); err != nil {
+		t.Errorf("the first direction was lost from the map: %v", err)
+	}
+}

--- a/skybrightness/dataset/dust/sfd_open_test.go
+++ b/skybrightness/dataset/dust/sfd_open_test.go
@@ -1,0 +1,342 @@
+package dust
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/remote/file"
+)
+
+// The real hemispheres are 64 MB each and live behind a Dataverse download, so
+// nothing offline can exercise Open against them. What can be exercised is
+// every reason Open refuses a file — and those are the failure modes that
+// actually happen: a deposit reorganised, an identifier repointed at the
+// reddening map, a header keyword dropped.
+//
+// The fixtures below are 2x2 SFD-shaped images built here rather than checked
+// in, so what each test is varying is visible in the test itself.
+
+const (
+	fitsBlock = 2880
+	fitsCard  = 80
+)
+
+// sfdHeader is the keyword set a hemisphere must carry. Values are strings
+// exactly as they appear on the card, so a test can corrupt one by name.
+func sfdHeader(nsgp string) map[string]string {
+	return map[string]string{
+		"BUNIT":    "'MJy/sr '",
+		"CTYPE1":   "'GLON-ZEA'",
+		"LAM_NSGP": nsgp,
+		"LAM_SCAL": "2",
+		"CRPIX1":   "1.5",
+		"CRPIX2":   "1.5",
+	}
+}
+
+// buildFITS renders a single-HDU image at the given BITPIX. Order matters —
+// SIMPLE, BITPIX, NAXIS and the NAXISn cards are mandatory and positional — so
+// they are written first and the rest follow in the order given.
+//
+// bitpix decides how each value is encoded: -32 and -64 are the two floating
+// forms SFD uses and pixels accepts, 16 the integer form it refuses.
+func buildFITS(t *testing.T, bitpix int, naxis []int, keys map[string]string, order []string, data []float64) []byte {
+	t.Helper()
+
+	var head bytes.Buffer
+
+	card := func(k, v string) {
+		t.Helper()
+
+		line := fmt.Sprintf("%-8s= %20s", k, v)
+		head.WriteString(line + strings.Repeat(" ", fitsCard-len(line)))
+	}
+
+	card("SIMPLE", "T")
+	card("BITPIX", strconv.Itoa(bitpix))
+	card("NAXIS", strconv.Itoa(len(naxis)))
+
+	for i, n := range naxis {
+		card(fmt.Sprintf("NAXIS%d", i+1), strconv.Itoa(n))
+	}
+
+	for _, k := range order {
+		if v, ok := keys[k]; ok {
+			card(k, v)
+		}
+	}
+
+	head.WriteString("END" + strings.Repeat(" ", fitsCard-3))
+
+	for head.Len()%fitsBlock != 0 {
+		head.WriteString(strings.Repeat(" ", fitsCard))
+	}
+
+	var payload bytes.Buffer
+
+	for _, v := range data {
+		switch bitpix {
+		case -32:
+			_ = binary.Write(&payload, binary.BigEndian, math.Float32bits(float32(v)))
+		case -64:
+			_ = binary.Write(&payload, binary.BigEndian, math.Float64bits(v))
+		case 16:
+			_ = binary.Write(&payload, binary.BigEndian, int16(v))
+		default:
+			t.Fatalf("buildFITS: BITPIX %d not supported by this helper", bitpix)
+		}
+	}
+
+	out := append(head.Bytes(), payload.Bytes()...)
+	for len(out)%fitsBlock != 0 {
+		out = append(out, 0)
+	}
+
+	return out
+}
+
+// keyOrder is the order the optional cards are written in; every fixture uses
+// it so a test varies only the values.
+var keyOrder = []string{"BUNIT", "CTYPE1", "LAM_NSGP", "LAM_SCAL", "CRPIX1", "CRPIX2"}
+
+// hemisphereFITS is a well-formed 2x2 float32 hemisphere with the four given
+// pixels.
+func hemisphereFITS(t *testing.T, nsgp string, px [4]float64) []byte {
+	t.Helper()
+
+	return buildFITS(t, -32, []int{2, 2}, sfdHeader(nsgp), keyOrder, px[:])
+}
+
+// serveSFD points remote.SFDDustMap at a bucket holding the two hemisphere
+// files, and grants the download consent Open needs.
+func serveSFD(t *testing.T, north, south []byte) {
+	t.Helper()
+
+	t.Cleanup(remote.Capture().Restore)
+
+	ctx := context.Background()
+	src := testutil.FileURL(t, t.TempDir())
+
+	if err := remote.SetURL(remote.SFDDustMap, src); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+
+	bucket, err := file.Open(ctx, src)
+	if err != nil {
+		t.Fatalf("open source bucket: %v", err)
+	}
+
+	for name, body := range map[string][]byte{northFile: north, southFile: south} {
+		if err := bucket.WriteAll(ctx, name, body, nil); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	remote.EnableDownloads(0, remote.SFDDustMap)
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+}
+
+// TestSFDOpenReadsBothHemispheres is the happy path Open never had:
+// two well-formed files, decoded, checked against each other and queried.
+func TestSFDOpenReadsBothHemispheres(t *testing.T) {
+	serveSFD(t,
+		hemisphereFITS(t, "1", [4]float64{1, 2, 3, 4}),
+		hemisphereFITS(t, "-1", [4]float64{5, 6, 7, 8}),
+	)
+
+	sfd, err := Open(context.Background())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// The north file is the one with LAM_NSGP +1, whichever order they were
+	// read in.
+	if sfd.north.nsgp != 1 || sfd.south.nsgp != -1 {
+		t.Errorf("hemispheres came back as nsgp %g and %g, want +1 and -1",
+			sfd.north.nsgp, sfd.south.nsgp)
+	}
+
+	if sfd.north.width != 2 || sfd.north.height != 2 {
+		t.Errorf("north is %dx%d, want 2x2", sfd.north.width, sfd.north.height)
+	}
+
+	if len(sfd.north.values) != 4 {
+		t.Fatalf("north holds %d pixels, want 4", len(sfd.north.values))
+	}
+
+	for i, want := range []float64{1, 2, 3, 4} {
+		if math.Abs(sfd.north.values[i]-want) > 1e-6 {
+			t.Errorf("north pixel %d = %v, want %v", i, sfd.north.values[i], want)
+		}
+	}
+}
+
+// TestSFDOpenRefusesTwoOfTheSameHemisphere: the identifiers are Dataverse file
+// numbers, not names, so a deposit reorganised under them is not visibly
+// wrong. LAM_NSGP is what says which hemisphere a file actually is, and two
+// norths would otherwise leave half the sky answered from the wrong map.
+func TestSFDOpenRefusesTwoOfTheSameHemisphere(t *testing.T) {
+	north := hemisphereFITS(t, "1", [4]float64{1, 2, 3, 4})
+
+	serveSFD(t, north, north)
+
+	_, err := Open(context.Background())
+	if !errors.Is(err, ErrSFD) {
+		t.Fatalf("err = %v, want ErrSFD", err)
+	}
+
+	if !strings.Contains(err.Error(), "opposite hemispheres") {
+		t.Errorf("the error does not say what is wrong: %v", err)
+	}
+}
+
+// TestSFDOpenRefusesAMisdescribedFile covers the header checks one at a time.
+// Each is a way the deposit can change without the identifier changing, and
+// each produces a map of plausible values that is not the one asked for.
+func TestSFDOpenRefusesAMisdescribedFile(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]string)
+		axes   []int
+		want   string
+	}{
+		{
+			name:   "reddening map instead of the 100 micron one",
+			mutate: func(k map[string]string) { k["BUNIT"] = "'mag     '" },
+			want:   "MJy/sr",
+		},
+		{
+			name:   "a different projection",
+			mutate: func(k map[string]string) { k["CTYPE1"] = "'GLON-TAN'" },
+			want:   "equal-area",
+		},
+		{
+			name:   "no scale keyword",
+			mutate: func(k map[string]string) { delete(k, "LAM_SCAL") },
+			want:   "usable projection",
+		},
+		{
+			name:   "a scale of zero",
+			mutate: func(k map[string]string) { k["LAM_SCAL"] = "0" },
+			want:   "usable projection",
+		},
+		{
+			name:   "no pole position",
+			mutate: func(k map[string]string) { delete(k, "CRPIX1") },
+			want:   "usable projection",
+		},
+		{
+			name:   "not a two-dimensional image",
+			mutate: func(map[string]string) {},
+			axes:   []int{2, 2, 2},
+			want:   "want 2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			keys := sfdHeader("1")
+			tc.mutate(keys)
+
+			axes := tc.axes
+			if axes == nil {
+				axes = []int{2, 2}
+			}
+
+			n := 1
+			for _, a := range axes {
+				n *= a
+			}
+
+			north := buildFITS(t, -32, axes, keys, keyOrder, make([]float64, n))
+
+			serveSFD(t, north, hemisphereFITS(t, "-1", [4]float64{5, 6, 7, 8}))
+
+			_, err := Open(context.Background())
+			if !errors.Is(err, ErrSFD) {
+				t.Fatalf("err = %v, want ErrSFD", err)
+			}
+
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("the error does not mention %q: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestSFDOpenReportsAMissingFile: without download consent nothing can be
+// fetched, and Open has to say so rather than come back with an empty map that
+// answers every direction with zero dust.
+func TestSFDOpenReportsAMissingFile(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	if err := remote.SetURL(remote.SFDDustMap, testutil.FileURL(t, t.TempDir())); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+
+	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
+
+	// Downloads deliberately not enabled.
+	if _, err := Open(context.Background()); !errors.Is(err, ErrSFD) {
+		t.Errorf("err = %v, want ErrSFD", err)
+	}
+}
+
+// TestSFDOpenReadsAFloat64Image: the decoder types the payload from BITPIX, so
+// -64 arrives as a different tensor than -32 and takes its own branch. SFD
+// ships as -32, but the deposit is not this package's to control.
+func TestSFDOpenReadsAFloat64Image(t *testing.T) {
+	north := buildFITS(t, -64, []int{2, 2}, sfdHeader("1"), keyOrder, []float64{1, 2, 3, 4})
+
+	serveSFD(t, north, hemisphereFITS(t, "-1", [4]float64{5, 6, 7, 8}))
+
+	sfd, err := Open(context.Background())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	for i, want := range []float64{1, 2, 3, 4} {
+		if math.Abs(sfd.north.values[i]-want) > 1e-9 {
+			t.Errorf("north pixel %d = %v, want %v", i, sfd.north.values[i], want)
+		}
+	}
+}
+
+// TestSFDOpenRefusesAnIntegerImage: an integer BITPIX would need BSCALE and
+// BZERO applied per pixel, and the package says so rather than guessing. The
+// refusal is the point — reading the raw integers as physical values would
+// produce a map that is wrong by whatever scaling the file declares, silently.
+func TestSFDOpenRefusesAnIntegerImage(t *testing.T) {
+	north := buildFITS(t, 16, []int{2, 2}, sfdHeader("1"), keyOrder, []float64{1, 2, 3, 4})
+
+	serveSFD(t, north, hemisphereFITS(t, "-1", [4]float64{5, 6, 7, 8}))
+
+	_, err := Open(context.Background())
+	if !errors.Is(err, ErrSFD) {
+		t.Fatalf("err = %v, want ErrSFD", err)
+	}
+
+	if !strings.Contains(err.Error(), "floating") {
+		t.Errorf("the error does not say why an integer image is refused: %v", err)
+	}
+}
+
+// TestSFDOpenRefusesSomethingThatIsNotAnImage: the identifier addresses a
+// deposited file, so what comes back need not be an image at all.
+func TestSFDOpenRefusesSomethingThatIsNotAnImage(t *testing.T) {
+	serveSFD(t,
+		[]byte(strings.Repeat("not a FITS file ", fitsBlock/16)),
+		hemisphereFITS(t, "-1", [4]float64{5, 6, 7, 8}),
+	)
+
+	if _, err := Open(context.Background()); !errors.Is(err, ErrSFD) {
+		t.Errorf("err = %v, want ErrSFD", err)
+	}
+}


### PR DESCRIPTION
Refs #122 — not `Closes`: `catalog/fink` (30.7%) and `skybrightness/plan` (39.4%) are untouched.

#122 names this tier as the one where coverage should be highest and is lowest. It is the
only tier CLAUDE.md allows to do I/O, so parse errors, schema drift and missing-data paths
are the failures that will actually happen in the field. Everything measured before this was
arithmetic; **nothing that touched a service or a file was covered at all.**

| function | before | after |
| :--- | ---: | ---: |
| `Fetch` | 0% | 100% |
| `readCache` | 0% | 100% |
| `writeCache` | 0% | 87.5% |
| `query` | 0% | 100% |
| `CachedDirections` | 0% | 93.3% |
| `SFD.Open` | 0% | 88.9% |
| `openHemisphere` | 0% | 82.4% |
| `fromImage` | 0% | 100% |
| `pixels` | 0% | 100% |
| **package** | **37.5%** | **96.5%** |

## The IRSA side

Against a local server and a temporary cache directory:

- **A second session asks nothing.** The client is built lazily, on the first sightline that
  actually needs asking, so a fully cached call must open no connection — asserted as a
  request count, not as elapsed time.
- **Directions inside one 0.1° cell are one question.**
- **A run cut off part way keeps what it already paid for.** Without that the next run
  re-asks for everything, which is the behaviour the cache exists to stop — this package
  once spent twenty-five minutes of IRSA's time re-answering answered questions.
- **A corrupt cache line costs the sightline on it, not the file.** Truncated, non-numeric,
  negative, NaN and infinite values are each rejected while the good lines either side
  survive.
- **A cold cache is an empty result, not an error.**

## The SFD side

Against synthetic 2×2 hemispheres built in the test. The real files are 64 MB behind a
Dataverse download, so no offline test can read them — but every reason `Open` refuses one
can be exercised, and those are the failures that happen:

- a deposit reorganised under identifiers that are Dataverse *file numbers*, not names;
- an identifier repointed at the reddening map — same deposit, plausible values, wrong
  quantity, and nothing downstream could detect it;
- a projection keyword dropped or a different projection;
- two files that are the same hemisphere;
- an integer BITPIX, which would need BSCALE and BZERO applied per pixel and is refused
  rather than guessed at.

Fixtures are built in the test rather than checked in, so what each case varies is visible
where it is asserted.

`CachedDirections`' ordering is pinned too. Go randomises map iteration, so without the sort
the same cache reads back differently on consecutive runs and no comparison against it is
reproducible.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1 ./...`, `go test
-tags=validation ./...`, `golangci-lint run --build-tags="integration,network,validation"`
at 0 issues. The package's own runtime goes from 0.20 s to 5.2 s, almost all of it the
two-second pacing the service is owed; the ordering test is seeded through `writeCache`
rather than `Fetch` for exactly that reason.

| mutation | killed by |
| :--- | :--- |
| re-query a cell already on disk | `TestFetchServesASecondSessionFromDisk` |
| accept any `BUNIT` | `TestSFDOpenRefusesAMisdescribedFile` |
| accept two of the same hemisphere | `TestSFDOpenRefusesTwoOfTheSameHemisphere` |
| keep negative and NaN cache values | `TestReadCacheSkipsUnusableLines` |

## Two rows of #122's table are stale

Worth correcting rather than leaving to mislead: `dust` was 23% and is 37.5% on main before
this change, and `remote/s3` is listed as having no tests when it has one — it holds no
executable statements at all, so its coverage is undefined rather than zero. The issue's
suggestion for it ("a compile-only test asserting the blank import registers the `s3://`
scheme") is already what `remote/s3/s3_test.go` does.
