### PR TITLE
plan: replace variadic props and six-parameter scoring with structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ tables you can check against published references.
 - **Sub-second boundary refinement** — Chandrupatla (continuous altitude) + bisection (discrete constraints)
 - Observable windows with constraint evaluation
 - Altitude/airmass/separation constraints
-- Target scoring and ranking (`ScoreObservable` at midpoint altitude × priority)
+- Target scoring and ranking (`Scorer` at midpoint altitude × priority)
 - **Production Scheduling Engine**:
   - `Block` and `Configuration` abstractions for observing requests
   - `TransitionModel` for slew and instrument setup time

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -219,8 +219,8 @@ when lunar phase / sky brightness from moonlight is too high.
       always passes for the Moon itself. Implements `ConstraintCtx` (added to the
       compile-time assertion block alongside `MoonSep`).
 - [ ] Optional coupling with `MoonSep` (separation × illumination scoring)
-- [x] Integration with `ScoreObservable` — `MoonIllum` composes as an ordinary
-      `Constraint`/`ConstraintCtx`, same as every other constraint `ScoreObservable`
+- [x] Integration with `Scorer` — `MoonIllum` composes as an ordinary
+      `Constraint`/`ConstraintCtx`, same as every other constraint `Scorer`
       accepts.
 
 **Inspiration:** astroplan `MoonIlluminationConstraint`.

--- a/docs/changelog.d/221-detail-overrides.md
+++ b/docs/changelog.d/221-detail-overrides.md
@@ -1,0 +1,9 @@
+---
+type: Changed — BREAKING
+pr: 221
+---
+`Observable.GetDetails` takes a `plan.DetailOverrides` struct instead of
+`props ...string` read two at a time. That form had three silent failures: an
+odd count dropped the last argument, a misspelled key landed in `ExtraProps`
+while the field it meant to override kept its computed value, and a key and
+value could be swapped with nothing to notice (#116).

--- a/docs/changelog.d/221-scorer.md
+++ b/docs/changelog.d/221-scorer.md
@@ -1,0 +1,8 @@
+---
+type: Changed — BREAKING
+pr: 221
+---
+`plan.ScoreObservable` no longer exists; scoring is `plan.Scorer{...}.Score(obj, t)`.
+It took six parameters, two of them nilable pointers that were nil at nearly
+every call site including the README's — and two adjacent nils of different
+types can be transposed without the compiler noticing (#116).

--- a/docs/skybrightness.md
+++ b/docs/skybrightness.md
@@ -1443,8 +1443,12 @@ of the physics.
 | ~~Legacy-only, explicitly named~~ | **Not carried out, and the record should say so.** The plan was `KS91 → LegacyKS91` with the constant airglow kept as a named climatology fallback. Neither exists. KS91 was deleted outright rather than preserved under a legacy name, because a closed-form V-band fit has no spectrum to project and keeping it would have meant shipping a component that cannot answer the question this module asks; and the constant airglow became a fetched SkyCalc spectrum rather than a fallback, so there is nothing left to fall back *to*. |
 | Deleted | `bortle.go`, `natural.TophatJohnson`, `natural.NewFastEngine`, `mode.go` (replaced by `Fidelity`), `scratch.go`, `atmos.RayleighOnly`, `limitingmag.go`. |
 
-`plan.LimitingMagnitudeConstraint`, `plan.ScoreObservable` and examples 18 and 21 were
-removed with it. **Example 18 has returned. The other three have not**, and the condition
+`plan.LimitingMagnitudeConstraint`, `plan.ScoreObservable` (no longer exists — scoring is
+now `plan.Scorer`) and examples 18 and 21 were
+removed with it. **Example 18 has returned, and so has `plan.LimitingMagnitudeConstraint`,
+differently shaped** — it takes a `SkyDepth` rather than a light-pollution floor, and by
+default scores on a soft ramp rather than rejecting (see `docs/ROADMAP.md` §28). Example 21
+has not returned, and the condition
 originally written here — "once Phases 2–3 make a defensible limiting magnitude possible" —
 has since been half-met in a way worth stating precisely rather than leaving as a promise
 nobody is tracking.

--- a/examples/14_target_scoring/main.go
+++ b/examples/14_target_scoring/main.go
@@ -1,6 +1,6 @@
 // Example: Composite target scoring with configurable weights.
 //
-// This demonstrates the plan.ScoreObservable merit function that combines
+// This demonstrates the plan.Scorer merit function that combines
 // altitude, urgency (time until set), and Moon separation into a single
 // score for observation prioritization.
 //
@@ -122,7 +122,11 @@ func main() {
 		var results []result
 
 		for _, obj := range targets {
-			score, err := plan.ScoreObservable(obj, tm, site, profile.cfg, nil, constraints...)
+			score, err := plan.Scorer{
+				Site:        site,
+				Config:      *profile.cfg,
+				Constraints: constraints,
+			}.Score(obj, tm)
 			if err != nil {
 				fmt.Printf("  %-14s  error: %v\n", obj.Name(), err)
 				continue

--- a/examples/15_target_details/deep-sky/main.go
+++ b/examples/15_target_details/deep-sky/main.go
@@ -46,7 +46,7 @@ func main() {
 		log.Fatalf("build target: %v", err)
 	}
 
-	details, err := m31.GetDetails(ctx, "Description", "Andromeda Galaxy", "Source", "OpenNGC")
+	details, err := m31.GetDetails(ctx, plan.DetailOverrides{Description: "Andromeda Galaxy", Source: "OpenNGC"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/15_target_details/moon/main.go
+++ b/examples/15_target_details/moon/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	moon := plan.NewMoon(prov)
 
-	details, err := moon.GetDetails(ctx, "Description", "Earth's natural satellite", "Source", "JPL DE442")
+	details, err := moon.GetDetails(ctx, plan.DetailOverrides{Description: "Earth's natural satellite", Source: "JPL DE442"})
 	if err != nil {
 		log.Fatalf("failed to get details: %v", err)
 	}

--- a/examples/15_target_details/planets/main.go
+++ b/examples/15_target_details/planets/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	mars := plan.NewMars(prov)
 
-	details, err := mars.GetDetails(ctx, "Description", "The Red Planet", "Source", "JPL DE442")
+	details, err := mars.GetDetails(ctx, plan.DetailOverrides{Description: "The Red Planet", Source: "JPL DE442"})
 	if err != nil {
 		log.Fatalf("failed to get details: %v", err)
 	}

--- a/examples/15_target_details/satellites/main.go
+++ b/examples/15_target_details/satellites/main.go
@@ -48,7 +48,7 @@ func main() {
 	t := catTarget.Epoch
 	ctx := coord.NewContext(t, loc, atmosphere.StandardRefraction)
 
-	details, err := iss.GetDetails(ctx, "Description", "International Space Station", "Source", "NORAD TLE")
+	details, err := iss.GetDetails(ctx, plan.DetailOverrides{Description: "International Space Station", Source: "NORAD TLE"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/15_target_details/stars/main.go
+++ b/examples/15_target_details/stars/main.go
@@ -46,19 +46,7 @@ func main() {
 		log.Fatalf("build target: %v", err)
 	}
 
-	details, err := sirius.GetDetails(ctx,
-		"Bayer letter", "α CMa",
-		"Flamsteed number", "9 CMa",
-		"FK5 number", "FK5 257",
-		"BSC5 number", "HR 2491",
-		"Hipparcos number", "HIP 32349",
-		"Tycho-2 number", "TYC 5949-02777-1",
-		"Designation for variable", "NSV 17173",
-		"TDSC number", "TDSC 16356",
-		"WDS number", "WDS 06451-1643",
-		"Spectral type", "A1",
-		"Luminosity class", "V - dwarfs/main sequence",
-	)
+	details, err := sirius.GetDetails(ctx, plan.DetailOverrides{Extra: map[string]string{"Bayer letter": "α CMa", "Flamsteed number": "9 CMa", "FK5 number": "FK5 257", "BSC5 number": "HR 2491", "Hipparcos number": "HIP 32349", "Tycho-2 number": "TYC 5949-02777-1", "Designation for variable": "NSV 17173", "TDSC number": "TDSC 16356", "WDS number": "WDS 06451-1643", "Spectral type": "A1", "Luminosity class": "V - dwarfs/main sequence"}})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/15_target_details/sun/main.go
+++ b/examples/15_target_details/sun/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	sun := plan.NewSun(prov)
 
-	details, err := sun.GetDetails(ctx, "Description", "Our local star", "Source", "JPL DE442")
+	details, err := sun.GetDetails(ctx, plan.DetailOverrides{Description: "Our local star", Source: "JPL DE442"})
 	if err != nil {
 		log.Fatalf("failed to get details: %v", err)
 	}

--- a/examples/17_equinox_prediction/main.go
+++ b/examples/17_equinox_prediction/main.go
@@ -236,7 +236,7 @@ func main() {
 	atm := atmosphere.AtAltitude(835.05)
 	ctx := coord.NewContext(now, loc, atm)
 
-	details, err := moonTarget.GetDetails(ctx)
+	details, err := moonTarget.GetDetails(ctx, plan.DetailOverrides{})
 	if err != nil {
 		log.Fatalf("moon details: %v", err)
 	}

--- a/plan/angular_size_test.go
+++ b/plan/angular_size_test.go
@@ -164,7 +164,7 @@ func TestAngularDiameter_DetailsAutoPopulateAndOverride(t *testing.T) {
 	prov := &fixedVecProvider{vec: vector.Vec3{X: 1.0}}
 	sun := NewSun(prov)
 
-	d, err := sun.GetDetails(ctx)
+	d, err := sun.GetDetails(ctx, DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestAngularDiameter_DetailsAutoPopulateAndOverride(t *testing.T) {
 		t.Error("GetDetails: AngularSize was not auto-populated for the Sun")
 	}
 
-	dOverride, err := sun.GetDetails(ctx, "AngularSize", "OVERRIDDEN")
+	dOverride, err := sun.GetDetails(ctx, DetailOverrides{AngularSize: "OVERRIDDEN"})
 	if err != nil {
 		t.Fatalf("GetDetails with override: %v", err)
 	}

--- a/plan/asteroid.go
+++ b/plan/asteroid.go
@@ -161,8 +161,8 @@ func (a *Asteroid) GeocentricVec(t time.Time) (vector.Vec3, error) {
 }
 
 // GetDetails computes observational details using the given coordinate context.
-func (a *Asteroid) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(a, ctx, props...)
+func (a *Asteroid) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(a, ctx, over)
 }
 
 // ApparentMagnitude computes the apparent magnitude using the best available

--- a/plan/bench_test.go
+++ b/plan/bench_test.go
@@ -23,7 +23,7 @@ func (m benchMock) ICRS(_ time.Time) (coord.ICRS, error) {
 
 func (m benchMock) Name() string                             { return "mock" }
 func (m benchMock) Position(_ time.Time) (coord.ICRS, error) { return m.c, nil }
-func (m benchMock) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (m benchMock) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }
 

--- a/plan/comet.go
+++ b/plan/comet.go
@@ -81,8 +81,8 @@ func (c *Comet) GeocentricVec(t time.Time) (vector.Vec3, error) {
 }
 
 // GetDetails returns the target details for the comet.
-func (c *Comet) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(c, ctx, props...)
+func (c *Comet) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(c, ctx, over)
 }
 
 // ApparentMagnitude computes total apparent magnitude using M1/k1.

--- a/plan/constellation.go
+++ b/plan/constellation.go
@@ -57,6 +57,6 @@ func (c *Constellation) Position(_ time.Time) (coord.ICRS, error) {
 }
 
 // GetDetails computes observational details using the given coordinate context.
-func (c *Constellation) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(c, ctx, props...)
+func (c *Constellation) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(c, ctx, over)
 }

--- a/plan/constellation_test.go
+++ b/plan/constellation_test.go
@@ -63,7 +63,7 @@ func TestNewConstellation_GetDetailsAndWindows(t *testing.T) {
 		t.Fatalf("NewConstellation: %v", err)
 	}
 
-	d, err := c.GetDetails(testContext(t))
+	d, err := c.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}

--- a/plan/day_episode_test.go
+++ b/plan/day_episode_test.go
@@ -330,7 +330,7 @@ func (errObservable) Position(time.Time) (coord.ICRS, error) {
 	return coord.ICRS{}, errAlwaysFails
 }
 
-func (errObservable) GetDetails(*coord.Context, ...string) (*TargetDetails, error) {
+func (errObservable) GetDetails(*coord.Context, DetailOverrides) (*TargetDetails, error) {
 	return nil, errAlwaysFails
 }
 

--- a/plan/deepsky.go
+++ b/plan/deepsky.go
@@ -76,8 +76,8 @@ func (d *DeepSkyObject) Position(_ time.Time) (coord.ICRS, error) {
 }
 
 // GetDetails computes observational details using the given coordinate context.
-func (d *DeepSkyObject) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(d, ctx, props...)
+func (d *DeepSkyObject) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(d, ctx, over)
 }
 
 // StaticMagnitude returns the catalog V-band magnitude if set.

--- a/plan/details.go
+++ b/plan/details.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 
@@ -116,7 +117,7 @@ func (d TargetDetails) String() string {
 
 // ── computeDetails ──────────────────────────────────────────────────────────
 
-func computeDetails(obs Observable, ctx *coord.Context, props ...string) (*TargetDetails, error) {
+func computeDetails(obs Observable, ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
 	d := &TargetDetails{
 		Name:       obs.Name(),
 		ExtraProps: make(map[string]string),
@@ -161,8 +162,8 @@ func computeDetails(obs Observable, ctx *coord.Context, props ...string) (*Targe
 	// ── Type-specific catalog properties ──
 	fillTypedProps(d, obs)
 
-	// ── Custom props (override anything above) ──
-	applyProps(d, props)
+	// ── Caller overrides (replace anything above) ──
+	over.apply(d)
 
 	// ── Rise/Set/Transit events ──
 	fillRiseSetTransit(d, obs, ctx)
@@ -208,9 +209,8 @@ func fillMovingBody(d *TargetDetails, mb MovingBody, t time.Time, ctx *coord.Con
 
 	// Apparent/angular diameter — silently skipped for bodies with no
 	// known physical radius (asteroids, comets), same best-effort
-	// pattern as Elongation below. A caller-injected "AngularSize" prop
-	// (applyProps, called after computeDetails' fillMovingBody) still
-	// overrides this.
+	// pattern as Elongation below. DetailOverrides.AngularSize, applied
+	// after computeDetails' fillMovingBody, still overrides this.
 	if diam, err := AngularDiameter(mb, t, ctx); err == nil {
 		d.AngularSize = formatAngularSize(diam)
 	}
@@ -316,27 +316,70 @@ func fillAliasProps(d *TargetDetails, aliases []string) {
 
 // ── Custom property overrides ───────────────────────────────────────────────
 
-// applyProps processes key/value pairs that override auto-computed fields.
-func applyProps(d *TargetDetails, props []string) {
-	for i := 0; i < len(props)-1; i += 2 {
-		key := props[i]
-		val := props[i+1]
+// DetailOverrides carries what this package cannot compute — a human
+// description, where the numbers came from — and replaces what it can, for a
+// caller who has a better answer.
+//
+// # Why a struct and not the key/value pairs it replaces
+//
+// GetDetails used to take `props ...string` read two at a time. Three ways to
+// get that wrong, all silent:
+//
+//   - An odd count dropped the last argument, because the loop ran to
+//     len(props)-1.
+//   - A misspelled key did not fail; it landed in ExtraProps, and the field it
+//     meant to override kept its computed value. A key one letter away from
+//     "Description" was just as valid, with an entirely different effect.
+//   - A key and a value could be swapped with nothing to notice.
+//
+// The zero value overrides nothing, which is the common case and what a caller
+// with nothing to add should pass.
+type DetailOverrides struct {
+	// Description is prose about the target — what it is, why it is on the
+	// list. Nothing computes this.
+	Description string
 
-		switch key {
-		case "Description":
-			d.Description = val
-		case "Source":
-			d.Source = val
-		case "Magnitude":
-			d.Magnitude = val
-		case "RadialVelocity":
-			d.RadialVelocity = val
-		case "AngularSize":
-			d.AngularSize = val
-		default:
-			d.ExtraProps[key] = val
-		}
+	// Source records where the target's data came from: a catalogue name, a
+	// kernel, an element set.
+	Source string
+
+	// Magnitude, RadialVelocity and AngularSize replace the computed strings
+	// when a caller holds a better value than this package can derive. Empty
+	// leaves the computed one.
+	Magnitude      string
+	RadialVelocity string
+	AngularSize    string
+
+	// Extra is anything else, verbatim, in TargetDetails.ExtraProps. This is
+	// where a genuinely open-ended key belongs — and it being a separate field
+	// is what makes a typo in one of the named ones a compile error rather
+	// than a silent demotion to here.
+	Extra map[string]string
+}
+
+// apply writes the non-empty overrides onto d.
+func (o DetailOverrides) apply(d *TargetDetails) {
+	if o.Description != "" {
+		d.Description = o.Description
 	}
+
+	if o.Source != "" {
+		d.Source = o.Source
+	}
+
+	if o.Magnitude != "" {
+		d.Magnitude = o.Magnitude
+	}
+
+	if o.RadialVelocity != "" {
+		d.RadialVelocity = o.RadialVelocity
+	}
+
+	if o.AngularSize != "" {
+		d.AngularSize = o.AngularSize
+	}
+
+	maps.Copy(d.ExtraProps, o.Extra)
 }
 
 // ── Rise/Set/Transit events ─────────────────────────────────────────────────

--- a/plan/details_test.go
+++ b/plan/details_test.go
@@ -19,7 +19,7 @@ import (
 // TestGetDetails_Star exercises computeDetails' non-MovingBody path
 // (fillStaticMagnitude, the direct ICRSToAltAz branch), fillTypedProps'
 // Star case (parallax → Distance, proper motion → ExtraProps),
-// fillAliasProps (Messier number extraction), and applyProps overrides.
+// fillAliasProps (Messier number extraction), and DetailOverrides.
 // None of this was previously exercised by any test — every mock Observable
 // elsewhere in this package implements its own trivial GetDetails stub.
 func TestGetDetails_Star(t *testing.T) {
@@ -39,7 +39,7 @@ func TestGetDetails_Star(t *testing.T) {
 		WithAliases("M 45", "HR 7001"),
 	)
 
-	d, err := star.GetDetails(ctx, "Description", "A bright star in Lyra")
+	d, err := star.GetDetails(ctx, DetailOverrides{Description: "A bright star in Lyra"})
 	testutil.AssertNoError(t, err)
 
 	if d.Name != "Vega" {
@@ -70,7 +70,7 @@ func TestGetDetails_Star(t *testing.T) {
 	}
 
 	if d.Description != "A bright star in Lyra" {
-		t.Errorf("Description = %q, want override applied via applyProps", d.Description)
+		t.Errorf("Description = %q, want the DetailOverrides value", d.Description)
 	}
 
 	// Altitude/Azimuth must have been populated by the non-MovingBody
@@ -97,7 +97,7 @@ func TestGetDetails_DeepSkyObject(t *testing.T) {
 		WithDSOAliases("NGC 224", "M31"),
 	)
 
-	d, err := dso.GetDetails(ctx)
+	d, err := dso.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	if got := d.ExtraProps["NGC/IC number"]; got != "NGC 224" {
@@ -120,7 +120,7 @@ func TestGetDetails_MovingBody(t *testing.T) {
 
 	mars := NewMars(eph.Default())
 
-	d, err := mars.GetDetails(ctx)
+	d, err := mars.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	if d.Name != "Mars" {
@@ -158,7 +158,7 @@ func TestGetDetails_String(t *testing.T) {
 
 	star := NewStar("Sirius", angle.Hour(6.75), angle.Deg(-16.72), WithStarMagnitude(-1.46))
 
-	d, err := star.GetDetails(ctx)
+	d, err := star.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	s := d.String()
@@ -189,7 +189,7 @@ func TestGetDetails_RadialVelocity(t *testing.T) {
 
 	star := NewStar("Sirius", ra, dec, WithRadialVelocity(rvBarycentric))
 
-	d, err := star.GetDetails(ctx)
+	d, err := star.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	if d.RadialVelocity == "" {
@@ -230,7 +230,7 @@ func TestGetDetails_RadialVelocity_NotSet(t *testing.T) {
 
 	star := NewStar("Vega", angle.Hour(18.615), angle.Deg(38.78))
 
-	d, err := star.GetDetails(ctx)
+	d, err := star.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	if d.RadialVelocity != "" {
@@ -239,7 +239,7 @@ func TestGetDetails_RadialVelocity_NotSet(t *testing.T) {
 
 	dso := NewDeepSkyObject("M31", angle.Hour(0.712), angle.Deg(41.269))
 
-	d2, err := dso.GetDetails(ctx)
+	d2, err := dso.GetDetails(ctx, DetailOverrides{})
 	testutil.AssertNoError(t, err)
 
 	if d2.RadialVelocity != "" {
@@ -247,9 +247,9 @@ func TestGetDetails_RadialVelocity_NotSet(t *testing.T) {
 	}
 }
 
-// TestGetDetails_RadialVelocity_PropOverride confirms an injected
-// "RadialVelocity" prop wins over the computed value, matching every
-// other applyProps-overridable field.
+// TestGetDetails_RadialVelocity_PropOverride confirms
+// DetailOverrides.RadialVelocity wins over the computed value.
+// TestDetailOverridesAppliesEveryField covers the other fields.
 func TestGetDetails_RadialVelocity_PropOverride(t *testing.T) {
 	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	testutil.AssertNoError(t, err)
@@ -262,7 +262,7 @@ func TestGetDetails_RadialVelocity_PropOverride(t *testing.T) {
 
 	star := NewStar("Sirius", angle.Hour(6.7525), angle.Deg(-16.7161), WithRadialVelocity(-5.5))
 
-	d, err := star.GetDetails(ctx, "RadialVelocity", "custom override")
+	d, err := star.GetDetails(ctx, DetailOverrides{RadialVelocity: "custom override"})
 	testutil.AssertNoError(t, err)
 
 	if d.RadialVelocity != "custom override" {
@@ -294,7 +294,7 @@ func TestGetDetails_RadialVelocity_SixMonthSwing(t *testing.T) {
 	parseTopo := func(tm time.Time) float64 {
 		ctx := coord.NewContext(tm, loc, site.Refraction())
 
-		d, err := star.GetDetails(ctx)
+		d, err := star.GetDetails(ctx, DetailOverrides{})
 		testutil.AssertNoError(t, err)
 
 		var topo, bary float64
@@ -427,3 +427,147 @@ func (failingProvider) State(eph.ID, time.Time) (core.State, error) {
 }
 
 func (failingProvider) Close() error { return nil }
+
+// TestDetailOverridesAppliesEveryField walks every field of DetailOverrides
+// one at a time and confirms it reaches the matching TargetDetails field.
+//
+// One field per subtest, not all six at once: a single combined assertion
+// passes as long as *some* field lands, so a struct that silently ignored
+// Source would go unnoticed. Two of these fields — Source and Magnitude —
+// were in exactly that position before this test existed.
+//
+// `computed` marks the fields this package fills on its own, where the
+// override has to win against a real value rather than fill a blank. Only
+// three do: Description and Source have no computed counterpart at all, and
+// Extra is by definition open-ended.
+func TestDetailOverridesAppliesEveryField(t *testing.T) {
+	t.Parallel()
+
+	star := NewStar("Vega", angle.Hour(18.615), angle.Deg(38.78),
+		WithStarMagnitude(0.03),
+		WithParallax(angle.Arcsec(0.130)),
+		WithRadialVelocity(-13.9),
+	)
+
+	// AngularSize is only ever computed for a MovingBody with a known
+	// physical radius, so the precedence check for it needs a planet.
+	mars := NewMars(eph.Default())
+
+	for _, tc := range []struct {
+		name     string
+		target   Observable
+		over     DetailOverrides
+		get      func(*TargetDetails) string
+		want     string
+		computed bool
+	}{
+		{
+			name: "Description", target: star,
+			over: DetailOverrides{Description: "in Lyra"},
+			get:  func(d *TargetDetails) string { return d.Description },
+			want: "in Lyra",
+		},
+		{
+			name: "Source", target: star,
+			over: DetailOverrides{Source: "Hipparcos"},
+			get:  func(d *TargetDetails) string { return d.Source },
+			want: "Hipparcos",
+		},
+		{
+			name: "Magnitude", target: star,
+			over: DetailOverrides{Magnitude: "0.03 (V)"},
+			get:  func(d *TargetDetails) string { return d.Magnitude },
+			want: "0.03 (V)", computed: true,
+		},
+		{
+			name: "RadialVelocity", target: star,
+			over: DetailOverrides{RadialVelocity: "-13.9 km/s"},
+			get:  func(d *TargetDetails) string { return d.RadialVelocity },
+			want: "-13.9 km/s", computed: true,
+		},
+		{
+			name: "AngularSize", target: mars,
+			over: DetailOverrides{AngularSize: "5.7 arcsec"},
+			get:  func(d *TargetDetails) string { return d.AngularSize },
+			want: "5.7 arcsec", computed: true,
+		},
+		{
+			name: "Extra", target: star,
+			over: DetailOverrides{Extra: map[string]string{"Spectral type": "A0Va"}},
+			get:  func(d *TargetDetails) string { return d.ExtraProps["Spectral type"] },
+			want: "A0Va",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+			testutil.AssertNoError(t, err)
+
+			site, err := NewSite("Test", loc)
+			testutil.AssertNoError(t, err)
+
+			ctx := coord.NewContext(time.FromJD(2451545.0, time.UTC), loc, site.Refraction())
+
+			base, err := tc.target.GetDetails(ctx, DetailOverrides{})
+			testutil.AssertNoError(t, err)
+
+			d, err := tc.target.GetDetails(ctx, tc.over)
+			testutil.AssertNoError(t, err)
+
+			if got := tc.get(d); got != tc.want {
+				t.Errorf("%s = %q, want the override %q", tc.name, got, tc.want)
+			}
+
+			// An override that only ever fills a blank proves nothing about
+			// precedence, so assert the computed value was really there.
+			if tc.computed && tc.get(base) == "" {
+				t.Errorf("%s had no computed value to override; the fixture "+
+					"no longer tests precedence", tc.name)
+			}
+		})
+	}
+}
+
+// TestDetailOverridesZeroValueOverridesNothing pins the documented contract of
+// the zero value, which is what nearly every call site passes.
+//
+// An empty string means "I have nothing to add", never "blank this field".
+// Getting that backwards would erase the computed magnitude and radial
+// velocity of every target described through a plain DetailOverrides{} —
+// silently, since a blank field renders as a missing line rather than an
+// error.
+func TestDetailOverridesZeroValueOverridesNothing(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Test", loc)
+	testutil.AssertNoError(t, err)
+
+	ctx := coord.NewContext(time.FromJD(2451545.0, time.UTC), loc, site.Refraction())
+
+	star := NewStar("Vega", angle.Hour(18.615), angle.Deg(38.78),
+		WithStarMagnitude(0.03),
+		WithParallax(angle.Arcsec(0.130)),
+		WithRadialVelocity(-13.9),
+	)
+
+	d, err := star.GetDetails(ctx, DetailOverrides{})
+	testutil.AssertNoError(t, err)
+
+	for _, f := range []struct {
+		name string
+		got  string
+	}{
+		{"Magnitude", d.Magnitude},
+		{"RadialVelocity", d.RadialVelocity},
+		{"Name", d.Name},
+	} {
+		if f.got == "" {
+			t.Errorf("%s was blanked by a zero DetailOverrides; the zero "+
+				"value must override nothing", f.name)
+		}
+	}
+}

--- a/plan/doc.go
+++ b/plan/doc.go
@@ -25,7 +25,7 @@
 //     [MoonEvents]/[MoonriseMoonset], [TwilightEvents], [CivilDawnDusk],
 //     [NauticalDawnDusk], [AstronomicalDawnDusk]
 //   - Observability windows & scoring — [VisibilityEvents], [IsObservable],
-//     [ScoreObservable], [RankObservables], [ObservableWindows],
+//     [Scorer], [RankObservables], [ObservableWindows],
 //     [Constraint] ([Altitude], [Airmass], [Sun], [MoonSep])
 //   - Geometric events — [Conjunctions], [ConjunctionsEcliptic], [Appulses],
 //     [Oppositions], [GreatestElongations], [FullMoonOppositions]

--- a/plan/events_altitudes_test.go
+++ b/plan/events_altitudes_test.go
@@ -24,7 +24,7 @@ func (errMovingBody) Position(time.Time) (coord.ICRS, error) {
 	return coord.ICRS{}, nil
 }
 
-func (errMovingBody) GetDetails(*coord.Context, ...string) (*TargetDetails, error) {
+func (errMovingBody) GetDetails(*coord.Context, DetailOverrides) (*TargetDetails, error) {
 	return nil, errMovingBodyFails
 }
 

--- a/plan/events_test.go
+++ b/plan/events_test.go
@@ -505,7 +505,7 @@ func (m *mockLinearTarget) Constraints() []Constraint { return nil }
 func (m *mockLinearTarget) Catalog() string           { return "MOCK" }
 func (m *mockLinearTarget) ID() string                { return "Linear" }
 func (m *mockLinearTarget) Name() string              { return "LinearName" }
-func (m *mockLinearTarget) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (m *mockLinearTarget) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }
 
@@ -613,7 +613,7 @@ func (m *mockParabolicTarget) Constraints() []Constraint { return nil }
 func (m *mockParabolicTarget) Catalog() string           { return "MOCK" }
 func (m *mockParabolicTarget) ID() string                { return "Para" }
 func (m *mockParabolicTarget) Name() string              { return "ParaName" }
-func (m *mockParabolicTarget) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (m *mockParabolicTarget) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }
 
@@ -667,6 +667,6 @@ func (m *mockDynamicTarget) Constraints() []Constraint                { return n
 func (m *mockDynamicTarget) Catalog() string                          { return "DYN" }
 func (m *mockDynamicTarget) ID() string                               { return "Dyn" }
 func (m *mockDynamicTarget) Name() string                             { return "DynName" }
-func (m *mockDynamicTarget) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (m *mockDynamicTarget) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }

--- a/plan/generic.go
+++ b/plan/generic.go
@@ -61,6 +61,6 @@ func (g *GenericBody) GeocentricVec(t time.Time) (vector.Vec3, error) {
 }
 
 // GetDetails returns the target details.
-func (g *GenericBody) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(g, ctx, props...)
+func (g *GenericBody) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(g, ctx, over)
 }

--- a/plan/moons_test.go
+++ b/plan/moons_test.go
@@ -165,7 +165,7 @@ func TestPlanetaryMoon_GetDetails(t *testing.T) {
 		t.Fatalf("NewPlanetaryMoon: %v", err)
 	}
 
-	d, err := moon.GetDetails(testContext(t))
+	d, err := moon.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}

--- a/plan/moving_bodies_test.go
+++ b/plan/moving_bodies_test.go
@@ -226,7 +226,7 @@ func TestAsteroid_PositionAndGetDetails(t *testing.T) {
 		t.Errorf("GeocentricVec norm = %v, want 1.77 AU", vec.Norm())
 	}
 
-	d, err := a.GetDetails(testContext(t))
+	d, err := a.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestNewAsteroid_KeplerBackedProvider(t *testing.T) {
 		t.Errorf("GeocentricVec norm = %v AU, outside plausible band [%v, %v]", vec.Norm(), minPlausible, maxPlausible)
 	}
 
-	d, err := a.GetDetails(testContext(t))
+	d, err := a.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestComet_ApparentMagnitudeAndDetails(t *testing.T) {
 		t.Errorf("GeocentricVec norm = %v, want 1.77 AU", vec.Norm())
 	}
 
-	d, err := c.GetDetails(testContext(t))
+	d, err := c.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}
@@ -413,7 +413,7 @@ func TestGenericBody_PositionAndDetails(t *testing.T) {
 
 	// GenericBody deliberately does NOT implement MagnitudeComputer — confirm
 	// GetDetails doesn't report a spurious magnitude for it.
-	d, err := g.GetDetails(testContext(t))
+	d, err := g.GetDetails(testContext(t), DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}

--- a/plan/observable.go
+++ b/plan/observable.go
@@ -14,7 +14,7 @@ type Observable interface {
 	// Position returns the ICRS coordinates at the given time.
 	Position(t time.Time) (coord.ICRS, error)
 	// GetDetails retrieves comprehensive properties at the given context.
-	GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error)
+	GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error)
 }
 
 // MovingBody is implemented by targets with ephemeris providers

--- a/plan/parallax_test.go
+++ b/plan/parallax_test.go
@@ -15,7 +15,7 @@ import (
 // detailer is the subset of Observable this file needs; every concrete target
 // type implements it.
 type detailer interface {
-	GetDetails(ctx *coord.Context, props ...string) (*plan.TargetDetails, error)
+	GetDetails(ctx *coord.Context, props plan.DetailOverrides) (*plan.TargetDetails, error)
 }
 
 // TestConstraintAndDetailsAgreeOnAltitude is the guard the diurnal-parallax
@@ -101,7 +101,7 @@ func TestConstraintAndDetailsAgreeOnAltitude(t *testing.T) {
 					t.Fatalf("%02dh IsObservable: %v", hour, err)
 				}
 
-				details, err := d.GetDetails(ctx)
+				details, err := d.GetDetails(ctx, plan.DetailOverrides{})
 				if err != nil {
 					t.Fatalf("%02dh GetDetails: %v", hour, err)
 				}

--- a/plan/pipelines_test.go
+++ b/plan/pipelines_test.go
@@ -57,7 +57,7 @@ func TestSatelliteAltitudePipelinesAgree(t *testing.T) {
 			t.Fatalf("+%dmin IsObservable: %v", minute, err)
 		}
 
-		details, err := iss.GetDetails(ctx)
+		details, err := iss.GetDetails(ctx, plan.DetailOverrides{})
 		if err != nil {
 			t.Fatalf("+%dmin GetDetails: %v", minute, err)
 		}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -221,7 +221,7 @@ type Prioritized interface {
 }
 
 // ScoreConfig controls the weights of the composite merit function used by
-// ScoreObservable. All weights are normalized internally; they do not need
+// Scorer. All weights are normalized internally; they do not need
 // to sum to 1.0.
 type ScoreConfig struct {
 	// AltitudeWeight controls the contribution of the target's current
@@ -275,7 +275,7 @@ func (sc ScoreConfig) normalize() (wAlt, wUrg, wMoon float64) {
 }
 
 // moonPosCacheSize bounds the number of distinct epochs moonSepCache holds
-// at once. Rank and ScoreObservable evaluate many targets concurrently
+// at once. Rank and Scorer evaluate many targets concurrently
 // (errgroup), each potentially at its own epoch (e.g. a per-object peak-time
 // search) — a single-entry cache thrashes to a ~0% hit rate under that
 // access pattern, since every concurrent lookup at a different epoch evicts
@@ -398,8 +398,40 @@ func estimateHoursUntilSet(obj Observable, t time.Time, site *Site, currentAlt f
 	return math.Inf(1)
 }
 
-// ScoreObservable calculates a composite desirability score for a target at a
-// given time and site using a configurable merit function.
+// Scorer ranks targets by a configurable merit function.
+//
+// A zero Config uses DefaultScoreConfig().
+//
+// # Why a struct rather than six parameters
+//
+// This was ScoreObservable(obj, t, site, cfg, ctx, constraints...), and the two
+// pointers in the middle were nil at nearly every call site — including the
+// README's. Positional nils say nothing about what they are declining, and two
+// adjacent ones of different types can be transposed without the compiler
+// noticing. Named fields say which is which, and the ones a caller does not set
+// are the ones they did not have to think about.
+//
+// A Scorer is safe to reuse across targets and times; Score holds no state.
+type Scorer struct {
+	// Site is where the observing happens. Required.
+	Site *Site
+
+	// Config is the merit weighting. The zero value means
+	// DefaultScoreConfig().
+	Config ScoreConfig
+
+	// Context, when set, is reused instead of building one per call — the
+	// ~91 µs Apco13 solve. It fixes the epoch, so a Scorer carrying one is
+	// only valid for scoring at that instant; leave it nil to score across
+	// times.
+	Context *coord.Context
+
+	// Constraints are the requirements a target must satisfy to score above
+	// zero.
+	Constraints []Constraint
+}
+
+// Score calculates a composite desirability score for a target at a given time.
 //
 // The composite score combines three factors:
 //
@@ -410,18 +442,10 @@ func estimateHoursUntilSet(obj Observable, t time.Time, site *Site, currentAlt f
 //     Targets far from the Moon score higher.
 //
 // The weighted composite is multiplied by the target's priority if it
-// implements the Prioritized interface.
-//
-// If cfg is nil, DefaultScoreConfig() is used.
-func ScoreObservable(
-	obj Observable,
-	t time.Time,
-	site *Site,
-	cfg *ScoreConfig,
-	ctx *coord.Context,
-	constraints ...Constraint,
-) (float64, error) {
-	eval, err := isObservableCtx(obj, t, site, ctx, constraints...)
+// implements the Prioritized interface. A target failing any constraint scores
+// zero.
+func (s Scorer) Score(obj Observable, t time.Time) (float64, error) {
+	eval, err := isObservableCtx(obj, t, s.Site, s.Context, s.Constraints...)
 	if err != nil {
 		return 0, err
 	}
@@ -430,9 +454,9 @@ func ScoreObservable(
 		return 0, nil
 	}
 
-	sc := DefaultScoreConfig()
-	if cfg != nil {
-		sc = *cfg
+	sc := s.Config
+	if sc == (ScoreConfig{}) {
+		sc = DefaultScoreConfig()
 	}
 
 	wAlt, wUrg, wMoon := sc.normalize()
@@ -445,7 +469,7 @@ func ScoreObservable(
 	var urgMerit float64
 
 	if wUrg > 0 {
-		hoursLeft := estimateHoursUntilSet(obj, t, site, altDeg)
+		hoursLeft := estimateHoursUntilSet(obj, t, s.Site, altDeg)
 		urgMerit = math.Min(1.0/(math.Max(hoursLeft, 0.5)), 1.0)
 	}
 
@@ -491,7 +515,7 @@ func RankObservables(
 	constraints ...Constraint,
 ) ([]ScoredTarget, error) {
 	scores, err := parallel.Map(objs, 0, func(_ int, obj Observable) (float64, error) {
-		return ScoreObservable(obj, t, site, nil, nil, constraints...)
+		return Scorer{Site: site, Constraints: constraints}.Score(obj, t)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("plan: score: %w", err)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"errors"
+	"math"
 	"sync"
 	"testing"
 
@@ -204,7 +205,7 @@ func TestIsObservable(t *testing.T) {
 	})
 }
 
-func TestScoreObservable(t *testing.T) {
+func TestScorer(t *testing.T) {
 	loc, _ := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
 	site, _ := NewSite("Test", loc)
 	tm := time.FromJD(2451545.0, time.UTC) // J2000 Noon (LST ~18.69h)
@@ -215,8 +216,8 @@ func TestScoreObservable(t *testing.T) {
 		// Target 2: Lower (Alt ~45)
 		obj2 := NewStar("T", angle.Hour(18.69), angle.Deg(45))
 
-		s1, _ := ScoreObservable(obj1, tm, site, nil, nil)
-		s2, _ := ScoreObservable(obj2, tm, site, nil, nil)
+		s1, _ := Scorer{Site: site}.Score(obj1, tm)
+		s2, _ := Scorer{Site: site}.Score(obj2, tm)
 
 		if s1 <= s2 {
 			t.Errorf("Expected higher altitude to have higher score: %f <= %f", s1, s2)
@@ -228,7 +229,7 @@ func TestScoreObservable(t *testing.T) {
 		// Force fail with extreme altitude threshold
 		c := Altitude{Threshold: angle.Deg(95)}
 
-		s, err := ScoreObservable(obj, tm, site, nil, nil, c)
+		s, err := Scorer{Site: site, Constraints: []Constraint{c}}.Score(obj, tm)
 		testutil.AssertNoError(t, err)
 
 		if s != 0 {
@@ -243,8 +244,8 @@ func TestScoreObservable(t *testing.T) {
 
 		obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
 
-		sAlt, _ := ScoreObservable(obj, tm, site, altOnly, nil)
-		sUrg, _ := ScoreObservable(obj, tm, site, urgOnly, nil)
+		sAlt, _ := Scorer{Site: site, Config: *altOnly}.Score(obj, tm)
+		sUrg, _ := Scorer{Site: site, Config: *urgOnly}.Score(obj, tm)
 
 		// Both should be positive for a visible target
 		if sAlt <= 0 {
@@ -258,7 +259,7 @@ func TestScoreObservable(t *testing.T) {
 
 	t.Run("CompositeHigherThanZero", func(t *testing.T) {
 		obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
-		s, err := ScoreObservable(obj, tm, site, nil, nil) // Default config
+		s, err := Scorer{Site: site}.Score(obj, tm) // Default config
 		testutil.AssertNoError(t, err)
 
 		if s <= 0 {
@@ -366,7 +367,7 @@ func (erroringCoordObject) Position(time.Time) (coord.ICRS, error) {
 	return coord.ICRS{}, errCoordObjectICRS
 }
 
-func (erroringCoordObject) GetDetails(*coord.Context, ...string) (*TargetDetails, error) {
+func (erroringCoordObject) GetDetails(*coord.Context, DetailOverrides) (*TargetDetails, error) {
 	return nil, errCoordObjectICRS
 }
 
@@ -482,5 +483,215 @@ func TestScoreConfig_Defaults(t *testing.T) {
 	total := wA + wU + wM
 	if total < 0.999 || total > 1.001 {
 		t.Errorf("Expected normalized weights to sum to 1.0, got %f", total)
+	}
+}
+
+// TestScorerConfigIsUsed pins that Scorer.Config actually reaches the merit
+// weighting, rather than the default being applied unconditionally.
+//
+// The existing UrgencyBoost subtest passes a custom config but only asserts
+// the result is positive, which a Scorer that ignored Config entirely would
+// also satisfy. This asserts the exact number instead: with AltitudeWeight
+// alone, normalize() makes wAlt 1.0, so the composite is altMerit — and the
+// ×90 rescaling turns that back into the altitude in degrees. A weighting
+// this test can predict end to end is the only kind that proves the weights
+// were read.
+func TestScorerConfigIsUsed(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Test", loc)
+	testutil.AssertNoError(t, err)
+
+	tm := time.FromJD(2451545.0, time.UTC) // J2000 noon, LST ~18.69h
+	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
+
+	eval, err := IsObservable(obj, tm, site)
+	testutil.AssertNoError(t, err)
+
+	altDeg := eval.AltAz.Alt().Degrees()
+
+	altOnly, err := Scorer{Site: site, Config: ScoreConfig{AltitudeWeight: 1}}.Score(obj, tm)
+	testutil.AssertNoError(t, err)
+	testutil.AssertNear(t, "altitude-only score", altOnly, altDeg, 1e-9)
+
+	// And it must not coincide with the default weighting, or the assertion
+	// above would hold for a Scorer that ignored Config.
+	dflt, err := Scorer{Site: site}.Score(obj, tm)
+	testutil.AssertNoError(t, err)
+
+	if math.Abs(dflt-altOnly) < 1.0 {
+		t.Errorf("default score %.6f is indistinguishable from the "+
+			"altitude-only score %.6f; Config may be ignored", dflt, altOnly)
+	}
+}
+
+// TestScorerContextIsReusedAndFixesTheEpoch covers both halves of the Context
+// field's contract.
+//
+// Reused: a Context built at the scoring epoch must give the same answer as
+// the one Score builds itself — a caller passing one is asking to skip the
+// ~91 µs Apco13 solve, not to change the result.
+//
+// Fixes the epoch: a Context built at a *different* instant is used as given,
+// not silently rebuilt for t. That is the trap in the field, so it is worth a
+// test rather than only a doc comment: six hours of Earth rotation moves this
+// equatorial target from the zenith to roughly 45°, and a Scorer that quietly
+// rebuilt the context would hide the mistake instead of reporting it.
+func TestScorerContextIsReusedAndFixesTheEpoch(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Test", loc)
+	testutil.AssertNoError(t, err)
+
+	tm := time.FromJD(2451545.0, time.UTC)
+	obj := NewStar("T", angle.Hour(18.69), angle.Deg(0))
+
+	fresh, err := Scorer{Site: site}.Score(obj, tm)
+	testutil.AssertNoError(t, err)
+
+	atEpoch, err := Scorer{
+		Site:    site,
+		Context: coord.NewContext(tm, loc, site.Refraction()),
+	}.Score(obj, tm)
+	testutil.AssertNoError(t, err)
+	testutil.AssertNear(t, "score with a Context at the scoring epoch", atEpoch, fresh, 1e-9)
+
+	sixHoursEarlier, err := Scorer{
+		Site:    site,
+		Context: coord.NewContext(tm.AddDays(-0.25), loc, site.Refraction()),
+	}.Score(obj, tm)
+	testutil.AssertNoError(t, err)
+
+	if math.Abs(sixHoursEarlier-fresh) < 10.0 {
+		t.Errorf("score with a six-hour-stale Context (%.6f) is within 10 of "+
+			"the fresh score (%.6f); the supplied Context is not being used",
+			sixHoursEarlier, fresh)
+	}
+}
+
+// TestScorerMeritTerms pins the three parts of the composite that a caller can
+// reach only indirectly, each with a number the test can predict from the
+// documented formula rather than from a previous run.
+//
+// All three predate the Scorer struct and none was asserted before; they are
+// covered here because the rewrite moved them, and a merit term nothing checks
+// is one a refactor can drop silently.
+func TestScorerMeritTerms(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Test", loc)
+	testutil.AssertNoError(t, err)
+
+	tm := time.FromJD(2451545.0, time.UTC)
+
+	t.Run("priority multiplies the composite", func(t *testing.T) {
+		t.Parallel()
+
+		base := NewStar("T", angle.Hour(18.69), angle.Deg(45))
+
+		plain, err := Scorer{Site: site}.Score(base, tm)
+		testutil.AssertNoError(t, err)
+
+		ranked, err := Scorer{Site: site}.Score(
+			prioritizedTarget{Observable: base, priority: 3.0}, tm)
+		testutil.AssertNoError(t, err)
+
+		testutil.AssertNear(t, "priority-3 score", ranked, 3.0*plain, 1e-9)
+	})
+
+	t.Run("a target below the horizon scores zero, not negative", func(t *testing.T) {
+		t.Parallel()
+
+		// No constraints, so nothing rejects this target: Evaluation.Observable
+		// stays true and the altitude merit is what has to stay in range. A
+		// negative score would sort *below* a rejected target, inverting the
+		// meaning of the zero that a failed constraint returns.
+		below := NewStar("below", angle.Hour(6.69), angle.Deg(0))
+
+		eval, err := IsObservable(below, tm, site)
+		testutil.AssertNoError(t, err)
+
+		if eval.AltAz.Alt().Degrees() >= 0 {
+			t.Fatalf("fixture is above the horizon at %.3f°; it no longer "+
+				"tests the clamp", eval.AltAz.Alt().Degrees())
+		}
+
+		score, err := Scorer{Site: site, Config: ScoreConfig{AltitudeWeight: 1}}.Score(below, tm)
+		testutil.AssertNoError(t, err)
+
+		if score < 0 {
+			t.Errorf("score = %.6f for a target %.3f° below the horizon; the "+
+				"altitude merit must clamp at zero", score, eval.AltAz.Alt().Degrees())
+		}
+	})
+
+	t.Run("a zero MoonFullPenaltyDeg falls back to 30 degrees", func(t *testing.T) {
+		t.Parallel()
+
+		// ScoreConfig{MoonWeight: 1} is a natural thing to write, and without
+		// the fallback its threshold would be zero: sep/0 is +Inf, min(+Inf, 1)
+		// is 1, and every target would score a perfect Moon merit — the Moon
+		// itself included.
+		moon, err := getMoonPosition(tm)
+		testutil.AssertNoError(t, err)
+
+		// 15° away along the meridian is half the default 30° threshold, so
+		// the merit is 0.5 and the ×90 rescaling makes the score exactly 45.
+		near := NewStar("near the Moon", moon.RA(), moon.Dec()+angle.Deg(15))
+
+		const wantHalfMerit = 45.0
+
+		explicit, err := Scorer{
+			Site:   site,
+			Config: ScoreConfig{MoonWeight: 1, MoonFullPenaltyDeg: 30},
+		}.Score(near, tm)
+		testutil.AssertNoError(t, err)
+		testutil.AssertNear(t, "score with an explicit 30° threshold", explicit, wantHalfMerit, 1e-6)
+
+		fallback, err := Scorer{Site: site, Config: ScoreConfig{MoonWeight: 1}}.Score(near, tm)
+		testutil.AssertNoError(t, err)
+		testutil.AssertNear(t, "score with a zero threshold", fallback, wantHalfMerit, 1e-6)
+	})
+}
+
+// TestScorerReportsFailureRatherThanZero is the error-vs-absence check for
+// Score: a target that cannot be evaluated must not come back as a score of
+// zero with a nil error.
+//
+// Zero is already a meaningful answer here — FailingConstraint above asserts
+// it is what a rejected target gets — so a swallowed error would place a
+// broken target at the bottom of a ranking instead of stopping the run, and
+// a scheduler would go on to plan a night around the remaining targets as
+// though nothing had gone wrong.
+func TestScorerReportsFailureRatherThanZero(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Zero(), angle.Zero(), 0)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Test", loc)
+	testutil.AssertNoError(t, err)
+
+	score, err := Scorer{Site: site}.Score(errObservable{}, fixedEpoch())
+	if err == nil {
+		t.Fatalf("Score returned (%v, nil) for a target whose Position fails; "+
+			"a failure must not be indistinguishable from a rejected target", score)
+	}
+
+	if !errors.Is(err, errAlwaysFails) {
+		t.Errorf("error = %v, want it to wrap the target's own failure", err)
+	}
+
+	if score != 0 {
+		t.Errorf("score = %v alongside an error, want 0", score)
 	}
 }

--- a/plan/planet.go
+++ b/plan/planet.go
@@ -134,8 +134,8 @@ func (p *Planet) GeocentricVec(t time.Time) (vector.Vec3, error) {
 }
 
 // GetDetails returns the target details.
-func (p *Planet) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(p, ctx, props...)
+func (p *Planet) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(p, ctx, over)
 }
 
 // ApparentMagnitude returns the Mallama & Hilton (2018) apparent magnitude.

--- a/plan/predicate_errors_test.go
+++ b/plan/predicate_errors_test.go
@@ -39,7 +39,7 @@ func (unreachableTarget) Position(_ time.Time) (coord.ICRS, error) {
 	return coord.ICRS{}, errPositionUnavailable
 }
 
-func (unreachableTarget) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (unreachableTarget) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return nil, errPositionUnavailable
 }
 

--- a/plan/satellite.go
+++ b/plan/satellite.go
@@ -88,8 +88,8 @@ func (s *Satellite) GeocentricVec(t time.Time) (vector.Vec3, error) {
 }
 
 // GetDetails computes the position and visual magnitude of the satellite.
-func (s *Satellite) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(s, ctx, props...)
+func (s *Satellite) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(s, ctx, over)
 }
 
 // errNoObserverCtx is returned when satellite magnitude is called without a context.

--- a/plan/satellite_test.go
+++ b/plan/satellite_test.go
@@ -79,7 +79,7 @@ func TestPlanSatellite_PositionAndDetails(t *testing.T) {
 
 	ctx := coord.NewContext(tm, site.Location(), site.Refraction())
 
-	d, err := sat.GetDetails(ctx)
+	d, err := sat.GetDetails(ctx, DetailOverrides{})
 	if err != nil {
 		t.Fatalf("GetDetails: %v", err)
 	}

--- a/plan/star.go
+++ b/plan/star.go
@@ -87,8 +87,8 @@ func (s *Star) Position(_ time.Time) (coord.ICRS, error) {
 }
 
 // GetDetails returns the target details.
-func (s *Star) GetDetails(ctx *coord.Context, props ...string) (*TargetDetails, error) {
-	return computeDetails(s, ctx, props...)
+func (s *Star) GetDetails(ctx *coord.Context, over DetailOverrides) (*TargetDetails, error) {
+	return computeDetails(s, ctx, over)
 }
 
 // StaticMagnitude returns the catalog V-band magnitude if set.

--- a/plan/strategy.go
+++ b/plan/strategy.go
@@ -356,14 +356,18 @@ func mergeConstraints(a, b []Constraint) []Constraint {
 }
 
 // scoreBlockPlacement evaluates how desirable a block placement is by
-// scoring the target at the observation midpoint using ScoreObservable.
+// scoring the target at the observation midpoint.
 //
-// If ctx is non-nil it is reused; otherwise ScoreObservable creates one.
+// If ctx is non-nil it is reused; otherwise the Scorer builds one.
 // Falls back to static block priority if scoring fails.
 func scoreBlockPlacement(block *Block, start, end time.Time, planner *Planner, ctx *coord.Context) float64 {
 	mid := start.Add(end.Sub(start) / 2)
 
-	score, err := ScoreObservable(block.Target, mid, planner.Site, nil, ctx, planner.Constraints...)
+	score, err := Scorer{
+		Site:        planner.Site,
+		Context:     ctx,
+		Constraints: planner.Constraints,
+	}.Score(block.Target, mid)
 	if err != nil {
 		return block.Priority
 	}

--- a/plan/visibility_test.go
+++ b/plan/visibility_test.go
@@ -22,7 +22,7 @@ func (m mockObject) ICRS(_ time.Time) (coord.ICRS, error) {
 
 func (m mockObject) Name() string                             { return "mock" }
 func (m mockObject) Position(_ time.Time) (coord.ICRS, error) { return m.pos, nil }
-func (m mockObject) GetDetails(_ *coord.Context, _ ...string) (*TargetDetails, error) {
+func (m mockObject) GetDetails(_ *coord.Context, _ DetailOverrides) (*TargetDetails, error) {
 	return &TargetDetails{}, nil
 }
 


### PR DESCRIPTION
Closes #116.

Two public APIs in `plan` took loose parameter lists the compiler could not
check. Both become structs.

## The issue's premise was wrong, and the real defect is worse

#116 read `GetDetails(ctx, props ...string)` as a property *selector* —
"pass the names you want computed". It was not. The variadic was key/value
pairs, consumed two at a time:

```go
for i := 0; i < len(props)-1; i += 2 {
    switch props[i] {
    case "Description":
        d.Description = props[i+1]
    // ...
    default:
        d.ExtraProps[props[i]] = props[i+1]
    }
}
```

Three ways to get that wrong, all silent:

| mistake | what happened |
| --- | --- |
| odd argument count | the last argument was dropped — the loop ran to `len(props)-1` |
| a key one letter off | landed in `ExtraProps`; the field it meant to override kept its computed value |
| key and value swapped | nothing noticed |

`DetailOverrides` names the five overridable fields and puts genuinely
open-ended keys behind `Extra`. A typo in a named field is now a compile
error rather than a demotion to `ExtraProps`. The zero value overrides
nothing — what nearly every call site passes.

```go
// before
d, err := star.GetDetails(ctx, "Description", "A bright star in Lyra")

// after
d, err := star.GetDetails(ctx, plan.DetailOverrides{Description: "A bright star in Lyra"})
```

## ScoreObservable

Six parameters, two of them nilable pointers that were nil at nearly every
call site including the README's:

```go
// before
score, err := plan.ScoreObservable(obj, t, site, nil, nil, constraints...)

// after
score, err := plan.Scorer{Site: site, Constraints: constraints}.Score(obj, t)
```

Two adjacent nils of different types — `*ScoreConfig` and `*coord.Context` —
transpose without the compiler noticing. `Scorer` makes the site required,
the config's zero value mean `DefaultScoreConfig()`, and a nil context mean
"build one per call".

## Tests

Mutation testing drove seven new cases. Mutants that survived the existing
suite:

| mutant | now killed by |
| --- | --- |
| `DetailOverrides.Source` never applied | `TestDetailOverridesAppliesEveryField/Source` |
| `DetailOverrides.Magnitude` never applied | `.../Magnitude` |
| an empty override blanks the computed field | `TestDetailOverridesZeroValueOverridesNothing` |
| `Scorer.Config` ignored, default always used | `TestScorerConfigIsUsed` |
| `Scorer.Context` ignored, always rebuilt | `TestScorerContextIsReusedAndFixesTheEpoch` |
| priority multiplier dropped | `TestScorerMeritTerms` |
| altitude merit not clamped at zero | `TestScorerMeritTerms` |
| `MoonFullPenaltyDeg` fallback to 30° dropped | `TestScorerMeritTerms` |
| **an evaluation error returned as `(0, nil)`** | `TestScorerReportsFailureRatherThanZero` |

The last one is the error-vs-absence case this repo keeps finding (#102,
#172, #177, #182): zero is already a meaningful score — it is what a target
rejected by a constraint gets — so a swallowed error would sort a broken
target to the bottom of a ranking instead of stopping the run, and a
scheduler would plan the night around the survivors as though nothing had
gone wrong.

`TestScorerConfigIsUsed` asserts an exact number rather than a sign: with
`AltitudeWeight` alone, `normalize()` makes `wAlt` 1.0, so the composite is
the altitude merit and the ×90 rescaling turns it back into the altitude in
degrees. The pre-existing `UrgencyBoost` subtest passed a custom config but
only checked the result was positive, which a `Scorer` ignoring `Config`
entirely also satisfies.

One surviving mutant is equivalent, not a gap: nothing computes
`Description`, so guarding its assignment on `!= ""` is unobservable.

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation"`,
`go test ./...`, `go test -race -short -count=1 ./...`,
`go test -tags=validation`, `go test -tags=integration`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.

Call sites converted: 10 `GetDetails` implementations, 7 examples, 15 test
files, 10 `ScoreObservable` sites, plus the prose in `README.md`,
`plan/doc.go`, `docs/ROADMAP.md` and `docs/skybrightness.md`.
