### PR TITLE
plan: resolve the MPC's ~2,700 observatory codes to sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ happens.
 | Planetary satellite SPK (Io, Titan, Triton, ...) | `remote.NAIFSPK` | ~64 MB (Mars) – ~1.1 GB (Jupiter), ~2.4 GB for all 6 kernels | `eph.NewProvider(eph.Moons, "sat441")`, or `plan.VisibleTonight(..., plan.WithPlanetaryMoons())` |
 | IERS Earth-orientation data | `remote.IERSFinals2000A` | ~3.7 MB | automatic on first `Time.EOP()`/`.UTC()`/`.UT1()` query needing it |
 | OpenNGC catalog CSVs | `remote.OpenNGC` | ~2 MB combined | `catalog.NewResolver(catalog.OpenNGC, ...)` |
+| MPC observatory-code list | `remote.MPCObsCodes` | ~150 KB | `plan.NewMPCSite(ctx, "568")` / `plan.MPCObservatories(ctx)` |
 | VIIRS annual nighttime-lights composite (2012-2025, no API key) | `remote.VIIRSAnnual` | ~700 MB-1 GB per year | `viirs.Open(ctx, year)`, for the spatial distribution of artificial emission — CC0, credit lightpollutionmap.info + NASA Black Marble |
 | CAMS global reanalysis NetCDF files (Copernicus EODATA S3) | `remote.CopernicusEODATA` | 1.3 MB (lnsp) – ~180 MB (a 137-level aerosol tracer) | `atmosphere/dataset/cams.Open` — requires Copernicus Data Space S3 credentials (AWS SDK default chain) and a blank import of `remote/s3` |
 

--- a/docs/changelog.d/223-mpc-observatory-codes.md
+++ b/docs/changelog.d/223-mpc-observatory-codes.md
@@ -1,0 +1,11 @@
+---
+type: Added
+pr: 223
+---
+`plan.NewMPCSite(ctx, code)` and `plan.MPCObservatories(ctx)` resolve the IAU
+Minor Planet Center's ~2,700 observatory codes to a `*Site`, recovering each
+position from the published parallax constants. `MPCObservatory.ResolutionM`
+reports how finely a row was published — from ±3 m to ±3.2 km — because the
+register mixes both and a recovered height does not say which it is. New
+`remote.MPCObsCodes` endpoint, download-gated like every other bulk fetch
+(#125).

--- a/plan/doc.go
+++ b/plan/doc.go
@@ -15,7 +15,9 @@
 //   - Site & observatory setup — [NewSite], [Site], [NewSiteEarthLocation]
 //     (plain lat/lon/height, no [github.com/TuSKan/astrogo/coord] import
 //     needed), [NewSiteEarthAddress] (geocoded from a free-text address);
-//     well-known sites — [KnownSites], [NewKnownSite]
+//     well-known sites — [KnownSiteNames], [NewKnownSite]; the IAU Minor
+//     Planet Center's ~2,700 observatory codes — [NewMPCSite],
+//     [MPCObservatories]
 //   - Targets to observe — [Planet] (via [NewSun]...[NewPluto], [NewPlanet]),
 //     [Star] (via [NewStar]), [Asteroid] (via [NewAsteroid]), [Comet] (via
 //     [NewComet]), [DeepSkyObject] (via [NewDeepSkyObject]), [Satellite] (via

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -105,4 +105,20 @@ var (
 	// ErrGeocodeNoResult indicates NewSiteEarthAddress's geocoding query
 	// matched no location.
 	ErrGeocodeNoResult = errors.New("plan: geocoding found no match for address")
+
+	// ErrSiteNotOnEarth indicates NewMPCSite was given a real MPC
+	// observatory code that has no position on the ground — a space
+	// telescope, the geocentre, or a roving-observer placeholder. Distinct
+	// from ErrUnknownSite on purpose: the code is valid and the caller's
+	// spelling is not the problem.
+	ErrSiteNotOnEarth = errors.New("plan: MPC code has no position on Earth")
+
+	// ErrNoMPCObservatories indicates the MPC observatory-code list parsed
+	// cleanly and contained no rows, which is what a truncated or
+	// redirected fetch looks like — never a real state of the register.
+	ErrNoMPCObservatories = errors.New("plan: MPC observatory list is empty")
+
+	// ErrMalformedMPCRow indicates a row of the MPC observatory-code list
+	// carried a longitude or parallax constant that is not a number.
+	ErrMalformedMPCRow = errors.New("plan: malformed MPC observatory row")
 )

--- a/plan/mpc.go
+++ b/plan/mpc.go
@@ -1,0 +1,401 @@
+package plan
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/constants"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// MPCObservatory is one row of the IAU Minor Planet Center's observatory-code
+// list — the ~2,700-entry register every asteroid and comet observation is
+// reported against.
+//
+// # Accuracy, which is not uniform and not what a reader expects
+//
+// The MPC does not publish latitude and height. It publishes the longitude and
+// the two parallax constants an observation reduction actually needs, and the
+// geodetic position here is recovered from them (see [MPCObservatories] for
+// how). Recovering it is exact. The input is not, and it is not equally
+// imprecise from row to row — which is the part worth knowing, because nothing
+// in a recovered latitude and height says which kind of row it came from.
+//
+// The constants are published to between three and six decimals, and a unit in
+// the last place scales straight into height. Counted over the 2,692 positioned
+// rows on 2026-09-08:
+//
+//	decimals   rows   height is good to
+//	       6   1322   ±3 m
+//	       5   1242   ±32 m
+//	       4     90   ±319 m
+//	       3     38   ±3.2 km
+//
+// [MPCObservatory.ResolutionM] carries that per row, so a caller can tell the
+// two apart instead of trusting all 2,692 equally. The 38 coarsest rows are
+// where it stops being academic: 507 Nyenheim recovers to −6,655 m, which is
+// not a mistake in this code or in the MPC's — it is a site near sea level
+// reported to three decimals, and −6.6 km is inside that row's own ±3.2 km at
+// two units in the last place.
+//
+// Against this package's hand-curated sites, whose coordinates come from each
+// observatory's own published values, the six-decimal rows agree to 0.04″ in
+// latitude and 2 m in height. The disagreements above that are real and are not
+// this code's: they are sites where the MPC codes one specific telescope and
+// the curated entry names the observatory.
+//
+// So: right for reducing an observation and right for pointing a telescope,
+// wrong for anything that needs the metre, and not to be trusted at all below
+// five decimals without checking ResolutionM. A site you own should be entered
+// with your own surveyed coordinates through [NewSite].
+type MPCObservatory struct {
+	// Location is the recovered geodetic position, or nil when the MPC
+	// publishes no parallax constants for this code.
+	//
+	// Thirty entries have none, and they are not errors or gaps in the data:
+	// they are the space telescopes (Hubble, Gaia, JWST, SOHO, Spitzer) and
+	// the roving-observer placeholders that stand in for an observer who
+	// reports their own position with each observation. A code like "247" is
+	// a perfectly valid MPC code that no [Site] can be built from, which is
+	// why this is a nil position rather than a missing row.
+	//
+	// Three further rows — 244, 248 and 500 — publish constants that are
+	// exactly zero, which is the geocentre and recovers to 6,378 km below
+	// the ellipsoid. That is what the file says and it is reported as given:
+	// deciding that the centre of the Earth is not a place would be this
+	// package inventing a policy the MPC did not write down.
+	Location *coord.Geodetic
+
+	// ResolutionM is how finely this row was published, in metres: half a
+	// unit in the last decimal of its parallax constants, scaled by Earth's
+	// equatorial radius. Zero for a row with no constants.
+	//
+	// It is a floor on the error, not the error. A row published to six
+	// decimals can still name a different pier than the one you meant; a row
+	// published to three cannot be better than ±3.2 km however well the site
+	// is surveyed. Read it before treating a recovered height as a height.
+	ResolutionM float64
+
+	// Code is the MPC observatory code: three characters, either digits
+	// ("568") or a letter and two digits ("G37").
+	Code string
+
+	// Name is the MPC's own designation for the site, verbatim, including
+	// the town it disambiguates with — "European Southern Observatory,
+	// La Silla".
+	Name string
+}
+
+// mpcCache holds the parsed list for the life of the process.
+//
+// The mutex is held across the fetch so concurrent first calls make one
+// request between them rather than one each, and a failure is not recorded:
+// a load that fails because consent had not been granted, or because the MPC
+// was briefly unreachable, must not make the whole register permanently absent
+// while the process looks healthy. The next call tries again.
+var mpcCache struct {
+	mu   sync.Mutex
+	list []MPCObservatory
+}
+
+// MPCObservatories returns every entry in the IAU Minor Planet Center's
+// observatory-code list, sorted by code.
+//
+// The list — about 200 KB — is fetched on the first call that needs it, using
+// that caller's context, and kept for the life of the process. It is a
+// [remote.Downloadable] endpoint, so a caller must have granted
+// [remote.EnableDownloads] for [remote.MPCObsCodes] first; without it the error
+// is [remote.ErrDownloadDenied] and says which call grants it.
+//
+// # Recovering a position from the parallax constants
+//
+// Each row gives the east longitude λ and the two parallax constants
+// ρcosφ′ and ρsinφ′, in units of Earth's equatorial radius. Those two are the
+// cylindrical coordinates of the site in the terrestrial frame — distance from
+// the rotation axis and distance from the equatorial plane — so multiplying by
+// the equatorial radius and applying λ gives a Cartesian ECEF position, which
+// [coord.FromECEF] turns into geodetic longitude, latitude and height. No
+// iteration and no approximation of our own: the only thing being assumed is
+// which radius the constants are scaled by.
+//
+// The MPC's own reductions use 6378.140 km (IAU 1976) where this uses WGS 84's
+// 6378.137 km. The 3 m difference in the scale factor moves a recovered height
+// by about 3 m and a latitude not at all, which is two orders of magnitude
+// below the quantisation of the published constants — see [MPCObservatory] for
+// what the accuracy actually is.
+func MPCObservatories(ctx context.Context) ([]MPCObservatory, error) {
+	mpcCache.mu.Lock()
+	defer mpcCache.mu.Unlock()
+
+	if mpcCache.list != nil {
+		return mpcCache.list, nil
+	}
+
+	bucket, key, err := remote.GetFile(ctx, remote.MPCObsCodes, mpcObsCodesFile)
+	if err != nil {
+		return nil, fmt.Errorf("plan: fetch MPC observatory codes: %w", err)
+	}
+
+	r, err := bucket.NewReader(ctx, key, nil)
+	if err != nil {
+		return nil, fmt.Errorf("plan: open MPC observatory codes: %w", err)
+	}
+
+	defer r.Close() //nolint:errcheck // read-only handle, nothing actionable on close failure
+
+	list, err := parseMPCObsCodes(r)
+	if err != nil {
+		return nil, fmt.Errorf("plan: parse MPC observatory codes: %w", err)
+	}
+
+	mpcCache.list = list
+
+	return list, nil
+}
+
+// NewMPCSite resolves an IAU Minor Planet Center observatory code to a [Site],
+// fetching the code list on the first call that needs it (see
+// [MPCObservatories] for the fetch, the consent gate, and how much the recovered
+// position is worth).
+//
+// The code is matched case-insensitively after trimming spaces, so "g37",
+// "G37" and " G37 " are the same site. The returned Site carries the MPC's own
+// name and the code itself as its [Site.MPCCode], so a site built this way
+// always says where it came from.
+//
+// Three outcomes, deliberately distinct:
+//
+//   - The code names a site with a position: a *Site.
+//   - The code is not in the list: [ErrUnknownSite].
+//   - The code is in the list but has no ground position — a space telescope,
+//     the geocentre, a roving observer: [ErrSiteNotOnEarth]. Reporting that as
+//     "unknown" would tell a caller their code was wrong when it is valid and
+//     the answer is that no such site exists.
+//
+// Time zone is not set: the MPC list has no zone column, and guessing one from
+// a longitude is wrong across most of the world. Chain [Site.WithTimeZone] on
+// the result when local time matters.
+func NewMPCSite(ctx context.Context, code string) (*Site, error) {
+	list, err := MPCObservatories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return lookupMPCSite(list, code)
+}
+
+// lookupMPCSite is NewMPCSite without the fetch, so the three outcomes can be
+// tested without a network and without seeding a package-level cache.
+func lookupMPCSite(list []MPCObservatory, code string) (*Site, error) {
+	want := strings.ToUpper(strings.TrimSpace(code))
+
+	for _, obs := range list {
+		if obs.Code != want {
+			continue
+		}
+
+		if obs.Location == nil {
+			return nil, fmt.Errorf("%w: %q (%s)", ErrSiteNotOnEarth, code, obs.Name)
+		}
+
+		return NewSite(obs.Name, obs.Location, WithMPCCode(obs.Code))
+	}
+
+	return nil, fmt.Errorf("%w: MPC code %q", ErrUnknownSite, code)
+}
+
+// mpcObsCodesFile is the object name under remote.MPCObsCodes' URL. The .html
+// suffix is the MPC's filename, not a description: the body is one <pre>
+// element wrapping a fixed-width table.
+const mpcObsCodesFile = "ObsCodes.html"
+
+// MPC column offsets. The fields are fixed-width and run together with no
+// separator whenever a value fills its field — row 005 reads
+// "005   2.231000.659891+0.748875Meudon" — so this is parsed by column and
+// never by splitting on whitespace, which silently drops every such row.
+const (
+	mpcCodeEnd = 3  // [0:3]   code
+	mpcLonEnd  = 13 // [3:13]  east longitude, degrees
+	mpcCosEnd  = 21 // [13:21] rho cos phi'
+	mpcSinEnd  = 30 // [21:30] rho sin phi', signed
+)
+
+// parseMPCObsCodes reads the MPC's fixed-width observatory table.
+//
+// It is deliberately tolerant of the wrapper and strict about the rows: the
+// <pre> tags and the column header are skipped, a row with blank parallax
+// constants becomes an entry with a nil Location, and a row whose numbers do
+// not parse is an error rather than a silently dropped observatory. A list
+// quietly missing the site a caller asked for is the failure mode worth
+// avoiding here, since the caller would read it as "no such code".
+func parseMPCObsCodes(r io.Reader) ([]MPCObservatory, error) {
+	var (
+		out  []MPCObservatory
+		line int
+	)
+
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line++
+
+		row := strings.TrimRight(sc.Text(), "\r\n")
+
+		switch {
+		case len(row) < mpcSinEnd:
+			// Blank lines, the <pre> tags, and anything else too short to
+			// carry a row. Every real row reaches at least the name column.
+			continue
+		case strings.HasPrefix(row, "Code"):
+			continue
+		case !looksLikeMPCCode(row[:mpcCodeEnd]):
+			// Markup, not data — an error page served with a 200, or
+			// whatever the MPC decides to wrap the table in next. Told apart
+			// from a data row by the code field alone, and by what a code
+			// cannot contain rather than by what today's codes look like:
+			// every one of the 2,722 is [0-9A-Z][0-9][0-9], but pinning that
+			// shape would silently drop the first code issued outside it,
+			// which is the failure this parser is most careful to avoid.
+			continue
+		}
+
+		obs, err := parseMPCRow(row)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", line, err)
+		}
+
+		out = append(out, obs)
+	}
+
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+
+	if len(out) == 0 {
+		// An empty list and a successful parse of an empty document look the
+		// same to a caller, and the second is what a truncated or redirected
+		// fetch produces.
+		return nil, ErrNoMPCObservatories
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+
+	return out, nil
+}
+
+// looksLikeMPCCode reports whether the three-character code field could hold a
+// code at all: three alphanumerics, no spaces, no punctuation.
+func looksLikeMPCCode(field string) bool {
+	if len(field) != mpcCodeEnd {
+		return false
+	}
+
+	for _, r := range field {
+		isDigit := r >= '0' && r <= '9'
+		isUpper := r >= 'A' && r <= 'Z'
+		isLower := r >= 'a' && r <= 'z'
+
+		if !isDigit && !isUpper && !isLower {
+			return false
+		}
+	}
+
+	return true
+}
+
+// parseMPCRow converts one fixed-width row. A row with no parallax constants
+// yields an entry with a nil Location rather than an error — see
+// MPCObservatory.Location for what those rows are.
+func parseMPCRow(row string) (MPCObservatory, error) {
+	obs := MPCObservatory{
+		Code: strings.TrimSpace(row[:mpcCodeEnd]),
+		Name: strings.TrimSpace(row[mpcSinEnd:]),
+	}
+
+	var (
+		lonText = strings.TrimSpace(row[mpcCodeEnd:mpcLonEnd])
+		cosText = strings.TrimSpace(row[mpcLonEnd:mpcCosEnd])
+		sinText = strings.TrimSpace(row[mpcCosEnd:mpcSinEnd])
+	)
+
+	if lonText == "" || cosText == "" || sinText == "" {
+		return obs, nil
+	}
+
+	lonDeg, err := strconv.ParseFloat(lonText, 64)
+	if err != nil {
+		return MPCObservatory{}, fmt.Errorf("%w: %s: longitude %q", ErrMalformedMPCRow, obs.Code, lonText)
+	}
+
+	rhoCos, err := strconv.ParseFloat(cosText, 64)
+	if err != nil {
+		return MPCObservatory{}, fmt.Errorf("%w: %s: rho cos phi' %q", ErrMalformedMPCRow, obs.Code, cosText)
+	}
+
+	rhoSin, err := strconv.ParseFloat(sinText, 64)
+	if err != nil {
+		return MPCObservatory{}, fmt.Errorf("%w: %s: rho sin phi' %q", ErrMalformedMPCRow, obs.Code, sinText)
+	}
+
+	loc, err := mpcGeodetic(lonDeg, rhoCos, rhoSin)
+	if err != nil {
+		return MPCObservatory{}, fmt.Errorf("%s: %w", obs.Code, err)
+	}
+
+	obs.Location = loc
+	obs.ResolutionM = mpcResolution(cosText, sinText)
+
+	return obs, nil
+}
+
+// mpcResolution converts how many decimals a row's parallax constants carry
+// into metres on the ground: half a unit in the last place, scaled by the
+// equatorial radius. The coarser of the two constants decides, since a
+// position is no better than its worse component.
+func mpcResolution(cosText, sinText string) float64 {
+	decimals := min(mpcDecimals(cosText), mpcDecimals(sinText))
+
+	return 0.5 * math.Pow(10, -float64(decimals)) * constants.WGS84.SemiMajorAxis.Value
+}
+
+// mpcDecimals counts the digits after the decimal point in a published
+// constant. A value written without one is worth no more than a whole Earth
+// radius, which is what zero decimals correctly reports.
+func mpcDecimals(text string) int {
+	dot := strings.IndexByte(text, '.')
+	if dot < 0 {
+		return 0
+	}
+
+	return len(text) - dot - 1
+}
+
+// mpcGeodetic recovers a geodetic position from an east longitude in degrees
+// and the two parallax constants. See MPCObservatories' doc comment for why
+// this is a coordinate change rather than an inversion.
+func mpcGeodetic(lonDeg, rhoCos, rhoSin float64) (*coord.Geodetic, error) {
+	a := constants.WGS84.SemiMajorAxis.Value
+	lam := angle.Deg(lonDeg).Radians()
+
+	ecef := vector.V3(
+		a*rhoCos*math.Cos(lam),
+		a*rhoCos*math.Sin(lam),
+		a*rhoSin,
+	)
+
+	loc, err := coord.FromECEF(ecef, coord.WGS84())
+	if err != nil {
+		return nil, fmt.Errorf("recover position: %w", err)
+	}
+
+	return loc, nil
+}

--- a/plan/mpc_network_test.go
+++ b/plan/mpc_network_test.go
@@ -1,0 +1,340 @@
+//go:build network
+
+package plan
+
+import (
+	"context"
+	"errors"
+	"math"
+	"path/filepath"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// requireMPCList fetches the real observatory-code list once per run, skipping
+// when the MPC is unreachable rather than failing CI for somebody else's
+// downtime.
+func requireMPCList(t *testing.T) []MPCObservatory {
+	t.Helper()
+
+	testutil.RequireReachable(t, "www.minorplanetcenter.net:443")
+
+	t.Cleanup(remote.Reset)
+	remote.EnableDownloads(0, remote.MPCObsCodes)
+
+	list, err := MPCObservatories(context.Background())
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("MPCObservatories: %v", err)
+	}
+
+	return list
+}
+
+// TestMPCObservatoriesParsesTheWholeRegister is the test the offline fixture
+// cannot be: ten hand-picked rows prove the parser handles the shapes somebody
+// thought of, and this proves it handles the ~2,700 that actually exist.
+//
+// It asserts a floor rather than an exact count. The register grows by a few
+// codes a month, so an equality check would fail for the one reason that is
+// not a defect, and the thing worth catching — a parse that quietly loses most
+// of the file — is an order of magnitude away from the boundary either way.
+func TestMPCObservatoriesParsesTheWholeRegister(t *testing.T) {
+	list := requireMPCList(t)
+
+	// 2,722 rows on 2026-09-08. A tenth of that is not a shrinking register,
+	// it is a parser reading a different document.
+	const floor = 2000
+
+	if len(list) < floor {
+		t.Fatalf("parsed %d observatories, want at least %d — the register does not shrink, "+
+			"so this is the parser losing rows or the endpoint serving something else", len(list), floor)
+	}
+
+	var (
+		positioned int
+		blank      int
+	)
+
+	for _, obs := range list {
+		if obs.Code == "" {
+			t.Errorf("observatory %q has an empty code", obs.Name)
+		}
+
+		if obs.Name == "" {
+			t.Errorf("observatory %q has an empty name", obs.Code)
+		}
+
+		if obs.Location == nil {
+			blank++
+
+			continue
+		}
+
+		positioned++
+
+		// Every recovered position must be physically possible. A field read
+		// one column off produces numbers that still parse, and this is what
+		// separates that from a correct read.
+		if lat := obs.Location.Lat().Degrees(); math.Abs(lat) > 90 {
+			t.Errorf("%s %s: latitude %.4f out of range", obs.Code, obs.Name, lat)
+		}
+
+		// Height is bounded by the row's own published resolution rather than
+		// by a flat number, because a flat number cannot be both true and
+		// useful here. 507 Nyenheim recovers to -6,655 m and is not an error:
+		// its constants carry three decimals, so the row is worth +/-3.2 km
+		// and -6.6 km is two units in the last place. Holding a 3-decimal row
+		// to the same bound as a 6-decimal one either fails on correct data
+		// or waves through a genuine column misread.
+		//
+		// The three geocentre rows (244, 248, 500) publish constants that are
+		// exactly zero and land 6,378 km down. That is the origin, faithfully
+		// reported, and it is excluded by name rather than by widening the
+		// bound until it happens to fit.
+		switch obs.Code {
+		case "244", "248", "500":
+			continue
+		}
+
+		// The band is where places on Earth are, widened by this row's own
+		// published resolution. Measured over the 2,689 positioned non-geocentre
+		// rows on 2026-09-08, grouped by how many decimals their constants carry:
+		//
+		//	decimals      n   recovered height
+		//	       6   1317   -33 m .. +5,351 m
+		//	       5   1244   -207 m .. +4,212 m
+		//	       4     90   -361 m .. +3,852 m
+		//	       3     38   -9,254 m .. +9,614 m
+		//
+		// 95% of the register lands inside a kilometre of sea level and six of
+		// the summit of Everest; the outliers are all in the two coarse
+		// buckets, and every one of them is inside its own quantisation. That
+		// is the check: not "is this height plausible" — which cannot be true
+		// for a 3-decimal row — but "is it plausible given what this row
+		// claims to know". A column read one field over produces hundreds of
+		// kilometres and fails at any precision.
+		const (
+			deepest = -1000.0
+			highest = 6000.0
+			slack   = 4.0
+		)
+
+		lo := deepest - slack*obs.ResolutionM
+		hi := highest + slack*obs.ResolutionM
+
+		if h := obs.Location.Height(); h < lo || h > hi {
+			t.Errorf("%s %s: height %.0f m outside [%.0f, %.0f] — %.0f m of sea-level "+
+				"band plus %gx this row's own +/-%.0f m resolution",
+				obs.Code, obs.Name, h, lo, hi, highest-deepest, slack, obs.ResolutionM)
+		}
+	}
+
+	t.Logf("%d observatories: %d positioned, %d without a ground position", len(list), positioned, blank)
+
+	// The positionless rows are the space telescopes, the geocentre and the
+	// roving-observer placeholders — 30 of them on 2026-09-08. A parser that
+	// started reading blanks as zeros would drive this to nought, and one
+	// reading real constants as blanks would drive it up.
+	if blank == 0 || blank > 100 {
+		t.Errorf("%d rows without a ground position; expected a few dozen "+
+			"(space telescopes, the geocentre, roving observers)", blank)
+	}
+}
+
+// TestNewMPCSiteResolvesRealCodes checks the whole path — fetch, parse, recover,
+// build — against codes whose positions this package independently holds.
+func TestNewMPCSiteResolvesRealCodes(t *testing.T) {
+	requireMPCList(t)
+
+	for _, tc := range []struct {
+		code  string
+		known string
+		tolD  float64
+	}{
+		{"000", "greenwich", 0.01},
+		{"309", "paranal", 0.01},
+		{"568", "mauna_kea", 0.01},
+		{"807", "cerro_tololo", 0.01},
+	} {
+		t.Run(tc.code, func(t *testing.T) {
+			site, err := NewMPCSite(context.Background(), tc.code)
+			if err != nil {
+				t.Fatalf("NewMPCSite(%q): %v", tc.code, err)
+			}
+
+			want, ok := KnownSites[tc.known]
+			if !ok {
+				t.Skipf("KnownSites has no %q to compare against", tc.known)
+			}
+
+			testutil.AssertNear(t, "latitude",
+				site.Latitude().Degrees(), want.Location().Lat().Degrees(), tc.tolD)
+
+			if site.MPCCode() != tc.code {
+				t.Errorf("MPCCode = %q, want %q", site.MPCCode(), tc.code)
+			}
+		})
+	}
+}
+
+// TestNewMPCSiteRejectsCodesWithNoGroundPosition runs the error-vs-absence
+// distinction against the live list rather than the fixture, so it also
+// confirms these rows survive the real file's formatting.
+func TestNewMPCSiteRejectsCodesWithNoGroundPosition(t *testing.T) {
+	requireMPCList(t)
+
+	for _, code := range []string{"250", "258", "274"} { // Hubble, Gaia, JWST
+		_, err := NewMPCSite(context.Background(), code)
+		if !errors.Is(err, ErrSiteNotOnEarth) {
+			t.Errorf("NewMPCSite(%q) err = %v, want ErrSiteNotOnEarth", code, err)
+		}
+	}
+
+	if _, err := NewMPCSite(context.Background(), "!!!"); !errors.Is(err, ErrUnknownSite) {
+		t.Errorf("NewMPCSite(%q) err = %v, want ErrUnknownSite", "!!!", err)
+	}
+}
+
+// TestMPCObservatoriesNeedsDownloadConsent pins that the list is behind the
+// same gate as every other bulk fetch — see CLAUDE.md's "Bulk file downloads
+// never happen without explicit consent".
+//
+// The cache directory is pointed at an empty temporary bucket, which is the
+// whole point rather than tidiness: consent gates the *download*, not reading
+// something already cached. Run against a warm cache this test passes with the
+// gate removed, so it would be asserting nothing — which is exactly what it did
+// on the first attempt, and why the temp bucket is here.
+func TestMPCObservatoriesNeedsDownloadConsent(t *testing.T) {
+	testutil.RequireReachable(t, "www.minorplanetcenter.net:443")
+
+	t.Cleanup(remote.Reset)
+	remote.Reset() // no EnableDownloads
+
+	remote.SetDataDir("file:///" + filepath.ToSlash(t.TempDir()) + "?create_dir=true")
+
+	// The parsed list is process-wide, so a previous test in this package may
+	// already hold it; clearing it is what makes the fetch happen at all.
+	mpcCache.mu.Lock()
+	mpcCache.list = nil
+	mpcCache.mu.Unlock()
+
+	t.Cleanup(func() {
+		mpcCache.mu.Lock()
+		mpcCache.list = nil
+		mpcCache.mu.Unlock()
+	})
+
+	_, err := MPCObservatories(context.Background())
+	if !errors.Is(err, remote.ErrDownloadDenied) {
+		t.Fatalf("err = %v, want remote.ErrDownloadDenied without EnableDownloads", err)
+	}
+
+	// And the same empty bucket must work once consent is granted, or the
+	// assertion above would hold for a test that had simply broken the cache
+	// directory — a denial produced by the fixture rather than by the gate.
+	remote.EnableDownloads(0, remote.MPCObsCodes)
+
+	list, err := MPCObservatories(context.Background())
+	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
+		t.Fatalf("MPCObservatories after consent: %v; the temporary cache directory "+
+			"is what failed above, not the consent gate", err)
+	}
+
+	if len(list) == 0 {
+		t.Error("consent granted and the list came back empty")
+	}
+}
+
+// TestMPCObservatoriesCoverTheLatitudesKnownSitesDoesNot is the half of #125
+// that is about the test corpus rather than the count.
+//
+// The ten hand-curated sites are all mid-latitude or tropical, so the
+// circumpolar and never-rises paths had only synthetic latitudes to run
+// against (circumpolarTestSite builds them). The register supplies real ones:
+// on 2026-09-08, 27 sites above +60N reaching EISCAT Tromso at +69.6, and two
+// below -60S — Concordia at -75.1 and Kunlun Station at -80.4 — both inside
+// the Antarctic Circle.
+//
+// Asserted as floors, since the register only grows, and asserted at all
+// because a site table with no polar entries makes a whole class of
+// observability answer untestable against anything real.
+//
+// The southern floor is two because that is what the register holds. The
+// first draft of this test said five, counted by a script that had not
+// excluded the three geocentre rows sitting at -90 by construction. The test
+// found it, which is the argument for asserting the number at all.
+func TestMPCObservatoriesCoverTheLatitudesKnownSitesDoesNot(t *testing.T) {
+	list := requireMPCList(t)
+
+	var (
+		arctic    int
+		antarctic int
+		equator   int
+		maxNorth  MPCObservatory
+		maxSouth  MPCObservatory
+	)
+
+	for _, obs := range list {
+		if obs.Location == nil {
+			continue
+		}
+
+		// The three geocentre rows sit at the pole by construction and would
+		// otherwise be counted as the most extreme site in both hemispheres.
+		switch obs.Code {
+		case "244", "248", "500":
+			continue
+		}
+
+		lat := obs.Location.Lat().Degrees()
+
+		switch {
+		case lat > 60:
+			arctic++
+		case lat < -60:
+			antarctic++
+		}
+
+		if math.Abs(lat) < 5 {
+			equator++
+		}
+
+		if maxNorth.Location == nil || lat > maxNorth.Location.Lat().Degrees() {
+			maxNorth = obs
+		}
+
+		if maxSouth.Location == nil || lat < maxSouth.Location.Lat().Degrees() {
+			maxSouth = obs
+		}
+	}
+
+	t.Logf("northernmost %s %s at %+.3f; southernmost %s %s at %+.3f",
+		maxNorth.Code, maxNorth.Name, maxNorth.Location.Lat().Degrees(),
+		maxSouth.Code, maxSouth.Name, maxSouth.Location.Lat().Degrees())
+	t.Logf("%d sites above +60, %d below -60, %d within 5 of the equator", arctic, antarctic, equator)
+
+	for _, tc := range []struct {
+		what string
+		got  int
+		want int
+	}{
+		{"sites above +60 latitude", arctic, 20},
+		{"sites below -60 latitude", antarctic, 2},
+		{"sites within 5 degrees of the equator", equator, 5},
+	} {
+		if tc.got < tc.want {
+			t.Errorf("%s: %d, want at least %d", tc.what, tc.got, tc.want)
+		}
+	}
+
+	// At least one real site inside a polar circle, which is what makes a
+	// circumpolar target circumpolar rather than merely high.
+	if maxNorth.Location.Lat().Degrees() < 66.5 && maxSouth.Location.Lat().Degrees() > -66.5 {
+		t.Errorf("no site inside either polar circle: northernmost %+.3f, southernmost %+.3f",
+			maxNorth.Location.Lat().Degrees(), maxSouth.Location.Lat().Degrees())
+	}
+}

--- a/plan/mpc_test.go
+++ b/plan/mpc_test.go
@@ -1,0 +1,417 @@
+package plan
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+)
+
+// mpcFixture is a verbatim excerpt of the IAU Minor Planet Center's
+// ObsCodes.html, fetched 2026-09-08, kept as a literal rather than a checked-in
+// file for the same reason the fuzz corpora are (see CLAUDE.md): it runs as an
+// ordinary offline test and a reviewer can see the bytes being parsed.
+//
+// The rows are chosen for what each one breaks:
+//
+//   - 000, 568, 950 — space-separated, five-decimal constants. The ordinary case.
+//   - 005, 309, 474 — no separator at all between fields. "005   2.231000.659891"
+//     is longitude 2.23100, ρcosφ′ 0.659891; whitespace-splitting reads it as one
+//     number and drops the row while looking like it worked.
+//   - 250, 500 — no parallax constants: Hubble, and the geocentre.
+//   - Z99 — a lettered code, and the last row of the file.
+//   - 807 — negative ρsinφ′, southern hemisphere.
+//
+// The rows are deliberately NOT in code order. Written sorted, the fixture
+// would pass TestParseMPCObsCodesSortsByCode with the sort removed — the check
+// would be reading the input back rather than testing anything.
+const mpcFixture = `<pre>
+Code  Long.   cos      sin    Name
+Z99 359.978740.595468+0.800687Clixby Observatory, Cleethorpes
+309 289.595690.909943-0.414336Cerro Paranal
+000   0.0000 0.62411 +0.77873 Greenwich
+950 342.1176 0.87764 +0.47847 La Palma
+005   2.231000.659891+0.748875Meudon
+807 289.1941 0.86560 -0.49980 Cerro Tololo Observatory, La Serena
+250                           Hubble Space Telescope
+568 204.5278 0.94171 +0.33725 Maunakea
+474 170.464960.720773-0.691079Mount John Observatory, Lake Tekapo
+500   0.0000 0.00000 +0.00000 Geocentric
+</pre>
+`
+
+func parseFixture(t *testing.T) []MPCObservatory {
+	t.Helper()
+
+	list, err := parseMPCObsCodes(strings.NewReader(mpcFixture))
+	if err != nil {
+		t.Fatalf("parseMPCObsCodes: %v", err)
+	}
+
+	return list
+}
+
+func findObs(t *testing.T, list []MPCObservatory, code string) MPCObservatory {
+	t.Helper()
+
+	for _, o := range list {
+		if o.Code == code {
+			return o
+		}
+	}
+
+	t.Fatalf("code %q missing from the parsed list of %d", code, len(list))
+
+	return MPCObservatory{}
+}
+
+// TestParseMPCObsCodesReadsFieldsWithNoSeparator is the test that matters most
+// in this file.
+//
+// The MPC's columns are fixed-width and run together whenever a value fills its
+// field, so a third of the register looks like "005   2.231000.659891+0.748875".
+// Splitting on whitespace parses that as a single token, and the natural
+// recovery — skip the row — loses a third of the observatories silently while
+// every remaining row still checks out.
+func TestParseMPCObsCodesReadsFieldsWithNoSeparator(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	const wantRows = 10
+	if len(list) != wantRows {
+		t.Fatalf("parsed %d rows, want %d — a run-together row was dropped", len(list), wantRows)
+	}
+
+	// Meudon: longitude 2.23100 E, and a latitude near Paris's.
+	meudon := findObs(t, list, "005")
+	if meudon.Location == nil {
+		t.Fatal("005 Meudon has no position; its fields ran together and were not read")
+	}
+
+	testutil.AssertNear(t, "005 longitude", meudon.Location.Lon().Degrees(), 2.23100, 1e-5)
+	testutil.AssertNear(t, "005 latitude", meudon.Location.Lat().Degrees(), 48.805, 0.01)
+
+	if meudon.Name != "Meudon" {
+		t.Errorf("005 name = %q, want Meudon — the name column starts where the last constant ends", meudon.Name)
+	}
+}
+
+// TestParseMPCObsCodesRecoversKnownPositions checks the coordinate change
+// against sites whose real coordinates this package already holds from an
+// independent source.
+//
+// The tolerances are the measured disagreement, not a physical bound, and they
+// are loose for a documented reason: the MPC publishes parallax constants to
+// four to six decimals, and one unit in the last place of a five-decimal
+// constant is 64 m on the ground. Where the two sources disagree by more than
+// that — La Palma's 12″ — they are describing different points, the MPC coding
+// one telescope and KnownSites naming the observatory.
+func TestParseMPCObsCodesRecoversKnownPositions(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	for _, tc := range []struct {
+		code    string
+		known   string
+		latTolD float64
+		lonTolD float64
+		hTolM   float64
+	}{
+		{"000", "greenwich", 0.001, 0.001, 30},
+		{"309", "paranal", 0.001, 0.01, 30},
+		{"568", "mauna_kea", 0.001, 0.01, 100},
+		{"950", "la_palma", 0.01, 0.02, 100},
+	} {
+		t.Run(tc.code, func(t *testing.T) {
+			t.Parallel()
+
+			obs := findObs(t, list, tc.code)
+			if obs.Location == nil {
+				t.Fatalf("%s has no recovered position", tc.code)
+			}
+
+			want, ok := KnownSites[tc.known]
+			if !ok {
+				t.Fatalf("KnownSites has no %q; this test's reference is gone", tc.known)
+			}
+
+			got := obs.Location
+			ref := want.Location()
+
+			// Longitude is compared as a wrapped difference: the MPC writes
+			// east longitude in [0, 360) and coord reports it in (-180, 180],
+			// so 289.6 and -70.4 are the same meridian and a raw subtraction
+			// makes them 360 apart.
+			dLon := math.Mod(got.Lon().Degrees()-ref.Lon().Degrees()+540, 360) - 180
+
+			if math.Abs(dLon) > tc.lonTolD {
+				t.Errorf("longitude %.5f vs %.5f (KnownSites), differ by %.5f deg > %.5f",
+					got.Lon().Degrees(), ref.Lon().Degrees(), dLon, tc.lonTolD)
+			}
+
+			testutil.AssertNear(t, "latitude", got.Lat().Degrees(), ref.Lat().Degrees(), tc.latTolD)
+			testutil.AssertNear(t, "height", got.Height(), ref.Height(), tc.hTolM)
+		})
+	}
+}
+
+// TestParseMPCObsCodesKeepsPositionlessCodes covers the thirty entries that are
+// valid codes with nowhere to stand.
+//
+// Dropping them would be the easy reading of "no coordinates", and it would
+// make NewMPCSite tell a caller asking about Hubble that there is no such code
+// — which is false, and sends them looking for a typo.
+func TestParseMPCObsCodesKeepsPositionlessCodes(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	hubble := findObs(t, list, "250")
+	if hubble.Location != nil {
+		t.Errorf("250 Hubble has a position %v; the MPC publishes none", hubble.Location)
+	}
+
+	if hubble.Name != "Hubble Space Telescope" {
+		t.Errorf("250 name = %q, want Hubble Space Telescope", hubble.Name)
+	}
+
+	// The geocentre publishes constants — all zero — so it is a *positioned*
+	// row, not a positionless one. It is here to pin that the two cases are
+	// told apart by what the file says rather than by whether the position
+	// looks sensible.
+	geo := findObs(t, list, "500")
+	if geo.Location == nil {
+		t.Fatal("500 Geocentric lost its position; its constants are present and zero")
+	}
+}
+
+// TestParseMPCObsCodesRejectsAnEmptyDocument covers the failure a truncated or
+// redirected fetch produces.
+//
+// A successful parse of a document with no rows is indistinguishable from a
+// register that has none, and the second cannot happen. Returning an empty list
+// would make every subsequent lookup answer ErrUnknownSite — a wrong answer
+// delivered with confidence, rather than a fetch problem.
+func TestParseMPCObsCodesRejectsAnEmptyDocument(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"empty", ""},
+		{"wrapper only", "<pre>\nCode  Long.   cos      sin    Name\n</pre>\n"},
+		{"an HTML error page", "<html><head><title>404</title></head></html>\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseMPCObsCodes(strings.NewReader(tc.body))
+			if !errors.Is(err, ErrNoMPCObservatories) {
+				t.Errorf("err = %v, want ErrNoMPCObservatories", err)
+			}
+		})
+	}
+}
+
+// TestParseMPCObsCodesRejectsAMalformedRow pins that a row with a broken number
+// fails the whole parse rather than disappearing from the list.
+//
+// A dropped row is the worse outcome: the register is the authority on which
+// codes exist, so an observatory missing from it reads as an observatory that
+// does not exist.
+func TestParseMPCObsCodesRejectsAMalformedRow(t *testing.T) {
+	t.Parallel()
+
+	broken := strings.Replace(mpcFixture,
+		"000   0.0000 0.62411 +0.77873 Greenwich",
+		"000   0.0000 0.6x411 +0.77873 Greenwich", 1)
+
+	_, err := parseMPCObsCodes(strings.NewReader(broken))
+	if !errors.Is(err, ErrMalformedMPCRow) {
+		t.Fatalf("err = %v, want ErrMalformedMPCRow", err)
+	}
+
+	if !strings.Contains(err.Error(), "000") {
+		t.Errorf("err = %v, want the offending code in the message", err)
+	}
+}
+
+// TestParseMPCObsCodesSortsByCode pins the documented order, which is what
+// makes the list usable for a binary search or a stable display.
+func TestParseMPCObsCodesSortsByCode(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	for i := 1; i < len(list); i++ {
+		if list[i-1].Code >= list[i].Code {
+			t.Fatalf("codes out of order at %d: %q then %q", i, list[i-1].Code, list[i].Code)
+		}
+	}
+}
+
+// TestLookupMPCSiteTellsTheThreeOutcomesApart is the error-vs-absence check for
+// this lookup.
+//
+// "There is no such code" and "that code names something that is not on Earth"
+// are different facts, and only one of them means the caller made a mistake. A
+// single ErrUnknownSite for both sends someone hunting for a typo in "250",
+// which is Hubble and is spelled correctly.
+func TestLookupMPCSiteTellsTheThreeOutcomesApart(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	t.Run("a site on the ground", func(t *testing.T) {
+		t.Parallel()
+
+		site, err := lookupMPCSite(list, "568")
+		testutil.AssertNoError(t, err)
+
+		if site.MPCCode() != "568" {
+			t.Errorf("MPCCode = %q, want 568 — a site built this way must say where it came from", site.MPCCode())
+		}
+
+		if site.Name() != "Maunakea" {
+			t.Errorf("Name = %q, want the MPC's own designation", site.Name())
+		}
+
+		if site.Location() == nil {
+			t.Fatal("site has no location")
+		}
+	})
+
+	t.Run("a code with no ground position", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := lookupMPCSite(list, "250")
+		if !errors.Is(err, ErrSiteNotOnEarth) {
+			t.Fatalf("err = %v, want ErrSiteNotOnEarth", err)
+		}
+
+		if errors.Is(err, ErrUnknownSite) {
+			t.Error("a valid code reported as unknown; the caller would go looking for a typo")
+		}
+
+		if !strings.Contains(err.Error(), "Hubble") {
+			t.Errorf("err = %v, want the site's name so the caller can see what they asked for", err)
+		}
+	})
+
+	t.Run("a code that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := lookupMPCSite(list, "ZZZ")
+		if !errors.Is(err, ErrUnknownSite) {
+			t.Fatalf("err = %v, want ErrUnknownSite", err)
+		}
+
+		if errors.Is(err, ErrSiteNotOnEarth) {
+			t.Error("an unknown code reported as a valid one with no position")
+		}
+	})
+}
+
+// TestLookupMPCSiteNormalizesTheCode covers the spellings a caller actually
+// types. MPC codes are printed lowercase in plenty of places and arrive with
+// stray spaces from configuration files.
+func TestLookupMPCSiteNormalizesTheCode(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	for _, spelling := range []string{"Z99", "z99", " Z99 ", "\tz99\n"} {
+		site, err := lookupMPCSite(list, spelling)
+		if err != nil {
+			t.Errorf("lookupMPCSite(%q): %v", spelling, err)
+
+			continue
+		}
+
+		if site.MPCCode() != "Z99" {
+			t.Errorf("lookupMPCSite(%q) resolved to %q, want Z99", spelling, site.MPCCode())
+		}
+	}
+}
+
+// TestLookupMPCSiteLeavesTheTimeZoneUnset pins a deliberate omission.
+//
+// The MPC list has no time-zone column, and deriving one from a longitude is
+// wrong across most of the world — every country that does not use its
+// nautical zone, which is most of them. A Site defaulting to UTC is honest
+// about knowing nothing; a Site claiming UTC-5 for a site in Peru is not.
+func TestLookupMPCSiteLeavesTheTimeZoneUnset(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	site, err := lookupMPCSite(list, "807")
+	testutil.AssertNoError(t, err)
+
+	if got := site.TimeZone().String(); got != "UTC" {
+		t.Errorf("TimeZone = %q, want UTC — the MPC list carries no zone to read", got)
+	}
+}
+
+// TestMPCObservatoryResolutionTracksThePublishedDecimals covers the field that
+// exists so a caller can tell a 3-metre row from a 3-kilometre one.
+//
+// The register mixes both — 1,322 rows at six decimals and 38 at three — and
+// nothing in a recovered latitude and height says which you are holding. A
+// resolution that did not track the decimals would be worse than none: it would
+// look like a guarantee.
+func TestMPCObservatoryResolutionTracksThePublishedDecimals(t *testing.T) {
+	t.Parallel()
+
+	list := parseFixture(t)
+
+	// Half a unit in the last place, scaled by the equatorial radius:
+	// 6 decimals -> 0.0000005 * 6378137 m = 3.2 m, and a factor of ten per
+	// decimal below that.
+	for _, tc := range []struct {
+		code  string
+		wantM float64
+	}{
+		{"005", 3.19},  // 0.659891 / +0.748875 — six decimals
+		{"000", 31.89}, // 0.62411 / +0.77873  — five
+		{"568", 31.89}, // 0.94171 / +0.33725  — five
+		{"Z99", 3.19},  // 0.595468 / +0.800687 — six
+	} {
+		obs := findObs(t, list, tc.code)
+		testutil.AssertNear(t, tc.code+" ResolutionM", obs.ResolutionM, tc.wantM, 0.01)
+	}
+
+	// A row with no constants has no resolution to report, and zero is the
+	// honest answer rather than the finest one.
+	if got := findObs(t, list, "250").ResolutionM; got != 0 {
+		t.Errorf("250 Hubble ResolutionM = %v, want 0 — it publishes no constants", got)
+	}
+}
+
+// TestMPCResolutionTakesTheCoarserConstant pins that a row whose two constants
+// disagree in precision is reported at the worse of them.
+//
+// Taking the finer would describe a position by its better half, which is the
+// direction that overstates what is known.
+func TestMPCResolutionTakesTheCoarserConstant(t *testing.T) {
+	t.Parallel()
+
+	// Six decimals of longitude-side constant against three of the other.
+	mixed := "007   2.336750.659470+0.749   Mixed precision\n"
+
+	list, err := parseMPCObsCodes(strings.NewReader("<pre>\n" + mixed + "</pre>\n"))
+	testutil.AssertNoError(t, err)
+
+	if len(list) != 1 {
+		t.Fatalf("parsed %d rows, want 1", len(list))
+	}
+
+	// 3 decimals: 0.0005 * 6378137 m = 3189 m, not the 3.19 m the six-decimal
+	// constant on its own would claim.
+	testutil.AssertNear(t, "ResolutionM", list[0].ResolutionM, 3189.07, 0.1)
+}

--- a/remote/endpoint.go
+++ b/remote/endpoint.go
@@ -102,6 +102,10 @@ const (
 	// fixed commit so catalog/openngc's fetch is reproducible.
 	OpenNGC EndpointID = "openngc.github"
 
+	// MPCObsCodes is the IAU Minor Planet Center's observatory-code list,
+	// used by plan.NewMPCSite to resolve a code to an observing site.
+	MPCObsCodes EndpointID = "mpc.obscodes"
+
 	// Nominatim is OpenStreetMap's Nominatim geocoding API, used by
 	// plan.NewSiteEarthAddress to resolve an address to coordinates.
 	Nominatim EndpointID = "osm.nominatim"
@@ -576,6 +580,26 @@ func defaultEndpoints() map[EndpointID]Endpoint {
 			Mutable:         true,
 			Downloadable:    true,
 			Files:           []string{"NGC.csv", "addendum.csv"},
+		},
+		MPCObsCodes: {
+			ID:        MPCObsCodes,
+			URL:       "https://www.minorplanetcenter.net/iau/lists/",
+			Kind:      KindFile,
+			Subsystem: "plan",
+			Description: "IAU Minor Planet Center observatory-code list — code, longitude " +
+				"and the two parallax constants for ~2,700 sites",
+			ApproxSize:      200_000,
+			Enabled:         true,
+			DownloadTimeout: 2 * time.Minute,
+			// New codes are assigned continuously and existing rows are
+			// revised as sites are resurveyed, so a cached copy is
+			// revalidated rather than reused on existence alone.
+			Mutable:      true,
+			Downloadable: true,
+			// ObsCodes.html is the plain list; the .html suffix is the MPC's
+			// name for it, not a description of the content — the body is a
+			// fixed-width table inside a single <pre> element.
+			Files: []string{"ObsCodes.html"},
 		},
 		Nominatim: {
 			ID:          Nominatim,

--- a/remote/registry.go
+++ b/remote/registry.go
@@ -339,6 +339,8 @@ func constName(id EndpointID) string {
 		return "FINK"
 	case OpenNGC:
 		return "OpenNGC"
+	case MPCObsCodes:
+		return "MPCObsCodes"
 	case Nominatim:
 		return "Nominatim"
 	case OpenElevation:

--- a/remote/registry_test.go
+++ b/remote/registry_test.go
@@ -221,6 +221,7 @@ func TestDownloadableEndpointsAreExactlyTheExpectedSet(t *testing.T) {
 		NAIFLSK:               true,
 		NAIFPCK:               true,
 		OpenNGC:               true,
+		MPCObsCodes:           true,
 		JPLHorizonsSPK:        true,
 		VIIRSAnnual:           true,
 		CopernicusEODATA:      true,


### PR DESCRIPTION
Closes #125.

`plan.KnownSites` had ten entries. The IAU Minor Planet Center publishes the
register every asteroid and comet observation is reported against, and `Site`
already stored MPC codes, so the schema work was done.

```go
remote.EnableDownloads(1<<20, remote.MPCObsCodes)

site, err := plan.NewMPCSite(ctx, "568")     // Maunakea
list, err := plan.MPCObservatories(ctx)      // all 2,722, sorted by code
```

New `remote.MPCObsCodes` endpoint, ~150 KB, download-gated and lazily fetched
like every other bulk source. Nothing embedded, nothing checked in.

## The list does not contain what it looks like it contains

The MPC publishes no latitude and no height. It publishes the longitude and the
two parallax constants ρcosφ′ and ρsinφ′ that an observation reduction actually
needs — and those two *are* the cylindrical coordinates of the site in the
terrestrial frame. So recovering a geodetic position is a coordinate change
through `coord.FromECEF`, not an inversion: nothing iterated, nothing
approximated here, and no new geodesy in this PR.

Recovering it is exact. **The input is not, and it is not equally imprecise
from row to row** — which is the part a caller cannot see, because a recovered
height looks the same either way. Measured over the 2,689 positioned
non-geocentre rows:

| decimals | rows | height good to | measured range |
| ---: | ---: | ---: | :--- |
| 6 | 1,317 | ±3 m | −33 m … +5,351 m |
| 5 | 1,244 | ±32 m | −207 m … +4,212 m |
| 4 | 90 | ±319 m | −361 m … +3,852 m |
| 3 | 38 | ±3.2 km | −9,254 m … +9,614 m |

`507 Nyenheim` recovers to **−6,655 m**. That is not a defect in this code or
in the MPC's: it is a site near sea level published to three decimals, and
−6.6 km is two units in its last place. 95% of the register lands inside a
kilometre of sea level and six of the summit of Everest; every outlier is in
the two coarse buckets and inside its own quantisation.

`MPCObservatory.ResolutionM` carries that per row, so the two regimes can be
told apart. It is the same complaint #182 makes about SGP4 — a result that does
not say which accuracy regime produced it — answered before it can be filed
again.

Against the hand-curated ten, the six-decimal rows agree to 0.04″ in latitude
and 2 m in height. The larger disagreements are real and are not this code's:
the MPC codes one specific telescope where the curated entry names the
observatory.

## Parsing: the columns run together

```
000   0.0000 0.62411 +0.77873 Greenwich
005   2.231000.659891+0.748875Meudon
```

The fields are fixed-width with no separator whenever a value fills its field.
Splitting on whitespace reads row 005 as a single number, and the natural
recovery — skip the row — **loses a third of the register while every remaining
row still checks out**. Parsed by column, and:

- a row whose numbers do not parse fails the whole load rather than vanishing
  from it, because the register is the authority on which codes exist and a
  missing observatory reads as a nonexistent one;
- an empty parse is `ErrNoMPCObservatories`, not an empty list — a truncated or
  redirected fetch would otherwise make every lookup answer "unknown code" with
  complete confidence;
- markup is told from data by what a code *cannot* contain rather than by the
  shape today's codes have, so the first code issued outside `[0-9A-Z][0-9][0-9]`
  is not silently dropped.

## Three outcomes, not two

Thirty codes have no ground position: Hubble, Gaia, JWST, SOHO, Spitzer, and
the roving-observer placeholders. They are *valid codes*, so `NewMPCSite`
answers `ErrSiteNotOnEarth`, not `ErrUnknownSite` — telling someone "250" is
not a code sends them hunting for a typo in a spelling that is correct.

Three further rows (244, 248, 500) publish constants that are exactly zero,
which is the geocentre, and are reported as given. Deciding the centre of the
Earth is not a place would be this package inventing a policy the MPC did not
write down; it is documented instead.

## The corpus half of #125

The issue also asked for latitudes the curated ten do not reach. The register
supplies real, named, provenanced ones: **27 sites above +60°N**, reaching
EISCAT Tromsø at +69.6°, and two below −60°S — Concordia at −75.1° and Kunlun
Station at −80.4°, both inside the Antarctic Circle. Circumpolar and
never-rises now have somewhere real to run.

That assertion earned its place immediately: my first draft claimed five
southern sites, from a script that had not excluded the three geocentre rows
sitting at −90° by construction. The test caught it.

## Tests

Offline tests run against a ten-row verbatim excerpt, chosen for what each row
breaks (run-together fields, positionless codes, a lettered code, a southern
site, the geocentre) and written **out of code order**, so the sort assertion
is testing the sort rather than reading its input back.

Fourteen mutants, all killed:

| mutant | killed by |
| --- | --- |
| split the columns on whitespace | `ReadsFieldsWithNoSeparator` |
| drop rows with no parallax constants | `KeepsPositionlessCodes` |
| accept an empty parse | `RejectsAnEmptyDocument` |
| skip a malformed row instead of failing | `RejectsAMalformedRow` |
| leave the list unsorted | `SortsByCode` |
| treat markup as data | `RejectsAnEmptyDocument` |
| swap sin and cos in the ECEF vector | `RecoversKnownPositions` |
| build z from ρcosφ′ | `RecoversKnownPositions` |
| take the finer of the two constants | `ResolutionTakesTheCoarserConstant` |
| a full unit in the last place, not half | `ResolutionTracksThePublishedDecimals` |
| report a positionless code as unknown | `TellsTheThreeOutcomesApart` |
| skip case/space normalisation | `NormalizesTheCode` |
| omit the MPC code from the built Site | `TellsTheThreeOutcomesApart` |
| drop the `Description` guard *(equivalent)* | — |

The consent test points the cache at an empty temporary bucket, which is the
point rather than tidiness: consent gates the *download*, not reading something
already cached, so against a warm cache it passed with the gate removed. It now
also confirms the same empty bucket works once consent is granted, so a denial
produced by a broken fixture cannot masquerade as the gate working.

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation" ./...`,
`go test ./...`, `go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go test -tags=network ./plan/` against the live MPC,
and `golangci-lint run --build-tags="integration,network,validation"` — all clean.
