### PR TITLE
ephemeris/jpl/spk: an unreadable kernel is not a corrupt one

### DIFF
--- a/docs/changelog.d/228-unreadable-is-not-corrupt.md
+++ b/docs/changelog.d/228-unreadable-is-not-corrupt.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 228
+---
+**A kernel that could not be read was deleted as corrupt.** "Access is denied"
+and a checksum mismatch shared one branch, so a process losing a race to a file
+lock deleted the shared 32 MB kernel out from under every other process — the
+observed cause of intermittent Windows CI failures. Only a proven content
+failure is destructive now; an I/O failure leaves the file for the next open to
+retry (#227).

--- a/ephemeris/jpl/spk/discard_test.go
+++ b/ephemeris/jpl/spk/discard_test.go
@@ -1,0 +1,260 @@
+package spk
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote/file"
+)
+
+var errStorageMisbehaved = errors.New("discard_test: open kernel: Access is denied")
+
+// seedKernel writes a byte into a fresh bucket and returns it with its key, so
+// a test can ask whether the file survived a decision.
+func seedKernel(t *testing.T) (*file.Bucket, string) {
+	t.Helper()
+
+	bucket, err := file.Open(t.Context(), testutil.FileURL(t, t.TempDir()))
+	if err != nil {
+		t.Fatalf("open bucket: %v", err)
+	}
+
+	const key = "jpl/planets/de440s.bsp"
+
+	if err := bucket.WriteAll(t.Context(), key, []byte("kernel bytes"), nil); err != nil {
+		t.Fatalf("seed kernel: %v", err)
+	}
+
+	return bucket, key
+}
+
+func exists(t *testing.T, bucket *file.Bucket, key string) bool {
+	t.Helper()
+
+	ok, err := bucket.Exists(t.Context(), key)
+	if err != nil {
+		t.Fatalf("exists %s: %v", key, err)
+	}
+
+	return ok
+}
+
+// TestDiscardIfCorruptKeepsAKernelItMerelyCouldNotRead is the whole point of
+// the helper.
+//
+// A cached kernel that cannot be read and one whose bytes are wrong are
+// different facts wanting opposite responses, and they used to share a branch.
+// The wrong half of that is destructive and shared: `go test ./...` runs
+// packages as separate processes against one cache directory, so a package
+// losing a race to a file lock deleted a 32 MB kernel out from under the
+// others, which then spent three minutes each failing to find it. It is the
+// observed cause of intermittent Windows CI failures on main (#227).
+func TestDiscardIfCorruptKeepsAKernelItMerelyCouldNotRead(t *testing.T) {
+	t.Parallel()
+
+	bucket, key := seedKernel(t)
+
+	closed := false
+	err := discardIfCorrupt(t.Context(), bucket, key,
+		func() error { closed = true; return nil },
+		errStorageMisbehaved)
+
+	if !errors.Is(err, errStorageMisbehaved) {
+		t.Errorf("err = %v, want it to wrap the underlying failure", err)
+	}
+
+	if !closed {
+		t.Error("the file handle was not closed; it is closed on both paths")
+	}
+
+	if !exists(t, bucket, key) {
+		t.Error("the kernel was deleted after a read failure that says nothing " +
+			"about its content; the next open should have found it and tried again")
+	}
+}
+
+// TestDiscardIfCorruptDeletesAKernelThatIsWrong is the other half: the
+// auto-heal this helper must not lose while it stops over-reaching.
+//
+// A checksum that computed cleanly and did not match is a statement about the
+// bytes, and the cached copy is worthless. Deleting it is what makes the next
+// run heal itself, which is the behaviour CacheDownload's comment has always
+// claimed.
+func TestDiscardIfCorruptDeletesAKernelThatIsWrong(t *testing.T) {
+	t.Parallel()
+
+	bucket, key := seedKernel(t)
+
+	const sidecar = "jpl/planets/de440s.bsp.sha256"
+
+	if err := bucket.WriteAll(t.Context(), sidecar, []byte("deadbeef"), nil); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+
+	cause := errors.New("sha256 mismatch") //nolint:err113 // a stand-in for the real message, wrapped below
+
+	closed := false
+	err := discardIfCorrupt(t.Context(), bucket, key,
+		func() error { closed = true; return nil },
+		errors.Join(ErrCorruptSPK, cause),
+		func() error { return bucket.Delete(t.Context(), sidecar) })
+
+	if !errors.Is(err, ErrCorruptSPK) {
+		t.Errorf("err = %v, want it to keep reporting ErrCorruptSPK", err)
+	}
+
+	if !closed {
+		t.Error("the file handle was not closed")
+	}
+
+	if exists(t, bucket, key) {
+		t.Error("a kernel whose checksum did not match was left in the cache; " +
+			"the next run would keep failing on the same bytes")
+	}
+
+	// The sidecar describes the kernel and must not outlive it, or the next
+	// download's bootstrap compares against a recording of the corrupt one.
+	if exists(t, bucket, sidecar) {
+		t.Error("the checksum sidecar outlived the kernel it describes")
+	}
+}
+
+// TestDiscardIfCorruptRunsExtrasOnlyWhenItDeletes pins the asymmetry.
+//
+// The extra cleanups exist to remove things that describe the kernel. Running
+// them on a read failure would delete the checksum sidecar of a kernel that is
+// still there and still valid, silently turning the next open's verification
+// into a fresh bootstrap — which would then record whatever the file contains,
+// including corruption it was supposed to catch.
+func TestDiscardIfCorruptRunsExtrasOnlyWhenItDeletes(t *testing.T) {
+	t.Parallel()
+
+	bucket, key := seedKernel(t)
+
+	ran := 0
+	extra := func() error { ran++; return nil }
+
+	_ = discardIfCorrupt(t.Context(), bucket, key, func() error { return nil },
+		errStorageMisbehaved, extra)
+
+	if ran != 0 {
+		t.Errorf("extra cleanup ran %d times after a read failure, want 0", ran)
+	}
+
+	_ = discardIfCorrupt(t.Context(), bucket, key, func() error { return nil },
+		ErrCorruptSPK, extra)
+
+	if ran != 1 {
+		t.Errorf("extra cleanup ran %d times after a corruption finding, want 1", ran)
+	}
+}
+
+// TestDiscardIfCorruptReportsACloseFailure covers the handle, which is closed
+// on both paths and whose failure must not be swallowed by either.
+func TestDiscardIfCorruptReportsACloseFailure(t *testing.T) {
+	t.Parallel()
+
+	closeFailed := errors.New("discard_test: close failed") //nolint:err113 // a stand-in, joined below
+
+	bucket, key := seedKernel(t)
+
+	for _, tc := range []struct {
+		name  string
+		cause error
+	}{
+		{"after a read failure", errStorageMisbehaved},
+		{"after a corruption finding", ErrCorruptSPK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := discardIfCorrupt(t.Context(), bucket, key,
+				func() error { return closeFailed }, tc.cause)
+
+			if !errors.Is(err, closeFailed) {
+				t.Errorf("err = %v, want it to carry the close failure too", err)
+			}
+
+			if !errors.Is(err, tc.cause) {
+				t.Errorf("err = %v, want it to still carry the cause", err)
+			}
+		})
+	}
+}
+
+// TestNewReaderCallsAShortFileCorrupt keeps the auto-heal working for the one
+// read failure that really is a statement about the content.
+//
+// A file too short to hold an SPK's own 1024-byte file record cannot be a
+// valid kernel however well the storage behaved, so it carries ErrCorruptSPK
+// and a cached copy is discarded. Without this, splitting I/O failures from
+// content failures would have quietly stopped truncated downloads from healing.
+func TestNewReaderCallsAShortFileCorrupt(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{"empty", 0},
+		{"one byte", 1},
+		{"one byte short of a file record", RecordSize - 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewReader(nopCloser{io.NewSectionReader(
+				readerAtFunc(make([]byte, tc.size)), 0, int64(tc.size))})
+
+			if !errors.Is(err, ErrCorruptSPK) {
+				t.Errorf("err = %v, want ErrCorruptSPK — a file shorter than its own "+
+					"file record is bad content, not a storage failure", err)
+			}
+		})
+	}
+}
+
+// TestNewReaderKeepsARealReadFailureAsOne is the complement: a storage error
+// that is not a short read must not be dressed up as corruption, or it deletes
+// a kernel that is fine.
+func TestNewReaderKeepsARealReadFailureAsOne(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewReader(nopCloser{failingReaderAt{}})
+
+	if errors.Is(err, ErrCorruptSPK) {
+		t.Errorf("err = %v, want it not to claim corruption for a storage failure", err)
+	}
+
+	if !errors.Is(err, errStorageMisbehaved) {
+		t.Errorf("err = %v, want it to wrap the storage failure", err)
+	}
+}
+
+// readerAtFunc serves a fixed byte slice, returning io.EOF past its end the
+// way any short file does.
+type readerAtFunc []byte
+
+func (b readerAtFunc) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(b)) {
+		return 0, io.EOF
+	}
+
+	n := copy(p, b[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+// failingReaderAt is storage that is broken rather than short.
+type failingReaderAt struct{}
+
+func (failingReaderAt) ReadAt([]byte, int64) (int, error) { return 0, errStorageMisbehaved }
+
+type nopCloser struct{ io.ReaderAt }
+
+func (nopCloser) Close() error { return nil }

--- a/ephemeris/jpl/spk/reader.go
+++ b/ephemeris/jpl/spk/reader.go
@@ -91,10 +91,7 @@ func CacheDownload(ctx context.Context, kernel string) (*Reader, error) {
 
 	r, err := NewReader(ra)
 	if err != nil {
-		closeErr := ra.Close()
-		removeErr := bucket.Delete(ctx, key)
-
-		return nil, errors.Join(err, closeErr, removeErr)
+		return nil, discardIfCorrupt(ctx, bucket, key, ra.Close, err)
 	}
 
 	// Validate physical file size against DAF logical file length
@@ -122,10 +119,7 @@ func CacheDownload(ctx context.Context, kernel string) (*Reader, error) {
 
 	// Verify file integrity immediately to auto-heal CI pipelines
 	if _, err := r.ReadSummaries(); err != nil {
-		closeErr := r.Close()
-		removeErr := bucket.Delete(ctx, key)
-
-		return nil, errors.Join(fmt.Errorf("jpl: corrupt SPK file gracefully deleted: %w", err), closeErr, removeErr)
+		return nil, discardIfCorrupt(ctx, bucket, key, r.Close, err)
 	}
 
 	// ReadSummaries only parses the DAF directory/summary records, a small
@@ -136,11 +130,12 @@ func CacheDownload(ctx context.Context, kernel string) (*Reader, error) {
 	// against it on every later open of the same cached path. Hashing reads
 	// through the already-open ra handle instead of opening the file again.
 	if err := verifyOrBootstrapChecksum(ctx, bucket, key, ra, size); err != nil {
-		closeErr := r.Close()
-		removeErr := bucket.Delete(ctx, key)
-		sumRemoveErr := removeChecksumSidecar(ctx, bucket, key)
-
-		return nil, errors.Join(fmt.Errorf("jpl: corrupt SPK file gracefully deleted: %w", err), closeErr, removeErr, sumRemoveErr)
+		// The sidecar goes with the kernel: keeping a checksum for a file
+		// that is no longer there would make the next download's bootstrap
+		// compare against a recording of the corrupt one.
+		return nil, discardIfCorrupt(ctx, bucket, key, r.Close, err, func() error {
+			return removeChecksumSidecar(ctx, bucket, key)
+		})
 	}
 
 	return r, nil
@@ -211,6 +206,17 @@ func verifyOrBootstrapChecksum(ctx context.Context, bucket *file.Bucket, key str
 func NewReader(f ReadAtCloser) (*Reader, error) {
 	buf := make([]byte, RecordSize)
 	if _, err := f.ReadAt(buf, 0); err != nil {
+		// A short read at offset zero is the file being smaller than an
+		// SPK's own file record, which no valid kernel can be — that is a
+		// statement about the content, so it carries ErrCorruptSPK and a
+		// cached copy is discarded. Any other read failure is the storage
+		// misbehaving and says nothing about the bytes; see
+		// discardIfCorrupt for why the difference decides whether a shared
+		// 32 MB kernel gets deleted.
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, fmt.Errorf("%w: file shorter than the %d-byte file record", ErrCorruptSPK, RecordSize)
+		}
+
 		return nil, fmt.Errorf("spk: read file record: %w", err)
 	}
 
@@ -780,4 +786,58 @@ func EvalChebyshev(coeffs []float64, tau, radius float64, calcDeriv bool) (p, v 
 	}
 
 	return p, v
+}
+
+// discardIfCorrupt is the one place that decides whether a kernel that failed
+// to open should be deleted from the cache.
+//
+// # Why it is a decision and not a cleanup
+//
+// Opening a cached kernel can fail for two entirely different reasons, and
+// they want opposite responses:
+//
+//   - The bytes are wrong — a checksum that computed cleanly and did not
+//     match, a DAF structure that parsed and was invalid, a file shorter than
+//     its own header says it is. The cached copy is worthless and deleting it
+//     is what makes the next run heal itself. Every one of these wraps
+//     [ErrCorruptSPK].
+//   - The bytes could not be read — "Access is denied" because another
+//     process holds the handle, a short read, a cancelled context, a full
+//     disk. The file is very likely fine and the condition is transient.
+//
+// These used to be the same branch, so the second deleted the file. That is
+// worse than merely wrong, because the cache is shared: `go test ./...` runs
+// packages as separate processes against one cache directory, and one of them
+// losing a race deleted the 32 MB kernel out from under the others, which then
+// spent three minutes each failing to find a file that had been there. It is
+// the observed cause of intermittent Windows CI failures on main, and a user
+// running a scheduler alongside an analysis script hits the same thing with a
+// 3 GB DE441 part.
+//
+// So an I/O failure now returns and leaves the file alone. The next open tries
+// again, which is exactly what a transient condition wants. Only a proven
+// content failure is destructive.
+//
+// The handle is closed either way. extra runs only when the file is deleted —
+// it is for artefacts that describe the kernel and must not outlive it.
+func discardIfCorrupt(ctx context.Context, bucket *file.Bucket, key string,
+	closeFile func() error, cause error, extra ...func() error,
+) error {
+	closeErr := closeFile()
+
+	if !errors.Is(cause, ErrCorruptSPK) {
+		return errors.Join(fmt.Errorf("jpl: open SPK %s: %w", key, cause), closeErr)
+	}
+
+	errs := []error{
+		fmt.Errorf("jpl: corrupt SPK file gracefully deleted: %w", cause),
+		closeErr,
+		bucket.Delete(ctx, key),
+	}
+
+	for _, fn := range extra {
+		errs = append(errs, fn())
+	}
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
Closes #227.

Windows CI has been failing intermittently on `main` as well as on pull
requests, and the mechanism is destructive rather than merely flaky: **one
package that cannot read the shared kernel deletes it for every other package
in the run.**

From `main` ([run 34231753581](https://github.com/TuSKan/astrogo/actions/runs/34231753581)):

```
agreement_test.go:66: setup failed: jpl: failed to load planetary kernel:
  jpl: corrupt SPK file gracefully deleted: jpl: checksum: read:
  remote/file: range read jpl/planets/de440s.bsp at 31522816: EOF
```

and three packages at once on a PR branch:

```
jpl:  range read ... at 17825792: ... open ...de440s.bsp: Access is denied.
      → "corrupt SPK file gracefully deleted"
spk:  range read ... at 7864320: EOF
      → "corrupt SPK file gracefully deleted"
jpl:  could not obtain kernel "de440s" within 3m0s: ...
      The system cannot find the file specified.
```

The third is the consequence of the first two.

## The defect

Opening a cached kernel can fail for two entirely different reasons, and they
want **opposite** responses:

| | what it means | right response |
| :--- | :--- | :--- |
| checksum mismatch, invalid DAF structure, file shorter than its own header | the bytes are wrong | delete — this is what makes the next run heal |
| `Access is denied`, a short read, a cancelled context, a full disk | the bytes could not be read | leave it; the file is very likely fine |

They shared one branch, so the second deleted the file. `go test ./...` runs
packages as separate processes against one cache directory, so a package losing
a race to a file lock deleted the 32 MB kernel out from under the others.

"Access is denied" being reported as corrupt data is the same error-vs-absence
mistake this project has already fixed in #102, #172, #177 and #182 — except
here it is worse than indistinguishable, because the two get opposite correct
responses and the code picked the destructive one.

## The fix was smaller than the bug

**The sentinel to discriminate on already existed and was already correct
everywhere.** `ReadSummaries` wraps `ErrCorruptSPK` for structural findings and
returns a plain error for read failures; `verifyOrBootstrapChecksum` does the
same for a mismatch versus an unreadable file or sidecar. Nothing consulted it.

All three call sites now go through one helper that does, so the decision is in
one place with the reasoning attached rather than repeated three times as
cleanup.

## One case that would have been lost

A file too short to hold an SPK's own 1024-byte file record fails with `io.EOF`
— a *read* failure by mechanism, but a statement about the content: no valid
kernel can be that short however well the storage behaved. Splitting on I/O
versus content would have quietly stopped truncated downloads from healing.
`NewReader` now says `ErrCorruptSPK` for exactly that case, and
`TestNewReaderCallsAShortFileCorrupt` pins it at 0, 1 and 1023 bytes.

## Tests

Six mutants, all killed:

| mutant | killed by |
| --- | --- |
| delete on every failure again | `KeepsAKernelItMerelyCouldNotRead` |
| never delete at all | `DeletesAKernelThatIsWrong` |
| run the sidecar cleanup on both paths | `RunsExtrasOnlyWhenItDeletes` |
| skip closing the handle | `KeepsAKernelItMerelyCouldNotRead` |
| stop calling a short file corrupt | `NewReaderCallsAShortFileCorrupt` |
| call every read failure corrupt | `NewReaderKeepsARealReadFailureAsOne` |

The sidecar asymmetry is worth its own note: running the extra cleanups on a
read failure would delete the checksum sidecar of a kernel that is still there
and still valid, silently turning the next open's verification into a fresh
bootstrap — which would then record whatever the file contains, including
corruption it was supposed to catch.

The existing `TestCacheDownloadDetectsChecksumCorruption` still passes
unchanged, so the auto-heal this PR narrows is demonstrably still there.

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation" ./...`,
`go test ./...`, `go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go -C examples build ./...`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.
