### PR TITLE
test: a 403 is the service declining, not astrogo asking wrongly

### DIFF
--- a/docs/changelog.d/208-403-is-the-service-declining.md
+++ b/docs/changelog.d/208-403-is-the-service-declining.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 208
+---
+**A 403 failed the build instead of skipping the test.** CelesTrak answers a
+burst of requests with "Forbidden: Access is denied" and serves the same query
+normally a minute later, which `testutil.SkipOnUpstreamFailure` classified as
+astrogo sending a bad request. To a caller that sent no credential there is
+nothing to correct, so it now skips; 401 still fails, and a new registry test
+keeps the invariant that argument rests on (#206).

--- a/internal/testutil/upstream.go
+++ b/internal/testutil/upstream.go
@@ -19,11 +19,31 @@ import (
 // outage at CelesTrak or JPL is reported as a defect in this repository — and
 // it blocks pull requests that never touched the package.
 //
-// The classification is deliberately narrow. A 5xx, a 429, a 408, a request
-// that never completed and a connection dropped mid-transfer are the
+// The classification is deliberately narrow. A 5xx, a 429, a 408, a 403, a
+// request that never completed and a connection dropped mid-transfer are the
 // upstream's problem. Every other 4xx is not: a 400 or a 404 means astrogo
 // built a request the service rejected, which is exactly the defect these
 // tests exist to catch, and it stays a failure.
+//
+// # Why 403 is on the upstream's side and 401 is not
+//
+// They look like the same case and are opposite ones. A 401 says "you must
+// authenticate", which for an endpoint astrogo believes is public means
+// astrogo's model of that endpoint is wrong — the URL moved, or the service
+// grew an auth requirement — and that is a defect to see. A 403 says "I know
+// who you are and I decline", and to a caller that sent no credential there is
+// nothing to get right: it is the service's policy, not our request.
+//
+// That reasoning holds only while astrogo sends no credential the service
+// requires, which remote.TokenEnv's contract states ("a token is an
+// optimisation, never a requirement") and remote's
+// TestNoAPIEndpointRequiresACredential enforces. Break that invariant and this
+// arm starts hiding a real authorization failure — which is why the test that
+// keeps it true names this function.
+//
+// Observed rather than assumed: CelesTrak answers a burst of requests with an
+// IIS "403 - Forbidden: Access is denied" page and serves the same query
+// normally a minute later. See #206.
 func SkipOnUpstreamFailure(tb testing.TB, err error) {
 	tb.Helper()
 
@@ -51,8 +71,13 @@ func upstreamFailure(err error) (string, bool) {
 			return "rate limited", true
 		case code == http.StatusRequestTimeout:
 			return "request timeout", true
+		case code == http.StatusForbidden:
+			// The service declined to serve a request that carried no
+			// credential, so there is nothing about the request to correct.
+			// See this function's doc comment for why 401 is not here.
+			return "refused by the service", true
 		default:
-			// 4xx other than the two above means we sent a bad request.
+			// 4xx other than those above means we sent a bad request.
 			return "", false
 		}
 	}

--- a/internal/testutil/upstream_test.go
+++ b/internal/testutil/upstream_test.go
@@ -50,11 +50,20 @@ func TestUpstreamFailureClassification(t *testing.T) {
 		{"network timeout", timeout, true},
 		{"wrapped 500", fmt.Errorf("norad: fetch failed: %w", &httpStatusError{500}), true},
 
+		// A service declining to serve a request that carried no credential.
+		// CelesTrak answers a burst this way — an IIS "Forbidden: Access is
+		// denied" page — and serves the same query normally a minute later.
+		{"403 forbidden", &httpStatusError{403}, true},
+		{"wrapped 403", fmt.Errorf("norad: fetch failed: %w", &httpStatusError{403}), true},
+
 		// We sent a bad request: exactly what these tests exist to catch.
 		{"400 bad request", &httpStatusError{400}, false},
 		{"404 not found", &httpStatusError{404}, false},
+		// 401 is the opposite of the 403 above and not a near-duplicate of it.
+		// It says the service wants authentication, which for an endpoint
+		// astrogo believes is public means astrogo's model of that endpoint is
+		// wrong — the URL moved, or the service grew an auth requirement.
 		{"401 unauthorized", &httpStatusError{401}, false},
-		{"403 forbidden", &httpStatusError{403}, false},
 		{"parse failure", errStaticParse, false},
 		{"connection refused", &net.DNSError{}, false},
 	}

--- a/remote/endpoint_test.go
+++ b/remote/endpoint_test.go
@@ -103,3 +103,77 @@ func TestDefaultEndpointsCacheDirsMatchOnDiskLayout(t *testing.T) {
 		}
 	}
 }
+
+// TestNoAPIEndpointRequiresACredential is what internal/testutil's
+// SkipOnUpstreamFailure treats a 403 as the upstream's problem on the strength
+// of.
+//
+// # The argument it holds up
+//
+// A 403 says "I know who you are and I decline". To a caller that sent no
+// credential there is nothing about the request to correct, so it is the
+// service's policy rather than astrogo's defect — CelesTrak answers a burst
+// that way and serves the same query normally a minute later (#206). A 401 is
+// the opposite and stays a failure: it says the service wants authentication,
+// which for an endpoint astrogo believes is public means the endpoint moved or
+// grew a requirement.
+//
+// That reasoning is only sound while astrogo never sends a credential the
+// service demands. TokenEnv's own contract says so — "a token is an
+// optimisation, never a requirement: every endpoint that declares one must
+// still work without it" — and this is where the contract stops being prose.
+//
+// # Why the list rather than a flag
+//
+// An inventory, not an exclusion list: adding an entry means writing down why
+// the endpoint needs a token and confirming it still answers without one. A
+// boolean would be set without either.
+//
+// The KindAPI restriction is the other half. Credentials also reach
+// CopernicusEODATA, through the AWS SDK's default chain, and a 403 from there
+// is a real configuration error a developer needs to see. It never reaches the
+// classifier: SkipOnUpstreamFailure matches errors carrying an HTTPStatus, and
+// only remote/api's HTTPError has one — a blob-backed endpoint's failures come
+// from gocloud and the AWS SDK instead. So the invariant is specifically that
+// no *KindAPI* endpoint requires a credential.
+func TestNoAPIEndpointRequiresACredential(t *testing.T) {
+	// Every KindAPI endpoint that declares a token, and why it is optional
+	// there. Gaia@AIP serves the same DR3 tables unauthenticated; the token
+	// only raises the row limit and the queue priority.
+	optional := map[EndpointID]string{
+		GaiaAIP:      "Gaia@AIP serves the same DR3 tables anonymously; a token raises row limits and queue priority",
+		GaiaAIPAsync: "the same mirror's async job endpoint, and the same token, with the same anonymous fallback",
+	}
+
+	for _, ep := range Endpoints() {
+		if ep.TokenEnv == "" {
+			continue
+		}
+
+		if ep.Kind != KindAPI {
+			continue
+		}
+
+		if _, ok := optional[ep.ID]; !ok {
+			t.Errorf("endpoint %s declares TokenEnv %q and is not in this test's inventory.\n"+
+				"  If the token is optional, add it with the reason. If the service now *requires*\n"+
+				"  one, internal/testutil.SkipOnUpstreamFailure must stop treating 403 as the\n"+
+				"  upstream's problem — it would hide a real authorization failure.",
+				ep.ID, ep.TokenEnv)
+		}
+	}
+
+	// The inventory must not outlive its entries either, or it stops being a
+	// record of anything.
+	for id := range optional {
+		ep, ok := Lookup(id)
+		if !ok {
+			t.Errorf("inventory names %s, which is not a registered endpoint", id)
+			continue
+		}
+
+		if ep.TokenEnv == "" {
+			t.Errorf("inventory names %s as token-carrying, but it declares no TokenEnv", id)
+		}
+	}
+}


### PR DESCRIPTION
Closes #206.

CelesTrak answers a burst of requests with an IIS **"403 - Forbidden: Access is denied"**
page and serves the same query normally a minute later. It failed two gate runs on branches
that touched neither `catalog/norad` nor the network:

```
--- FAIL: TestFetchISS_Live (11.51s)
    norad_network_test.go:68: norad: fetch failed: remote/api: http 403 -
      <title>403 - Forbidden: Access is denied</title>
```

## Why the old classification does not cover it

`SkipOnUpstreamFailure` put 403 with the 400s, and had a reason for it — every other 4xx
means astrogo built a request the service rejected, which is the defect these tests exist to
catch. That reasoning does not reach this case.

- **401** says *"you must authenticate"*. For an endpoint astrogo believes is public, that
  means astrogo's model of it is wrong — the URL moved, or the service grew a requirement.
  A defect worth seeing. **Stays a failure.**
- **403** says *"I know who you are and I decline"*. To a caller that sent no credential
  there is nothing about the request to correct. It is the service's policy. **Now skips.**

The test table now says that, so the two read as opposites rather than as near-duplicates
someone will "tidy up" later.

## The invariant the argument rests on

This is only sound while astrogo never sends a credential a service *demands*.
`remote.TokenEnv`'s contract already says so —

> A token is an optimisation, never a requirement: every endpoint that declares one must
> still work without it.

— and it was prose with nothing enforcing it. `TestNoAPIEndpointRequiresACredential` is
where it stops being prose: an inventory of the `KindAPI` endpoints carrying a token, each
with *why* it is optional there, failing on any addition and pointing at
`SkipOnUpstreamFailure` by name. An inventory rather than a boolean, because adding an entry
means writing down that the endpoint still answers without one; a flag would be set without
checking.

`KindAPI` is the right restriction rather than an oversight, and the test says why.
Credentials also reach `CopernicusEODATA` through the AWS SDK's default chain, and a 403
*there* is a real configuration error a developer needs to see. It never reaches this
classifier: `SkipOnUpstreamFailure` matches errors carrying an `HTTPStatus()`, and only
`remote/api`'s `HTTPError` has one — a blob-backed endpoint's failures arrive from gocloud
and the AWS SDK instead.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags=validation ./...`, `go test -tags=integration ./catalog/...`,
`golangci-lint run --build-tags="integration,network,validation"` at 0 issues.

| mutation | killed by |
| :--- | :--- |
| 403 back among the failures | `TestUpstreamFailureClassification` |
| 401 joining the skips | `TestUpstreamFailureClassification` |
| a `KindAPI` endpoint gains a token with no inventory entry | `TestNoAPIEndpointRequiresACredential` |

Together with #204 — which made these tests report *what* failed — a CelesTrak throttle now
skips with the status in the message instead of failing a build with `Failed to resolve ISS`.
