### PR TITLE
time: report the second a negative leap second removes

### DIFF
--- a/docs/changelog.d/209-negative-leap-second-report.md
+++ b/docs/changelog.d/209-negative-leap-second-report.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 209
+---
+`time.Date` reports a `23:59:59` that a registered ΔAT record says was removed
+by a negative leap second — the mirror of the `23:59:60` warning, on the same
+terms. None has ever been announced, which is why it is written now: Levine,
+Tavella & Milton (2023) project one by about 2030 and warn that never having
+happened is what makes errors near-certain when it does (#147).

--- a/time/doc.go
+++ b/time/doc.go
@@ -153,6 +153,17 @@
 // whether the day in question carried a real leap second or whether the
 // timestamp names an instant that never existed at all.
 //
+// The mirror case has never happened and is now expected to. A negative leap
+// second removes the last second of a day — 23:59:58 is followed directly by
+// 00:00:00 — and [Time] can no more say a civil second is absent than it can
+// say one is present. The ITU-R has permitted one since 1972 and none has been
+// announced; Levine, Tavella & Milton (2023) project one by about 2030 and
+// warn that because they "have never happened ... it is almost a certainty
+// that there will be widespread errors in realizing the event". [Date] reports
+// a 23:59:59 that a registered ΔAT record says was removed, on the same terms
+// as the positive case. Nothing in the published record triggers it today,
+// which is exactly why it is written now rather than then.
+//
 // If you have data with real 23:59:60 timestamps in it, hold those instants in
 // TAI, which has no leap seconds to label and no ambiguity across the step.
 // SOFA's own answer is different — iauDtf2d lets the UTC day run to 86401

--- a/time/leapsecond_alias.go
+++ b/time/leapsecond_alias.go
@@ -143,3 +143,75 @@ func nextDay(y, m, d int) (int, int, int, float64) {
 func isoSecond(y, m, d, hour, minute, second int) string {
 	return fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ", y, m, d, hour, minute, second)
 }
+
+// The mirror image, which has never happened and is now expected to.
+//
+// A negative leap second removes the last second of a UTC day: 23:59:58 is
+// followed directly by 00:00:00, and 23:59:59 is an instant that did not occur.
+// The ITU-R has permitted one since 1972 and none has ever been announced, so
+// fifty years of one-sided history sit behind every assumption here — Levine,
+// Tavella & Milton (2023) project one "by about the year 2030" and warn that
+// because they "have never happened ... it is almost a certainty that there
+// will be widespread errors in realizing the event".
+//
+// [Time] cannot say a civil second is absent any more than it can say one is
+// present, so the answer is the same as for the positive case: report it. See
+// #147, and #144 for the representation question both share.
+
+var warnSecondRemovedOnce sync.Once
+
+// warnIfSecondRemoved reports, once per process, that an instant named the
+// second a negative leap second took out of the record. Called for any second
+// of 59; it decides the rest.
+//
+// The decision runs on the UTC components, not on the ones the caller wrote.
+// The removal happens at the end of a UTC day, so in UTC+13 the same instant is
+// 12:59:59 on the following date — a gate on the caller's own hour and minute
+// would never fire there, and would then look at the wrong day anyway. Found by
+// the test for it, after a first version gated in Date on the local clock.
+//
+// The order is deliberate, and the cost is worth stating rather than calling
+// cheap. Measured on Date, i9-11980HK, ns/op:
+//
+//	ordinary second                    19.6
+//	second 59, UTC                     22.1   the branch and a no-op conversion
+//	second 59, UTC+13                  54.0   a real zone conversion
+//	23:59:59 UTC                      209.7   plus the two ΔAT lookups
+//
+// So one timestamp in sixty pays a few nanoseconds, one in 86400 pays the
+// lookups, and today none reaches the classifier's true branch at all, because
+// no negative leap second has ever been announced.
+func warnIfSecondRemoved(year int, month time.Month, day, hour, minute int, loc *time.Location) {
+	y, m, d, hh, mm := utcComponents(year, month, day, hour, minute, loc)
+
+	if hh != 23 || mm != 59 {
+		return
+	}
+
+	if !negativeLeapSecondEndsDay(y, int(m), d) {
+		return
+	}
+
+	warnSecondRemovedOnce.Do(func() { logSecondRemoved(y, int(m), d, hh, mm) })
+}
+
+// logSecondRemoved writes the warning, split from its [sync.Once] for the same
+// reason as [logLeapSecondAliased].
+func logSecondRemoved(y, m, d, hour, minute int) {
+	logging.Warn("second removed by a negative leap second, instant did not occur",
+		"utc", isoSecond(y, m, d, hour, minute, 59),
+		"reason", "this UTC day ended at 23:59:58; the next instant was the following midnight",
+		"delta_at_before", deltaAT(y, m, d, 0.5),
+		"delta_at_after", deltaAT(nextDay(y, m, d)),
+		"remedy", "check the source of this timestamp; UTC never labelled this second")
+}
+
+// negativeLeapSecondEndsDay reports whether the last second of the UTC day
+// (y, m, d) was removed — that is, whether 23:59:59 never happened on it.
+//
+// The mirror of [leapSecondEndsDay], and a whole second in the other
+// direction for the same reason: pre-1972 ΔAT drifts by microseconds across
+// every day, so only a step of exactly −1 is a leap second at all.
+func negativeLeapSecondEndsDay(y, m, d int) bool {
+	return math.Abs(deltaAT(nextDay(y, m, d))-deltaAT(y, m, d, 0.0)+1.0) < 1e-9
+}

--- a/time/negative_leapsecond_alias_test.go
+++ b/time/negative_leapsecond_alias_test.go
@@ -1,0 +1,241 @@
+package time
+
+import (
+	"bytes"
+	"log/slog"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+	stdtime "time"
+
+	"github.com/TuSKan/astrogo/internal/gofaext"
+	"github.com/TuSKan/astrogo/logging"
+)
+
+// builtinRecord reads gofa's own ΔAT table back out as registry entries.
+//
+// Derived rather than transcribed: RegisterLeapSeconds refuses a table that
+// contradicts the built-in record, so a hand-copied one would have to be kept
+// in step with a gofa upgrade by hand, and the failure would look like a
+// registry bug rather than a stale fixture. The scan is the same one
+// builtinLastStep uses.
+func builtinRecord(t *testing.T) []LeapSecond {
+	t.Helper()
+
+	const (
+		firstYear = 1972
+		lastYear  = 2100
+	)
+
+	var (
+		out      []LeapSecond
+		previous float64
+	)
+
+	for y := firstYear; y <= lastYear; y++ {
+		for _, m := range [2]int{1, 7} {
+			got, status := gofaext.Dat(y, m, 1, 0)
+			if status < 0 {
+				continue
+			}
+
+			if len(out) == 0 || math.Abs(got-previous) > 1e-9 {
+				out = append(out, LeapSecond{Year: y, Month: m, Day: 1, DeltaAT: got})
+			}
+
+			previous = got
+		}
+	}
+
+	if len(out) == 0 {
+		t.Fatal("gofa reported no ΔAT steps; the scan is wrong")
+	}
+
+	return out
+}
+
+// withNegativeLeapSecondAt2030 registers the published record extended by a
+// hypothetical negative leap second at the end of 2029 — ΔAT dropping by one,
+// which has never been announced and which Levine, Tavella & Milton (2023)
+// project for about 2030.
+//
+// Whether one is ever announced for that date is beside the point. What is
+// exercised is that an announced one would be recognised.
+func withNegativeLeapSecondAt2030(t *testing.T) {
+	t.Helper()
+
+	record := builtinRecord(t)
+	last := record[len(record)-1]
+
+	if err := RegisterLeapSeconds(append(record,
+		LeapSecond{Year: 2030, Month: 1, Day: 1, DeltaAT: last.DeltaAT - 1},
+	), "test: hypothetical negative leap second"); err != nil {
+		t.Fatalf("RegisterLeapSeconds: %v", err)
+	}
+
+	t.Cleanup(ResetLeapSeconds)
+}
+
+// TestNegativeLeapSecondEndsDay: the classifier has to tell a removed second
+// from an inserted one and from an ordinary day, and fifty years of history
+// contains only the middle case.
+func TestNegativeLeapSecondEndsDay(t *testing.T) {
+	withNegativeLeapSecondAt2030(t)
+
+	tests := []struct {
+		y, m, d int
+		want    bool
+		why     string
+	}{
+		{2029, 12, 31, true, "the hypothetical negative leap second"},
+		{2016, 12, 31, false, "a positive leap second is not a removed one"},
+		{2029, 12, 30, false, "the day before the step, not the step"},
+		{2030, 1, 1, false, "the day after"},
+		{2029, 6, 30, false, "a mid-year boundary with no step"},
+		{1965, 12, 31, false, "pre-1972 ΔAT drifts by microseconds, which is not a leap second"},
+	}
+
+	for _, tt := range tests {
+		if got := negativeLeapSecondEndsDay(tt.y, tt.m, tt.d); got != tt.want {
+			t.Errorf("negativeLeapSecondEndsDay(%d-%02d-%02d) = %v, want %v (%s)",
+				tt.y, tt.m, tt.d, got, tt.want, tt.why)
+		}
+	}
+}
+
+// TestPositiveAndNegativeClassifiersDoNotOverlap: a day carries at most one
+// kind of leap second, and reporting an inserted one as removed would send the
+// caller looking for the opposite defect.
+func TestPositiveAndNegativeClassifiersDoNotOverlap(t *testing.T) {
+	withNegativeLeapSecondAt2030(t)
+
+	for _, d := range []struct {
+		y, m, day          int
+		positive, negative bool
+	}{
+		{2016, 12, 31, true, false},
+		{2029, 12, 31, false, true},
+		{2020, 12, 31, false, false},
+	} {
+		gotP := leapSecondEndsDay(d.y, d.m, d.day)
+		gotN := negativeLeapSecondEndsDay(d.y, d.m, d.day)
+
+		if gotP != d.positive || gotN != d.negative {
+			t.Errorf("%d-%02d-%02d: inserted = %v (want %v), removed = %v (want %v)",
+				d.y, d.m, d.day, gotP, d.positive, gotN, d.negative)
+		}
+	}
+}
+
+// TestSecondRemovedWarningIsAWarningNotProgress mirrors the positive case:
+// Date has no error return, so this is the only notice a caller gets that the
+// instant they built is one UTC never labelled.
+func TestSecondRemovedWarningIsAWarningNotProgress(t *testing.T) {
+	// Not parallel: it swaps the process-wide logger and the leap-second table.
+	defer logging.Set(nil)
+
+	withNegativeLeapSecondAt2030(t)
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	// Called directly rather than through warnSecondRemoved, whose sync.Once
+	// would be spent by whichever test ran first.
+	logSecondRemoved(2029, 12, 31, 23, 59)
+
+	out := buf.String()
+
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("the removed-second message is not at WARN:\n%s\n"+
+			"  The default logger drops everything below WARN, so demoting this "+
+			"would make the loss silent.", out)
+	}
+
+	for _, want := range []string{
+		`msg="second removed by a negative leap second, instant did not occur"`,
+		"utc=2029-12-31T23:59:59Z",
+		"delta_at_before=37",
+		"delta_at_after=36",
+		"remedy=",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the message does not carry %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDateReportsARemovedSecond is the wiring, and the two negatives beside it
+// are what keep the warning from becoming noise: 23:59:59 is an ordinary
+// instant on every day in history so far, and the check must stay silent on
+// all of them.
+func TestDateReportsARemovedSecond(t *testing.T) {
+	defer logging.Set(nil)
+
+	withNegativeLeapSecondAt2030(t)
+
+	warnSecondRemovedOnce = sync.Once{}
+	defer func() { warnSecondRemovedOnce = sync.Once{} }()
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	Date(2029, 12, 31, 23, 59, 59, 0, stdtime.UTC)
+
+	if !strings.Contains(buf.String(), "second removed by a negative leap second") {
+		t.Errorf("Date built a second that never occurred without reporting it; logger saw:\n%q", buf.String())
+	}
+
+	for _, quiet := range []struct {
+		name               string
+		y, mo, d, h, mi, s int
+	}{
+		{"the same second on an ordinary day", 2029, 12, 30, 23, 59, 59},
+		{"the second before the removed one", 2029, 12, 31, 23, 59, 58},
+		{"23:59:59 on a positive leap-second day", 2016, 12, 31, 23, 59, 59},
+	} {
+		buf.Reset()
+
+		warnSecondRemovedOnce = sync.Once{}
+
+		Date(quiet.y, stdtime.Month(quiet.mo), quiet.d, quiet.h, quiet.mi, quiet.s, 0, stdtime.UTC)
+
+		if buf.String() != "" {
+			t.Errorf("%s: Date warned about an ordinary instant:\n%q", quiet.name, buf.String())
+		}
+	}
+}
+
+// TestRemovedSecondWarningReportsTheUTCDate: the removal happens at the end of
+// a UTC day, so a caller in another zone writes it with a different date and a
+// different hour — and the check has to run on the UTC components or it looks
+// at the wrong day entirely.
+func TestRemovedSecondWarningReportsTheUTCDate(t *testing.T) {
+	defer logging.Set(nil)
+
+	withNegativeLeapSecondAt2030(t)
+
+	warnSecondRemovedOnce = sync.Once{}
+	defer func() { warnSecondRemovedOnce = sync.Once{} }()
+
+	// UTC+13: 2029-12-31 23:59:59 UTC is 2030-01-01 12:59:59 there.
+	east := stdtime.FixedZone("UTC+13", 13*3600)
+
+	var buf bytes.Buffer
+
+	logging.Set(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	Date(2030, stdtime.January, 1, 12, 59, 59, 0, east)
+
+	out := buf.String()
+
+	if !strings.Contains(out, "second removed by a negative leap second") {
+		t.Fatalf("a removed second written in UTC+13 was not recognised; logger saw:\n%q", out)
+	}
+
+	if !strings.Contains(out, "utc=2029-12-31T23:59:59Z") {
+		t.Errorf("the warning reports the local components rather than the UTC ones:\n%s", out)
+	}
+}

--- a/time/time.go
+++ b/time/time.go
@@ -676,12 +676,22 @@ func (t Time) AddDays(d float64) Time {
 //
 // A second of 60 — the label UTC gives an inserted leap second — cannot be
 // represented and is normalised onto the following midnight, one second later
-// than the instant asked for. That is reported through [logging] rather than
-// returned, since this constructor has no error to return; see
-// leapsecond_alias.go for why the type cannot hold it.
+// than the instant asked for. 23:59:59 on the day of a negative leap second is
+// the mirror problem: a second UTC never labelled, which this returns anyway.
+// Both are reported through [logging] rather than returned, since this
+// constructor has no error to return; see leapsecond_alias.go for why the type
+// can hold neither.
 func Date(year int, month time.Month, day, hour, minute, second, nanosecond int, loc *time.Location) Time {
-	if second >= 60 {
+	switch {
+	case second >= 60:
 		warnLeapSecondAliased(year, month, day, hour, minute, second, loc)
+
+	// Only the last second of a UTC day can be one a negative leap second
+	// removed. Which second that is depends on the caller's zone, so the hour
+	// and minute are checked after converting rather than here — see
+	// warnIfSecondRemoved.
+	case second == 59:
+		warnIfSecondRemoved(year, month, day, hour, minute, loc)
 	}
 
 	// For years within Go's time.Time range, delegate to FromGo which


### PR DESCRIPTION
Closes #147. The representation question — what `Time` should *hold* for either kind of leap
second — stays on #144.

#198 made `Date` say when it aliases an inserted leap second away. This is the mirror, which
#147 asks for and which `negative_leapsecond_test.go` already names as the gap it cannot
cover:

> on the day of a negative leap second 23:59:59 does not exist, and `time.Time` has no way
> to say that a civil second is absent — the mirror image of #144, where it has no way to
> say 23:59:60 is present

## Why now, for something that has never happened

A negative leap second removes the last second of a UTC day: 23:59:58 is followed directly
by 00:00:00. The ITU-R has permitted one since 1972 and none has ever been announced — and
that is the argument for writing it now rather than then. Levine, Tavella & Milton (2023)
project one by about 2030 and warn that because they *"have never happened ... it is almost
a certainty that there will be widespread errors in realizing the event"*.

Fifty years of one-sided history is what writes an assumption into code without anyone
deciding to, and this repository has already found one: the record's own well-formedness
test asserted every step was **+1 s** and would have rejected the first correct table
containing a negative entry (#148).

`Date` now reports a `23:59:59` that the ΔAT record in force says was removed, naming the
values either side of the step. Reachable today only through `RegisterLeapSeconds` — which
is how an early adopter would prepare, and how these tests exercise it.

## What the tests caught that I had wrong

The first version gated in `Date` on **the caller's own hour and minute**. The removal
happens at the end of a *UTC* day, so in UTC+13 the same instant is written `12:59:59` on
the following date: the gate never fired, and had it fired it would have asked the
classifier about the wrong day. The decision now runs on the converted components and `Date`
gates only on `second == 59`.

`TestRemovedSecondWarningReportsTheUTCDate` is what found it, and the mutation that puts the
bug back is one of the three below.

## Cost, measured rather than called cheap

Recorded in the code, i9-11980HK, ns/op:

| case | ns/op |
| :--- | ---: |
| ordinary second | 19.6 |
| second 59, UTC | 22.1 |
| second 59, UTC+13 (a real zone conversion) | 54.0 |
| 23:59:59 UTC (plus the two ΔAT lookups) | 209.7 |

One timestamp in sixty pays the first, one in 86400 the last, and today none reaches the
classifier's true branch at all. The UTC↔TAI hot path does not go through `Date` and is
unchanged at 44 ns/op against its documented 43.2 baseline.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags=validation ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

The test fixture builds its ΔAT table by reading gofa's own record back out rather than
transcribing it, so a gofa upgrade cannot turn a stale fixture into what looks like a
registry bug.

| mutation | killed by |
| :--- | :--- |
| `Date` never checks second 59 | `TestDateReportsARemovedSecond` |
| classifier accepts a step of either sign | `TestPositiveAndNegativeClassifiersDoNotOverlap` |
| gate on the caller's local hour/minute | `TestRemovedSecondWarningReportsTheUTCDate` |

#147's second half — the two places stating |UT1−UTC| ≤ 0.9 s as a bound — was already
fixed: `time/doc.go` and `logEOPUnavailable` both now carry the CGPM Resolution 4 (2022)
caveat and the "unbounded after 2035" wording.
