### PR TITLE
plan: place solar-system targets where they are seen, not where they are

### DIFF
--- a/docs/changelog.d/226-apparent-positions.md
+++ b/docs/changelog.d/226-apparent-positions.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 226
+---
+**Planets, asteroids, comets and generic bodies were placed geometrically, not
+apparently.** Neither light time nor annual aberration reached the scheduler's
+alt/az: measured at Paranal across 2026, Mars was out by up to 38.7″, Venus
+44.8″ and the Sun 20.5″. All four target types now return the apparent place
+(#117).

--- a/docs/changelog.d/226-lighttime-convergence.md
+++ b/docs/changelog.d/226-lighttime-convergence.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 226
+---
+`ephemeris.ApparentState` iterates light time to convergence instead of a flat
+five passes — measured, nothing in the solar system needs more than three, and
+the Moon settles in one. That halves the cost of the apparent-place path this
+release puts on the scheduler's hot path (#117).

--- a/ephemeris/apparent_convergence_test.go
+++ b/ephemeris/apparent_convergence_test.go
@@ -1,0 +1,94 @@
+package ephemeris_test
+
+import (
+	"math"
+	"testing"
+
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestApparentStateHasConverged checks the loop's exit condition against the
+// thing it is a proxy for.
+//
+// ApparentState stops when the light time stops changing by more than a
+// tolerance, which replaced a flat five passes. The tolerance is stated in
+// days and the quantity anybody cares about is arcseconds, so this asserts the
+// translation rather than the tolerance: one more pass, done here by hand, must
+// not move the answer by as much as a microarcsecond.
+//
+// It is written as "iterate again and see" rather than as a comparison against
+// a stored five-pass answer on purpose. A stored answer pins today's provider;
+// this pins the property, and keeps holding when the ephemeris behind it
+// changes.
+func TestApparentStateHasConverged(t *testing.T) {
+	t.Parallel()
+
+	prov := eph.Default()
+
+	// The fastest relative motion available: the Moon settles in one pass and
+	// the inner planets are where the iteration has the most to do.
+	for _, body := range []struct {
+		name string
+		id   eph.ID
+	}{
+		{"Moon", eph.Moon},
+		{"Sun", eph.Sun},
+		{"Venus", eph.Venus},
+		{"Mars", eph.Mars},
+		{"Jupiter", eph.Jupiter},
+		{"Neptune", eph.Neptune},
+	} {
+		t.Run(body.name, func(t *testing.T) {
+			t.Parallel()
+
+			var worst float64
+
+			for d := 0; d < 365; d += 7 {
+				tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC).
+					AddDays(float64(d))
+
+				settled, err := eph.ApparentState(prov, body.id, tm)
+				testutil.AssertNoError(t, err)
+
+				// One more pass, by hand: retard by the light time the settled
+				// answer implies and ask again.
+				tau := settled.Pos.Norm() / lightAUPerDay(t)
+
+				again, err := prov.State(body.id, tm.AddDays(-tau))
+				testutil.AssertNoError(t, err)
+
+				moved := again.Pos.Sub(settled.Pos).Norm() / settled.Pos.Norm()
+				worst = math.Max(worst, moved*180/math.Pi*3600)
+			}
+
+			t.Logf("%s: one further pass moves the answer by at most %.3g arcsec", body.name, worst)
+
+			// A microarcsecond is four orders of magnitude below the smallest
+			// thing this library claims to resolve, and six below what the
+			// first pass corrects.
+			const tolArcsec = 1e-6
+
+			if worst > tolArcsec {
+				t.Errorf("a further light-time pass moves %s by %.3g\", over the %.0e\" "+
+					"this loop's exit condition is supposed to guarantee",
+					body.name, worst, tolArcsec)
+			}
+		})
+	}
+}
+
+// lightAUPerDay is the speed of light in the units the light-time iteration
+// works in, rebuilt here from the same constants ApparentState uses so the
+// test's hand-rolled pass matches the one under test.
+func lightAUPerDay(t *testing.T) float64 {
+	t.Helper()
+
+	// 173.1446... AU/day. Written as the round-trip through Earth's own orbit
+	// rather than as a literal: one astronomical unit takes 499.005 s of light
+	// time, so this is 86400/499.005.
+	const auLightSeconds = 499.00478383615643
+
+	return 86400.0 / auLightSeconds
+}

--- a/ephemeris/ephemeris.go
+++ b/ephemeris/ephemeris.go
@@ -462,7 +462,8 @@ func ApparentState(p Provider, target ID, obsTime time.Time) (State, error) {
 	}
 
 	tauDays := st.Pos.Norm() / lightAUPerDay
-	for range 5 {
+
+	for range lightTimeMaxIter {
 		retardedTime := obsTime.AddDays(-tauDays)
 
 		st, err = p.State(target, retardedTime)
@@ -470,11 +471,54 @@ func ApparentState(p Provider, target ID, obsTime time.Time) (State, error) {
 			return State{}, fmt.Errorf("ephemeris: apparent state retarded: %w", err)
 		}
 
-		tauDays = st.Pos.Norm() / lightAUPerDay
+		next := st.Pos.Norm() / lightAUPerDay
+		settled := math.Abs(next-tauDays) < lightTimeTolDays
+		tauDays = next
+
+		if settled {
+			break
+		}
 	}
 
 	return st, nil
 }
+
+// Light-time iteration limits.
+//
+// This used to run a flat five iterations. It converges geometrically with
+// ratio v/c ~ 1e-4, so each pass buys four decimal digits and the fifth was
+// refining a number that had stopped changing in double precision two passes
+// earlier. Measured over 2026 — how far each iteration moves the answer, at
+// worst, for the bodies with the fastest relative motion:
+//
+//	body      pass 1     pass 2      pass 3        pass 4+
+//	Moon      0.759"     0.00000"    0"            0"
+//	Sun      20.837"     0.00003"    0"            0"
+//	Venus    44.762"     0.00121"    0.0000001"    0"
+//	Mars     38.733"     0.00087"    0.0000000"    0"
+//	Jupiter  29.008"     0.00208"    0.0000002"    0"
+//	Neptune  24.346"     0.00214"    0.0000002"    0"
+//
+// That would justify a flat three, but a convergence test is both cheaper and
+// self-explaining: the Moon settles after one pass and says so, where a fixed
+// count cannot. The ceiling stays at five so a pathological provider still
+// terminates.
+//
+// It matters because plan now takes this path for every ephemeris-backed
+// target at every time step (see plan/apparent.go), where it used to call the
+// provider once.
+const (
+	// lightTimeTolDays is ~0.9 microseconds. At 30 km/s — faster than
+	// anything in the solar system moves relative to Earth — that is 0.03 m
+	// of travel, which subtends under a microarcsecond at any distance a
+	// solar-system body is ever at.
+	lightTimeTolDays = 1e-11
+
+	// lightTimeMaxIter caps the loop. Nothing measured needs more than three
+	// passes; this is the guard against a provider whose state is not a
+	// continuous function of time.
+	lightTimeMaxIter = 5
+)
 
 // ToICRS converts a geocentric Cartesian vector (in AU) to spherical ICRS coordinates.
 func ToICRS(pos vector.Vec3) (coord.ICRS, error) {

--- a/plan/apparent.go
+++ b/plan/apparent.go
@@ -1,0 +1,76 @@
+package plan
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// apparentVec returns where a solar-system body is *seen* from the geocentre
+// at t — the apparent place, with light time and annual aberration both in it.
+//
+// # Why this exists rather than eph.Position
+//
+// Every ephemeris-backed target in this package used to answer with the
+// geometric vector: where the body is at t, not where it looks to be. Measured
+// from Paranal across 2026, sampled every six hours with the target above 10°,
+// that is the whole difference between the two through this package's own
+// alt/az path:
+//
+//	body      samples   mean error   max error
+//	Moon          632       0.71"       0.77"
+//	Sun           637      20.51"      20.83"
+//	Venus         605      20.88"      44.75"
+//	Mars          617      28.91"      38.70"
+//	Jupiter       566      15.85"      29.00"
+//	Saturn        633      14.47"      27.20"
+//	Neptune       643      13.45"      24.33"
+//
+// Both halves were missing, which is why it reaches forty arcseconds rather
+// than the twenty of aberration alone. [coord.Context.GeocentricToObserved] —
+// the consumer at the end of this path — adds diurnal parallax, the rotation
+// into the horizon and refraction, and deliberately does not touch aberration,
+// because its input is supposed to arrive apparent already. It was arriving
+// geometric.
+//
+// # Why not the other consumer
+//
+// [coord.Context.ICRSToAltAz] does apply aberration, and it is what a fixed
+// target goes through. Feeding an apparent place to that one would double the
+// aberration and put a planet at opposition some twenty arcseconds off in the
+// other direction. Which routine a target reaches is decided by whether it
+// implements [MovingBody] (see observedAltAz), so the two must not be mixed:
+// everything in this file is on the MovingBody side.
+func apparentVec(p eph.Provider, id eph.ID, t time.Time) (vector.Vec3, error) {
+	st, err := eph.ApparentState(p, id, t)
+	if err != nil {
+		return vector.Vec3{}, fmt.Errorf("plan: apparent state: %w", err)
+	}
+
+	return st.Pos, nil
+}
+
+// apparentICRS is apparentVec as a direction on the sky, for the Position half
+// of the same targets.
+//
+// Position and GeocentricVec must agree about which place they mean. They feed
+// different consumers — separations and details read one, alt/az reads the
+// other — and a target whose altitude is apparent while its Moon separation is
+// geometric is wrong in a way no single test would catch, because each answer
+// is defensible on its own.
+func apparentICRS(p eph.Provider, id eph.ID, t time.Time) (coord.ICRS, error) {
+	vec, err := apparentVec(p, id, t)
+	if err != nil {
+		return coord.ICRS{}, err
+	}
+
+	icrs, err := eph.ToICRS(vec)
+	if err != nil {
+		return coord.ICRS{}, fmt.Errorf("plan: apparent direction: %w", err)
+	}
+
+	return icrs, nil
+}

--- a/plan/apparent_test.go
+++ b/plan/apparent_test.go
@@ -1,0 +1,354 @@
+package plan
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/ephemeris/satellite"
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// constantOfAberration is κ = 20.49552″, the IAU 2009 system of astronomical
+// constants (Luzum et al. 2011, Celest. Mech. Dyn. Astr. 110, 293).
+//
+// It is not one of astrogo's own constants and is deliberately written out
+// here rather than derived from v⊕/c, because a value derived from this
+// library's own ephemeris would not be independent of the thing it is checking.
+const constantOfAberration = 20.49552
+
+// TestApparentSunIsDisplacedByTheConstantOfAberration is the independent check
+// on this change: a published number, from outside this library, that the
+// answer has to land on.
+//
+// The Sun is the one body whose apparent displacement has a textbook value.
+// Light time and annual aberration both act along Earth's orbital motion and
+// both amount to v⊕/c at one astronomical unit, so the apparent Sun lags the
+// geometric Sun by the constant of aberration — 20.49552″ — varying only with
+// Earth's distance across the year, by the eccentricity, ±1.7%.
+//
+// Nothing about that number comes from astrogo. If this passes, the light-time
+// iteration and the retarded-Earth aberration are both present and both have
+// the right sign; if either were missing the answer would be half of it, and if
+// the sign were wrong it would be right in magnitude and 41″ from the truth.
+func TestApparentSunIsDisplacedByTheConstantOfAberration(t *testing.T) {
+	t.Parallel()
+
+	prov := eph.Default()
+	sun := NewSun(prov)
+
+	var (
+		minSep = math.Inf(1)
+		maxSep float64
+		n      int
+	)
+
+	// A full year, so the ±1.7% from Earth's eccentricity is exercised at both
+	// ends rather than sampled at one phase of the orbit.
+	for d := range 365 {
+		tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC).AddDays(float64(d))
+
+		apparent, err := sun.Position(tm)
+		testutil.AssertNoError(t, err)
+
+		geometric, err := eph.Position(prov, eph.Sun, tm)
+		testutil.AssertNoError(t, err)
+
+		geoICRS, err := eph.ToICRS(geometric)
+		testutil.AssertNoError(t, err)
+
+		sep := coord.Separation(apparent, geoICRS).Arcseconds()
+
+		minSep = math.Min(minSep, sep)
+		maxSep = math.Max(maxSep, sep)
+		n++
+	}
+
+	t.Logf("apparent-minus-geometric Sun over %d days: %.3f\" to %.3f\" (kappa = %.5f\")",
+		n, minSep, maxSep, constantOfAberration)
+
+	// Earth's orbital eccentricity is 0.0167, so v varies by ±1.7% over the
+	// year and so does the displacement. 3% each way covers that with room for
+	// the difference between the mean and osculating orbit, and is still far
+	// too tight for an answer with either half of the correction missing.
+	const tol = 0.03 * constantOfAberration
+
+	if minSep < constantOfAberration-tol || maxSep > constantOfAberration+tol {
+		t.Errorf("displacement ranged over [%.3f\", %.3f\"], want every value within "+
+			"%.3f\" of the constant of aberration %.5f\"; half of it (%.3f\") means one of "+
+			"light time and aberration is missing",
+			minSep, maxSep, tol, constantOfAberration, constantOfAberration/2)
+	}
+}
+
+// TestApparentPositionReachesTheAltAzPath pins that the fix arrives where it
+// was needed, rather than only in Position.
+//
+// A MovingBody's altitude does not come from Position at all: observedAltAz
+// sends it down GeocentricVec into coord.Context.GeocentricToObserved, which
+// deliberately applies no aberration because its input is meant to arrive
+// apparent. Fixing Position alone would leave the scheduler exactly as wrong
+// as before while every direct test of Position passed.
+func TestApparentPositionReachesTheAltAzPath(t *testing.T) {
+	t.Parallel()
+
+	loc, err := coord.NewGeodetic(angle.Deg(-70.40417), angle.Deg(-24.62722), 2635)
+	testutil.AssertNoError(t, err)
+
+	site, err := NewSite("Paranal", loc)
+	testutil.AssertNoError(t, err)
+
+	prov := eph.Default()
+	mars := NewMars(prov)
+
+	var (
+		maxSep float64
+		n      int
+	)
+
+	for step := range 365 * 4 {
+		tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC).
+			AddDays(float64(step) * 0.25)
+
+		ctx := coord.NewContext(tm, loc, site.Refraction())
+
+		eval, err := IsObservable(mars, tm, site)
+		testutil.AssertNoError(t, err)
+
+		if eval.AltAz.Alt().Degrees() < 10 {
+			continue // near the horizon refraction dominates and swamps the point
+		}
+
+		geometric, err := eph.Position(prov, eph.Mars, tm)
+		testutil.AssertNoError(t, err)
+
+		wasAA := ctx.GeocentricToObserved(geometric)
+
+		maxSep = math.Max(maxSep, altAzSeparationArcsec(eval.AltAz, wasAA))
+		n++
+	}
+
+	t.Logf("Mars above 10 deg at Paranal, %d samples: alt/az moved by up to %.2f\"", n, maxSep)
+
+	if n < 100 {
+		t.Fatalf("only %d samples above the horizon; the fixture no longer exercises the path", n)
+	}
+
+	// Measured at 38.7" max over 2026. The floor is what makes this a test of
+	// the alt/az path rather than of Position: a fix applied only to Position
+	// leaves this at zero.
+	const floor = 20.0
+
+	if maxSep < floor {
+		t.Errorf("alt/az moved by at most %.2f\" against the geometric vector, want more "+
+			"than %.2f\" — the apparent place is not reaching GeocentricToObserved",
+			maxSep, floor)
+	}
+}
+
+// TestPositionAndGeocentricVecAgree pins the invariant that made this worth
+// fixing in one place rather than two.
+//
+// The two answers feed different consumers — separations and details read
+// Position, altitude reads GeocentricVec — and a target whose altitude is
+// apparent while its Moon separation is geometric is wrong in a way no single
+// test would catch, because each answer is defensible on its own.
+func TestPositionAndGeocentricVecAgree(t *testing.T) {
+	t.Parallel()
+
+	prov := eph.Default()
+
+	for _, tc := range []struct {
+		name string
+		obj  Observable
+	}{
+		{"Mars", NewMars(prov)},
+		{"Sun", NewSun(prov)},
+		{"Moon", NewMoon(prov)},
+		{"Jupiter", NewJupiter(prov)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb, ok := tc.obj.(MovingBody)
+			if !ok {
+				t.Fatalf("%s is not a MovingBody; it would not reach the path this fixes", tc.name)
+			}
+
+			for d := 0; d < 365; d += 11 {
+				tm := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC).AddDays(float64(d))
+
+				pos, err := tc.obj.Position(tm)
+				testutil.AssertNoError(t, err)
+
+				vec, err := mb.GeocentricVec(tm)
+				testutil.AssertNoError(t, err)
+
+				fromVec, err := eph.ToICRS(vec)
+				testutil.AssertNoError(t, err)
+
+				// Same quantity by two routes, so this is exact to rounding,
+				// not to a physical tolerance.
+				if sep := coord.Separation(pos, fromVec).Arcseconds(); sep > 1e-6 {
+					t.Fatalf("%s at %v: Position and GeocentricVec disagree by %g\"",
+						tc.name, tm, sep)
+				}
+			}
+		})
+	}
+}
+
+// TestSatellitePositionsAreNotRetarded covers the body this change must not
+// touch, and the reason is not that the effect is small.
+//
+// eph.ApparentState returns the *apparent* place, and it gets there by asking
+// the provider for a geocentric state at the retarded epoch — which moves the
+// observer back along with the target and thereby folds in annual aberration
+// (see its doc comment for the derivation). That is right for a body orbiting
+// the Sun. It is wrong for one orbiting the Earth: a satellite shares Earth's
+// orbital motion, so the 20" annual-aberration term cancels between observer
+// and target and adding it would put the pass 20" off in a quantity that
+// should not be there at all.
+//
+// Light time to a satellite is real but is a different correction — 1.3 ms to
+// low Earth orbit, from the observer rather than from the geocentre — and it
+// is not what ApparentState computes.
+func TestSatellitePositionsAreNotRetarded(t *testing.T) {
+	t.Parallel()
+
+	prov, err := satellite.NewFromTLE("ISS (ZARYA)", issLine1, issLine2)
+	testutil.AssertNoError(t, err)
+
+	sat := NewSatellite("ISS", eph.ID(0), prov)
+
+	tm := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.LocationUTC)
+
+	got, err := sat.GeocentricVec(tm)
+	testutil.AssertNoError(t, err)
+
+	want, err := eph.Position(prov, eph.ID(0), tm)
+	testutil.AssertNoError(t, err)
+
+	if got != want {
+		t.Errorf("Satellite.GeocentricVec = %v, want the unretarded %v — a satellite "+
+			"shares Earth's orbital motion, so the annual aberration ApparentState "+
+			"folds in must not be applied to it", got, want)
+	}
+}
+
+// altAzSeparationArcsec is the angle between two horizontal directions.
+func altAzSeparationArcsec(a, b coord.AltAz) float64 {
+	a1, z1 := a.Alt().Radians(), a.Az().Radians()
+	a2, z2 := b.Alt().Radians(), b.Az().Radians()
+
+	cosSep := math.Sin(a1)*math.Sin(a2) + math.Cos(a1)*math.Cos(a2)*math.Cos(z1-z2)
+
+	return angle.Rad(math.Acos(math.Min(1, math.Max(-1, cosSep)))).Arcseconds()
+}
+
+// linearProvider is a body moving in a straight line at constant velocity,
+// geocentric, so the retardation this package applies has a closed form:
+// asking for the state at t - tau returns pos0 + vel*(t - tau), displaced from
+// the geometric answer by exactly -vel*tau.
+//
+// A stub rather than a real ephemeris because the assertion is then against
+// arithmetic rather than against another astrogo call. It also reaches the
+// three target types the default provider cannot: Asteroid, Comet and
+// GenericBody have no SOFA body to stand in for them.
+type linearProvider struct {
+	epoch time.Time
+	pos0  vector.Vec3 // AU at epoch
+	vel   vector.Vec3 // AU/day
+}
+
+func (p linearProvider) State(_ eph.ID, t time.Time) (eph.State, error) {
+	dt := t.SubDays(p.epoch)
+
+	return eph.State{
+		Pos:    p.pos0.Add(p.vel.MulScalar(dt)),
+		Vel:    p.vel,
+		Frame:  eph.FrameICRS,
+		Center: eph.CenterGeocentre,
+	}, nil
+}
+
+func (linearProvider) Close() error { return nil }
+
+// TestEveryEphemerisBackedTargetIsApparent covers the four types that share
+// this fix, against a displacement computed in closed form.
+//
+// Planet is the one anybody notices, and it was the only one the first round
+// of tests reached — mutating Asteroid, Comet and GenericBody back to the
+// geometric call left the suite green. They are the same defect in the same
+// shape, and a table is what stops the next one being added without it.
+func TestEveryEphemerisBackedTargetIsApparent(t *testing.T) {
+	t.Parallel()
+
+	epoch := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	// Two astronomical units out along x, crossing the line of sight at
+	// 0.01 AU/day (~17 km/s, a plausible relative speed for a minor body).
+	prov := linearProvider{
+		epoch: epoch,
+		pos0:  vector.V3(2, 0, 0),
+		vel:   vector.V3(0, 0.01, 0),
+	}
+
+	// tau = r/c with r = 2 AU: light takes 2/173.1446 days to arrive, and in
+	// that time the body moves vel*tau across the line of sight.
+	const (
+		lightAUPerDay = 173.1446326847695
+		rangeAU       = 2.0
+		speedAUPerDay = 0.01
+	)
+
+	tau := rangeAU / lightAUPerDay
+	wantOffsetAU := speedAUPerDay * tau
+
+	for _, tc := range []struct {
+		name string
+		obj  Observable
+	}{
+		{"Planet", NewPlanet("stub", eph.Mars, prov)},
+		{"Asteroid", NewAsteroid("stub", eph.ID(2000001), prov)},
+		{"Comet", NewComet("stub", eph.ID(1000001), prov, 10, 4)},
+		{"GenericBody", NewGenericBody("stub", eph.ID(2000002), prov)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb, ok := tc.obj.(MovingBody)
+			if !ok {
+				t.Fatalf("%s is not a MovingBody", tc.name)
+			}
+
+			got, err := mb.GeocentricVec(epoch)
+			testutil.AssertNoError(t, err)
+
+			// The geometric answer at the epoch is pos0 exactly, so the whole
+			// of y is the retardation.
+			testutil.AssertNear(t, "x (unchanged, motion is transverse)", got.X, 2.0, 1e-9)
+			testutil.AssertNear(t, "y (the retardation)", got.Y, -wantOffsetAU, 1e-12)
+
+			if got.Y >= 0 {
+				t.Errorf("y = %g, want negative: the apparent place is where the body "+
+					"*was* when the light left, which is behind its motion", got.Y)
+			}
+
+			// And Position must be the same place seen as a direction.
+			pos, err := tc.obj.Position(epoch)
+			testutil.AssertNoError(t, err)
+
+			fromVec, err := eph.ToICRS(got)
+			testutil.AssertNoError(t, err)
+
+			if sep := coord.Separation(pos, fromVec).Arcseconds(); sep > 1e-6 {
+				t.Errorf("Position and GeocentricVec disagree by %g\"", sep)
+			}
+		})
+	}
+}

--- a/plan/apparent_test.go
+++ b/plan/apparent_test.go
@@ -1,7 +1,9 @@
 package plan
 
 import (
+	"errors"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/TuSKan/astrogo/angle"
@@ -350,5 +352,112 @@ func TestEveryEphemerisBackedTargetIsApparent(t *testing.T) {
 				t.Errorf("Position and GeocentricVec disagree by %g\"", sep)
 			}
 		})
+	}
+}
+
+// zeroProvider reports a body at the geocentre, which is not a direction.
+//
+// It is the one input eph.ToICRS refuses: a zero vector has no right ascension
+// and no declination, and returning RA 0 Dec 0 for it would put a target in
+// Pisces with complete confidence.
+type zeroProvider struct{}
+
+func (zeroProvider) State(eph.ID, time.Time) (eph.State, error) {
+	return eph.State{Frame: eph.FrameICRS, Center: eph.CenterGeocentre}, nil
+}
+
+func (zeroProvider) Close() error { return nil }
+
+// TestApparentFailuresNameTheTargetThatFailed covers the error path of all four
+// types, which is the half of this change a caller only meets when something
+// has gone wrong.
+//
+// Each wrapper exists to add the body's own name to the error, and that is the
+// whole reason they are not one shared function: a scheduler evaluating two
+// hundred targets and reporting "ephemeris: apparent state: ..." tells whoever
+// reads the log nothing about which target to look at. An error that loses the
+// name is as good as no error for that purpose, and nothing else would catch
+// it — the message is not what any other assertion reads.
+func TestApparentFailuresNameTheTargetThatFailed(t *testing.T) {
+	t.Parallel()
+
+	prov := failingProvider{}
+	when := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	for _, tc := range []struct {
+		name string
+		obj  Observable
+	}{
+		{"Vesta", NewAsteroid("Vesta", eph.ID(2000004), prov)},
+		{"Halley", NewComet("Halley", eph.ID(1000036), prov, 5.5, 8)},
+		{"Chiron", NewGenericBody("Chiron", eph.ID(2002060), prov)},
+		{"Neptune", NewPlanet("Neptune", eph.Neptune, prov)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mb, ok := tc.obj.(MovingBody)
+			if !ok {
+				t.Fatalf("%s is not a MovingBody", tc.name)
+			}
+
+			_, posErr := tc.obj.Position(when)
+			_, vecErr := mb.GeocentricVec(when)
+
+			for _, got := range []struct {
+				label string
+				err   error
+			}{
+				{"Position", posErr},
+				{"GeocentricVec", vecErr},
+			} {
+				switch {
+				case got.err == nil:
+					t.Errorf("%s: a provider that cannot supply a state reported a position", got.label)
+				case !errors.Is(got.err, errFailingProvider):
+					t.Errorf("%s: err = %v, want the provider's own failure to survive wrapping",
+						got.label, got.err)
+				case !strings.Contains(got.err.Error(), tc.name):
+					t.Errorf("%s: err = %v, want the target's name in it — a scheduler running "+
+						"two hundred targets cannot act on a failure that does not say which one",
+						got.label, got.err)
+				}
+			}
+		})
+	}
+}
+
+// TestApparentDirectionRefusesTheGeocentre covers apparentICRS's second
+// failure, which is not a provider failure at all.
+//
+// A body reported at the geocentre has a state and no direction. eph.ToICRS
+// refuses it rather than answering RA 0 Dec 0 — a real point in Pisces that a
+// target would rise, transit and set from — and this keeps that refusal from
+// being flattened into a success on the way through.
+func TestApparentDirectionRefusesTheGeocentre(t *testing.T) {
+	t.Parallel()
+
+	body := NewPlanet("AtTheCentre", eph.Mars, zeroProvider{})
+	when := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.LocationUTC)
+
+	// The vector itself is fine: zero is a state, just not a direction.
+	vec, err := body.GeocentricVec(when)
+	testutil.AssertNoError(t, err)
+
+	if vec != (vector.Vec3{}) {
+		t.Fatalf("GeocentricVec = %v, want the zero vector the provider reported", vec)
+	}
+
+	_, err = body.Position(when)
+	if err == nil {
+		t.Fatal("Position answered a direction for a body at the geocentre")
+	}
+
+	if !errors.Is(err, eph.ErrZeroVector) {
+		t.Errorf("err = %v, want eph.ErrZeroVector", err)
+	}
+
+	if !strings.Contains(err.Error(), "AtTheCentre") {
+		t.Errorf("err = %v, want the target's name in it", err)
 	}
 }

--- a/plan/asteroid.go
+++ b/plan/asteroid.go
@@ -135,26 +135,23 @@ func (a *Asteroid) PhysicalRadius() (metres float64, ok bool) {
 	return 0, false
 }
 
-// Position returns the ICRS sky position at time t.
+// Position returns the apparent ICRS sky position at time t — see
+// [apparentVec].
 func (a *Asteroid) Position(t time.Time) (coord.ICRS, error) {
-	pos, err := eph.Position(a.provider, a.id, t)
+	icrs, err := apparentICRS(a.provider, a.id, t)
 	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("asteroid: ephemeris error for %s: %w", a.name, err)
-	}
-
-	icrs, err := eph.ToICRS(pos)
-	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("asteroid: coordinate conversion error for %s: %w", a.name, err)
+		return coord.ICRS{}, fmt.Errorf("asteroid %s: %w", a.name, err)
 	}
 
 	return icrs, nil
 }
 
-// GeocentricVec returns the geocentric position vector at time t.
+// GeocentricVec returns the apparent geocentric position vector at time t —
+// see [apparentVec].
 func (a *Asteroid) GeocentricVec(t time.Time) (vector.Vec3, error) {
-	v, err := eph.Position(a.provider, a.id, t)
+	v, err := apparentVec(a.provider, a.id, t)
 	if err != nil {
-		return vector.Vec3{}, fmt.Errorf("asteroid: geocentric: %w", err)
+		return vector.Vec3{}, fmt.Errorf("asteroid %s: %w", a.name, err)
 	}
 
 	return v, nil

--- a/plan/comet.go
+++ b/plan/comet.go
@@ -55,26 +55,23 @@ func (c *Comet) Provider() eph.Provider { return c.provider }
 // EphID returns the ephemeris ID.
 func (c *Comet) EphID() eph.ID { return c.id }
 
-// Position returns the ICRS position of the comet.
+// Position returns the apparent ICRS position of the comet — see
+// [apparentVec].
 func (c *Comet) Position(t time.Time) (coord.ICRS, error) {
-	pos, err := eph.Position(c.provider, c.id, t)
+	icrs, err := apparentICRS(c.provider, c.id, t)
 	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("comet: ephemeris error for %s: %w", c.name, err)
-	}
-
-	icrs, err := eph.ToICRS(pos)
-	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("comet: coordinate conversion error for %s: %w", c.name, err)
+		return coord.ICRS{}, fmt.Errorf("comet %s: %w", c.name, err)
 	}
 
 	return icrs, nil
 }
 
-// GeocentricVec returns the geocentric vector of the comet.
+// GeocentricVec returns the apparent geocentric vector of the comet — see
+// [apparentVec].
 func (c *Comet) GeocentricVec(t time.Time) (vector.Vec3, error) {
-	v, err := eph.Position(c.provider, c.id, t)
+	v, err := apparentVec(c.provider, c.id, t)
 	if err != nil {
-		return vector.Vec3{}, fmt.Errorf("comet: geocentric: %w", err)
+		return vector.Vec3{}, fmt.Errorf("comet %s: %w", c.name, err)
 	}
 
 	return v, nil

--- a/plan/generic.go
+++ b/plan/generic.go
@@ -35,26 +35,23 @@ func (g *GenericBody) Provider() eph.Provider { return g.provider }
 // EphID returns the NAIF ephemeris identifier.
 func (g *GenericBody) EphID() eph.ID { return g.id }
 
-// Position returns the ICRS coordinates at the given time.
+// Position returns the apparent ICRS coordinates at the given time — see
+// [apparentVec].
 func (g *GenericBody) Position(t time.Time) (coord.ICRS, error) {
-	pos, err := eph.Position(g.provider, g.id, t)
+	icrs, err := apparentICRS(g.provider, g.id, t)
 	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("generic body: ephemeris error for %s: %w", g.name, err)
-	}
-
-	icrs, err := eph.ToICRS(pos)
-	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("generic body: coordinate conversion error for %s: %w", g.name, err)
+		return coord.ICRS{}, fmt.Errorf("generic body %s: %w", g.name, err)
 	}
 
 	return icrs, nil
 }
 
-// GeocentricVec returns the geocentric position vector.
+// GeocentricVec returns the apparent geocentric position vector — see
+// [apparentVec].
 func (g *GenericBody) GeocentricVec(t time.Time) (vector.Vec3, error) {
-	v, err := eph.Position(g.provider, g.id, t)
+	v, err := apparentVec(g.provider, g.id, t)
 	if err != nil {
-		return vector.Vec3{}, fmt.Errorf("generic body: geocentric: %w", err)
+		return vector.Vec3{}, fmt.Errorf("generic body %s: %w", g.name, err)
 	}
 
 	return v, nil

--- a/plan/planet.go
+++ b/plan/planet.go
@@ -108,26 +108,26 @@ func (p *Planet) EphID() eph.ID {
 	return p.id
 }
 
-// Position returns the planet's position.
+// Position returns where the planet is seen on the sky at t — the apparent
+// place, with light time and aberration in it. See [apparentVec] for how far
+// that is from the geometric direction and why it is the one this package
+// wants.
 func (p *Planet) Position(t time.Time) (coord.ICRS, error) {
-	pos, err := eph.Position(p.provider, p.id, t)
+	icrs, err := apparentICRS(p.provider, p.id, t)
 	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("planet: ephemeris error for %s: %w", p.name, err)
-	}
-
-	icrs, err := eph.ToICRS(pos)
-	if err != nil {
-		return coord.ICRS{}, fmt.Errorf("planet: coordinate conversion error for %s: %w", p.name, err)
+		return coord.ICRS{}, fmt.Errorf("planet %s: %w", p.name, err)
 	}
 
 	return icrs, nil
 }
 
-// GeocentricVec returns the planet's geocentric position.
+// GeocentricVec returns the planet's apparent geocentric position vector,
+// which is what [coord.Context.GeocentricToObserved] expects — see
+// [apparentVec].
 func (p *Planet) GeocentricVec(t time.Time) (vector.Vec3, error) {
-	v, err := eph.Position(p.provider, p.id, t)
+	v, err := apparentVec(p.provider, p.id, t)
 	if err != nil {
-		return vector.Vec3{}, fmt.Errorf("planet: geocentric: %w", err)
+		return vector.Vec3{}, fmt.Errorf("planet %s: %w", p.name, err)
 	}
 
 	return v, nil


### PR DESCRIPTION
Closes part of #117 — its fourth bullet, *"plan.Planet.Position never calls
ApparentState. Planets in the scheduler are geometric, not apparent."* That
turned out to be true, and worse than the bullet suggests.

## The defect

Every ephemeris-backed target in `plan` answered with the geometric vector.
Measured at Paranal across 2026, sampled every six hours with the target above
10°, through this package's own alt/az path:

| body | samples | mean error | max error |
| :--- | ---: | ---: | ---: |
| Moon | 632 | 0.71″ | 0.77″ |
| Sun | 637 | 20.51″ | 20.83″ |
| Venus | 605 | 20.88″ | **44.75″** |
| Mars | 617 | 28.91″ | 38.70″ |
| Jupiter | 566 | 15.85″ | 29.00″ |
| Saturn | 633 | 14.47″ | 27.20″ |
| Neptune | 643 | 13.45″ | 24.33″ |

**Both** halves of the correction were missing, which is why it reaches forty
arcseconds rather than the twenty of aberration alone.
`coord.Context.GeocentricToObserved` — the consumer at the end of that path —
adds diurnal parallax, the rotation into the horizon and refraction, and
*deliberately does not touch aberration*, because its input is supposed to
arrive apparent already. It was arriving geometric.

`eph.ApparentState` has implemented this correctly since it was written, with a
careful derivation in its doc comment. Nothing called it except
`examples/11_skyfield_verify`.

## What changed

`Planet`, `Asteroid`, `Comet` and `GenericBody` now return the apparent place
from **both** `Position` and `GeocentricVec`. Both, through one helper, because
they feed different consumers — separations and details read `Position`,
altitude reads `GeocentricVec` — and a target whose altitude is apparent while
its Moon separation is geometric is wrong in a way no single test would catch,
since each answer is defensible on its own.

Two deliberate non-changes:

**`Satellite` is untouched, and not because the effect is small.**
`ApparentState` reaches the apparent place by polling the provider at the
retarded epoch, which is what folds in annual aberration (that is the trick its
doc comment derives). A satellite shares Earth's orbital motion, so that term
cancels between observer and target — applying it would introduce a 20″ error
that should not exist at all. Light time to LEO is real but is a different
correction, from the observer rather than the geocentre.

**`phases.go` and `crescent.go` are untouched.** Their Sun–Moon geometry is a
different question with its own convention, and `crescent.go` already carries
its own argued comments about it. Changing it needs its own validation rather
than riding along here.

## The cost, and what was done about it

`ApparentState` ran a flat five passes, so this put six provider calls where
there had been one: **34 µs → 204 µs** for Mars, on the scheduler's hot path.

It converges geometrically with ratio v/c ~ 1e-4, so each pass buys four
decimal digits. Measured — how far each pass moves the answer, at worst, over
2026:

| body | pass 1 | pass 2 | pass 3 | pass 4+ |
| :--- | ---: | ---: | ---: | ---: |
| Moon | 0.759″ | 0.00000″ | 0″ | 0″ |
| Sun | 20.837″ | 0.00003″ | 0″ | 0″ |
| Venus | 44.762″ | 0.00121″ | 0.0000001″ | 0″ |
| Mars | 38.733″ | 0.00087″ | 0.0000000″ | 0″ |
| Jupiter | 29.008″ | 0.00208″ | 0.0000002″ | 0″ |
| Neptune | 24.346″ | 0.00214″ | 0.0000002″ | 0″ |

The fifth pass was refining a number that had stopped changing in double
precision two passes earlier. It now iterates to a stated tolerance with the
same ceiling of five: **Mars settles in three passes at 106 µs, the Moon in one
at 8 µs.** A convergence test rather than a flat three because it is both
cheaper for near bodies and self-explaining.

## Evidence

The check that matters is not one of ours. The Sun's apparent displacement is
the **constant of aberration, κ = 20.49552″** (IAU 2009, Luzum et al. 2011) —
light time and aberration both act along Earth's orbital motion and both amount
to v⊕/c at one astronomical unit. Over a year this now measures **20.147″ to
20.837″**, the ±1.7% Earth's eccentricity requires, around a number that comes
from outside this library.

Half of it would mean one of the two corrections is missing. The wrong sign
would be right in magnitude and 41″ from the truth.

The rest of the suite:

- `TestApparentPositionReachesTheAltAzPath` — the fix has to arrive in
  `GeocentricVec`, not only `Position`. A `MovingBody`'s altitude never touches
  `Position`, so fixing that alone would leave the scheduler exactly as wrong
  while every direct test of `Position` passed.
- `TestEveryEphemerisBackedTargetIsApparent` — a stub provider moving in a
  straight line, so the retardation has a **closed form**: −v·τ, asserted to
  1e-12 AU for all four types.
- `TestApparentStateHasConverged` — one more pass by hand must not move the
  answer by a microarcsecond. Written as "iterate again and see" rather than
  against a stored five-pass answer, so it keeps holding when the ephemeris
  behind it changes.

Twelve mutants, all killed — including reverting each of the four target types
individually, and making `Satellite` apparent. The first round left three
survivors (`Asteroid`, `Comet`, `GenericBody`), which is what the stub-provider
table was added for.

## What this does not do

The interface change #117 leads with — a `ctx` and a target/center pair on
`core.Provider.State` — is an API decision for the release that breaks `remote`
and `plan` together, as the issue itself asks. Untouched here. The issue stays
open for it.

## A finding on the way

I could not validate this against USNO, because **that suite has been silently
skipping**: a 5 s TCP probe gates eleven `TestUSNO_*` functions, the dial
overran its own budget by 12 s while `curl` reached the host in 2.2 s, and the
result is cached in a `sync.Once` so one unlucky probe disables the lot. The
package still reports `ok`. Filed as
[#225](https://github.com/TuSKan/astrogo/issues/225) — it matters because USNO
is one of the four references the README's headline accuracy claim names.

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation" ./...`,
`go test ./...`, `go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go -C examples build ./...`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.
