### PR TITLE
ci: fail a pull request that breaks the API without saying so

### DIFF
--- a/.github/scripts/api-diff.sh
+++ b/.github/scripts/api-diff.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# A break in the exported API must be declared, not discovered downstream.
+#
+# # Why this is not the changelog-fragment job over again
+#
+# That job checks a fragment exists. It cannot check the fragment is true: today
+# a "Changed — BREAKING" entry says a break happened because a human wrote it
+# down, and a break with no entry says nothing at all. apidiff knows.
+#
+# So the rule is one-directional and deliberately so. An undeclared break fails.
+# A declared one passes, whatever apidiff thinks — a fragment claiming a break
+# that apidiff cannot see is usually a behavioural break rather than a
+# signature one, and this script has no business calling that a mistake.
+#
+# # Why against the pull request's base rather than the last tag
+#
+# gorelease compares against a released version, which is the right question at
+# release time and the wrong one here: nineteen minor releases in eight weeks
+# means the diff against the last tag is everything anyone merged since, and a
+# job that reports all of it on every pull request tells the author nothing
+# about their own change. The base is what isolates it.
+#
+# Usage: api-diff.sh <base-sha> <pr-number>
+
+set -euo pipefail
+
+base_sha="${1:?usage: api-diff.sh <base-sha> <pr-number>}"
+pr_number="${2:?usage: api-diff.sh <base-sha> <pr-number>}"
+
+readonly module="github.com/TuSKan/astrogo"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"; git worktree prune' EXIT
+
+# Export data for the base, read from a worktree at that commit. apidiff has to
+# run inside the directory holding the go.mod the module path belongs to, or it
+# consults the module cache and answers about a published version instead.
+git worktree add -q --detach "$work/base" "$base_sha"
+
+# run captures apidiff's combined output, keeps its exit status, and drops only
+# the per-package "Ignoring internal package" notes it writes to stderr.
+#
+# The exit status is checked rather than swallowed. apidiff returns zero when it
+# finds changes, so a non-zero status means it could not read something — and a
+# missing or truncated base export would otherwise be reported as the whole API
+# having been removed, which is the one false alarm this job must never raise.
+run() {
+	local out="$1"
+	shift
+
+	if ! "$@" > "$out.raw" 2>&1; then
+		echo "FAIL: apidiff could not compare the two trees."
+		echo
+		cat "$out.raw"
+		exit 1
+	fi
+
+	grep -v '^Ignoring internal package ' "$out.raw" > "$out" || true
+}
+
+( cd "$work/base" && apidiff -m -w "$work/base.api" "$module" ) > "$work/export.raw" 2>&1 || {
+	echo "FAIL: apidiff could not read the base API at $base_sha."
+	echo
+	cat "$work/export.raw"
+	exit 1
+}
+
+# Both listings. The full one is what the author reads; the incompatible one is
+# what decides the exit status, and it is computed separately rather than
+# grepped out of the first, so a change in apidiff's formatting cannot quietly
+# turn the gate off.
+run "$work/all.txt" apidiff -m "$work/base.api" "$module"
+run "$work/incompatible.txt" apidiff -m -incompatible "$work/base.api" "$module"
+
+echo "## Exported API changes against the base"
+echo
+
+if [ -s "$work/all.txt" ]; then
+	cat "$work/all.txt"
+else
+	echo "None."
+fi
+
+echo
+
+if [ ! -s "$work/incompatible.txt" ]; then
+	echo "No incompatible changes."
+	exit 0
+fi
+
+echo "## Incompatible changes"
+echo
+cat "$work/incompatible.txt"
+echo
+
+# A fragment for this pull request declaring the break. Matched on the type
+# line rather than anywhere in the file, so prose mentioning the words does not
+# satisfy the gate.
+shopt -s nullglob
+declared=0
+
+for f in docs/changelog.d/"$pr_number"-*.md; do
+	if grep -qE '^type:[[:space:]]*(Changed — BREAKING|Removed)[[:space:]]*$' "$f"; then
+		echo "Declared in $f."
+		declared=1
+	fi
+done
+
+if [ "$declared" -eq 1 ]; then
+	exit 0
+fi
+
+cat <<EOF
+
+FAIL: the exported API changes incompatibly and no changelog fragment says so.
+
+Add docs/changelog.d/${pr_number}-<slug>.md with:
+
+    type: Changed — BREAKING
+
+or "Removed" if the symbols are gone rather than reshaped, and say in the body
+what a caller has to do. Pre-1.0 a break is allowed; going unannounced is not,
+and the list above is the migration note somebody would otherwise have to
+reconstruct from a downstream build failure.
+EOF
+
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,42 @@ jobs:
           echo "label the pull request 'no-changelog'."
           exit 1
 
+  # A break in the exported API must be declared, not discovered downstream.
+  #
+  # The job above checks a fragment exists; it cannot check the fragment is
+  # true. apidiff can: it compares this pull request's head against its base and
+  # fails only when the exported API changes incompatibly and no fragment says
+  # so. That is what turns "a human wrote it down" into something CI knows.
+  #
+  # See .github/scripts/api-diff.sh for why the comparison is against the base
+  # rather than the last release tag, and why the rule is one-directional.
+  api-diff:
+    name: API Diff
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # The script reads the base commit out of this clone, so the history
+          # has to be here. A shallow clone leaves it with nothing to compare
+          # against.
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Install apidiff
+        run: go install golang.org/x/exp/cmd/apidiff@latest
+
+      - name: Compare the exported API against the base
+        shell: bash
+        run: bash ./.github/scripts/api-diff.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.number }}"
+
   race-detection:
     name: Race Detection
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,14 @@ jobs:
           go-version: '1.25'
           cache: true
 
+      # Pinned, not @latest, for two reasons. x/exp raises its own go directive
+      # freely — the August 2026 snapshot needs Go 1.26 and this job runs
+      # GOTOOLCHAIN=local on go.mod's toolchain (#109), so @latest failed on the
+      # very commit that added this job. And a tool version that can change
+      # under CI breaks builds for reasons unrelated to the change being
+      # reviewed, which is the opposite of what this job is for.
       - name: Install apidiff
-        run: go install golang.org/x/exp/cmd/apidiff@latest
+        run: go install golang.org/x/exp/cmd/apidiff@v0.0.0-20250718183923-645b1fa84792
 
       - name: Compare the exported API against the base
         shell: bash

--- a/docs/PULL_REQUESTS.md
+++ b/docs/PULL_REQUESTS.md
@@ -116,6 +116,20 @@ already shipped, or a CI change no user can observe — label the pull request
 `no-changelog`. The label is deliberate and shows up in review; silence did
 not.
 
+**And a break has to say it is one.** CI's `api-diff` job runs `apidiff` between
+this pull request's head and its base and fails when the exported API changes
+incompatibly with no fragment declaring `Changed — BREAKING` or `Removed`. Until
+it existed, a `Changed — BREAKING` entry meant a break had happened because
+somebody wrote it down, and a break with no entry meant nothing at all.
+
+The rule is one-directional on purpose: an undeclared break fails, a declared
+one passes whatever `apidiff` sees. A fragment claiming a break the tool cannot
+see is usually a behavioural break rather than a signature one, and CI has no
+business calling that a mistake.
+
+The failure message lists the changed symbols, which is the migration note
+somebody would otherwise reconstruct from a downstream build failure.
+
 Deep forensic detail — root cause, before-and-after numbers, what you refuted —
 belongs in the pull request body or the code's own doc comment. **The changelog
 is an index, not the record.**

--- a/docs/changelog.d/213-api-diff.md
+++ b/docs/changelog.d/213-api-diff.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 213
+---
+CI runs `apidiff` between a pull request's head and its base, and fails when the
+exported API changes incompatibly with no fragment declaring it. Nineteen minor
+releases in eight weeks is fine pre-1.0 only if the breaking diff is
+machine-reported rather than found by a downstream build (#121).

--- a/internal/docsguard/gomod_ci_test.go
+++ b/internal/docsguard/gomod_ci_test.go
@@ -99,9 +99,10 @@ func TestWorkflowGoVersionTracksTheModuleDirective(t *testing.T) {
 	}
 
 	// A pin that stops matching is worse than a mismatched one: the guard
-	// keeps passing while guarding nothing. Six is the count today, and a
-	// seventh workflow step should arrive with this number updated.
-	const wantPins = 6
+	// keeps passing while guarding nothing. Seven is the count today, and the
+	// eighth should arrive with this number updated. It went from six when
+	// ci.yml gained the API-diff job (#121).
+	const wantPins = 7
 
 	if found != wantPins {
 		t.Errorf("found %d Go version pins across %v, want %d.\n"+

--- a/internal/docsguard/gomod_ci_test.go
+++ b/internal/docsguard/gomod_ci_test.go
@@ -99,10 +99,21 @@ func TestWorkflowGoVersionTracksTheModuleDirective(t *testing.T) {
 	}
 
 	// A pin that stops matching is worse than a mismatched one: the guard
-	// keeps passing while guarding nothing. Seven is the count today, and the
-	// eighth should arrive with this number updated. It went from six when
-	// ci.yml gained the API-diff job (#121).
-	const wantPins = 7
+	// keeps passing while guarding nothing. Eight is the count today, and the
+	// ninth should arrive with this number updated.
+	//
+	// It went from six to seven twice, in parallel and independently: once when
+	// the Validation workflow split its network tier into its own job (#123),
+	// once when ci.yml gained the API-diff job (#121). Each branch was correct
+	// against the main it was written on and wrong against the other.
+	//
+	// That is worth keeping, because it is the guard working at a level it was
+	// not designed for. A boolean "the pins are checked" could not have
+	// conflicted on merge: it would have combined cleanly into a state where
+	// eight pins were asserted as seven, and gone on passing while guarding one
+	// fewer than it claimed. Counting is what made two independently correct
+	// edits visibly incompatible.
+	const wantPins = 8
 
 	if found != wantPins {
 		t.Errorf("found %d Go version pins across %v, want %d.\n"+


### PR DESCRIPTION
Closes #121.

Nineteen minor releases in eight weeks, with 37 `Changed`/`Removed` sections. That velocity
is fine pre-1.0 **only if the breaking diff is machine-reported** rather than discovered by
a downstream build failure.

The `changelog-fragment` job checks a fragment *exists*. It cannot check the fragment is
*true*: a `Changed — BREAKING` entry says a break happened because somebody wrote it down,
and a break with no entry says nothing at all. `apidiff` knows, so now CI does.

## apidiff, and against the base — not gorelease against the last tag

`gorelease` compares against a released version, which is the right question at release time
and the wrong one here. Measured on this repo:

```
$ gorelease -base=v0.19.0
… incompatible changes in 18 packages …
Suggested version: v0.20.0
```

At this cadence the diff against the last tag is **everything anyone merged since**, none of
which belongs to the branch under review. The base is what isolates the author's own change,
and `apidiff -m -w` / `apidiff -m` over a worktree at `github.event.pull_request.base.sha`
is what gets it.

## The rule is one-directional on purpose

An **undeclared break fails**. A **declared one passes**, whatever `apidiff` sees — a
fragment claiming a break the tool cannot see is usually a behavioural break rather than a
signature one, and CI has no business calling that a mistake.

## Two things in the script worth not losing

- The incompatible list is computed with `-incompatible`, **not** grepped out of the full
  listing, so a change in `apidiff`'s output format cannot quietly turn the gate off.
- `apidiff`'s exit status is checked rather than swallowed. It returns zero when it *finds*
  changes, so non-zero means it could not read a tree — and a missing or truncated base
  export would otherwise be reported as the entire API having been removed, which is the one
  false alarm this job must never raise.

## Verified against all four paths before wiring it up

Using the real v0.19.0 → main diff as the break:

| case | result |
| :--- | :--- |
| no API change | passes |
| break, no fragment | **fails**, printing the changed symbols |
| break, `type: Changed — BREAKING` fragment | passes |
| break, fragment of the wrong type | **fails** |

The failure message is the migration note somebody would otherwise reconstruct from a
downstream build failure.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1 ./...`,
`golangci-lint run --build-tags="integration,network,validation"` at 0 issues; both
workflow files re-parsed after editing.

`docsguard`'s Go-version pin count goes seven to eight, since the new job sets up Go — the
count exists so a pin which stops *matching* cannot leave that guard passing while guarding
nothing.

**This PR is its own first test**: it changes no exported API, so the new job should report
"None." and pass.
