### PR TITLE
time: report which epochs a smeared clock could have written

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,20 @@ for _, star := range targets {
 }
 ```
 
+### Epochs From a Smeared System Clock
+
+Around a leap second, a host clock disciplined by NTP may be **deliberately wrong by up to 0.5 s for up to 24 hours**, and no library can detect it. Rather than repeat or skip a second, providers spread the step over hours: Google adjusts frequency for the 24 h before, Facebook for the 18 h after, Alibaba symmetrically 12 h either side, Microsoft for the second before — and they "generally do not indicate which method is being used" (Levine, Tavella & Milton 2023, *Metrologia* **60** 014001, table 2).
+
+For this library 0.5 s is 0.3 arcsec of lunar motion, 7.5 arcsec of Earth rotation and 3.8 km of ISS ground track: far above the accuracy the rest of astrogo works to, and far below the threshold at which anything looks wrong.
+
+This is the host's clock, not astrogo's, so there is nothing to fix — only something to know:
+
+- An epoch built with `time.Date` or `time.FromJD` never touches a clock and is never smeared. Anything meant to be reproducible should be doing this regardless.
+- PTP (IEEE 1588) distributes TAI plus the current UTC offset, so there is no step to smear. NTP distributes UTC and may.
+- `Time.LeapSmearWindow` reports whether an epoch falls within a day of a leap second and names the step, so a caller can treat those as good to 0.5 s rather than to the microsecond. It is false for every instant since 2016-12-31.
+
+See [`time`'s package documentation](https://pkg.go.dev/github.com/TuSKan/astrogo/time) for the full account.
+
 ### Scheduler Optimality
 
 `SwapOptimizedStrategy` is a **local search heuristic**, not a global optimizer. It improves on greedy/priority strategies via adjacent swaps and gap insertion, with monotonic score guarantees — but it does not find the globally optimal schedule.

--- a/docs/changelog.d/210-leap-smear-window.md
+++ b/docs/changelog.d/210-leap-smear-window.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 210
+---
+`time.Time.LeapSmearWindow` reports whether an epoch falls within a day of a
+leap second and names the step. An NTP-disciplined host may be deliberately
+wrong by up to 0.5 s for up to 24 hours around one — 3.8 km of ISS ground track
+— and no library can detect it, so this says where the question arises rather
+than answering it (#146).

--- a/time/doc.go
+++ b/time/doc.go
@@ -124,7 +124,11 @@
 //     the current UTC offset, so there is no step to smear.
 //   - If neither is possible and the work spans a leap second, treat epochs
 //     from that window as good to 0.5 s rather than to the microsecond, and
-//     say so in whatever the results feed.
+//     say so in whatever the results feed. [Time.LeapSmearWindow] is how a
+//     caller finds out which epochs those are: it reports whether an instant
+//     falls within a day of a leap second, and names the step. It cannot say
+//     whether a particular host smeared — nothing can — only that this is an
+//     epoch where the question arises.
 //
 // This is not a defect this package can fix — the host clock is the host's —
 // and it is worth knowing rather than discovering. The window is also

--- a/time/smear.go
+++ b/time/smear.go
@@ -1,0 +1,119 @@
+package time
+
+import (
+	"math"
+
+	"github.com/TuSKan/astrogo/internal/gofaext"
+)
+
+// smearWindowDays is how far either side of a leap second a host clock may be
+// deliberately wrong.
+//
+// One day, which is the envelope of the four published methods rather than any
+// one of them (Levine, Tavella & Milton 2023, Metrologia 60 014001, table 2):
+// Google adjusts for the 24 h before, Facebook for the 18 h after, Alibaba
+// symmetrically 12 h either side, Microsoft for the second before. Providers
+// "generally do not indicate which method is being used", so a caller cannot
+// narrow it by asking, and the union is the only honest answer.
+const smearWindowDays = 1.0
+
+// LeapSmearWindow reports whether t falls close enough to a leap second that a
+// host clock disciplined by NTP may have been deliberately wrong when it was
+// read, and returns the leap second responsible.
+//
+// # What the window means
+//
+// Rather than repeat or skip a second, an NTP provider spreads the step over
+// hours by running the clock slightly fast or slow. All the published methods
+// "have an error on the order of ±0.5 s during the adjustment period", and for
+// this library 0.5 s is 0.3 arcsec of lunar motion, 7.5 arcsec of Earth
+// rotation and 3.8 km of ISS ground track — far above the accuracy the rest of
+// this package works to, and far below the threshold at which anything looks
+// wrong.
+//
+// # What to do with a true
+//
+// Nothing automatic, which is why this reports rather than corrects. No library
+// can tell whether a given host smeared, by how much, or in which direction:
+// the answer depends on whose NTP server it happened to be using, and the host
+// cannot say. What a caller can do is treat such an epoch as good to 0.5 s
+// rather than to the microsecond, and say so in whatever the results feed.
+//
+// # When it is worth asking
+//
+// Only for an epoch that came from a host clock — [Now], [NowUTC], or a
+// timestamp recorded by some other machine. An epoch built with [Date] or
+// [FromJD] never touched a clock and is never smeared, so asking about one
+// answers a question nobody has.
+//
+// The answer is false for every instant since 2016-12-31, the most recent leap
+// second, and none is currently scheduled. It is historical data, and the
+// negative leap second projected for about 2030, that this is for.
+//
+// The record consulted is the one in force — see [RegisterLeapSeconds] — so a
+// caller who registered an announced step gets it before gofa's table carries
+// it.
+func (t Time) LeapSmearWindow() (LeapSecond, bool) {
+	utc := t.UTC()
+	y, m, _, _ := utc.Calendar()
+
+	// A leap second takes effect at midnight beginning the first of a month,
+	// and months are at least 28 days, so the 48-hour window around t can
+	// reach at most one such boundary: this month's start or the next one's.
+	for _, b := range [2]struct{ y, m int }{{y, m}, nextMonth(y, m)} {
+		step, ok := leapStepAt(b.y, b.m)
+		if !ok {
+			continue
+		}
+
+		if math.Abs(utc.JD()-monthStartJD(b.y, b.m)) <= smearWindowDays {
+			return step, true
+		}
+	}
+
+	return LeapSecond{}, false
+}
+
+// leapStepAt reports the leap second taking effect at midnight beginning
+// (y, m, 1), if one does.
+//
+// A whole second, in either direction: pre-1972 ΔAT drifts by microseconds
+// across every boundary, and calling that a leap second would put half the
+// 1960s inside a smear window that did not exist — leap smearing postdates
+// leap seconds, which postdate that drift.
+func leapStepAt(y, m int) (LeapSecond, bool) {
+	after := deltaAT(y, m, 1, 0.0)
+	before := deltaAT(prevDay(y, m, 1))
+
+	if math.Abs(math.Abs(after-before)-1.0) > 1e-9 {
+		return LeapSecond{}, false
+	}
+
+	return LeapSecond{Year: y, Month: m, Day: 1, DeltaAT: after}, true
+}
+
+// monthStartJD is the Julian Date of midnight beginning (y, m, 1) UTC.
+func monthStartJD(y, m int) float64 {
+	jd1, jd2, _ := gofaext.Dtf2d("UTC", y, m, 1, 0, 0, 0)
+	return jd1 + jd2
+}
+
+// nextMonth returns the month following (y, m).
+func nextMonth(y, m int) struct{ y, m int } {
+	if m == 12 {
+		return struct{ y, m int }{y + 1, 1}
+	}
+
+	return struct{ y, m int }{y, m + 1}
+}
+
+// prevDay returns the calendar date before (y, m, d), with a trailing 0.0 day
+// fraction so the result feeds [deltaAT] directly — the mirror of [nextDay],
+// and via the Julian Date for the same reason.
+func prevDay(y, m, d int) (int, int, int, float64) {
+	jd1, jd2, _ := gofaext.Dtf2d("UTC", y, m, d, 0, 0, 0)
+
+	py, pm, pd, _, _ := gofaext.JdToDate(jd1, jd2-1.0)
+
+	return py, pm, pd, 0.0
+}

--- a/time/smear_test.go
+++ b/time/smear_test.go
@@ -1,0 +1,258 @@
+package time
+
+import (
+	"math"
+	"testing"
+	stdtime "time"
+
+	"github.com/TuSKan/astrogo/internal/gofaext"
+)
+
+// utcAt is a UTC instant, built without going through the leap-second warnings
+// in Date's boundary branches.
+func utcAt(y int, m stdtime.Month, d, hh, mm, ss int) Time {
+	return Date(y, m, d, hh, mm, ss, 0, stdtime.UTC)
+}
+
+// TestLeapSmearWindowAroundARealLeapSecond walks the real 2016-12-31 step.
+//
+// The window is one day either side, which is the union of the four published
+// smearing methods rather than any one of them, so the boundaries are what this
+// pins: 24 h out is inside, a minute past that is not.
+func TestLeapSmearWindowAroundARealLeapSecond(t *testing.T) {
+	tests := []struct {
+		name string
+		when Time
+		want bool
+	}{
+		{"the instant of the step", utcAt(2017, stdtime.January, 1, 0, 0, 0), true},
+		{"an hour before", utcAt(2016, stdtime.December, 31, 23, 0, 0), true},
+		{"an hour after", utcAt(2017, stdtime.January, 1, 1, 0, 0), true},
+		{"24 h before, still inside", utcAt(2016, stdtime.December, 31, 0, 0, 0), true},
+		{"24 h after, still inside", utcAt(2017, stdtime.January, 2, 0, 0, 0), true},
+		{"a minute too early", utcAt(2016, stdtime.December, 30, 23, 59, 0), false},
+		{"a minute too late", utcAt(2017, stdtime.January, 2, 0, 1, 0), false},
+		{"a week before", utcAt(2016, stdtime.December, 24, 12, 0, 0), false},
+		{"an ordinary summer day", utcAt(2016, stdtime.July, 15, 12, 0, 0), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.when.LeapSmearWindow()
+			if ok != tt.want {
+				t.Fatalf("LeapSmearWindow() = %v, want %v", ok, tt.want)
+			}
+
+			if !ok {
+				return
+			}
+
+			if got.Year != 2017 || got.Month != 1 || got.Day != 1 {
+				t.Errorf("named %d-%02d-%02d, want the 2017-01-01 step", got.Year, got.Month, got.Day)
+			}
+
+			if got.DeltaAT != 37 {
+				t.Errorf("DeltaAT = %v, want 37", got.DeltaAT)
+			}
+		})
+	}
+}
+
+// TestLeapSmearWindowIsQuietForRecentEpochs: the most recent leap second was
+// 2016-12-31 and none is scheduled, so every instant a caller is likely to hold
+// is outside a window. A helper that answered true routinely would be worth
+// nothing.
+func TestLeapSmearWindowIsQuietForRecentEpochs(t *testing.T) {
+	for _, when := range []Time{
+		utcAt(2026, stdtime.September, 6, 22, 0, 0),
+		utcAt(2020, stdtime.January, 1, 0, 0, 0),
+		utcAt(2024, stdtime.July, 1, 0, 0, 0),
+		utcAt(2021, stdtime.December, 31, 23, 59, 30),
+	} {
+		if got, ok := when.LeapSmearWindow(); ok {
+			t.Errorf("%v was reported inside a smear window for %+v", when, got)
+		}
+	}
+}
+
+// TestLeapSmearWindowIgnoresPre1972Drift: before 1972 UTC tracked UT2 by rate
+// offsets and fractional steps, so ΔAT changes across every month boundary by
+// microseconds. Reading that as a leap second would put most of the 1960s
+// inside a smear window — and leap smearing postdates leap seconds, which
+// postdate the drift.
+func TestLeapSmearWindowIgnoresPre1972Drift(t *testing.T) {
+	for _, when := range []Time{
+		utcAt(1965, stdtime.January, 1, 0, 0, 0),
+		utcAt(1968, stdtime.February, 1, 0, 0, 0),
+		utcAt(1971, stdtime.December, 31, 23, 0, 0),
+	} {
+		if got, ok := when.LeapSmearWindow(); ok {
+			t.Errorf("%v was reported inside a smear window for %+v", when, got)
+		}
+	}
+}
+
+// TestLeapSmearWindowAcceptsAnyScale: the window is a property of the instant,
+// not of how it is labelled. A caller holding TAI or TT must get the same
+// answer as one holding the same instant in UTC, or the helper would report on
+// whichever scale the caller happened to convert to.
+func TestLeapSmearWindowAcceptsAnyScale(t *testing.T) {
+	utc := utcAt(2016, stdtime.December, 31, 23, 0, 0)
+
+	for _, when := range []Time{utc, utc.TAI(), utc.TT(), utc.TDB()} {
+		got, ok := when.LeapSmearWindow()
+		if !ok {
+			t.Errorf("scale %v: not reported inside the 2016-12-31 window", when.Scale())
+			continue
+		}
+
+		if got.Year != 2017 {
+			t.Errorf("scale %v: named the %d step, want 2017", when.Scale(), got.Year)
+		}
+	}
+
+	// The discriminating case, and the reason the conversion is not decorative:
+	// TT runs 69.184 s ahead of UTC, so an instant a minute outside the early
+	// edge lands 9 s inside it if the JD is compared without converting first.
+	// Nothing above catches that — an hour from the boundary, a 69-second shift
+	// changes no answer.
+	justOutside := utcAt(2016, stdtime.December, 30, 23, 59, 0)
+
+	for _, when := range []Time{justOutside, justOutside.TAI(), justOutside.TT(), justOutside.TDB()} {
+		if got, ok := when.LeapSmearWindow(); ok {
+			t.Errorf("scale %v: an instant a minute outside the window was reported inside it, for %+v",
+				when.Scale(), got)
+		}
+	}
+}
+
+// withLeapSecondAt registers gofa's own record extended by one hypothetical
+// step, and restores the built-in table afterwards.
+//
+// The base record is read back out of gofa rather than transcribed, because
+// RegisterLeapSeconds refuses a table that contradicts the built-in one: a
+// hand-copied fixture would need updating by hand on a gofa upgrade, and the
+// failure would read as a registry bug rather than a stale test.
+func withLeapSecondAt(t *testing.T, year, month int, deltaAT float64) {
+	t.Helper()
+
+	const (
+		firstYear = 1972
+		lastYear  = 2100
+	)
+
+	var (
+		record   []LeapSecond
+		previous float64
+	)
+
+	for y := firstYear; y <= lastYear; y++ {
+		for _, m := range [2]int{1, 7} {
+			got, status := gofaext.Dat(y, m, 1, 0)
+			if status < 0 {
+				continue
+			}
+
+			if len(record) == 0 || math.Abs(got-previous) > 1e-9 {
+				record = append(record, LeapSecond{Year: y, Month: m, Day: 1, DeltaAT: got})
+			}
+
+			previous = got
+		}
+	}
+
+	if len(record) == 0 {
+		t.Fatal("gofa reported no ΔAT steps; the scan is wrong")
+	}
+
+	err := RegisterLeapSeconds(append(record,
+		LeapSecond{Year: year, Month: month, Day: 1, DeltaAT: deltaAT},
+	), "test: hypothetical leap second")
+	if err != nil {
+		t.Fatalf("RegisterLeapSeconds: %v", err)
+	}
+
+	t.Cleanup(ResetLeapSeconds)
+}
+
+// TestLeapSmearWindowSeesARegisteredStep: the record consulted is the one in
+// force, so a caller who registered an announced leap second is answered from
+// it before gofa's table carries it. That is the whole reason the registry
+// exists, and it is how the next leap second will arrive.
+func TestLeapSmearWindowSeesARegisteredStep(t *testing.T) {
+	withLeapSecondAt(t, 2030, 1, 38)
+
+	got, ok := utcAt(2029, stdtime.December, 31, 20, 0, 0).LeapSmearWindow()
+	if !ok {
+		t.Fatal("a registered leap second did not open a smear window")
+	}
+
+	if got.Year != 2030 || got.Month != 1 {
+		t.Errorf("named %d-%02d, want the 2030-01 step", got.Year, got.Month)
+	}
+
+	if got.DeltaAT != 38 {
+		t.Errorf("DeltaAT = %v, want 38", got.DeltaAT)
+	}
+
+	if _, ok := utcAt(2029, stdtime.December, 20, 12, 0, 0).LeapSmearWindow(); ok {
+		t.Error("an instant eleven days before the step was reported inside its window")
+	}
+}
+
+// TestLeapSmearWindowSeesARemovedSecond: a negative step opens a window too.
+// None has ever been announced, and the smearing literature is explicit that
+// the published methods say nothing about how one would be handled — so a
+// caller has more reason to ask, not less.
+func TestLeapSmearWindowSeesARemovedSecond(t *testing.T) {
+	withLeapSecondAt(t, 2030, 1, 36)
+
+	got, ok := utcAt(2029, stdtime.December, 31, 20, 0, 0).LeapSmearWindow()
+	if !ok {
+		t.Fatal("a registered negative leap second did not open a smear window")
+	}
+
+	if got.DeltaAT != 36 {
+		t.Errorf("DeltaAT = %v, want 36 — a negative step lowers it", got.DeltaAT)
+	}
+}
+
+// TestPrevDayCarries mirrors TestNextDayCarries: leap seconds land on the first
+// of a month, so every real call crosses a month boundary and most cross a year
+// boundary too.
+func TestPrevDayCarries(t *testing.T) {
+	tests := []struct {
+		y, m, d    int
+		wy, wm, wd int
+	}{
+		{2017, 1, 1, 2016, 12, 31},
+		{2015, 7, 1, 2015, 6, 30},
+		{2016, 3, 1, 2016, 2, 29}, // leap year
+		{1900, 3, 1, 1900, 2, 28}, // not a leap year in the Gregorian calendar
+		{2000, 3, 1, 2000, 2, 29}, // but 2000 is
+	}
+
+	for _, tt := range tests {
+		y, m, d, fd := prevDay(tt.y, tt.m, tt.d)
+		if y != tt.wy || m != tt.wm || d != tt.wd || fd != 0.0 {
+			t.Errorf("prevDay(%d-%02d-%02d) = %d-%02d-%02d+%v, want %d-%02d-%02d+0",
+				tt.y, tt.m, tt.d, y, m, d, fd, tt.wy, tt.wm, tt.wd)
+		}
+	}
+}
+
+// TestNextMonthCarries: the year boundary is the case that matters, since
+// December is where leap seconds most often land.
+func TestNextMonthCarries(t *testing.T) {
+	for _, tt := range []struct{ y, m, wy, wm int }{
+		{2016, 12, 2017, 1},
+		{2015, 6, 2015, 7},
+		{2020, 1, 2020, 2},
+	} {
+		got := nextMonth(tt.y, tt.m)
+		if got.y != tt.wy || got.m != tt.wm {
+			t.Errorf("nextMonth(%d-%02d) = %d-%02d, want %d-%02d",
+				tt.y, tt.m, got.y, got.m, tt.wy, tt.wm)
+		}
+	}
+}


### PR DESCRIPTION
Closes #146.

The issue asks for two things. **The documentation half is already done** — `time/doc.go`'s
"The clock you are given" section carries the four published smearing methods, the ±0.5 s
they agree on, and what 0.5 s is worth here. This is the other half, which the issue leaves
as *"consider"*: a helper that flags an epoch falling near a leap second, since only a
library holding the leap-second table can offer one.

## What it reports, and what it refuses to

`Time.LeapSmearWindow` returns whether an instant falls within a day of a leap second, and
which step. It deliberately does **not** correct anything: no library can tell whether a
given host smeared, by how much, or in which direction — the answer depends on whose NTP
server it happened to be using, and the host cannot say. What a caller does with a `true` is
treat that epoch as good to 0.5 s rather than to the microsecond, and say so in whatever the
results feed.

For this library 0.5 s is 0.3 arcsec of lunar motion, 7.5 arcsec of Earth rotation and 3.8
km of ISS ground track: far above the accuracy the rest of the package works to, and far
below the threshold at which anything looks wrong.

## Two decisions worth stating

**One day either side** is the union of the four published methods rather than any one of
them — Google adjusts for the 24 h before, Facebook for the 18 h after, Alibaba
symmetrically 12 h either side, Microsoft for the second before. Since providers "generally
do not indicate which method is being used" (Levine, Tavella & Milton 2023, table 2), the
union is the only honest answer.

**The step must be a whole second**, not merely a change in ΔAT. Pre-1972 UTC tracked UT2 by
rate offsets, so ΔAT moves across every month boundary by microseconds; reading that as a
leap second would put most of the 1960s inside a smear window that postdates it by a decade.

## It answers false today, and that is the point

The most recent leap second was 2016-12-31 and none is scheduled. This is for historical
data taken around one, and for the negative leap second projected for about 2030. It reads
the record **in force**, so a caller who registered an announced step is answered from it
before gofa's table carries it.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags=validation ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

| mutation | killed by |
| :--- | :--- |
| window widened to a week | `TestLeapSmearWindowAroundARealLeapSecond` |
| any ΔAT change counts, not a whole second | `TestLeapSmearWindowIgnoresPre1972Drift` |
| only the current month's boundary considered | `TestLeapSmearWindowSeesARemovedSecond` |
| compare the caller's JD without converting to UTC | `TestLeapSmearWindowAcceptsAnyScale` |

The last one **survived the first version of that test**. TT runs 69.184 s ahead of UTC,
which changes no answer an hour from the boundary — so the test now also uses an instant a
minute *outside* the early edge, where a 69-second shift moves it 9 s inside.

`README.md` gains the Known Limitations entry the issue asks for.

Note for review order: `smear_test.go`'s `withLeapSecondAt` overlaps
`withNegativeLeapSecondAt2030` in #209, which is not merged. Both read gofa's record back
out rather than transcribing it; worth unifying once both land.
