### PR TITLE
plan: four more constraints, and a consumer for WithHorizonProfile

### DIFF
--- a/docs/changelog.d/217-more-constraints.md
+++ b/docs/changelog.d/217-more-constraints.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 217
+---
+Four `plan` constraints: `SunSep` (the companion to `MoonSep` for the other
+bright source), `GalacticLatitude` (distance from the plane, unsigned so it
+serves both the surveys that avoid it and those that want it), `TimeWindow` (a
+coordination window or a deadline, the constraint with nothing to do with the
+sky), and `Horizon`, which is the first consumer of `WithHorizonProfile` — the
+per-azimuth terrain limit `Altitude` cannot express (#129).

--- a/plan/constraint_more.go
+++ b/plan/constraint_more.go
@@ -1,0 +1,262 @@
+package plan
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// Four more constraints, each a few lines against the existing interface and
+// each answering a question somebody actually asks a scheduler. See #129 for
+// the inventory they come from, and for the two that are not here.
+//
+// PhaseConstraint is absent because [Observable] carries no ephemeris — an
+// epoch and a period — so a periodic target cannot be expressed at all yet;
+// that is a type change rather than a constraint. LocalTime is absent because
+// [TimeWindow] answers the same question in the scale the rest of this package
+// works in, and a local-clock window is a display convention rather than a
+// physical one.
+
+var (
+	_ ConstraintCtx = SunSep{}
+	_ ConstraintCtx = GalacticLatitude{}
+	_ ConstraintCtx = TimeWindow{}
+	_ ConstraintCtx = Horizon{}
+)
+
+// SunSep passes if the angular separation between the target and the Sun is
+// at or above a threshold.
+//
+// The companion to [MoonSep] for the other bright source, and the one that
+// decides whether a daytime or twilight observation is possible at all: scattered
+// sunlight near the Sun defeats any exposure, and a solar-adjacent pointing is
+// an instrument-safety question before it is a photometric one.
+//
+// A target that *is* the Sun passes automatically, on the same reasoning
+// [MoonSep] applies to the Moon: its separation from itself is not a
+// constraint on observing it.
+type SunSep struct {
+	// Threshold is the minimum acceptable separation.
+	Threshold angle.Angle
+
+	// Provider supplies the Sun's position. Nil means [eph.Default], the
+	// convention [MoonIllum] documents and this package has settled on.
+	Provider eph.Provider
+}
+
+// Check evaluates Sun separation for a given target and time.
+func (c SunSep) Check(obj Observable, t time.Time, site *Site) (Result, error) {
+	ctx := coord.NewContext(t, site.Location(), site.Refraction())
+	return c.CheckCtx(obj, t, site, ctx)
+}
+
+// CheckCtx evaluates Sun separation using a pre-built coord.Context.
+func (c SunSep) CheckCtx(obj Observable, _ time.Time, _ *Site, ctx *coord.Context) (Result, error) {
+	if p, ok := obj.(*Planet); ok && p.EphID() == eph.Sun {
+		return Result{Pass: true, Value: 180}, nil
+	}
+
+	pos, err := obj.Position(ctx.Time())
+	if err != nil {
+		return Result{}, fmt.Errorf("constraint: sun separation position: %w", err)
+	}
+
+	sunPos, err := NewSun(c.Provider).Position(ctx.Time())
+	if err != nil {
+		return Result{}, fmt.Errorf("constraint: sun position: %w", err)
+	}
+
+	val := coord.Separation(pos, sunPos).Degrees()
+	thresh := c.Threshold.Degrees()
+	pass := val >= thresh
+
+	reason := ""
+	if !pass {
+		reason = fmt.Sprintf("sun separation %.2f is below threshold %.2f", val, thresh)
+	}
+
+	return Result{Pass: pass, Value: val, Reason: reason}, nil
+}
+
+// GalacticLatitude passes if the target lies at least Threshold from the
+// Galactic plane.
+//
+// Which way this cuts depends on the programme, and that is why it is stated
+// as a distance from the plane rather than as a latitude range. An
+// extragalactic survey avoids the plane because stellar crowding and dust
+// extinction there are severe; a Galactic-structure programme wants exactly
+// that region and expresses it by inverting the sense of the constraint in
+// its own scoring rather than by a second type here.
+//
+// The value reported is |b| in degrees, so it is comparable across both uses.
+type GalacticLatitude struct {
+	// Threshold is the minimum acceptable |b|.
+	Threshold angle.Angle
+}
+
+// Check evaluates Galactic latitude for a given target and time.
+func (c GalacticLatitude) Check(obj Observable, t time.Time, site *Site) (Result, error) {
+	ctx := coord.NewContext(t, site.Location(), site.Refraction())
+	return c.CheckCtx(obj, t, site, ctx)
+}
+
+// CheckCtx evaluates Galactic latitude using a pre-built coord.Context.
+//
+// The Context supplies the epoch and nothing else: the rotation from ICRS to
+// Galactic is a fixed frame rotation with no observer and no time in it. A
+// moving target still moves, which is why the position is taken at the
+// Context's own instant rather than once.
+func (c GalacticLatitude) CheckCtx(
+	obj Observable, _ time.Time, _ *Site, ctx *coord.Context,
+) (Result, error) {
+	pos, err := obj.Position(ctx.Time())
+	if err != nil {
+		return Result{}, fmt.Errorf("constraint: galactic latitude position: %w", err)
+	}
+
+	b := coord.ICRSToGalactic(pos).B().Degrees()
+
+	val := math.Abs(b)
+	thresh := c.Threshold.Degrees()
+	pass := val >= thresh
+
+	reason := ""
+	if !pass {
+		reason = fmt.Sprintf("galactic latitude |b| %.2f is below threshold %.2f", val, thresh)
+	}
+
+	return Result{Pass: pass, Value: val, Reason: reason}, nil
+}
+
+// TimeWindow passes while the evaluated instant lies within [From, To],
+// inclusive at both ends.
+//
+// The constraint that has nothing to do with the sky: a target of opportunity
+// with a coordination window, an instrument available for part of the night, a
+// programme whose allocation ends at a stated time. Without it those have to be
+// expressed by slicing the schedule's own span, which conflates "this target
+// cannot be observed then" with "nobody observes then".
+//
+// Zero From or To means unbounded on that side, so a one-sided deadline needs
+// only the field it is about.
+type TimeWindow struct {
+	// From is the earliest acceptable instant. Zero means no lower bound.
+	From time.Time
+
+	// To is the latest acceptable instant. Zero means no upper bound.
+	To time.Time
+}
+
+// Check evaluates the window for a given time.
+func (c TimeWindow) Check(obj Observable, t time.Time, site *Site) (Result, error) {
+	ctx := coord.NewContext(t, site.Location(), site.Refraction())
+	return c.CheckCtx(obj, t, site, ctx)
+}
+
+// CheckCtx evaluates the window using the Context's instant.
+//
+// Value is hours from the nearer edge: positive inside the window, negative
+// outside, so a scorer can rank "well inside" above "about to close" without a
+// second call. A window unbounded on both sides reports zero, since there is no
+// edge to measure from.
+func (c TimeWindow) CheckCtx(_ Observable, _ time.Time, _ *Site, ctx *coord.Context) (Result, error) {
+	t := ctx.Time()
+
+	beforeStart := !c.From.IsZero() && t.Before(c.From)
+	afterEnd := !c.To.IsZero() && t.After(c.To)
+
+	switch {
+	case beforeStart:
+		return Result{
+			Value:  -c.From.Sub(t).Hours(),
+			Reason: fmt.Sprintf("%.2f h before the window opens", c.From.Sub(t).Hours()),
+		}, nil
+
+	case afterEnd:
+		return Result{
+			Value:  -t.Sub(c.To).Hours(),
+			Reason: fmt.Sprintf("%.2f h after the window closed", t.Sub(c.To).Hours()),
+		}, nil
+	}
+
+	return Result{Pass: true, Value: hoursToNearerEdge(t, c.From, c.To)}, nil
+}
+
+// hoursToNearerEdge is how much of the window is left on the tighter side.
+func hoursToNearerEdge(t, from, to time.Time) float64 {
+	switch {
+	case from.IsZero() && to.IsZero():
+		return 0
+	case from.IsZero():
+		return to.Sub(t).Hours()
+	case to.IsZero():
+		return t.Sub(from).Hours()
+	}
+
+	return math.Min(t.Sub(from).Hours(), to.Sub(t).Hours())
+}
+
+// Horizon passes if the target stands above the local terrain at its own
+// azimuth.
+//
+// The constraint [Altitude] cannot express. A single threshold describes a site
+// with a clean horizon in every direction, and almost no real site has one: a
+// ridge to the east delays every rise, a dome or a building blocks a sector
+// outright, and a target at 15 degrees is observable in one azimuth and behind
+// rock in another.
+//
+// The profile comes from the [Site], through [Site.HorizonAt], which is where
+// it belongs — a horizon is a property of the place, not of the question being
+// asked about it. [WithHorizonProfile] sets one; a site without one answers
+// with its scalar [Site.Horizon] at every azimuth, so this constraint is
+// meaningful either way and degrades to [Altitude] rather than to nothing.
+//
+// Where the profile comes from is the caller's problem and there are several
+// answers — a surveyed table, a digital elevation model, a fisheye photograph.
+// [HorizonProfile] is one function, so any of them fits behind it.
+type Horizon struct {
+	// Margin is added to the horizon before comparing, for the clearance a
+	// caller wants above the ridge line rather than exactly on it. Zero means
+	// the ridge itself.
+	Margin angle.Angle
+}
+
+// Check evaluates the terrain horizon for a given target and time.
+func (c Horizon) Check(obj Observable, t time.Time, site *Site) (Result, error) {
+	ctx := coord.NewContext(t, site.Location(), site.Refraction())
+	return c.CheckCtx(obj, t, site, ctx)
+}
+
+// CheckCtx evaluates the terrain horizon using a pre-built coord.Context.
+//
+// The site is read here rather than captured in the struct, which is why this
+// is the one constraint in the file that uses its site parameter: two sites can
+// share a constraint set and must not share a horizon.
+func (c Horizon) CheckCtx(
+	obj Observable, t time.Time, site *Site, ctx *coord.Context,
+) (Result, error) {
+	aa, err := skyAltAzCtx(obj, t, ctx)
+	if err != nil {
+		return Result{}, err
+	}
+
+	terrain := site.HorizonAt(aa.Az()).Degrees() + c.Margin.Degrees()
+	alt := aa.Alt().Degrees()
+
+	// Clearance rather than altitude, so the value means the same thing in
+	// every azimuth — which is the whole reason this is not Altitude.
+	val := alt - terrain
+	pass := val >= 0
+
+	reason := ""
+	if !pass {
+		reason = fmt.Sprintf("altitude %.2f is %.2f below the horizon at azimuth %.1f",
+			alt, -val, aa.Az().Degrees())
+	}
+
+	return Result{Pass: pass, Value: val, Reason: reason}, nil
+}

--- a/plan/constraint_more_test.go
+++ b/plan/constraint_more_test.go
@@ -1,0 +1,448 @@
+package plan
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
+)
+
+func moreSite(t *testing.T) *Site {
+	t.Helper()
+
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("Paranal", loc)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	return site
+}
+
+// TestSunSep uses the one geometry that needs no ephemeris table to predict:
+// at a solstice the Sun is near one of the tropics, so a star placed on its
+// coordinates is separated from it by nearly nothing, and its antipode by
+// nearly 180 degrees.
+func TestSunSep(t *testing.T) {
+	site := moreSite(t)
+	when := time.Date(2026, time.June, 21, 12, 0, 0, 0, time.LocationUTC)
+
+	sun := NewSun(nil)
+
+	sunPos, err := sun.Position(when)
+	if err != nil {
+		t.Fatalf("sun position: %v", err)
+	}
+
+	near := NewStar("beside the sun", sunPos.RA(), sunPos.Dec())
+	far := NewStar("opposite the sun",
+		sunPos.RA().Add(angle.Deg(180)), sunPos.Dec().Neg())
+
+	c := SunSep{Threshold: angle.Deg(30)}
+
+	res, err := c.Check(near, when, site)
+	testutil.AssertNoError(t, err)
+
+	if res.Pass {
+		t.Errorf("a target on the Sun's own coordinates passed a 30° separation constraint: %v", res)
+	}
+
+	if res.Value > 1 {
+		t.Errorf("separation from the Sun's own position = %.3f°, want ~0", res.Value)
+	}
+
+	res, err = c.Check(far, when, site)
+	testutil.AssertNoError(t, err)
+
+	if !res.Pass {
+		t.Errorf("a target opposite the Sun failed a 30° separation constraint: %v", res)
+	}
+
+	if res.Value < 170 {
+		t.Errorf("separation from the Sun's antipode = %.3f°, want ~180", res.Value)
+	}
+}
+
+// TestSunSepPassesTheSunItself mirrors MoonSep's treatment of the Moon: an
+// object's separation from itself is not a constraint on observing it, and
+// zero would otherwise fail every threshold.
+func TestSunSepPassesTheSunItself(t *testing.T) {
+	site := moreSite(t)
+	when := time.Date(2026, time.June, 21, 12, 0, 0, 0, time.LocationUTC)
+
+	res, err := SunSep{Threshold: angle.Deg(30)}.Check(NewSun(nil), when, site)
+	testutil.AssertNoError(t, err)
+
+	if !res.Pass {
+		t.Errorf("the Sun failed its own separation constraint: %v", res)
+	}
+}
+
+// TestGalacticLatitude is checked against the two directions the Galactic
+// frame is defined by, so the expected values are the definition rather than
+// a computation of it: the North Galactic Pole is b = +90 and the Galactic
+// centre b = 0.
+func TestGalacticLatitude(t *testing.T) {
+	site := moreSite(t)
+	when := time.FromJD(2451545.0, time.UTC)
+
+	// IAU 1958 Galactic frame, on ICRS: the pole and the centre.
+	pole := NewStar("north galactic pole", angle.Deg(192.85948), angle.Deg(27.12825))
+	centre := NewStar("galactic centre", angle.Deg(266.40510), angle.Deg(-28.93617))
+
+	c := GalacticLatitude{Threshold: angle.Deg(20)}
+
+	res, err := c.Check(pole, when, site)
+	testutil.AssertNoError(t, err)
+
+	if !res.Pass {
+		t.Errorf("the north galactic pole failed a |b| >= 20° constraint: %v", res)
+	}
+
+	if math.Abs(res.Value-90) > 0.01 {
+		t.Errorf("|b| at the pole = %.4f, want 90", res.Value)
+	}
+
+	res, err = c.Check(centre, when, site)
+	testutil.AssertNoError(t, err)
+
+	if res.Pass {
+		t.Errorf("the galactic centre passed a |b| >= 20° constraint: %v", res)
+	}
+
+	if math.Abs(res.Value) > 0.01 {
+		t.Errorf("|b| at the centre = %.4f, want 0", res.Value)
+	}
+}
+
+// TestGalacticLatitudeIsUnsigned: the constraint is a distance from the plane,
+// so a target the same way below it has to score the same as one above. A
+// signed comparison would pass everything in the northern galactic hemisphere
+// and nothing in the southern, which is a plausible-looking half-sky bug.
+func TestGalacticLatitudeIsUnsigned(t *testing.T) {
+	site := moreSite(t)
+	when := time.FromJD(2451545.0, time.UTC)
+
+	// The south galactic pole is the north one's antipode.
+	south := NewStar("south galactic pole", angle.Deg(12.85948), angle.Deg(-27.12825))
+
+	res, err := GalacticLatitude{Threshold: angle.Deg(20)}.Check(south, when, site)
+	testutil.AssertNoError(t, err)
+
+	if !res.Pass {
+		t.Errorf("the south galactic pole failed a |b| >= 20° constraint: %v", res)
+	}
+
+	if math.Abs(res.Value-90) > 0.01 {
+		t.Errorf("|b| at the south pole = %.4f, want 90", res.Value)
+	}
+}
+
+func TestTimeWindow(t *testing.T) {
+	site := moreSite(t)
+	obj := NewStar("anything", angle.Deg(0), angle.Deg(0))
+
+	open := time.Date(2026, time.April, 20, 2, 0, 0, 0, time.LocationUTC)
+	shut := time.Date(2026, time.April, 20, 6, 0, 0, 0, time.LocationUTC)
+
+	tests := []struct {
+		name string
+		when time.Time
+		win  TimeWindow
+		pass bool
+	}{
+		{"inside", open.Add(2 * time.Hour), TimeWindow{From: open, To: shut}, true},
+		{"on the opening edge", open, TimeWindow{From: open, To: shut}, true},
+		{"on the closing edge", shut, TimeWindow{From: open, To: shut}, true},
+		{"before it opens", open.Add(-time.Hour), TimeWindow{From: open, To: shut}, false},
+		{"after it closes", shut.Add(time.Hour), TimeWindow{From: open, To: shut}, false},
+
+		// One-sided: a deadline with no start, and a start with no deadline.
+		{"deadline, in time", open, TimeWindow{To: shut}, true},
+		{"deadline, too late", shut.Add(time.Minute), TimeWindow{To: shut}, false},
+		{"not before, and it is", shut, TimeWindow{From: open}, true},
+		{"not before, and it is not", open.Add(-time.Minute), TimeWindow{From: open}, false},
+
+		// Unbounded both ways constrains nothing, which is what a zero value
+		// of this type has to mean: a constraint nobody configured must not
+		// silently reject everything.
+		{"unbounded", open, TimeWindow{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.win.Check(obj, tt.when, site)
+			testutil.AssertNoError(t, err)
+
+			if res.Pass != tt.pass {
+				t.Errorf("Pass = %v, want %v (%v)", res.Pass, tt.pass, res)
+			}
+		})
+	}
+}
+
+// TestTimeWindowValueRanksByHeadroom: the value is what a scorer ranks on, so
+// it has to separate "two hours of window left" from "two minutes left" and
+// both from "closed an hour ago".
+func TestTimeWindowValueRanksByHeadroom(t *testing.T) {
+	site := moreSite(t)
+	obj := NewStar("anything", angle.Deg(0), angle.Deg(0))
+
+	open := time.Date(2026, time.April, 20, 2, 0, 0, 0, time.LocationUTC)
+	shut := time.Date(2026, time.April, 20, 6, 0, 0, 0, time.LocationUTC)
+	win := TimeWindow{From: open, To: shut}
+
+	value := func(when time.Time) float64 {
+		t.Helper()
+
+		res, err := win.Check(obj, when, site)
+		testutil.AssertNoError(t, err)
+
+		return res.Value
+	}
+
+	middle := value(open.Add(2 * time.Hour))
+	nearlyShut := value(shut.Add(-2 * time.Minute))
+	closed := value(shut.Add(time.Hour))
+
+	if !(middle > nearlyShut) {
+		t.Errorf("mid-window scores %.3f and nearly-closed %.3f; more headroom must score higher",
+			middle, nearlyShut)
+	}
+
+	if !(nearlyShut > closed) {
+		t.Errorf("nearly-closed scores %.3f and closed %.3f; inside must beat outside",
+			nearlyShut, closed)
+	}
+
+	if closed >= 0 {
+		t.Errorf("a closed window scores %.3f; outside the window must be negative", closed)
+	}
+
+	if math.Abs(middle-2) > 1e-6 {
+		t.Errorf("two hours into a four-hour window scores %.6f, want 2", middle)
+	}
+}
+
+// ridgeProfile is a horizon with one obstruction: flat everywhere except a
+// sector to the east, which is what a real site looks like in miniature.
+func ridgeProfile(az angle.Angle) angle.Angle {
+	d := math.Mod(az.Degrees()+360, 360)
+	if d >= 60 && d <= 120 {
+		return angle.Deg(25)
+	}
+
+	return angle.Deg(0)
+}
+
+func ridgeSite(t *testing.T, opts ...SiteOption) *Site {
+	t.Helper()
+
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4028), angle.Deg(-24.6251), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	site, err := NewSite("Paranal with a ridge", loc, opts...)
+	if err != nil {
+		t.Fatalf("NewSite: %v", err)
+	}
+
+	return site
+}
+
+// TestHorizon is the constraint Altitude cannot express: the same altitude is
+// observable in one azimuth and behind rock in another, so a single threshold
+// cannot describe the site.
+//
+// This is also the first production consumer of WithHorizonProfile, whose own
+// doc comment records that it had none — "purely additive data plumbing today"
+// — and names this constraint as the one it was waiting for.
+func TestHorizon(t *testing.T) {
+	site := ridgeSite(t, WithHorizonProfile(ridgeProfile))
+	when := time.Date(2026, time.April, 20, 3, 0, 0, 0, time.LocationUTC)
+
+	c := Horizon{}
+
+	for _, tc := range []struct {
+		name string
+		ra   angle.Angle
+		dec  angle.Angle
+	}{
+		{"somewhere", angle.Deg(120), angle.Deg(-20)},
+		{"elsewhere", angle.Deg(300), angle.Deg(-60)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := NewStar(tc.name, tc.ra, tc.dec)
+
+			ctx := coord.NewContext(when, site.Location(), site.Refraction())
+
+			aa, err := skyAltAzCtx(obj, when, ctx)
+			testutil.AssertNoError(t, err)
+
+			res, err := c.Check(obj, when, site)
+			testutil.AssertNoError(t, err)
+
+			want := aa.Alt().Degrees() - ridgeProfile(aa.Az()).Degrees()
+			if math.Abs(res.Value-want) > 1e-9 {
+				t.Errorf("clearance = %.6f, want %.6f (alt %.3f, terrain %.3f at az %.3f)",
+					res.Value, want, aa.Alt().Degrees(),
+					ridgeProfile(aa.Az()).Degrees(), aa.Az().Degrees())
+			}
+
+			if res.Pass != (res.Value >= 0) {
+				t.Errorf("Pass = %v with clearance %.3f", res.Pass, res.Value)
+			}
+		})
+	}
+}
+
+// TestHorizonVariesWithAzimuth is the property, stated directly: one profile,
+// one instant, two pointings, and the terrain the constraint compares against
+// differs between them. A constraint reading a scalar would report the same
+// horizon for both, and that is exactly the bug this type exists to prevent.
+func TestHorizonVariesWithAzimuth(t *testing.T) {
+	site := ridgeSite(t, WithHorizonProfile(ridgeProfile))
+
+	behind := site.HorizonAt(angle.Deg(90)).Degrees()
+	open := site.HorizonAt(angle.Deg(270)).Degrees()
+
+	if behind == open {
+		t.Fatalf("the profile reports %.2f in both azimuths; the fixture is not a ridge", behind)
+	}
+
+	if behind != 25 || open != 0 {
+		t.Errorf("profile gives %.2f east and %.2f west, want 25 and 0", behind, open)
+	}
+}
+
+// TestHorizonFallsBackToTheScalarLimit: a site with no profile is not a site
+// with no horizon. Site.HorizonAt answers with the scalar Horizon() at every
+// azimuth, so the constraint degrades to Altitude rather than to nothing —
+// which is what keeps it usable at the many sites nobody has surveyed.
+func TestHorizonFallsBackToTheScalarLimit(t *testing.T) {
+	site := ridgeSite(t) // no profile
+	when := time.Date(2026, time.April, 20, 3, 0, 0, 0, time.LocationUTC)
+	obj := NewStar("target", angle.Deg(120), angle.Deg(-20))
+
+	ctx := coord.NewContext(when, site.Location(), site.Refraction())
+
+	aa, err := skyAltAzCtx(obj, when, ctx)
+	testutil.AssertNoError(t, err)
+
+	res, err := Horizon{}.Check(obj, when, site)
+	testutil.AssertNoError(t, err)
+
+	want := aa.Alt().Degrees() - site.Horizon().Degrees()
+	if math.Abs(res.Value-want) > 1e-9 {
+		t.Errorf("clearance = %.6f, want %.6f against the scalar horizon", res.Value, want)
+	}
+}
+
+// TestHorizonMarginRaisesTheBar: the margin is clearance above the ridge line
+// rather than on it, so it can only make a constraint stricter.
+func TestHorizonMarginRaisesTheBar(t *testing.T) {
+	site := ridgeSite(t, WithHorizonProfile(ridgeProfile))
+	when := time.Date(2026, time.April, 20, 3, 0, 0, 0, time.LocationUTC)
+	obj := NewStar("target", angle.Deg(120), angle.Deg(-20))
+
+	bare, err := Horizon{}.Check(obj, when, site)
+	testutil.AssertNoError(t, err)
+
+	withMargin, err := Horizon{Margin: angle.Deg(5)}.Check(obj, when, site)
+	testutil.AssertNoError(t, err)
+
+	if math.Abs((bare.Value-withMargin.Value)-5) > 1e-9 {
+		t.Errorf("a 5° margin moved the clearance by %.6f°, want exactly 5",
+			bare.Value-withMargin.Value)
+	}
+}
+
+// TestHorizonReadsTheSiteItIsGiven: two sites can share a constraint set, so
+// the horizon has to come from the site passed to Check rather than from
+// anything the constraint captured.
+//
+// The blocking profile is built around the azimuth the target actually reaches,
+// found rather than assumed — the first version of this test picked a fixed
+// ridge sector, the target rose outside it, and both sites agreed for a reason
+// that had nothing to do with the property under test.
+func TestHorizonReadsTheSiteItIsGiven(t *testing.T) {
+	when := time.Date(2026, time.April, 20, 3, 0, 0, 0, time.LocationUTC)
+	obj := NewStar("target", angle.Deg(120), angle.Deg(-20))
+
+	flat := ridgeSite(t, WithHorizonProfile(func(angle.Angle) angle.Angle { return angle.Deg(0) }))
+
+	ctx := coord.NewContext(when, flat.Location(), flat.Refraction())
+
+	aa, err := skyAltAzCtx(obj, when, ctx)
+	testutil.AssertNoError(t, err)
+
+	// A wall exactly where this target is.
+	blocking := ridgeSite(t, WithHorizonProfile(func(az angle.Angle) angle.Angle {
+		if math.Abs(az.Sub(aa.Az()).WrapPi().Degrees()) < 5 {
+			return angle.Deg(89)
+		}
+
+		return angle.Deg(0)
+	}))
+
+	c := Horizon{}
+
+	open, err := c.Check(obj, when, flat)
+	testutil.AssertNoError(t, err)
+
+	blocked, err := c.Check(obj, when, blocking)
+	testutil.AssertNoError(t, err)
+
+	if !open.Pass {
+		t.Errorf("the target failed against a flat horizon at altitude %.2f: %v",
+			aa.Alt().Degrees(), open)
+	}
+
+	if blocked.Pass {
+		t.Errorf("the target passed a wall at its own azimuth: %v", blocked)
+	}
+
+	if math.Abs((open.Value-blocked.Value)-89) > 1e-9 {
+		t.Errorf("the two sites differ by %.6f°, want 89 — the horizon is not being read "+
+			"from the site passed to Check", open.Value-blocked.Value)
+	}
+}
+
+// TestSunSepDoesNotExemptOtherPlanets is the boundary on the exemption above,
+// and it needs no chosen epoch: Mercury is an inferior planet, so its greatest
+// elongation is about 28 degrees and it can never be 30 from the Sun. A
+// constraint that waved through every *Planet rather than the Sun itself would
+// report a pass here at any instant.
+//
+// Found by mutation — relaxing the check to any *Planet left every other test
+// in this file passing.
+func TestSunSepDoesNotExemptOtherPlanets(t *testing.T) {
+	site := moreSite(t)
+
+	for _, when := range []time.Time{
+		time.Date(2026, time.January, 15, 0, 0, 0, 0, time.LocationUTC),
+		time.Date(2026, time.June, 21, 12, 0, 0, 0, time.LocationUTC),
+		time.Date(2026, time.November, 3, 6, 0, 0, 0, time.LocationUTC),
+	} {
+		res, err := SunSep{Threshold: angle.Deg(30)}.Check(NewMercury(nil), when, site)
+		testutil.AssertNoError(t, err)
+
+		if res.Pass {
+			t.Errorf("at %v Mercury passed a 30° solar-separation constraint at %.2f°; "+
+				"an inferior planet never reaches that elongation", when, res.Value)
+		}
+
+		if res.Value == 180 {
+			t.Errorf("at %v Mercury was reported at 180° from the Sun, which is the "+
+				"exemption value — the check is matching any planet, not the Sun", when)
+		}
+	}
+}

--- a/plan/observatory.go
+++ b/plan/observatory.go
@@ -36,12 +36,12 @@ type Site struct {
 // increasing eastward, matching this package's existing azimuth
 // convention.
 //
-// This is purely additive data plumbing today: no production call site
-// consumes it yet (RiseSetThreshold and friends use HorizonDip, the
-// atmospheric dip from elevation, not this) — a future Horizon
-// constraint gating visibility per-azimuth (see docs/ROADMAP.md #29)
-// would be the natural consumer. Set it via WithHorizonProfile;
-// Site.HorizonAt falls back to the scalar Horizon() when none is set.
+// [Horizon] is the constraint that consumes it, gating visibility per
+// azimuth — the case a scalar threshold cannot express. RiseSetThreshold and
+// friends still use HorizonDip, the atmospheric dip from elevation, which is a
+// different quantity. Set a profile via WithHorizonProfile; Site.HorizonAt
+// falls back to the scalar Horizon() when none is set, so a site nobody has
+// surveyed still answers.
 type HorizonProfile func(azimuth angle.Angle) angle.Angle
 
 // KnownSiteNames returns the display names of every entry in the built-in


### PR DESCRIPTION
Closes #129.

Four of the constraints #129 lists are a few lines each against the existing interface. Two
are not, and are argued rather than added.

## The four

**`SunSep`** — the companion to `MoonSep` for the other bright source, and the one that
decides whether a daytime or twilight observation is possible at all. Scattered sunlight
near the Sun defeats any exposure, and a solar-adjacent pointing is an instrument-safety
question before it is a photometric one. The Sun passes its own constraint on `MoonSep`'s
reasoning; every other planet does not, which is a boundary a mutation found.

**`GalacticLatitude`** — stated as a *distance from the plane*, not a latitude range,
because which way it cuts depends on the programme: an extragalactic survey avoids the plane
for crowding and extinction, a Galactic-structure programme wants exactly that region.
Unsigned, so a target below the plane scores like one above — a signed comparison passes the
whole northern galactic hemisphere and none of the southern, which is a plausible-looking
half-sky bug.

**`TimeWindow`** — the constraint with nothing to do with the sky: a target of opportunity
with a coordination window, an instrument available for part of the night, an allocation
that ends. Without it those are expressed by slicing the schedule's own span, which
conflates *"this target cannot be observed then"* with *"nobody observes then"*. Its value is
hours from the nearer edge, so a scorer can rank "well inside" above "about to close".

**`Horizon`** — the per-azimuth terrain limit `Altitude` cannot express.

## The Horizon one is worth reading twice, because I built it wrong first

I gave it a `Profile` field over `atmosphere.HorizonProfile`. **`plan` already has its own**
— on the `Site`, set through `WithHorizonProfile`, read by `Site.HorizonAt`. That option's
doc comment says in as many words:

> This is purely additive data plumbing today: no production call site consumes it yet …
> a future Horizon constraint gating visibility per-azimuth (see docs/ROADMAP.md #29) would
> be the natural consumer.

I had built a parallel mechanism next to the one that was waiting for me. The constraint now
reads `Site.HorizonAt`, which is where a horizon belongs — a property of the place, not of
the question being asked about it — and **`WithHorizonProfile` finally has a consumer**. A
site with no profile answers with its scalar `Horizon()` at every azimuth, so the constraint
degrades to `Altitude` rather than to nothing.

## Not added, with reasons

- **`PhaseConstraint`** needs an epoch and a period on `Observable`, so a periodic target
  cannot be expressed at all yet. That is a type change, not a constraint.
- **`LocalTime`** answers the same question as `TimeWindow` in a display convention rather
  than a physical one.

#129 also orders the real work as horizon profile → weather → satellite illumination. This
is the first of those three; the other two are absent and stay absent.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1 ./...`, `go test
-tags=validation ./...`, `golangci-lint run --build-tags="integration,network,validation"`
at 0 issues. All four constraints carry the `ConstraintCtx` compile-time assertion the
existing ones do, so they get the scheduler's shared-Context fast path.

| mutation | killed by |
| :--- | :--- |
| read the scalar horizon instead of the profile | `TestHorizonReadsTheSiteItIsGiven` |
| signed galactic latitude | `TestGalacticLatitudeIsUnsigned` |
| `TimeWindow` open on the wrong side | `TestTimeWindow` |
| **exempt any planet, not just the Sun** | **survived** → `TestSunSepDoesNotExemptOtherPlanets` |

That last one needs no chosen epoch: Mercury is an inferior planet, so its greatest
elongation is about 28° and it can never pass a 30° solar-separation constraint at *any*
instant.

One test was rewritten for the same reason as the code. It picked a fixed ridge sector and a
fixed target, the target rose outside the sector, and both sites agreed for a reason that
had nothing to do with the property under test. It now finds the target's actual azimuth and
builds the obstruction there.
