### PR TITLE
time: add BDT, the BeiDou system time scale

### DIFF
--- a/docs/changelog.d/211-beidou-time-scale.md
+++ b/docs/changelog.d/211-beidou-time-scale.md
@@ -1,0 +1,9 @@
+---
+type: Added
+pr: 211
+---
+`time.BDT`, the BeiDou system time scale, and `Time.BDT()`. TAI − 33 s exactly,
+so BDT − UTC is 4 s today and BDT − GPST a permanent 14 s. Four seconds reads as
+a rounding difference and is 30 km of ISS ground track, which is the argument
+for a name rather than an offset the caller subtracts. GPST and BDT also join
+the scale round-trip matrix, which covered neither (#145).

--- a/ephemeris/satellite/doc.go
+++ b/ephemeris/satellite/doc.go
@@ -25,9 +25,9 @@
 //	t := time.FromJD(gpsJD, time.GPST)   // not time.UTC
 //	state, err := sat.State(0, t)
 //
-// BeiDou is a different offset again (TAI − 33 s) and is not expressible yet;
-// GLONASS is UTC plus three hours with leap seconds applied, so it needs no
-// scale of its own.
+// BeiDou is a different offset again — TAI − 33 s, so BDT − UTC is 4 s today —
+// and has [github.com/TuSKan/astrogo/time.BDT]. GLONASS is UTC plus three hours
+// with leap seconds applied, so it needs no scale of its own.
 //
 // # Accuracy, and where it does not hold
 //

--- a/time/bdt_test.go
+++ b/time/bdt_test.go
@@ -1,0 +1,181 @@
+package time_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The BeiDou tests share epoch(), labelSeconds() and secondsPerDay with the
+// GPS ones in gpst_test.go: the two scales are the same construction with a
+// different constant, and testing them apart from the same helpers is what
+// makes the constant the only thing that differs.
+
+// TestBDTOffsetFromTAIIsExactlyThirtyThreeSeconds pins the definition.
+//
+// BeiDou was set to UTC on 2006-01-01, when TAI−UTC was 33 s, and has run at
+// the TAI rate ignoring leap seconds ever since. So TAI − BDT is 33 s at every
+// epoch, not a table lookup.
+func TestBDTOffsetFromTAIIsExactlyThirtyThreeSeconds(t *testing.T) {
+	t.Parallel()
+
+	for _, when := range []time.Time{
+		epoch(),
+		time.Date(2006, time.January, 1, 0, 0, 0, 0, time.LocationUTC), // the synchronisation
+		time.Date(1999, time.June, 1, 0, 0, 0, 0, time.LocationUTC),    // before it
+		time.Date(2040, time.June, 1, 0, 0, 0, 0, time.LocationUTC),    // past the table
+	} {
+		got := labelSeconds(when.TAI(), when.BDT())
+		if math.Abs(got-33) > 1e-9 {
+			t.Errorf("at %v: TAI − BDT = %.9f s, want exactly 33", when, got)
+		}
+	}
+}
+
+// TestBDTIsFourSecondsAheadOfUTCToday: unlike the TAI offset, this one moves,
+// and it moves at every leap second. ΔAT is 37 s today, so BDT − UTC is 4 s.
+func TestBDTIsFourSecondsAheadOfUTCToday(t *testing.T) {
+	t.Parallel()
+
+	utc := epoch()
+
+	got := labelSeconds(utc.BDT(), utc)
+	if math.Abs(got-4) > 1e-9 {
+		t.Errorf("BDT − UTC = %.9f s, want 4 (ΔAT 37 − 33)", got)
+	}
+}
+
+// TestBDTAndGPSTDifferByFourteenSecondsForEver is the property that makes two
+// scales necessary rather than one.
+//
+// Both are TAI minus a frozen constant, so the gap between them is the
+// difference of those constants and cannot move — not at a leap second, not
+// ever. A caller handed a timestamp from a dual-constellation receiver has two
+// readings fourteen seconds apart and nothing in either number saying which is
+// which.
+func TestBDTAndGPSTDifferByFourteenSecondsForEver(t *testing.T) {
+	t.Parallel()
+
+	for _, when := range []time.Time{
+		epoch(),
+		time.Date(2006, time.January, 1, 0, 0, 0, 0, time.LocationUTC),
+		time.Date(2016, time.December, 31, 12, 0, 0, 0, time.LocationUTC), // a leap-second day
+		time.Date(2040, time.June, 1, 0, 0, 0, 0, time.LocationUTC),
+	} {
+		got := labelSeconds(when.GPST(), when.BDT())
+		if math.Abs(got-14) > 1e-9 {
+			t.Errorf("at %v: GPST − BDT = %.9f s, want exactly 14", when, got)
+		}
+	}
+}
+
+// TestBDTNamesTheSameInstantAsItsUTC is the contract that matters to a caller.
+//
+// The label differs by four seconds; the instant does not. Sub converts to a
+// common scale before subtracting, so a zero here means the conversion put the
+// BeiDou timestamp where the UTC one already was — which is the whole reason
+// to express the scale rather than leave the caller to subtract.
+func TestBDTNamesTheSameInstantAsItsUTC(t *testing.T) {
+	t.Parallel()
+
+	utc := epoch()
+
+	if got := utc.BDT().Sub(utc); got != 0 {
+		t.Errorf("BDT(t).Sub(t) = %v, want 0 — the same instant, differently labelled", got)
+	}
+
+	// And the other direction, which is the one a receiver forces: a caller
+	// builds an instant declaring BDT and asks for UTC.
+	//
+	// Through FromJDParts rather than FromJD. Collapsing the two-part JD into
+	// one float64 costs about 40 microseconds at a modern epoch, which is
+	// nothing physically and is enough to make an exact assertion fail — the
+	// same reason labelSeconds subtracts componentwise.
+	jd1, jd2 := utc.BDT().JDParts()
+	bdt := time.FromJDParts(jd1, jd2, time.BDT)
+
+	if got := bdt.UTC().Sub(utc); got != 0 {
+		t.Errorf("a BDT-declared instant converted to UTC is %v from the UTC it denotes, want 0", got)
+	}
+}
+
+// TestBDTMislabelledAsUTCIsFourSecondsWrong measures the defect the scale
+// exists to prevent, in the units a satellite user cares about.
+//
+// Four seconds is the offset most easily read as a rounding difference, and at
+// the ISS's 7.66 km/s it is 30 km of ground track.
+func TestBDTMislabelledAsUTCIsFourSecondsWrong(t *testing.T) {
+	t.Parallel()
+
+	utc := epoch()
+	receiver := utc.BDT()
+
+	// What a caller does today with no BDT scale: take the receiver's numbers
+	// and call them UTC. Deliberately through FromJD, since a single JD is the
+	// shape that number usually arrives in — which costs about 40 microseconds
+	// of resolution and is why the tolerance is a millisecond rather than
+	// exact.
+	mislabelled := time.FromJD(receiver.JD(), time.UTC)
+
+	got := mislabelled.Sub(utc).Seconds()
+	if math.Abs(got-4) > 1e-3 {
+		t.Errorf("a BDT timestamp passed as UTC lands %.6f s away, want 4", got)
+	}
+}
+
+// TestBDTRoundTripsThroughEveryScale: BDT is uniform, so every conversion out
+// of it and back has to return the instant it started from. The matrix test
+// covers this across epochs; this is the same property stated where a reader
+// looking for BDT will find it.
+func TestBDTRoundTripsThroughEveryScale(t *testing.T) {
+	t.Parallel()
+
+	start := epoch().BDT()
+
+	for _, tc := range []struct {
+		name string
+		trip func(time.Time) time.Time
+	}{
+		{"UTC", func(x time.Time) time.Time { return x.UTC().BDT() }},
+		{"TAI", func(x time.Time) time.Time { return x.TAI().BDT() }},
+		{"TT", func(x time.Time) time.Time { return x.TT().BDT() }},
+		{"TDB", func(x time.Time) time.Time { return x.TDB().BDT() }},
+		{"GPST", func(x time.Time) time.Time { return x.GPST().BDT() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			back := tc.trip(start)
+			if back.Scale() != time.BDT {
+				t.Fatalf("round trip through %s came back as %v", tc.name, back.Scale())
+			}
+
+			if got := math.Abs(labelSeconds(back, start)); got > 1e-6 {
+				t.Errorf("round trip through %s moved the label by %.9f s", tc.name, got)
+			}
+		})
+	}
+}
+
+// One mutation survives on purpose, and it is the same one gpst_test.go
+// records: dropping BDT from Scale.uniform() leaves every test here passing.
+//
+// uniform() is consulted in exactly one place — SubDays, to decide whether to
+// convert to TT before subtracting — and for BDT both routes give the same
+// answer, because BDT-to-TT is a constant that cancels in a difference. The
+// marking is still correct: UTC and UT1 are non-uniform because their labels do
+// not track SI seconds and BDT's do, and saying so keeps the predicate meaning
+// one thing rather than becoming a list of scales that happen to want the fast
+// path.
+
+// TestBDTStringIsItsName: the scale is printed in error messages and test
+// output, and "UNKNOWN" there would be worse than useless — it would suggest
+// the value is corrupt rather than newly added.
+func TestBDTStringIsItsName(t *testing.T) {
+	t.Parallel()
+
+	if got := time.BDT.String(); got != "BDT" {
+		t.Errorf("BDT.String() = %q, want %q", got, "BDT")
+	}
+}

--- a/time/doc.go
+++ b/time/doc.go
@@ -23,11 +23,12 @@
 //
 //	UTC ←→ TAI ←→ TT ←→ TDB
 //	 ↕     ↕
-//	UT1   GPST
+//	UT1   GPST, BDT
 //
 // Conversion status:
 //   - UTC ↔ TAI: Complete (via SOFA leap-second table)
 //   - TAI ↔ GPST: Complete (GPST = TAI − 19 s, exact by definition)
+//   - TAI ↔ BDT:  Complete (BDT = TAI − 33 s, exact by definition)
 //   - TAI ↔ TT:  Complete (TT = TAI + 32.184s, exact by definition)
 //   - TT  ↔ TDB: Complete (Fairhead & Bretagnon 1990 single-term, amplitude 1.657 ms)
 //   - UTC ↔ UT1: Complete when IERS EOP data is loaded; returns error when unavailable.

--- a/time/scale_matrix_test.go
+++ b/time/scale_matrix_test.go
@@ -21,6 +21,12 @@ func allScales() []scaleName {
 		{"TAI", time.Time.TAI},
 		{"TT", time.Time.TT},
 		{"TDB", time.Time.TDB},
+		// The two GNSS system times. Both are TAI plus a frozen constant, so
+		// they belong in the matrix for the same reason TAI does — and neither
+		// was in it before, which left the scales a satellite user most often
+		// holds outside the only test that converts everything to everything.
+		{"GPST", time.Time.GPST},
+		{"BDT", time.Time.BDT},
 		{"UT1", func(t time.Time) time.Time {
 			// UT1 needs Earth-orientation data and reports when it cannot
 			// get it; the fallback is what every other caller in the module

--- a/time/time.go
+++ b/time/time.go
@@ -258,13 +258,31 @@ const (
 	// likely remaining instance of that defect class.
 	//
 	// Galileo System Time shares this scale: it is also TAI − 19 s, and agrees
-	// with GPST to within nanoseconds by design. BeiDou does not — BDT is
-	// TAI − 33 s — and GLONASS needs no scale here at all, being UTC plus three
-	// hours with leap seconds applied. Neither is expressible today; see #145.
+	// with GPST to within nanoseconds by design. BeiDou does not, and has
+	// [BDT]. GLONASS needs no scale here at all, being UTC plus three hours
+	// with leap seconds applied — a caller holding one applies a fixed zone
+	// offset and is already in UTC.
 	//
 	// Reference: Levine, Tavella & Milton (2023), "Towards a consensus on a
 	// continuous coordinated universal time", Metrologia 60 014001, table 1.
 	GPST
+
+	// BDT is BeiDou Navigation Satellite System time.
+	//
+	// The same construction as [GPST] with a different constant, because the
+	// constellation was synchronised later: BDT was set to UTC on 2006-01-01,
+	// when TAI−UTC was 33 s, and has run at the TAI rate since.
+	//
+	//	TAI − BDT = 33 s, exactly and for ever
+	//	BDT − UTC = ΔAT − 33 s, which is 4 s today
+	//	GPST − BDT = 14 s, and will stay 14 s
+	//
+	// Four seconds is small enough to look like nothing and is 30 km of ISS
+	// ground track. It is also the offset most easily mistaken for a rounding
+	// difference, which is the argument for expressing it rather than leaving a
+	// caller to subtract it: GPST and BDT differ by a constant that neither
+	// timestamp carries.
+	BDT
 )
 
 // gpstMinusTAI is the fixed offset that defines GPS time.
@@ -274,6 +292,10 @@ const (
 // the system rather than a table lookup — which is what makes this scale cheap
 // to support correctly.
 const gpstMinusTAI = -19.0
+
+// bdtMinusTAI is the fixed offset that defines BeiDou time — the value of
+// TAI−UTC at BeiDou's 2006-01-01 synchronisation, frozen. See [BDT].
+const bdtMinusTAI = -33.0
 
 func (s Scale) String() string {
 	switch s {
@@ -289,6 +311,8 @@ func (s Scale) String() string {
 		return "TDB"
 	case GPST:
 		return "GPST"
+	case BDT:
+		return "BDT"
 	default:
 		return "UNKNOWN"
 	}
@@ -311,7 +335,9 @@ func (s Scale) String() string {
 // term between them varies by ±1.7 ms, so a TDB interval and the TT interval
 // it spans differ by up to a microsecond per hour. Arithmetic in TDB stays in
 // TDB, which is what an ephemeris interpolating in TDB days wants.
-func (s Scale) uniform() bool { return s == TAI || s == TT || s == TDB || s == GPST }
+func (s Scale) uniform() bool {
+	return s == TAI || s == TT || s == TDB || s == GPST || s == BDT
+}
 
 // Time represents a high-precision astronomical timestamp.
 //
@@ -1101,10 +1127,10 @@ func (t Time) UTC() Time {
 		// UTC = UT1 − DUT1. Since |DUT1| < 0.9s, UT1 ≈ UTC for lookup.
 		dut1 := dut1OrFallback(t.jd1, t.jd2)
 		return fromPartsPreserveLoc(t, t.jd1, t.jd2-dut1/86400.0, UTC)
-	case GPST:
-		// GPST → TAI → UTC. The first step is a constant and the second is
-		// the leap-second table, which is where the 18 s a GNSS user is
-		// missing actually comes from.
+	case GPST, BDT:
+		// GNSS → TAI → UTC. The first step is a constant and the second is
+		// the leap-second table, which is where the seconds a GNSS user is
+		// missing actually come from.
 		return t.TAI().UTC()
 	}
 
@@ -1143,6 +1169,10 @@ func (t Time) TAI() Time {
 		// offset was frozen at the 1980-01-06 synchronisation and GPS time
 		// has ignored leap seconds ever since.
 		return fromPartsPreserveLoc(t, t.jd1, t.jd2-gpstMinusTAI/86400.0, TAI)
+	case BDT:
+		// TAI = BDT + 33 s, exactly, frozen at BeiDou's 2006-01-01
+		// synchronisation for the same reason.
+		return fromPartsPreserveLoc(t, t.jd1, t.jd2-bdtMinusTAI/86400.0, TAI)
 	default:
 		// UT1 → UTC → TAI. UT1 genuinely has to go this way: DUT1 is defined
 		// against UTC, so there is no arithmetic path.
@@ -1207,8 +1237,8 @@ func (t Time) TT() Time {
 	case UT1:
 		// UT1 → UTC (with fallback) → TT
 		return t.UTC().TT()
-	case GPST:
-		// GPST → TAI → TT, both steps constant.
+	case GPST, BDT:
+		// GNSS → TAI → TT, both steps constant.
 		return t.TAI().TT()
 	}
 
@@ -1226,8 +1256,8 @@ func (t Time) TT() Time {
 // GPS time; building it with [FromJD] or [Date] and this scale, rather than
 // calling it UTC, is what stops those 18 seconds becoming 138 km of ISS track.
 //
-// Galileo System Time is the same scale to within nanoseconds. BeiDou is not
-// (BDT is TAI − 33 s) and is not expressible here — see [GPST]'s own note.
+// Galileo System Time is the same scale to within nanoseconds. BeiDou is not:
+// see [Time.BDT].
 func (t Time) GPST() Time {
 	if t.scale == GPST {
 		return t
@@ -1236,6 +1266,27 @@ func (t Time) GPST() Time {
 	tai := t.TAI()
 
 	return fromPartsPreserveLoc(t, tai.jd1, tai.jd2+gpstMinusTAI/86400.0, GPST)
+}
+
+// BDT returns a new Time converted to BeiDou system time.
+//
+// TAI − 33 s exactly, so like [Time.GPST] this is arithmetic and cannot fail.
+// Against UTC the gap is 4 s today and grows at every leap event; against GPST
+// it is a flat 14 s that will never change, since both were frozen against TAI.
+//
+// The direction that matters is the other one: a receiver on a BeiDou-capable
+// device hands out BDT, and building that instant with this scale rather than
+// calling it UTC is what stops four seconds becoming 30 km of ISS track. Four
+// seconds is small enough to read as a rounding difference, which is exactly
+// why it needs a name.
+func (t Time) BDT() Time {
+	if t.scale == BDT {
+		return t
+	}
+
+	tai := t.TAI()
+
+	return fromPartsPreserveLoc(t, tai.jd1, tai.jd2+bdtMinusTAI/86400.0, BDT)
 }
 
 // TDB returns a new Time converted to the Barycentric Dynamical Time scale.


### PR DESCRIPTION
Closes #145.

#145 asked for the GNSS scales and `GPST` landed; BeiDou did not, and both the `Scale`
documentation and `ephemeris/satellite`'s package doc said so in as many words — *"not
expressible yet"*. This is the rest of it.

`BDT` is the same construction as `GPST` with a different constant, because the
constellation was synchronised later: set to UTC on 2006-01-01, when TAI−UTC was 33 s, and
running at the TAI rate ever since.

```
TAI − BDT  = 33 s, exactly and for ever
BDT − UTC  = ΔAT − 33 s, which is 4 s today
GPST − BDT = 14 s, and will stay 14 s
```

## Why four seconds needs a name

It is small enough to read as a rounding difference, and it is **30 km of ISS ground
track**. A dual-constellation receiver hands out two readings fourteen seconds apart with
nothing in either number saying which is which — so the alternative to a scale is a caller
subtracting a constant they have to know about first, which is the defect #145 was filed
over.

GLONASS still needs no scale: UTC plus three hours with leap seconds applied, so a caller
applies a zone offset and is already in UTC. That is now stated rather than left as a gap.

## GPST and BDT join the round-trip matrix

`TestScaleRoundTripMatrix` converts every scale to every other across the epochs where a
time library actually breaks. It covered **neither** GNSS scale — which left the scales a
satellite user most often holds outside the only test that converts everything to
everything. Both are in it now, and that is what killed the second mutation below.

## Two assertions that failed first, correctly

Building an instant with `FromJD` collapses the two-part JD into one float64, costing about
40 µs at a modern epoch: physically nothing, and enough to make "exactly 4 seconds" read as
`4.000019`.

- `TestBDTNamesTheSameInstantAsItsUTC` moves to `FromJDParts`, which is the right fix.
- `TestBDTMislabelledAsUTCIsFourSecondsWrong` keeps `FromJD` **deliberately** — a single JD
  is the shape a receiver's number usually arrives in — and takes a millisecond tolerance
  with the reason written down.

## Verification

Full gate green: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1
./...`, `go test -tags=validation ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

| mutation | killed by |
| :--- | :--- |
| the constant off by one second | `TestBDTAndGPSTDifferByFourteenSecondsForEver` |
| BDT→TAI as an identity | `TestScaleRoundTripMatrix` (79 samples past contract) |
| **BDT dropped from `Scale.uniform()`** | **survives — deliberately** |

The third is recorded in the test file beside the identical note `gpst_test.go` already
carries: `uniform()` is consulted only by `SubDays`, and for a scale that differs from TT by
a constant both routes give the same answer, so removing it changes no result — only two
needless conversions. The marking is still correct, and saying so keeps the predicate
meaning one thing rather than becoming a list of scales that happen to want the fast path.
