### PR TITLE
ci: run the network tier nightly, the validation tier weekly

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,15 +1,31 @@
 name: Validation
 
 # Not on the PR path, by design. These jobs query JPL Horizons, USNO, NASA,
-# ESO and VizieR; someone else's downtime must never block a merge. They run
-# on a schedule so the accuracy record cannot silently rot between releases,
-# and on demand before a release.
+# ESO, CDS and CelesTrak; someone else's downtime must never block a merge.
+#
+# Two cadences, because the two tiers answer different questions and go stale
+# at different rates.
+#
+# The network tier runs nightly. It is the only thing that notices a SIMBAD
+# schema change, a Horizons response-format change or a VizieR column rename —
+# failures that arrive without warning, and that `go vet -tags` cannot see
+# because the code still compiles. A week is a long time to be wrong about
+# whether the catalogue layer works, and #102 is why: a schema change surfaces
+# as "target not found" rather than as an error.
+#
+# The validation and integration tiers stay weekly. JPL and USNO are stable,
+# the runs are heavier, and nothing they measure changes daily.
+#
+# Nightly against CDS is acceptable; hourly would not be. One run a day is the
+# cadence, and the per-run burst is the thing to watch instead — CelesTrak
+# answers a burst with a 403 (#206).
 on:
   workflow_dispatch:
   schedule:
-    # Weekly, not nightly: every run costs other people's services real
-    # requests, and nothing here changes fast enough to need daily polling.
-    - cron: '17 4 * * 1'
+    # Nightly: the network tier.
+    - cron: '17 4 * * *'
+    # Mondays: the validation and integration tiers.
+    - cron: '43 4 * * 1'
 
 permissions:
   contents: read
@@ -21,8 +37,12 @@ env:
   ASTROGO_METROLOGY_OUT: ${{ github.workspace }}/validation-out
 
 jobs:
-  validation:
-    name: Validation Tests (JPL Horizons + SOFA)
+  network:
+    name: Network Tests (live catalogue services)
+    # Every night, and on demand. The condition names the nightly cron rather
+    # than excluding the weekly one, so adding a third schedule cannot silently
+    # enrol this job in it.
+    if: github.event_name != 'schedule' || github.event.schedule == '17 4 * * *'
     runs-on: ubuntu-latest
 
     steps:
@@ -42,10 +62,42 @@ jobs:
       - name: Prepare output directory
         run: mkdir -p "$ASTROGO_METROLOGY_OUT"
 
-      # Every step below runs even when an earlier one fails: a failing
-      # integration suite must not hide the validation numbers, and a
-      # suite that did not run at all has to be visible as "not verified"
-      # rather than merely absent from the report.
+      - name: Run network-dependent tests
+        if: always()
+        shell: bash
+        run: go test -tags=network -v -count=1 -timeout=15m ./... 2>&1 | tee "$ASTROGO_METROLOGY_OUT/network.log"
+
+      - name: Upload network results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: network-${{ github.sha }}
+          path: ${{ env.ASTROGO_METROLOGY_OUT }}
+          retention-days: 90
+
+  validation:
+    name: Validation Tests (JPL Horizons + SOFA)
+    # Mondays, and on demand.
+    if: github.event_name != 'schedule' || github.event.schedule == '43 4 * * 1'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Prepare output directory
+        run: mkdir -p "$ASTROGO_METROLOGY_OUT"
+
+      # Both steps run even when the first fails: a failing integration suite
+      # must not hide the validation numbers, and a suite that did not run at
+      # all has to be visible as "not verified" rather than merely absent from
+      # the report.
       - name: Run integration tests
         id: integration
         if: always()
@@ -57,12 +109,6 @@ jobs:
         if: always()
         shell: bash
         run: go test -tags=validation -v -count=1 -timeout=15m ./... 2>&1 | tee "$ASTROGO_METROLOGY_OUT/validation.log"
-
-      - name: Run network-dependent validation
-        id: network
-        if: always()
-        shell: bash
-        run: go test -tags=network -v -count=1 -timeout=15m ./... 2>&1 | tee "$ASTROGO_METROLOGY_OUT/network.log"
 
       - name: Upload validation results
         if: always()

--- a/docs/changelog.d/212-nightly-network-tier.md
+++ b/docs/changelog.d/212-nightly-network-tier.md
@@ -1,0 +1,9 @@
+---
+type: Changed
+pr: 212
+---
+The `network` tier now runs nightly rather than weekly, in its own job; the
+`validation` and `integration` tiers stay weekly. Only the network tier notices
+a SIMBAD schema change or a Horizons format change — `go vet -tags` cannot, the
+code still compiles — and a week is a long time to be wrong about that. Still
+off the PR path (#123).

--- a/ephemeris/jpl/validation/README.md
+++ b/ephemeris/jpl/validation/README.md
@@ -18,8 +18,11 @@ go test -tags=validation ./ephemeris/jpl/validation/
 go test -tags=network    ./ephemeris/jpl/validation/
 ```
 
-Neither runs in ordinary CI. The scheduled `Validation` workflow runs both
-weekly, and uploads each suite's result document as an artifact.
+Neither runs in ordinary CI. The scheduled `Validation` workflow runs the
+`network` tier nightly and the `validation` tier weekly, and uploads each
+suite's result document as an artifact. The split is deliberate: only the
+network tier notices a response-format change upstream, and only it goes stale
+in a day.
 
 ## The corpus
 

--- a/internal/docsguard/gomod_ci_test.go
+++ b/internal/docsguard/gomod_ci_test.go
@@ -99,9 +99,10 @@ func TestWorkflowGoVersionTracksTheModuleDirective(t *testing.T) {
 	}
 
 	// A pin that stops matching is worse than a mismatched one: the guard
-	// keeps passing while guarding nothing. Six is the count today, and a
-	// seventh workflow step should arrive with this number updated.
-	const wantPins = 6
+	// keeps passing while guarding nothing. Seven is the count today — it went
+	// from six when the Validation workflow split its network tier into its own
+	// job (#123) — and the eighth should arrive with this number updated.
+	const wantPins = 7
 
 	if found != wantPins {
 		t.Errorf("found %d Go version pins across %v, want %d.\n"+


### PR DESCRIPTION
Closes #123.

The tagged suites all ran weekly in one job. They answer different questions and go stale at
different rates.

**The network tier is the only thing that notices a SIMBAD schema change**, a Horizons
response-format change or a VizieR column rename. `go vet -tags` cannot see any of those,
because the code still compiles — and #102 is why a week of not knowing is expensive: a
schema change surfaces as "target not found" rather than as an error, so the failure is
indistinguishable from an ordinary negative for as long as it goes unnoticed.

The validation and integration tiers stay weekly. JPL and USNO are stable, the runs are
heavier, and nothing they measure changes daily.

## Shape

Two jobs rather than conditional steps, each gated on the cron that should start it:

```yaml
schedule:
  - cron: '17 4 * * *'   # nightly: the network tier
  - cron: '43 4 * * 1'   # Mondays: validation and integration
```

Each `if:` names **its own** schedule rather than excluding the other, so adding a third
cron cannot silently enrol a job in it.

Still off the PR path. External flakiness must never block a merge, and that policy is not
what this changes.

On politeness: nightly against CDS is one run a day, which is acceptable where hourly would
not be. The per-run burst is the thing actually worth watching, and it already bit —
CelesTrak answers a burst with a 403 (#206, fixed in #208).

## The cached-fixture fallback already exists

#123 also asks for one, so a provider outage still exercises the parsing path. That is
already true, and better than proposed: **every** catalogue provider has offline tests
replaying recorded responses through `httptest.NewServer` or a `testdata` fixture — simbad,
vizier, gaia, mast, sbdb, jpl, norad and fink all carry them — and they run **untagged on
every commit**, not only when a service is down.

A fixture cannot catch a schema change in any case. That is what the live tier is for, and
it is the half this PR changes.

## One thing worth noting from the run

`docsguard`'s `TestWorkflowGoVersionTracksTheModuleDirective` caught the second job's Go
version pin. It counts the pins it checked, precisely so that a pin which stops *matching*
cannot leave the guard passing while guarding nothing. The count goes six to seven — the
guard working, not an obstacle to it.

Full gate green afterwards: `gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short
-count=1 ./...`, `golangci-lint run --build-tags="integration,network,validation"` at 0
issues.
