### PR TITLE
ephemeris: register the kernel backend instead of importing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,21 @@ without `astrogo/remote` links no storage backend at all — measured, a binary
 computing a Julian date is **2.5 MB rather than 19.4 MB** — and degrades to
 zero EOP exactly as an unconsented one does. To read a pre-seeded file without
 that dependency, register `time.FileEOPLoader("/path/to/finals2000A.data")`.
+
+`ephemeris` works the same way, and it buys more than a Julian date. The
+kernel-backed sources (`Planets`, `SmallBody`, `Asteroids`, `Comets`, `Moons`)
+read SPK files, so they reach `remote` and through it `gocloud.dev/blob`; the
+SOFA path does not. The kernel half therefore registers itself:
+
+```go
+import _ "github.com/TuSKan/astrogo/ephemeris/jpl"
+```
+
+Measured, a program asking `eph.Default()` where Mars is went from **13.9 MB and
+424 packages to 4.7 MB and 224**, with gRPC, OpenTelemetry, protobuf and
+`gocloud.dev` at zero — 64 packages of gRPC were arriving for an error-code
+enum. Without the import those five sources return an error naming it;
+`Satellites` and everything on SOFA are unaffected.
 OpenNGC works the same way — like every other catalog provider, it fetches over the
 network via
 `remote.EnableDownloads(remote.OpenNGC, ...)` (see "Enabling a download" above).

--- a/docs/changelog.d/218-kernel-backend-optin.md
+++ b/docs/changelog.d/218-kernel-backend-optin.md
@@ -1,0 +1,11 @@
+---
+type: Changed — BREAKING
+pr: 218
+---
+**`ephemeris`'s kernel sources now need one blank import.** `import _
+"github.com/TuSKan/astrogo/ephemeris/jpl"` registers the backend `Planets`,
+`SmallBody`, `Asteroids`, `Comets` and `Moons` use; without it they return an
+error naming it. Asking SOFA where Mars is went from 13.9 MB and 424 packages to
+4.7 MB and 224, with gRPC, OpenTelemetry, protobuf and `gocloud.dev` at zero —
+64 packages of gRPC were arriving for an error-code enum. `eph.JPL` is removed;
+name `jpl.Provider` (#112).

--- a/ephemeris/core/kernel.go
+++ b/ephemeris/core/kernel.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The kernel-backed sources are reached through a registered backend rather
+// than by the root package importing one.
+//
+// # Why a registration rather than an import
+//
+// Asking where Mars is costs 14 MB and 424 packages, of which 12 MB and 131
+// are an object-storage client the answer never touches: ephemeris imports
+// ephemeris/jpl, which imports remote, which imports gocloud.dev/blob, which
+// pulls 64 packages of gRPC for an error-code enum and 34 of OpenTelemetry
+// because it instruments unconditionally. A pure-SOFA call — no kernel, no
+// network, no file — paid for all of it because one branch of one factory
+// mentioned the type.
+//
+// The same pattern remote/s3 already uses: a subpackage that is nothing but a
+// registration, blank-imported by a build that needs the capability. See #112.
+//
+// # What it costs
+//
+// A compile-time failure becomes a runtime one. That is the trade, and it is
+// why [ErrNoKernelBackend] names the import to add rather than merely reporting
+// that something is missing.
+
+// KernelRequest is everything a kernel-backed provider needs to build one.
+//
+// A struct rather than a parameter list because it crosses a registration
+// boundary: a backend registered by one package and called by another cannot
+// be kept in step by the compiler when an argument is added, and a silently
+// dropped time interval is a provider that answers for the wrong window.
+type KernelRequest struct {
+	// Source is the kernel-backed source being asked for.
+	Source Source
+
+	// Kernel names the primary kernel — "de440", "433", and so on.
+	Kernel string
+
+	// Start and End restrict the coverage window for a generated small-body
+	// kernel. Both zero means the backend's own default.
+	Start, End time.Time
+
+	// ExtraKernels are additional kernels to load after the primary one.
+	ExtraKernels []string
+}
+
+// KernelBackend builds a provider for the kernel-backed sources.
+type KernelBackend func(ctx context.Context, req KernelRequest) (Provider, error)
+
+// ErrNoKernelBackend is returned for a kernel-backed source in a build that
+// registered no backend.
+//
+// The message names the import because that is the whole remedy, and because
+// the alternative — "unsupported source" — describes the symptom of a build
+// decision as though it were a limit of the library.
+var ErrNoKernelBackend = errors.New(
+	"eph: this build has no kernel backend; add " +
+		`import _ "github.com/TuSKan/astrogo/ephemeris/jpl"`)
+
+// kernelBackend holds the registered backend, or nil.
+//
+// Atomic rather than mutex-guarded for the same reason time's leap-second
+// registry is: it is read on a path callers hit repeatedly and written at most
+// once, by an init.
+var kernelBackend atomic.Pointer[KernelBackend]
+
+// RegisterKernelBackend installs the backend the kernel-backed sources use.
+//
+// Called by ephemeris/jpl's init, which is what a blank import of that package
+// runs. Nothing else should call it, and nothing needs to: there is one
+// implementation and the registration exists to make importing it a decision
+// rather than a default.
+func RegisterKernelBackend(b KernelBackend) {
+	if b == nil {
+		kernelBackend.Store(nil)
+		return
+	}
+
+	kernelBackend.Store(&b)
+}
+
+// KernelProvider builds a provider through the registered backend, or reports
+// [ErrNoKernelBackend].
+func KernelProvider(ctx context.Context, req KernelRequest) (Provider, error) {
+	b := kernelBackend.Load()
+	if b == nil {
+		return nil, ErrNoKernelBackend
+	}
+
+	return (*b)(ctx, req)
+}
+
+// HasKernelBackend reports whether this build can serve the kernel-backed
+// sources, for a caller that would rather check than fail.
+func HasKernelBackend() bool { return kernelBackend.Load() != nil }

--- a/ephemeris/core/kernel_test.go
+++ b/ephemeris/core/kernel_test.go
@@ -20,6 +20,16 @@ func restoreBackend(t *testing.T) {
 	t.Cleanup(func() { kernelBackend.Store(prev) })
 }
 
+// Sentinels for the failures these tests inject, declared here because a
+// dynamic errors.New inside a test is the same footgun it is anywhere else:
+// errors.Is against it works only by identity, and an inline one cannot be
+// referred to twice.
+var (
+	errKernelGone = errors.New("de440.bsp: no such file")
+	errFirst      = errors.New("first backend")
+	errSecond     = errors.New("second backend")
+)
+
 // stubProvider is the smallest thing satisfying Provider.
 type stubProvider struct{}
 
@@ -101,14 +111,12 @@ func TestRequestCrossesTheBoundaryIntact(t *testing.T) {
 func TestBackendErrorReachesTheCaller(t *testing.T) {
 	restoreBackend(t)
 
-	kernelGone := errors.New("de440.bsp: no such file")
-
 	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
-		return nil, kernelGone
+		return nil, errKernelGone
 	})
 
 	_, err := KernelProvider(context.Background(), KernelRequest{Source: Planets, Kernel: "de440"})
-	if !errors.Is(err, kernelGone) {
+	if !errors.Is(err, errKernelGone) {
 		t.Fatalf("err = %v, want the backend's own error", err)
 	}
 
@@ -123,18 +131,15 @@ func TestBackendErrorReachesTheCaller(t *testing.T) {
 func TestRegisterReplaces(t *testing.T) {
 	restoreBackend(t)
 
-	first := errors.New("first")
-	second := errors.New("second")
-
 	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
-		return nil, first
+		return nil, errFirst
 	})
 	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
-		return nil, second
+		return nil, errSecond
 	})
 
 	_, err := KernelProvider(context.Background(), KernelRequest{})
-	if !errors.Is(err, second) {
+	if !errors.Is(err, errSecond) {
 		t.Errorf("err = %v, want the second registration to win", err)
 	}
 

--- a/ephemeris/core/kernel_test.go
+++ b/ephemeris/core/kernel_test.go
@@ -1,0 +1,146 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// The registry is process-global by design — one backend, installed by an init
+// — so every test here restores it. They run in this package's own binary, so
+// nothing else is looking at it.
+func restoreBackend(t *testing.T) {
+	t.Helper()
+
+	prev := kernelBackend.Load()
+
+	t.Cleanup(func() { kernelBackend.Store(prev) })
+}
+
+// stubProvider is the smallest thing satisfying Provider.
+type stubProvider struct{}
+
+func (stubProvider) State(ID, time.Time) (State, error) {
+	return State{Pos: vector.Vec3{X: 1}}, nil
+}
+
+func (stubProvider) Close() error { return nil }
+
+// TestNoBackendReportsWhatToImport is the failure mode a build starts in, and
+// the reason the whole split is acceptable: the message has to be actionable,
+// because the alternative to this error used to be a compile error.
+func TestNoBackendReportsWhatToImport(t *testing.T) {
+	restoreBackend(t)
+	RegisterKernelBackend(nil)
+
+	if HasKernelBackend() {
+		t.Fatal("HasKernelBackend is true after registering nil")
+	}
+
+	_, err := KernelProvider(context.Background(), KernelRequest{Source: Planets, Kernel: "de440"})
+	if !errors.Is(err, ErrNoKernelBackend) {
+		t.Fatalf("err = %v, want ErrNoKernelBackend", err)
+	}
+}
+
+// TestRequestCrossesTheBoundaryIntact is why KernelRequest is a struct rather
+// than a parameter list. The backend is registered by one package and called by
+// another, so the compiler cannot keep a growing argument list in step — and a
+// silently dropped time interval is a provider answering for the wrong window.
+func TestRequestCrossesTheBoundaryIntact(t *testing.T) {
+	restoreBackend(t)
+
+	var got KernelRequest
+
+	RegisterKernelBackend(func(_ context.Context, req KernelRequest) (Provider, error) {
+		got = req
+		return stubProvider{}, nil
+	})
+
+	if !HasKernelBackend() {
+		t.Fatal("HasKernelBackend is false after registering a backend")
+	}
+
+	want := KernelRequest{
+		Source:       SmallBody,
+		Kernel:       "433",
+		Start:        time.FromJD(2461000.5, time.TT),
+		End:          time.FromJD(2461100.5, time.TT),
+		ExtraKernels: []string{"de441_part-2"},
+	}
+
+	p, err := KernelProvider(context.Background(), want)
+	if err != nil {
+		t.Fatalf("KernelProvider: %v", err)
+	}
+
+	if p == nil {
+		t.Fatal("KernelProvider returned a nil provider and no error")
+	}
+
+	switch {
+	case got.Source != want.Source:
+		t.Errorf("Source = %v, want %v", got.Source, want.Source)
+	case got.Kernel != want.Kernel:
+		t.Errorf("Kernel = %q, want %q", got.Kernel, want.Kernel)
+	case !got.Start.Equal(want.Start):
+		t.Errorf("Start = %v, want %v", got.Start, want.Start)
+	case !got.End.Equal(want.End):
+		t.Errorf("End = %v, want %v", got.End, want.End)
+	case len(got.ExtraKernels) != 1 || got.ExtraKernels[0] != "de441_part-2":
+		t.Errorf("ExtraKernels = %v, want [de441_part-2]", got.ExtraKernels)
+	}
+}
+
+// TestBackendErrorReachesTheCaller: the registry is a lookup, not a policy. A
+// backend that cannot open a kernel has to say so in its own words, or every
+// real failure would arrive looking like a missing import.
+func TestBackendErrorReachesTheCaller(t *testing.T) {
+	restoreBackend(t)
+
+	kernelGone := errors.New("de440.bsp: no such file")
+
+	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
+		return nil, kernelGone
+	})
+
+	_, err := KernelProvider(context.Background(), KernelRequest{Source: Planets, Kernel: "de440"})
+	if !errors.Is(err, kernelGone) {
+		t.Fatalf("err = %v, want the backend's own error", err)
+	}
+
+	if errors.Is(err, ErrNoKernelBackend) {
+		t.Error("a backend's own failure was reported as a missing backend")
+	}
+}
+
+// TestRegisterReplaces: last registration wins, and registering nil clears.
+// Neither is something a caller should do, but the state is process-global and
+// a half-cleared registry would be worse than either.
+func TestRegisterReplaces(t *testing.T) {
+	restoreBackend(t)
+
+	first := errors.New("first")
+	second := errors.New("second")
+
+	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
+		return nil, first
+	})
+	RegisterKernelBackend(func(context.Context, KernelRequest) (Provider, error) {
+		return nil, second
+	})
+
+	_, err := KernelProvider(context.Background(), KernelRequest{})
+	if !errors.Is(err, second) {
+		t.Errorf("err = %v, want the second registration to win", err)
+	}
+
+	RegisterKernelBackend(nil)
+
+	if _, err := KernelProvider(context.Background(), KernelRequest{}); !errors.Is(err, ErrNoKernelBackend) {
+		t.Errorf("err = %v after clearing, want ErrNoKernelBackend", err)
+	}
+}

--- a/ephemeris/doc.go
+++ b/ephemeris/doc.go
@@ -12,9 +12,30 @@
 // This mirrors the catalog package's unified [catalog.Resolver] pattern:
 // users rarely need to import subpackages directly.
 //
+// # The kernel sources need one blank import
+//
+// [Planets], [SmallBody], [Asteroids], [Comets] and [Moons] read SPK kernels,
+// which means files, a cache and a network — and that reaches
+// gocloud.dev/blob, whose transitive weight is about 12 MB of object-storage
+// client. A build that only asks SOFA where Mars is has no use for any of it,
+// and used to link all of it because one branch of [NewProvider] mentioned the
+// type.
+//
+// So the kernel half registers itself instead:
+//
+//	import _ "github.com/TuSKan/astrogo/ephemeris/jpl"
+//
+// Measured, a program calling eph.Default().State(eph.Mars, t) went from 13.9
+// MB and 424 packages to 4.7 MB and 224, with gRPC, OpenTelemetry, protobuf and
+// gocloud.dev at zero. Adding the import restores every byte of it, to the
+// build that wants it. The same pattern remote/s3 uses; see #112.
+//
+// Without the import, those five sources report an error naming it.
+// [Satellites], [Default] and everything built on SOFA are unaffected.
+//
 // # Quick Start
 //
-//	// JPL planetary ephemeris (DE442)
+//	// JPL planetary ephemeris (DE442). Needs the registration import above.
 //	p, err := eph.NewProvider(ctx, eph.Planets, "de442")
 //	if err != nil { log.Fatal(err) }
 //	defer p.Close()

--- a/ephemeris/ephemeris.go
+++ b/ephemeris/ephemeris.go
@@ -10,8 +10,6 @@ import (
 	"github.com/TuSKan/astrogo/constants"
 	"github.com/TuSKan/astrogo/coord"
 	"github.com/TuSKan/astrogo/ephemeris/core"
-	"github.com/TuSKan/astrogo/ephemeris/jpl"
-	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
 	"github.com/TuSKan/astrogo/ephemeris/kepler"
 	"github.com/TuSKan/astrogo/ephemeris/satellite"
 	"github.com/TuSKan/astrogo/internal/gofaext"
@@ -174,9 +172,6 @@ var (
 // Satellite is the SGP4 orbit propagator for NORAD TLE data.
 type Satellite = satellite.Satellite
 
-// JPL is the JPL DE4xx numerical ephemeris provider.
-type JPL = jpl.Provider
-
 // ─── Kepler two-body propagator ───────────────────────────────────────────────
 
 // Elements are classical heliocentric osculating orbital elements for
@@ -304,27 +299,23 @@ func NewProvider(ctx context.Context, source Source, kernel string, opts ...Opti
 
 	switch source {
 	case Planets, SmallBody, Asteroids, Comets, Moons:
-		var jplOpts []jpl.Option
-
-		if !cfg.Start.IsZero() && !cfg.End.IsZero() {
-			jplOpts = append(jplOpts, jpl.WithTimeInterval(cfg.Start, cfg.End))
-		}
-
-		p, err := jpl.NewProvider(ctx, source, kernel, jplOpts...)
+		// Through the registered backend rather than by importing one. This
+		// package knows SOFA and a source vocabulary; the kernel half reaches
+		// remote and gocloud.dev/blob, and a build that never asks for a kernel
+		// should not link it. See ephemeris/core/kernel.go and #112.
+		p, err := core.KernelProvider(ctx, core.KernelRequest{
+			Source:       source,
+			Kernel:       kernel,
+			Start:        cfg.Start,
+			End:          cfg.End,
+			ExtraKernels: cfg.ExtraKernels,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("ephemeris: new provider: %w", err)
-		}
-
-		for _, extra := range cfg.ExtraKernels {
-			k, err := spk.CacheDownload(ctx, "planets/"+extra+".bsp")
-			if err != nil {
-				return nil, fmt.Errorf("ephemeris: cache kernel %s: %w", extra, err)
-			}
-
-			err = p.AddKernel(k)
-			if err != nil {
-				return nil, fmt.Errorf("ephemeris: add kernel: %w", err)
-			}
+			// Wrapped, not replaced: errors.Is against core.ErrNoKernelBackend
+			// is how a caller distinguishes "this build has no kernel support"
+			// from "that kernel could not be read", and the message already
+			// names the import to add.
+			return nil, fmt.Errorf("ephemeris: %w", err)
 		}
 
 		return p, nil

--- a/ephemeris/jpl/register.go
+++ b/ephemeris/jpl/register.go
@@ -1,0 +1,63 @@
+package jpl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl/spk"
+)
+
+// Importing this package registers it as the backend the root ephemeris
+// package's kernel-backed sources use:
+//
+//	import _ "github.com/TuSKan/astrogo/ephemeris/jpl"
+//
+// That is the whole reason a blank import means anything here. Without it,
+// eph.NewProvider(ctx, eph.Planets, ...) reports [core.ErrNoKernelBackend] and
+// names this import; with it, the root package costs what a kernel-backed
+// build actually needs — this package reaches remote, which reaches
+// gocloud.dev/blob, and that is about 12 MB of client a pure-SOFA call has no
+// use for. See ephemeris/core/kernel.go and #112.
+//
+// A caller who imports this package for its own API — jpl.NewProvider,
+// jpl.Provider — gets the registration too, and wants it: the two are the same
+// capability.
+//
+// The lint exemption is narrow and the reason is the paragraph above: this
+// package's entire purpose under a blank import is the registration, so the
+// init is the contract rather than a hidden side effect. CLAUDE.md's rule
+// forbids the latter, and an exported Register() the caller had to remember to
+// invoke would make a blank import do nothing — which is the one behaviour a
+// reader of `import _` will not expect.
+//
+//nolint:gochecknoinits // the registration is this package's documented purpose under a blank import
+func init() { core.RegisterKernelBackend(build) }
+
+// build is the kernel-backed half of eph.NewProvider, moved here so the root
+// package no longer names this one.
+func build(ctx context.Context, req core.KernelRequest) (core.Provider, error) {
+	var opts []Option
+
+	if !req.Start.IsZero() && !req.End.IsZero() {
+		opts = append(opts, WithTimeInterval(req.Start, req.End))
+	}
+
+	p, err := NewProvider(ctx, req.Source, req.Kernel, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("ephemeris: new provider: %w", err)
+	}
+
+	for _, extra := range req.ExtraKernels {
+		k, err := spk.CacheDownload(ctx, "planets/"+extra+".bsp")
+		if err != nil {
+			return nil, fmt.Errorf("ephemeris: cache kernel %s: %w", extra, err)
+		}
+
+		if err := p.AddKernel(k); err != nil {
+			return nil, fmt.Errorf("ephemeris: add kernel: %w", err)
+		}
+	}
+
+	return p, nil
+}

--- a/ephemeris/jpl/register_test.go
+++ b/ephemeris/jpl/register_test.go
@@ -1,0 +1,77 @@
+package jpl
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// Importing this package is the whole contract under a blank import, so the
+// registration is what these check — not the kernel reading, which every other
+// test in this package already covers against a real DE440s.
+
+// TestImportingThisPackageRegistersTheBackend is the contract in one line.
+//
+// If it broke, nothing would fail to compile and nothing would look wrong: a
+// build with the blank import would simply report ErrNoKernelBackend, which is
+// the message telling the caller to add the import they already added.
+func TestImportingThisPackageRegistersTheBackend(t *testing.T) {
+	if !core.HasKernelBackend() {
+		t.Fatal("importing ephemeris/jpl did not register a kernel backend")
+	}
+}
+
+// TestBackendReportsTheKernelFailureNotAMissingImport: with the backend
+// registered, a kernel that cannot be read must arrive as that failure. The
+// registry is a lookup and not a policy, and confusing the two would send a
+// caller chasing an import they already have.
+func TestBackendReportsTheKernelFailureNotAMissingImport(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+
+	// Nothing can be fetched, so whatever comes back is a kernel failure.
+	remote.SetOffline(true)
+
+	_, err := core.KernelProvider(context.Background(), core.KernelRequest{
+		Source: core.Planets,
+		Kernel: "de440s",
+	})
+	if err == nil {
+		t.Fatal("an offline kernel fetch returned no error")
+	}
+
+	if errors.Is(err, core.ErrNoKernelBackend) {
+		t.Errorf("a kernel failure was reported as a missing backend:\n  %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "ephemeris: new provider") {
+		t.Errorf("the error does not say which step failed:\n  %v", err)
+	}
+}
+
+// TestBackendCarriesTheTimeInterval: a small-body kernel is generated for a
+// window, so an interval the backend drops is a provider that answers for the
+// wrong dates. Offline, this reaches the same failure either way — what it
+// pins is that the option translation runs at all rather than being skipped.
+func TestBackendCarriesTheTimeInterval(t *testing.T) {
+	t.Cleanup(remote.Capture().Restore)
+	remote.SetOffline(true)
+
+	_, err := core.KernelProvider(context.Background(), core.KernelRequest{
+		Source: core.SmallBody,
+		Kernel: "433",
+		Start:  time.FromJD(2461000.5, time.TT),
+		End:    time.FromJD(2461100.5, time.TT),
+	})
+	if err == nil {
+		t.Fatal("an offline small-body fetch returned no error")
+	}
+
+	if errors.Is(err, core.ErrNoKernelBackend) {
+		t.Errorf("a kernel failure was reported as a missing backend:\n  %v", err)
+	}
+}

--- a/ephemeris/kernelbackend_test.go
+++ b/ephemeris/kernelbackend_test.go
@@ -1,0 +1,78 @@
+package ephemeris_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// This package deliberately does not import ephemeris/jpl, so these tests run
+// in a build with no kernel backend — which is the state every consumer starts
+// in after #112, and the one whose error message has to be worth reading.
+//
+// The trade the registration makes is a compile-time failure for a runtime one.
+// That is only acceptable while the runtime failure says what to do, so the
+// message is tested rather than assumed.
+
+// TestKernelSourcesWithoutABackendSayWhatToImport is the whole cost of the
+// change, in one assertion.
+func TestKernelSourcesWithoutABackendSayWhatToImport(t *testing.T) {
+	if core.HasKernelBackend() {
+		t.Skip("a backend is registered in this build; the message under test cannot occur")
+	}
+
+	for _, source := range []eph.Source{
+		eph.Planets, eph.SmallBody, eph.Asteroids, eph.Comets, eph.Moons,
+	} {
+		_, err := eph.NewProvider(context.Background(), source, "de440")
+		if !errors.Is(err, core.ErrNoKernelBackend) {
+			t.Fatalf("source %v: err = %v, want ErrNoKernelBackend", source, err)
+		}
+
+		// The import path, verbatim, because a message that merely reports
+		// something missing describes a build decision as though it were a
+		// limit of the library.
+		if !strings.Contains(err.Error(), `import _ "github.com/TuSKan/astrogo/ephemeris/jpl"`) {
+			t.Errorf("source %v: the error does not name the import to add:\n  %v", source, err)
+		}
+	}
+}
+
+// TestSOFAPathNeedsNoBackend is the other half: everything that never wanted a
+// kernel keeps working in a build that has none. If this failed, the split
+// would have moved the cost rather than removed it.
+func TestSOFAPathNeedsNoBackend(t *testing.T) {
+	st, err := eph.Default().State(eph.Mars, time.J2000)
+	if err != nil {
+		t.Fatalf("Default().State(Mars): %v", err)
+	}
+
+	if st.Pos.Norm() == 0 {
+		t.Error("the SOFA provider returned a zero position")
+	}
+}
+
+// TestSatellitesNeedNoBackend: SGP4 is not kernel-backed, and grouping it with
+// the sources that are would be an easy mistake to make in the switch this
+// change edited.
+func TestSatellitesNeedNoBackend(t *testing.T) {
+	// A real ISS element set, checksum and all. My first attempt invented the
+	// digits and the parser refused it, correctly — a TLE carries its own
+	// checksum and this package validates it.
+	const (
+		l1 = "1 25544U 98067A   26109.48995873  .00010082  00000-0  19194-3 0  9999"
+		l2 = "2 25544  51.6329 230.6068 0006631 325.6576  34.3983 15.48833250562656"
+	)
+
+	p, err := eph.NewProvider(context.Background(), eph.Satellites, "ISS", eph.WithTLE(l1, l2))
+	if err != nil {
+		t.Fatalf("Satellites source failed in a build with no kernel backend: %v", err)
+	}
+
+	defer func() { _ = p.Close() }()
+}

--- a/examples/09_geometry_events/main.go
+++ b/examples/09_geometry_events/main.go
@@ -11,6 +11,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/10_jesus_christ/born/main.go
+++ b/examples/10_jesus_christ/born/main.go
@@ -16,6 +16,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/10_jesus_christ/crux/main.go
+++ b/examples/10_jesus_christ/crux/main.go
@@ -23,6 +23,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 // fridayCandidate stores metadata for a Friday Nisan 14 occurrence.

--- a/examples/10_jesus_christ/eclipse/main.go
+++ b/examples/10_jesus_christ/eclipse/main.go
@@ -22,6 +22,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/10_jesus_christ/herod/main.go
+++ b/examples/10_jesus_christ/herod/main.go
@@ -19,6 +19,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/11_skyfield_verify/main.go
+++ b/examples/11_skyfield_verify/main.go
@@ -12,6 +12,10 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 // This example verifies astrogo's planetary ephemeris against the JPL Horizons

--- a/examples/15_target_details/moon/main.go
+++ b/examples/15_target_details/moon/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/15_target_details/planets/main.go
+++ b/examples/15_target_details/planets/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/15_target_details/sun/main.go
+++ b/examples/15_target_details/sun/main.go
@@ -12,6 +12,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/16_planet_parade/main.go
+++ b/examples/16_planet_parade/main.go
@@ -23,6 +23,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 type planetDef struct {

--- a/examples/17_equinox_prediction/main.go
+++ b/examples/17_equinox_prediction/main.go
@@ -24,6 +24,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/examples/19_offline_setup/main.go
+++ b/examples/19_offline_setup/main.go
@@ -25,6 +25,10 @@ import (
 	eph "github.com/TuSKan/astrogo/ephemeris"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 // cacheLocation names where an endpoint's files are expected, for display

--- a/examples/20_whats_visible_tonight/main.go
+++ b/examples/20_whats_visible_tonight/main.go
@@ -49,6 +49,10 @@ import (
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/remote"
 	"github.com/TuSKan/astrogo/time"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 // magLimit is the brightness bound for this run — everything fainter than

--- a/examples/22_kepler_propagator/main.go
+++ b/examples/22_kepler_propagator/main.go
@@ -32,6 +32,10 @@ import (
 
 	"github.com/TuSKan/astrogo/catalog"
 	"github.com/TuSKan/astrogo/plan"
+
+	// The kernel-backed sources register their backend rather than being
+	// imported by the root package, so a build that wants them says so (#112).
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 func main() {

--- a/internal/docsguard/lightephemeris_test.go
+++ b/internal/docsguard/lightephemeris_test.go
@@ -1,0 +1,78 @@
+package docsguard_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEphemerisDoesNotLinkTheStorageClient keeps the split #112 made.
+//
+// # What it is guarding
+//
+// Asking SOFA where Mars is used to cost 13.9 MB and 424 packages, of which
+// about 12 MB and 131 were an object-storage client the answer never touches:
+// ephemeris imported ephemeris/jpl, which imports remote, which imports
+// gocloud.dev/blob, which pulls 64 packages of gRPC for an error-code enum and
+// 34 of OpenTelemetry because it instruments unconditionally.
+//
+// The kernel half now registers itself, so a build says whether it wants that.
+// The measurement afterwards was 4.7 MB and 224 packages with all four groups
+// at zero.
+//
+// # Why a dependency check rather than a size check
+//
+// A binary's size moves with the toolchain, the platform and the linker's mood;
+// its import graph does not. Byte thresholds either drift into meaninglessness
+// or fail on somebody's machine for a reason nobody can act on. "Does this
+// package reach gocloud.dev" has one answer, the same everywhere, and it is the
+// thing that actually decides the size.
+//
+// A regression here is one accidental import away and would be invisible:
+// everything keeps working, the binary is simply nine megabytes bigger.
+func TestEphemerisDoesNotLinkTheStorageClient(t *testing.T) {
+	// The whole transitive graph of the root package, as the toolchain sees it.
+	out, err := exec.CommandContext(t.Context(),
+		"go", "list", "-deps", "github.com/TuSKan/astrogo/ephemeris").Output()
+	if err != nil {
+		t.Fatalf("go list -deps: %v", err)
+	}
+
+	deps := strings.Split(string(out), "\n")
+
+	// Each of these arrives only through remote's storage layer, and none of
+	// them has anything to do with computing an ephemeris.
+	forbidden := map[string]string{
+		"gocloud.dev":                "the object-storage client, via remote",
+		"google.golang.org/grpc":     "gRPC, which gocloud.dev/gcerrors pulls for an error-code enum",
+		"go.opentelemetry.io":        "OpenTelemetry, which gocloud.dev/blob instruments with unconditionally",
+		"google.golang.org/protobuf": "protobuf, via gRPC",
+	}
+
+	counts := map[string]int{}
+
+	for _, d := range deps {
+		for prefix := range forbidden {
+			if strings.HasPrefix(strings.TrimSpace(d), prefix) {
+				counts[prefix]++
+			}
+		}
+	}
+
+	for prefix, why := range forbidden {
+		if counts[prefix] > 0 {
+			t.Errorf("ephemeris reaches %d packages under %s — %s.\n"+
+				"  Something in the ephemeris tree imported remote again. The kernel-backed\n"+
+				"  sources reach it through the backend ephemeris/jpl registers, so nothing\n"+
+				"  in the root package should name that package. See #112.",
+				counts[prefix], prefix, why)
+		}
+	}
+
+	if len(deps) < 50 {
+		t.Fatalf("go list reported only %d dependencies; the command is not doing what this "+
+			"test assumes", len(deps))
+	}
+
+	t.Logf("%d transitive packages, none under %d forbidden prefixes", len(deps)-1, len(forbidden))
+}

--- a/plan/integration_main_test.go
+++ b/plan/integration_main_test.go
@@ -7,6 +7,13 @@ import (
 	"testing"
 
 	"github.com/TuSKan/astrogo/remote"
+
+	// The kernel-backed sources reach their backend through a registration
+	// rather than an import, so a build that wants them says so (#112). This
+	// suite constructs real DE441/DE442 providers, so it wants them; a
+	// production plan build that never asks for a kernel does not, which is
+	// the point of the split.
+	_ "github.com/TuSKan/astrogo/ephemeris/jpl"
 )
 
 // TestMain grants download consent for this package's integration-tagged


### PR DESCRIPTION
Closes #112.

Asking SOFA where Mars is cost **13.9 MB and 424 packages**. About 12 MB and 131 of those
were an object-storage client the answer never touches:

```
ephemeris → ephemeris/jpl → remote → gocloud.dev/blob → 64 pkgs of gRPC   (an error-code enum)
                                                      → 34 pkgs of OTel   (instrumented unconditionally)
                                                      → 33 pkgs of protobuf
```

A call with no kernel, no network and no file paid for all of it because one branch of one
factory named the type.

| | before | after |
| :--- | ---: | ---: |
| binary (`-ldflags="-s -w"`) | 13.9 MB | **4.7 MB** |
| packages | 424 | **224** |
| gRPC / OTel / protobuf / gocloud.dev | 64 / 34 / 33 / 9 | **0 / 0 / 0 / 0** |

## The shape

The kernel half registers itself, the way `remote/s3` already works:

```go
import _ "github.com/TuSKan/astrogo/ephemeris/jpl"
```

The registry lives in `ephemeris/core`, which both sides already import and which exists for
exactly this — its own doc says it is there to break what would otherwise be a circular
import. **No new edge was added to the graph, only one removed.**

## What it costs, and why the message is tested

A compile-time failure becomes a runtime one. That is only acceptable while the runtime
failure says what to do, so `ErrNoKernelBackend` names the import verbatim and a test
asserts it for all five kernel-backed sources. "Unsupported source" would describe a *build
decision* as though it were a limit of the library.

`eph.JPL` is **removed** rather than kept — a type alias for `jpl.Provider` that forced the
import it was aliasing across. Nothing in the module used it.

## plan stays light

Both `plan` call sites are opt-in paths — `WithPlanetaryMoons`, and the small-body kernel
fallback for a target with no published elements — so `plan` itself needs no import. A
caller reaching either gets the error, and `visible_tonight` already routes that into its
skip collector, so it reads as *"this target was skipped, and here is why"* rather than as a
failure of the night.

Fourteen examples and `plan`'s integration `TestMain` gain the blank import, since they
genuinely want kernels.

## The guard is on the import graph, not the byte count

A binary's size moves with the toolchain and the platform; its import graph does not. A byte
threshold either drifts into meaninglessness or fails on somebody's machine for a reason
nobody can act on. *"Does this package reach `gocloud.dev`"* has one answer everywhere, and
it is the thing that decides the size.

Verified by mutation: restoring the import takes it from 223 packages to 423, and the guard
names which prefix came back.

## Two notes

The `init` in `ephemeris/jpl` carries a locally-scoped `nolint`. CLAUDE.md forbids `init`
side effects, and rightly — this one is the package's entire documented purpose under a
blank import, and an exported `Register` the caller had to remember would make `import _` do
nothing, which is the one thing a reader of that line will not expect.

One test fixture was invented and the parser refused it, correctly: I made up TLE digits,
and a TLE carries its own checksum. It uses a real ISS element set now.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1 ./...`, `go test
-tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues. `README.md` and
`ephemeris/doc.go` both carry the measurement and the import.
