### PR TITLE
fits: WCS accessors that copy, validate, and read like Go

### DIFF
--- a/docs/changelog.d/220-wcs-accessors.md
+++ b/docs/changelog.d/220-wcs-accessors.md
@@ -1,0 +1,8 @@
+---
+type: Changed — BREAKING
+pr: 220
+---
+`fits.WCS`'s getters lose their `Get` prefix (`GetCRVAL` is now `CRVAL`), and the
+five setters with a length invariant return `error` — a short CRPIX was a panic
+reachable from `PixelToWorld` and a long one a silent disagreement about axis
+count, both accepted without a word. New `NAxis` reports the invariant (#178).

--- a/docs/changelog.d/220-wcs-aliasing.md
+++ b/docs/changelog.d/220-wcs-aliasing.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 220
+---
+**`fits.WCS` could be rewritten without going through a setter, in both
+directions.** The getters returned the internal slice and the setters kept the
+caller's, so reading `CRVAL` to inspect it, or holding the slice you passed in,
+let you move an image on the sky at a distance. Both now copy, including the SIP
+and TPV coefficient maps (#178).

--- a/fits/wcs.go
+++ b/fits/wcs.go
@@ -2,6 +2,7 @@ package fits
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 )
@@ -43,44 +44,117 @@ func NewWCS(naxis int) *WCS {
 	}
 }
 
+// The accessors copy in both directions, and the ones with a length invariant
+// enforce it.
+//
+// # Why copying
+//
+// They used to store and return the caller's slice. Either direction is a way
+// to rewrite a WCS without going through a setter: a caller holding the slice
+// they passed to SetCRVAL could change the reference position afterwards, and
+// a caller mutating what CRVAL returned did the same from the other side. For a
+// value describing where an image is on the sky, that is state changing under
+// whoever is transforming coordinates through it.
+//
+// # Why the length is an error rather than a comment
+//
+// PixelToWorld indexes crpix, crval and cdelt from 0 to nAxis, so a slice
+// shorter than nAxis is a panic reachable from a public method — and one longer
+// is a silent misunderstanding about how many axes this WCS has. Both used to
+// be accepted without a word. The map-valued setters carry no such invariant
+// and return nothing.
+
 // SetCRPIX sets the reference pixel coordinate array (1-based FITS indexing).
-func (w *WCS) SetCRPIX(crpix []float64) {
-	w.crpix = crpix
+//
+// Returns [ErrWCSDimension] unless len(crpix) is the WCS's axis count.
+func (w *WCS) SetCRPIX(crpix []float64) error {
+	if len(crpix) != w.nAxis {
+		return fmt.Errorf("%w: CRPIX has %d values, want %d", ErrWCSDimension, len(crpix), w.nAxis)
+	}
+
+	w.crpix = append([]float64(nil), crpix...)
+
+	return nil
 }
 
 // SetCRVAL sets the world coordinate values at the reference pixel.
-func (w *WCS) SetCRVAL(crval []float64) {
-	w.crval = crval
+//
+// Returns [ErrWCSDimension] unless len(crval) is the WCS's axis count.
+func (w *WCS) SetCRVAL(crval []float64) error {
+	if len(crval) != w.nAxis {
+		return fmt.Errorf("%w: CRVAL has %d values, want %d", ErrWCSDimension, len(crval), w.nAxis)
+	}
+
+	w.crval = append([]float64(nil), crval...)
+
+	return nil
 }
 
 // SetCDELT sets the pixel scale (degrees per pixel) along each axis.
-func (w *WCS) SetCDELT(cdelt []float64) {
-	w.cdelt = cdelt
+//
+// Returns [ErrWCSDimension] unless len(cdelt) is the WCS's axis count.
+func (w *WCS) SetCDELT(cdelt []float64) error {
+	if len(cdelt) != w.nAxis {
+		return fmt.Errorf("%w: CDELT has %d values, want %d", ErrWCSDimension, len(cdelt), w.nAxis)
+	}
+
+	w.cdelt = append([]float64(nil), cdelt...)
+
+	return nil
 }
 
 // SetCTYPE sets the coordinate axis type identifiers (e.g., "RA---TAN", "DEC--TAN").
-func (w *WCS) SetCTYPE(ctype []string) {
-	w.ctype = ctype
+//
+// Returns [ErrWCSDimension] unless len(ctype) is the WCS's axis count.
+func (w *WCS) SetCTYPE(ctype []string) error {
+	if len(ctype) != w.nAxis {
+		return fmt.Errorf("%w: CTYPE has %d values, want %d", ErrWCSDimension, len(ctype), w.nAxis)
+	}
+
+	w.ctype = append([]string(nil), ctype...)
+
+	return nil
 }
 
 // SetPC sets the linear transformation (rotation/skew) matrix.
-func (w *WCS) SetPC(pc [][]float64) {
-	w.pc = pc
+//
+// Returns [ErrWCSDimension] unless pc is square with the WCS's axis count —
+// a ragged matrix is checked row by row, since one short row is enough to make
+// the transform index past its end.
+func (w *WCS) SetPC(pc [][]float64) error {
+	if len(pc) != w.nAxis {
+		return fmt.Errorf("%w: PC has %d rows, want %d", ErrWCSDimension, len(pc), w.nAxis)
+	}
+
+	out := make([][]float64, w.nAxis)
+
+	for i, row := range pc {
+		if len(row) != w.nAxis {
+			return fmt.Errorf("%w: PC row %d has %d values, want %d",
+				ErrWCSDimension, i, len(row), w.nAxis)
+		}
+
+		out[i] = append([]float64(nil), row...)
+	}
+
+	w.pc = out
+
+	return nil
 }
 
 // SetSIP sets the forward SIP distortion polynomial coefficients.
 // Each map key [2]int{p, q} represents the exponent pair for u^p * v^q.
 // The maps may be nil to disable SIP distortion.
 func (w *WCS) SetSIP(a, b map[[2]int]float64) {
-	w.sipA = a
-	w.sipB = b
+	w.sipA = cloneCoeffs(a)
+	w.sipB = cloneCoeffs(b)
 }
 
 // SetSIPInverse sets the inverse SIP polynomial coefficients (AP, BP).
 // These are used in WorldToPixel to compute a direct inverse without iteration.
 func (w *WCS) SetSIPInverse(ap, bp map[[2]int]float64) {
-	w.sipAP = ap
-	w.sipBP = bp
+	w.sipAP = cloneCoeffs(ap)
+	w.sipBP = cloneCoeffs(bp)
 }
 
 // SetTPV sets the TPV distortion polynomial coefficients.
@@ -88,34 +162,61 @@ func (w *WCS) SetSIPInverse(ap, bp map[[2]int]float64) {
 // pv1 corrects the longitude intermediate coordinate;
 // pv2 corrects the latitude intermediate coordinate.
 func (w *WCS) SetTPV(pv1, pv2 map[int]float64) {
-	w.tpv1 = pv1
-	w.tpv2 = pv2
+	w.tpv1 = cloneTPV(pv1)
+	w.tpv2 = cloneTPV(pv2)
 }
 
-// GetCRPIX returns the reference pixel coordinate array.
-func (w *WCS) GetCRPIX() []float64 {
-	return w.crpix
+// cloneCoeffs copies a SIP coefficient map, preserving nil — a nil map means
+// "no distortion" and an empty one would too, but only nil says it was never
+// set.
+func cloneCoeffs(m map[[2]int]float64) map[[2]int]float64 {
+	if m == nil {
+		return nil
+	}
+
+	out := make(map[[2]int]float64, len(m))
+	maps.Copy(out, m)
+
+	return out
 }
 
-// GetCRVAL returns the world coordinate values at the reference pixel.
-func (w *WCS) GetCRVAL() []float64 {
-	return w.crval
+// cloneTPV is cloneCoeffs for the TPV term maps.
+func cloneTPV(m map[int]float64) map[int]float64 {
+	if m == nil {
+		return nil
+	}
+
+	out := make(map[int]float64, len(m))
+	maps.Copy(out, m)
+
+	return out
 }
 
-// GetCDELT returns the pixel scale along each axis.
-func (w *WCS) GetCDELT() []float64 {
-	return w.cdelt
+// CRPIX returns the reference pixel coordinate array.
+func (w *WCS) CRPIX() []float64 { return append([]float64(nil), w.crpix...) }
+
+// CRVAL returns the world coordinate values at the reference pixel.
+func (w *WCS) CRVAL() []float64 { return append([]float64(nil), w.crval...) }
+
+// CDELT returns the pixel scale along each axis.
+func (w *WCS) CDELT() []float64 { return append([]float64(nil), w.cdelt...) }
+
+// CTYPE returns the coordinate axis type identifiers.
+func (w *WCS) CTYPE() []string { return append([]string(nil), w.ctype...) }
+
+// PC returns the linear transformation matrix.
+func (w *WCS) PC() [][]float64 {
+	out := make([][]float64, len(w.pc))
+	for i, row := range w.pc {
+		out[i] = append([]float64(nil), row...)
+	}
+
+	return out
 }
 
-// GetCTYPE returns the coordinate axis type identifiers.
-func (w *WCS) GetCTYPE() []string {
-	return w.ctype
-}
-
-// GetPC returns the linear transformation matrix.
-func (w *WCS) GetPC() [][]float64 {
-	return w.pc
-}
+// NAxis returns how many axes this WCS describes, which is every setter's
+// length invariant and PixelToWorld's expected input length.
+func (w *WCS) NAxis() int { return w.nAxis }
 
 const (
 	deg2rad = math.Pi / 180.0
@@ -782,11 +883,23 @@ func ExtractWCS(h *Header) (*WCS, error) {
 	}
 
 	w := NewWCS(naxis)
-	w.SetCTYPE(ctype)
-	w.SetCRVAL(crval)
-	w.SetCRPIX(crpix)
-	w.SetCDELT(cdelt)
-	w.SetPC(pc)
+
+	// Every array above was built at length naxis, so a refusal here means the
+	// construction above disagrees with itself rather than that the header is
+	// odd — the setters are the only thing that would notice. Reported rather
+	// than dropped: the alternative is a WCS silently holding NewWCS's zeros,
+	// which transforms every pixel to the same place.
+	for _, err := range []error{
+		w.SetCTYPE(ctype),
+		w.SetCRVAL(crval),
+		w.SetCRPIX(crpix),
+		w.SetCDELT(cdelt),
+		w.SetPC(pc),
+	} {
+		if err != nil {
+			return nil, fmt.Errorf("fits: building WCS from header: %w", err)
+		}
+	}
 
 	// Extract SIP distortion coefficients if present.
 	sipA := parseSIPPoly(h, "A")

--- a/fits/wcs_accessors_test.go
+++ b/fits/wcs_accessors_test.go
@@ -1,0 +1,223 @@
+package fits_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// A WCS says where an image is on the sky, so anything that can change one
+// without going through a setter can move a whole image silently. Three ways
+// that used to be possible, each measured before it was closed.
+
+// TestGettersReturnACopy: the getters used to hand back the internal slice, so
+// a caller reading CRVAL to inspect it could rewrite the reference position by
+// accident — and would then be transforming coordinates against a WCS nobody
+// meant to change.
+func TestGettersReturnACopy(t *testing.T) {
+	w := fits.NewWCS(2)
+
+	mustSet(t,
+		w.SetCRPIX([]float64{50, 50}),
+		w.SetCRVAL([]float64{10, 45}),
+		w.SetCDELT([]float64{-0.01, 0.01}),
+		w.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+	)
+
+	w.CRPIX()[0] = 999
+	w.CRVAL()[0] = 999
+	w.CDELT()[0] = 999
+	w.CTYPE()[0] = "GLON-AIT"
+	w.PC()[0][0] = 999
+
+	switch {
+	case w.CRPIX()[0] != 50:
+		t.Errorf("CRPIX was rewritten through its getter: %v", w.CRPIX())
+	case w.CRVAL()[0] != 10:
+		t.Errorf("CRVAL was rewritten through its getter: %v", w.CRVAL())
+	case w.CDELT()[0] != -0.01:
+		t.Errorf("CDELT was rewritten through its getter: %v", w.CDELT())
+	case w.CTYPE()[0] != "RA---TAN":
+		t.Errorf("CTYPE was rewritten through its getter: %v", w.CTYPE())
+	case w.PC()[0][0] != 1:
+		t.Errorf("PC was rewritten through its getter: %v", w.PC())
+	}
+}
+
+// TestSettersCopyTheirInput is the same hole from the other side: a caller who
+// kept the slice they passed in could change the WCS afterwards, at a distance,
+// with nothing at the call site to suggest it.
+func TestSettersCopyTheirInput(t *testing.T) {
+	w := fits.NewWCS(2)
+
+	crpix := []float64{50, 50}
+	crval := []float64{10, 45}
+	cdelt := []float64{-0.01, 0.01}
+	ctype := []string{"RA---TAN", "DEC--TAN"}
+	pc := [][]float64{{1, 0}, {0, 1}}
+
+	mustSet(t,
+		w.SetCRPIX(crpix),
+		w.SetCRVAL(crval),
+		w.SetCDELT(cdelt),
+		w.SetCTYPE(ctype),
+		w.SetPC(pc),
+	)
+
+	crpix[0], crval[0], cdelt[0] = 999, 999, 999
+	ctype[0] = "GLON-AIT"
+	pc[0][0] = 999
+
+	switch {
+	case w.CRPIX()[0] != 50:
+		t.Errorf("CRPIX followed the caller's slice: %v", w.CRPIX())
+	case w.CRVAL()[0] != 10:
+		t.Errorf("CRVAL followed the caller's slice: %v", w.CRVAL())
+	case w.CDELT()[0] != -0.01:
+		t.Errorf("CDELT followed the caller's slice: %v", w.CDELT())
+	case w.CTYPE()[0] != "RA---TAN":
+		t.Errorf("CTYPE followed the caller's slice: %v", w.CTYPE())
+	case w.PC()[0][0] != 1:
+		t.Errorf("PC followed the caller's row: %v", w.PC())
+	}
+}
+
+// TestSettersRefuseTheWrongLength: a short array is a panic reachable from
+// PixelToWorld, which indexes crpix and crval from 0 to NAxis; a long one is a
+// silent disagreement about how many axes this WCS has. Both used to be
+// accepted without a word.
+func TestSettersRefuseTheWrongLength(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*fits.WCS) error
+	}{
+		{"CRPIX too short", func(w *fits.WCS) error { return w.SetCRPIX([]float64{1}) }},
+		{"CRPIX too long", func(w *fits.WCS) error { return w.SetCRPIX([]float64{1, 2, 3}) }},
+		{"CRVAL too short", func(w *fits.WCS) error { return w.SetCRVAL([]float64{1}) }},
+		{"CDELT too long", func(w *fits.WCS) error { return w.SetCDELT([]float64{1, 2, 3}) }},
+		{"CTYPE too short", func(w *fits.WCS) error { return w.SetCTYPE([]string{"RA---TAN"}) }},
+		{"PC wrong row count", func(w *fits.WCS) error { return w.SetPC([][]float64{{1, 0}}) }},
+		{"PC ragged row", func(w *fits.WCS) error { return w.SetPC([][]float64{{1, 0}, {0}}) }},
+		{"nil", func(w *fits.WCS) error { return w.SetCRVAL(nil) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := fits.NewWCS(2)
+
+			if err := tc.set(w); !errors.Is(err, fits.ErrWCSDimension) {
+				t.Fatalf("err = %v, want ErrWCSDimension", err)
+			}
+		})
+	}
+}
+
+// TestARefusedSetLeavesTheWCSAlone: a rejected setter must not half-apply. A PC
+// matrix with a good first row and a ragged second one is the case that could —
+// the rows are copied one at a time.
+func TestARefusedSetLeavesTheWCSAlone(t *testing.T) {
+	w := fits.NewWCS(2)
+
+	mustSet(t, w.SetPC([][]float64{{2, 0}, {0, 2}}))
+
+	if err := w.SetPC([][]float64{{9, 9}, {9}}); !errors.Is(err, fits.ErrWCSDimension) {
+		t.Fatalf("err = %v, want ErrWCSDimension", err)
+	}
+
+	if got := w.PC(); got[0][0] != 2 || got[1][1] != 2 {
+		t.Errorf("a refused SetPC left the matrix as %v; it should be unchanged", got)
+	}
+}
+
+// TestDistortionSettersCopyTheirMaps: SIP coefficients have no length
+// invariant, so those setters take no error — but they are still maps the
+// caller keeps a reference to, and a distortion that changes under a WCS moves
+// every pixel it transforms.
+//
+// Observed through the transform, since the coefficients have no getter. The
+// two WCSes are built identically and only one has its caller-side map
+// rewritten afterwards, so any difference is the aliasing and nothing else.
+// (My first version of this also set TPV on one side and not the other, and
+// the 0.3-degree discrepancy it reported was that, not the property under
+// test.)
+func TestDistortionSettersCopyTheirMaps(t *testing.T) {
+	build := func(a, b map[[2]int]float64) *fits.WCS {
+		t.Helper()
+
+		w := fits.NewWCS(2)
+
+		mustSet(t,
+			w.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+			w.SetCRPIX([]float64{50, 50}),
+			w.SetCRVAL([]float64{10, 45}),
+			w.SetCDELT([]float64{-0.01, 0.01}),
+		)
+		w.SetSIP(a, b)
+
+		return w
+	}
+
+	reference := build(
+		map[[2]int]float64{{0, 2}: 1e-6},
+		map[[2]int]float64{{2, 0}: 2e-6},
+	)
+
+	a := map[[2]int]float64{{0, 2}: 1e-6}
+	b := map[[2]int]float64{{2, 0}: 2e-6}
+	subject := build(a, b)
+
+	// The caller changes their own map after handing it over.
+	a[[2]int{0, 2}] = 1
+	b[[2]int{2, 0}] = 1
+
+	pixel := []float64{60, 70}
+
+	want, err := reference.PixelToWorld(pixel)
+	if err != nil {
+		t.Fatalf("reference PixelToWorld: %v", err)
+	}
+
+	got, err := subject.PixelToWorld(pixel)
+	if err != nil {
+		t.Fatalf("PixelToWorld: %v", err)
+	}
+
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("the SIP coefficients followed the caller's map: got %v, want %v", got, want)
+	}
+}
+
+// TestNilDistortionStaysNil: nil means "no distortion" and an empty map would
+// evaluate to the same thing, but only nil says it was never set — and the
+// transform's fast path checks length, so a copy that turned nil into an empty
+// map would be correct and slower.
+func TestNilDistortionStaysNil(t *testing.T) {
+	w := fits.NewWCS(2)
+
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+		w.SetCRPIX([]float64{50, 50}),
+		w.SetCRVAL([]float64{10, 45}),
+		w.SetCDELT([]float64{-0.01, 0.01}),
+	)
+
+	w.SetSIP(nil, nil)
+	w.SetSIPInverse(nil, nil)
+	w.SetTPV(nil, nil)
+
+	// Nothing to assert but that it still transforms: a nil map turned into a
+	// non-nil empty one would take the distortion path and still be right, so
+	// this is a smoke test rather than a proof.
+	if _, err := w.PixelToWorld([]float64{50, 50}); err != nil {
+		t.Errorf("a WCS with nil distortion maps failed to transform: %v", err)
+	}
+}
+
+// TestNAxisReportsTheInvariant: every setter's length check is against this, so
+// a caller building a WCS from a header needs to be able to ask.
+func TestNAxisReportsTheInvariant(t *testing.T) {
+	for _, n := range []int{1, 2, 3, 4} {
+		if got := fits.NewWCS(n).NAxis(); got != n {
+			t.Errorf("NewWCS(%d).NAxis() = %d", n, got)
+		}
+	}
+}

--- a/fits/wcs_example_test.go
+++ b/fits/wcs_example_test.go
@@ -50,18 +50,36 @@ func ExampleExtractWCS() {
 	// WCS Extracted Successfully
 }
 
+// mustSet applies WCS setters and fails on the first refusal.
+//
+// The setters report a length that does not match the WCS's axis count, and a
+// fixture that gets that wrong is a test bug rather than something to ignore —
+// which is the whole reason they stopped accepting it silently. Arguments
+// evaluate before the call, so every setter runs and the first complaint wins.
+func mustSet(t *testing.T, errs ...error) {
+	t.Helper()
+
+	for _, err := range errs {
+		if err != nil {
+			t.Fatalf("building the WCS fixture: %v", err)
+		}
+	}
+}
+
 func TestPixelToWorld_TAN(t *testing.T) {
 	w := fits.NewWCS(2)
-	w.SetCTYPE([]string{"RA---TAN", "DEC--TAN"})
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
 
-	// Set reference pixel (center of image typically)
-	w.SetCRPIX([]float64{50.0, 50.0})
+		// Set reference pixel (center of image typically)
+		w.SetCRPIX([]float64{50.0, 50.0}),
 
-	// Coordinate at reference pixel (RA, DEC)
-	w.SetCRVAL([]float64{10.0, 45.0})
+		// Coordinate at reference pixel (RA, DEC)
+		w.SetCRVAL([]float64{10.0, 45.0}),
 
-	// Pixel scale (CDELT) in degrees per pixel
-	w.SetCDELT([]float64{-0.01, 0.01})
+		// Pixel scale (CDELT) in degrees per pixel
+		w.SetCDELT([]float64{-0.01, 0.01}),
+	)
 
 	// At reference pixel it must equal CRVAL perfectly
 	res, err := w.PixelToWorld([]float64{50.0, 50.0})
@@ -88,9 +106,11 @@ func TestPixelToWorld_TAN(t *testing.T) {
 func TestPixelToWorld_LinearFallback(t *testing.T) {
 	// 3D cube lacking explicit spherical metrics natively falls back to direct linear CDELT sums
 	w := fits.NewWCS(3)
-	w.SetCRVAL([]float64{0.0, 0.0, 1420.0}) // e.g. 1.4 GHz baseline
-	w.SetCRPIX([]float64{10.0, 10.0, 1.0})
-	w.SetCDELT([]float64{1.0, 1.0, 0.5})
+	_ = w.SetCRVAL([]float64{0.0, 0.0, 1420.0}) // e.g. 1.4 GHz baseline
+	mustSet(t,
+		w.SetCRPIX([]float64{10.0, 10.0, 1.0}),
+		w.SetCDELT([]float64{1.0, 1.0, 0.5}),
+	)
 
 	res, err := w.PixelToWorld([]float64{15.0, 10.0, 3.0})
 	if err != nil {
@@ -112,12 +132,16 @@ func TestPixelToWorld_LinearFallback(t *testing.T) {
 
 // makeWCS builds a minimal 2D WCS for a given projection centered at (ra0, dec0) degrees
 // with the given pixel scale (degrees/pixel).
-func makeWCS(proj string, ra0, dec0, scale float64) *fits.WCS {
+func makeWCS(t *testing.T, proj string, ra0, dec0, scale float64) *fits.WCS {
+	t.Helper()
+
 	w := fits.NewWCS(2)
-	w.SetCTYPE([]string{"RA---" + proj, "DEC--" + proj})
-	w.SetCRPIX([]float64{512.0, 512.0})
-	w.SetCRVAL([]float64{ra0, dec0})
-	w.SetCDELT([]float64{-scale, scale})
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---" + proj, "DEC--" + proj}),
+		w.SetCRPIX([]float64{512.0, 512.0}),
+		w.SetCRVAL([]float64{ra0, dec0}),
+		w.SetCDELT([]float64{-scale, scale}),
+	)
 
 	return w
 }
@@ -128,7 +152,7 @@ func TestProjectionRoundTrip_ReferencePixel(t *testing.T) {
 	projs := []string{"TAN", "SIN", "ARC", "STG", "AIT"}
 	for _, proj := range projs {
 		t.Run(proj, func(t *testing.T) {
-			w := makeWCS(proj, 83.633, 22.0145, 0.001) // near Orion Nebula
+			w := makeWCS(t, proj, 83.633, 22.0145, 0.001) // near Orion Nebula
 
 			res, err := w.PixelToWorld([]float64{512.0, 512.0})
 			if err != nil {
@@ -173,9 +197,9 @@ func TestProjectionRoundTrip_Grid(t *testing.T) {
 	for _, tc := range cases {
 		name := fmt.Sprintf("%s_ra%.0f_dec%.0f", tc.proj, tc.ra0, tc.dec0)
 		t.Run(name, func(t *testing.T) {
-			w := makeWCS(tc.proj, tc.ra0, tc.dec0, tc.scale)
+			w := makeWCS(t, tc.proj, tc.ra0, tc.dec0, tc.scale)
 
-			crpix := w.GetCRPIX()
+			crpix := w.CRPIX()
 
 			step := tc.fieldPix / 4
 			if step < 1 {
@@ -232,7 +256,7 @@ func TestProjectionForward_Symmetry(t *testing.T) {
 	projs := []string{"TAN", "SIN", "ARC", "STG"}
 	for _, proj := range projs {
 		t.Run(proj, func(t *testing.T) {
-			w := makeWCS(proj, 180.0, 45.0, 0.001)
+			w := makeWCS(t, proj, 180.0, 45.0, 0.001)
 
 			// Symmetric pixel offsets should produce symmetric Dec offsets
 			wPlus, _ := w.PixelToWorld([]float64{512.0, 522.0})  // +10 pix in Y
@@ -256,7 +280,7 @@ func TestProjectionRoundTrip_RAWrap(t *testing.T) {
 		t.Run(proj, func(t *testing.T) {
 			// Reference at RA=359.99, 0.001 deg/pix
 			// 15 pixels offset in -X → RA increases by ~0.015° → crosses 360
-			w := makeWCS(proj, 359.99, 30.0, 0.001)
+			w := makeWCS(t, proj, 359.99, 30.0, 0.001)
 
 			px := 512.0 - 15.0
 			py := 512.0
@@ -286,7 +310,7 @@ func TestProjectionRoundTrip_RAWrap(t *testing.T) {
 
 // TestProjection_SIN_OutOfBounds verifies the SIN projection rejects r²>1.
 func TestProjection_SIN_OutOfBounds(t *testing.T) {
-	w := makeWCS("SIN", 180.0, 45.0, 1.0) // 1 deg/pixel → huge field
+	w := makeWCS(t, "SIN", 180.0, 45.0, 1.0) // 1 deg/pixel → huge field
 
 	_, err := w.PixelToWorld([]float64{512.0 + 100, 512.0})
 	if err == nil {
@@ -296,7 +320,7 @@ func TestProjection_SIN_OutOfBounds(t *testing.T) {
 
 // TestProjection_AIT_OutOfBounds verifies the AIT projection rejects invalid regions.
 func TestProjection_AIT_OutOfBounds(t *testing.T) {
-	w := makeWCS("AIT", 0.0, 0.0, 1.0)
+	w := makeWCS(t, "AIT", 0.0, 0.0, 1.0)
 
 	_, err := w.PixelToWorld([]float64{512.0 + 500, 512.0})
 	if err == nil {
@@ -308,10 +332,12 @@ func TestProjection_AIT_OutOfBounds(t *testing.T) {
 // silently fall back to linear mapping (no spherical deprojection).
 func TestProjection_UnknownFallsBackToLinear(t *testing.T) {
 	w := fits.NewWCS(2)
-	w.SetCTYPE([]string{"RA---ZZZ", "DEC--ZZZ"})
-	w.SetCRPIX([]float64{50.0, 50.0})
-	w.SetCRVAL([]float64{10.0, 20.0})
-	w.SetCDELT([]float64{-0.01, 0.01})
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---ZZZ", "DEC--ZZZ"}),
+		w.SetCRPIX([]float64{50.0, 50.0}),
+		w.SetCRVAL([]float64{10.0, 20.0}),
+		w.SetCDELT([]float64{-0.01, 0.01}),
+	)
 
 	// With unknown projection, extractProjection returns "" → linear fallback.
 	// 5 pixels offset * 0.01 scale = 0.05 degrees
@@ -338,17 +364,21 @@ func TestProjection_UnknownFallsBackToLinear(t *testing.T) {
 func TestProjection_SwappedAxes(t *testing.T) {
 	// Standard layout: CTYPE1=RA, CTYPE2=DEC
 	std := fits.NewWCS(2)
-	std.SetCTYPE([]string{"RA---TAN", "DEC--TAN"})
-	std.SetCRPIX([]float64{512.5, 512.5})
-	std.SetCRVAL([]float64{150.0, 45.0})
-	std.SetCDELT([]float64{-0.001, 0.001})
+	mustSet(t,
+		std.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+		std.SetCRPIX([]float64{512.5, 512.5}),
+		std.SetCRVAL([]float64{150.0, 45.0}),
+		std.SetCDELT([]float64{-0.001, 0.001}),
+	)
 
 	// Swapped layout: CTYPE1=DEC, CTYPE2=RA
 	swp := fits.NewWCS(2)
-	swp.SetCTYPE([]string{"DEC--TAN", "RA---TAN"})
-	swp.SetCRPIX([]float64{512.5, 512.5})
-	swp.SetCRVAL([]float64{45.0, 150.0}) // Dec in slot 0, RA in slot 1
-	swp.SetCDELT([]float64{0.001, -0.001})
+	mustSet(t,
+		swp.SetCTYPE([]string{"DEC--TAN", "RA---TAN"}),
+		swp.SetCRPIX([]float64{512.5, 512.5}),
+	)
+	_ = swp.SetCRVAL([]float64{45.0, 150.0}) // Dec in slot 0, RA in slot 1
+	_ = swp.SetCDELT([]float64{0.001, -0.001})
 
 	// Standard pixel (530,520): dx=+17.5 on RA (axis 0), dy=+7.5 on Dec (axis 1).
 	// For swapped WCS to see the same field offset:
@@ -402,12 +432,14 @@ func TestSIPDistortion(t *testing.T) {
 	// Set up a standard TAN WCS for a 2048×2048 detector.
 	// CRPIX at center, 0.25 arcsec/pixel scale (typical HST/WFC3-like).
 	w := fits.NewWCS(2)
-	w.SetCTYPE([]string{"RA---TAN-SIP", "DEC--TAN-SIP"})
-	w.SetCRPIX([]float64{1024.5, 1024.5})
-	w.SetCRVAL([]float64{150.0, 45.0})
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---TAN-SIP", "DEC--TAN-SIP"}),
+		w.SetCRPIX([]float64{1024.5, 1024.5}),
+		w.SetCRVAL([]float64{150.0, 45.0}),
+	)
 
 	scale := 0.25 / 3600.0 // 0.25 arcsec in degrees
-	w.SetCDELT([]float64{-scale, scale})
+	_ = w.SetCDELT([]float64{-scale, scale})
 
 	// SIP forward distortion coefficients (order 3).
 	// These are representative of a moderately distorted survey camera.
@@ -448,10 +480,12 @@ func TestSIPDistortion(t *testing.T) {
 
 	// Also set up a pure TAN WCS (no SIP) for comparison.
 	wNoSIP := fits.NewWCS(2)
-	wNoSIP.SetCTYPE([]string{"RA---TAN", "DEC--TAN"})
-	wNoSIP.SetCRPIX([]float64{1024.5, 1024.5})
-	wNoSIP.SetCRVAL([]float64{150.0, 45.0})
-	wNoSIP.SetCDELT([]float64{-scale, scale})
+	mustSet(t,
+		wNoSIP.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+		wNoSIP.SetCRPIX([]float64{1024.5, 1024.5}),
+		wNoSIP.SetCRVAL([]float64{150.0, 45.0}),
+		wNoSIP.SetCDELT([]float64{-scale, scale}),
+	)
 
 	// Test 1: At reference pixel, SIP should produce zero distortion.
 	refWorld, err := w.PixelToWorld([]float64{1024.5, 1024.5})
@@ -525,12 +559,14 @@ func TestTPVDistortion(t *testing.T) {
 	// Set up a TAN-TPV WCS for a 4096×4096 detector.
 	// 0.25 arcsec/pixel scale — typical ground-based wide-field imager.
 	w := fits.NewWCS(2)
-	w.SetCTYPE([]string{"RA---TAN-TPV", "DEC--TAN-TPV"})
-	w.SetCRPIX([]float64{2048.5, 2048.5})
-	w.SetCRVAL([]float64{150.0, 45.0})
+	mustSet(t,
+		w.SetCTYPE([]string{"RA---TAN-TPV", "DEC--TAN-TPV"}),
+		w.SetCRPIX([]float64{2048.5, 2048.5}),
+		w.SetCRVAL([]float64{150.0, 45.0}),
+	)
 
 	scale := 0.25 / 3600.0 // 0.25 arcsec in degrees
-	w.SetCDELT([]float64{-scale, scale})
+	_ = w.SetCDELT([]float64{-scale, scale})
 
 	// TPV distortion coefficients (representative of SCAMP astrometric solution).
 	// PV1 affects the longitude axis, PV2 affects the latitude axis.
@@ -554,10 +590,12 @@ func TestTPVDistortion(t *testing.T) {
 
 	// Pure TAN for comparison.
 	wNoTPV := fits.NewWCS(2)
-	wNoTPV.SetCTYPE([]string{"RA---TAN", "DEC--TAN"})
-	wNoTPV.SetCRPIX([]float64{2048.5, 2048.5})
-	wNoTPV.SetCRVAL([]float64{150.0, 45.0})
-	wNoTPV.SetCDELT([]float64{-scale, scale})
+	mustSet(t,
+		wNoTPV.SetCTYPE([]string{"RA---TAN", "DEC--TAN"}),
+		wNoTPV.SetCRPIX([]float64{2048.5, 2048.5}),
+		wNoTPV.SetCRVAL([]float64{150.0, 45.0}),
+		wNoTPV.SetCDELT([]float64{-scale, scale}),
+	)
 
 	// Test 1: At reference pixel, TPV should produce zero distortion.
 	refWorld, err := w.PixelToWorld([]float64{2048.5, 2048.5})

--- a/fits/wcs_test.go
+++ b/fits/wcs_test.go
@@ -21,8 +21,8 @@ func TestExtractWCS(t *testing.T) {
 	wcs, err := ExtractWCS(h)
 	testutil.AssertNoError(t, err)
 
-	if wcs.GetCRVAL()[0] != 10.0 || wcs.GetCRVAL()[1] != 20.0 {
-		t.Errorf("expected CRVAL 10.0, 20.0, got %v", wcs.GetCRVAL())
+	if wcs.CRVAL()[0] != 10.0 || wcs.CRVAL()[1] != 20.0 {
+		t.Errorf("expected CRVAL 10.0, 20.0, got %v", wcs.CRVAL())
 	}
 
 	h2 := NewHeader()
@@ -69,7 +69,7 @@ func TestExtractWCS_CDMatrix(t *testing.T) {
 	testutil.AssertNear(t, "DEC at CRPIX", res[1], 2.0, 1e-10)
 
 	// CDELT should have been extracted from the CD matrix
-	cdelt := wcs.GetCDELT()
+	cdelt := wcs.CDELT()
 	testutil.AssertNear(t, "CDELT1 magnitude", math.Abs(cdelt[0]), scale, 1e-20)
 	testutil.AssertNear(t, "CDELT2 magnitude", math.Abs(cdelt[1]), scale, 1e-20)
 


### PR DESCRIPTION
Refs #178 — its first half. The second is argued below rather than done.

#178 asks whether `fits.WCS`'s eight `SetXxx` and five `GetXxx` are the shape to freeze at
1.0, and flags two things as *"worth checking"*. **Both were defects.**

## A WCS could be rewritten without going through a setter, from either side

The getters returned the internal slice; the setters kept the caller's. Measured before
changing anything:

```
DEFECT: the getter returns the internal slice; a caller can rewrite the WCS through it
DEFECT: the setter keeps the caller's slice; the caller can rewrite the WCS afterwards
a 5-element CRVAL on a 2-axis WCS was accepted: len=5
```

So reading `CRVAL` to inspect it could move the reference position by accident, and holding
the slice you passed to `SetCRVAL` could move it later, at a distance, with nothing at the
call site to suggest it. For a value that says where an image is on the sky, that is state
changing under whoever is transforming through it.

Both directions copy now — including the SIP and TPV coefficient maps, which had the same
hole.

## The setters validated nothing

`PixelToWorld` indexes `crpix`, `crval` and `cdelt` from 0 to `nAxis`, so **a short array was
a panic reachable from a public method**; a long one was a silent disagreement about how
many axes the WCS has.

The five setters with a length invariant return `ErrWCSDimension` now. The three map-valued
ones have no such invariant and still return nothing.

That turned out to matter for the one production caller: `ExtractWCS` builds every array at
`naxis` and then sets them, so a refusal means the construction disagrees with itself — and
dropping it would leave a WCS holding `NewWCS`'s zeros, which transforms every pixel to the
same place. It reports instead.

## The naming

`GetCRVAL` → `CRVAL`, which is what a Go caller reaches for and a name that cannot be
changed after 1.0. Every call site was in this package's own tests. New `NAxis` reports the
invariant every setter checks against.

## Not done, and the issue is right about why

`PixelToWorld` and `WorldToPixel` passing untyped `[]float64` belongs with #130. The axes are
`CTYPE`-dependent, so a world value is an angle on a celestial axis, a wavelength on a
spectral one and a duration on a time one — a typed API has to carry that rather than
mechanically swapping `[]float64` for `[]angle.Angle`. That is a decision about the whole
module's currency, not this package's.

## Verification

`gofmt`, `go vet ./...`, `go test ./...`, `go test -race -short -count=1 ./...`, `go test
-tags="integration,validation" ./...`, `golangci-lint run
--build-tags="integration,network,validation"` at 0 issues.

| mutation | killed by |
| :--- | :--- |
| getter returns the internal slice | `TestGettersReturnACopy` |
| setter keeps the caller's slice | `TestSettersCopyTheirInput` |
| drop a length check | `TestSettersRefuseTheWrongLength` |
| apply PC rows before validating them all | `TestARefusedSetLeavesTheWCSAlone` |
| store a SIP map directly | `TestDistortionSettersCopyTheirMaps` |

One of those tests was wrong first: it set TPV on one side and not the other, so the
0.3-degree discrepancy it reported had nothing to do with map aliasing. The two fixtures are
identical now and only one has its caller-side map rewritten — that note is in the test, so
nobody re-derives it.
