### PR TITLE
plan: stop the USNO suite from silently skipping

### DIFF
--- a/docs/changelog.d/229-usno-probe.md
+++ b/docs/changelog.d/229-usno-probe.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 229
+---
+**The USNO comparison suite had been silently skipping.** A single-shot TCP
+probe cached its failure in a `sync.Once`, so one dropped packet retired all
+fourteen `TestUSNO_*` functions for the rest of the binary — as SKIP, which
+reads as a pass. The probe now goes through `testutil.Reachable` (which retries
+over IPv4) and remembers only success; a new docsguard check stops the next
+hand-rolled probe (#225).

--- a/internal/docsguard/reachability_test.go
+++ b/internal/docsguard/reachability_test.go
@@ -1,0 +1,107 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// dialCall matches a raw connection attempt: net.Dial, net.DialTimeout, or a
+// net.Dialer's own DialContext.
+var dialCall = regexp.MustCompile(`\bnet\.Dial(Timeout|Context)?\(|\bnet\.Dialer\b`)
+
+// TestOnlyTestutilProbesReachability keeps every suite's "is the service
+// there?" question going through one implementation.
+//
+// # Why this is worth a guard
+//
+// A reachability probe is the one piece of test plumbing whose bugs are
+// invisible. Everything else fails loudly; this fails as SKIP, which reads as
+// a pass in every summary that exists, and the suite it disables is by
+// definition the one nobody is watching.
+//
+// It has happened twice, in two different hand-rolled probes:
+//
+//   - Go's dual-stack dialer spent the whole budget on an AAAA lookup for a
+//     record that did not exist, and every IRSA-dependent suite — the SFD dust
+//     map and the GAMBONS all-sky comparison among them — skipped on a host
+//     answering in 250 ms over IPv4.
+//   - plan/usno_test.go cached a failed probe in a sync.Once, so one dropped
+//     SYN retired all fourteen TestUSNO_* functions for the rest of the binary.
+//     Measured while the host answered curl in 2.2 s: a 5 s dial overran to
+//     17.3 s and failed, and the next one connected in 140 ms (#225).
+//
+// [github.com/TuSKan/astrogo/internal/testutil.Reachable] carries the fix for
+// both. A second implementation does not, and cannot be assumed to acquire the
+// third fix either.
+//
+// # Scope
+//
+// Test files only, and testutil itself is the sanctioned implementation.
+// Library code dialling is a different question this does not speak to —
+// nothing in astrogo does it today, and `remote` is where it would belong.
+func TestOnlyTestutilProbesReachability(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	var offenders []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "node_modules", "testutil":
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		src, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil //nolint:nilerr // unreadable is not an offence
+		}
+
+		for i, line := range strings.Split(string(src), "\n") {
+			// A comment explaining a past probe bug is not a probe. The
+			// guard is about code that dials, and usno_test.go's own doc
+			// comment quotes the call it replaced.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+
+			if dialCall.MatchString(line) {
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					rel = path
+				}
+
+				offenders = append(offenders, filepath.ToSlash(rel)+":"+itoa(i+1))
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("test files dial directly instead of using testutil.Reachable:\n  %s\n\n"+
+			"  A hand-rolled probe is how two suites came to skip against hosts that were "+
+			"answering, and a skip reads as a pass. testutil.Reachable already retries over "+
+			"IPv4 when the dual-stack dialer stalls; a second implementation starts without "+
+			"that and without whatever is learned next.",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/plan/usno_test.go
+++ b/plan/usno_test.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -25,6 +24,7 @@ import (
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/coord"
 	eph "github.com/TuSKan/astrogo/ephemeris"
+	"github.com/TuSKan/astrogo/internal/testutil"
 	"github.com/TuSKan/astrogo/plan"
 	"github.com/TuSKan/astrogo/time"
 )
@@ -132,42 +132,75 @@ var testLocations = []testLocation{
 // enforced independently of http.Client.Timeout (see usnoGet).
 const usnoRequestTimeout = 30 * time.Second
 
+// usnoHost is the address the pre-check probes and the API this file queries.
+const usnoHost = "aa.usno.navy.mil:443"
+
 var (
-	usnoReachableOnce sync.Once
-	usnoReachableOK   bool
+	// usnoReachableMu guards usnoReachableOK. Only a *success* is recorded:
+	// see requireUSNO for why a cached failure is the dangerous direction.
+	usnoReachableMu sync.Mutex
+	usnoReachableOK bool
 )
 
-// requireUSNO skips the calling test immediately if the USNO API is
-// unreachable, checked once per process via a cheap TCP dial (mirroring
-// this project's network-test convention of a fast reachability pre-check
-// rather than paying each call site's own timeout). Call it as the first
-// line of every top-level USNO test function — t.Skip halts that
+// requireUSNO skips the calling test if the USNO API is unreachable. Call it
+// as the first line of every top-level USNO test function — t.Skip halts that
 // function immediately, so no subtest beneath it runs either.
 //
-// Without this, a full USNO outage previously cost each of this file's
-// ~30 usnoGet call sites its own usnoRequestTimeout (30s) run
-// sequentially, summing past the CI job's own 10-minute test binary
-// timeout before the last few calls ever got a chance to skip
-// gracefully themselves — killing the whole package's test run instead
-// of skipping fast.
+// The pre-check exists because a full USNO outage otherwise costs each of this
+// file's ~30 usnoGet call sites its own usnoRequestTimeout (30s) run
+// sequentially, summing past the CI job's own 10-minute binary timeout before
+// the last few ever get a chance to skip gracefully — killing the package's
+// test run instead of skipping fast.
+//
+// # Only a success is remembered
+//
+// This used to hold both answers in a sync.Once, and one unlucky probe
+// therefore disabled all eleven TestUSNO_* functions for the rest of the
+// binary — reported as SKIP, which reads as a pass in every summary that
+// exists. Measured on a developer machine while the host was answering curl in
+// 2.2s: net.DialTimeout with a 5s budget overran to 17.3s and failed, and the
+// immediately following dial connected in 140ms. aa.usno.navy.mil resolves to
+// a single address and drops or delays SYNs intermittently, so a single-shot
+// probe is a coin toss that decides the whole suite.
+//
+// USNO is one of the four references the README's headline accuracy claim
+// names, the integration job is continue-on-error, and a skipped suite is
+// invisible. Caching only the positive costs one extra probe per top-level
+// test during a genuine outage — eleven times testutil.ReachableTimeout,
+// under a minute — and removes the failure mode where a moment of packet loss
+// silently retires the reference.
+//
+// testutil.Reachable rather than a dial of our own, because it already carries
+// the IPv4 retry that was added for exactly this class of bug: a probe that
+// declares a service absent because of the resolver's opinion of its address
+// family, on a service that is there.
 func requireUSNO(t *testing.T) {
 	t.Helper()
 
-	usnoReachableOnce.Do(func() {
-		//nolint:noctx // a liveness probe, not a request that should carry a deadline
-		conn, err := net.DialTimeout("tcp", "aa.usno.navy.mil:443", 5*time.Second)
-		if err != nil {
-			return
-		}
-
-		usnoReachableOK = true
-
-		_ = conn.Close()
-	})
-
-	if !usnoReachableOK {
-		t.Skip("USNO API unreachable, skipping")
+	if usnoReachable(func() bool { return testutil.Reachable(usnoHost) }) {
+		return
 	}
+
+	t.Skipf("%s did not answer within %v", usnoHost, testutil.ReachableTimeout*time.Nanosecond)
+}
+
+// usnoReachable is requireUSNO's memo, separated from the probe so the one
+// thing that went wrong here can be tested without a network: a failure must
+// not be remembered.
+//
+// Returns true once probe has succeeded, and calls probe again every time it
+// has not. See requireUSNO for why that asymmetry is the whole fix.
+func usnoReachable(probe func() bool) bool {
+	usnoReachableMu.Lock()
+	defer usnoReachableMu.Unlock()
+
+	if usnoReachableOK {
+		return true
+	}
+
+	usnoReachableOK = probe()
+
+	return usnoReachableOK
 }
 
 // usnoResult carries a completed request's outcome across the goroutine
@@ -1934,5 +1967,64 @@ func compareSunMoonEvents(t *testing.T, body string, usnoPhenomena []usnoPhenome
 
 			break
 		}
+	}
+}
+
+// TestUSNOReachabilityDoesNotRememberAFailure pins the defect this file's
+// pre-check used to have, without needing a network.
+//
+// Both answers used to live in a sync.Once, so one unlucky probe skipped all
+// fourteen TestUSNO_* functions for the rest of the binary — reported as SKIP,
+// which reads as a pass. The host resolves to a single address and drops SYNs
+// intermittently: measured while it answered curl in 2.2s, a 5s dial overran
+// to 17.3s and failed, and the very next one connected in 140ms (#225).
+//
+// So a failure has to be retried and a success may be kept. Asserting both
+// directions, because remembering nothing would be correct but would pay a
+// probe per call forever, and remembering everything is the bug.
+func TestUSNOReachabilityDoesNotRememberAFailure(t *testing.T) {
+	usnoReachableMu.Lock()
+	saved := usnoReachableOK
+	usnoReachableOK = false
+	usnoReachableMu.Unlock()
+
+	t.Cleanup(func() {
+		usnoReachableMu.Lock()
+		usnoReachableOK = saved
+		usnoReachableMu.Unlock()
+	})
+
+	calls := 0
+	answer := false
+	probe := func() bool { calls++; return answer }
+
+	if usnoReachable(probe) {
+		t.Fatal("reported reachable while the probe was failing")
+	}
+
+	if usnoReachable(probe) {
+		t.Fatal("reported reachable while the probe was failing")
+	}
+
+	if calls != 2 {
+		t.Errorf("probe ran %d times across two failures, want 2 — a cached failure "+
+			"is what retired the whole suite on one dropped packet", calls)
+	}
+
+	// The host comes back, as it did 140 ms later.
+	answer = true
+
+	if !usnoReachable(probe) {
+		t.Fatal("a recovered host was still reported unreachable")
+	}
+
+	if calls != 3 {
+		t.Errorf("probe ran %d times, want 3", calls)
+	}
+
+	// And a success is kept, so a real outage costs one probe per top-level
+	// test rather than one per usnoGet call site.
+	if !usnoReachable(probe) || calls != 3 {
+		t.Errorf("probe ran %d times after succeeding, want it remembered at 3", calls)
 	}
 }


### PR DESCRIPTION
Closes #225.

**Fourteen `TestUSNO_*` functions have not been running.** They report `SKIP`,
which reads as a pass in every summary that exists, and the `integration` job is
`continue-on-error`, so nothing anywhere noticed.

USNO is one of the four references [README.md line 14](README.md) names for the
library's headline accuracy claim.

## What was wrong

```go
usnoReachableOnce.Do(func() {
    conn, err := net.DialTimeout("tcp", "aa.usno.navy.mil:443", 5*time.Second)
    if err != nil {
        return           // ← failure recorded, for the rest of the binary
    }
    usnoReachableOK = true
    _ = conn.Close()
})
```

Measured on a developer machine while the host answered `curl` in 2.2 s:

```
timeout=5s   elapsed=17.308s  err=dial tcp 140.19.33.121:443: i/o timeout
timeout=20s  elapsed=140ms    err=<nil>
```

`aa.usno.navy.mil` resolves to a **single** address and drops or delays SYNs
intermittently. Two things follow, and the second is the one that matters:

1. `net.DialTimeout` overran its own 5 s budget by 12 s — so this is not a
   host that is simply slow, it is one where the dial itself misbehaves.
2. **The immediately following dial connected in 140 ms.** A single-shot probe
   is a coin toss, and the `sync.Once` let one toss decide all fourteen tests.

## The fix

- **`testutil.Reachable` instead of a dial of our own.** It already carries the
  IPv4 retry added after *the same failure mode* took out every IRSA-dependent
  suite — the SFD dust map and the GAMBONS all-sky comparison among them — on a
  host answering in 250 ms. A second implementation started without that fix
  and would start without whatever is learned next.
- **Only a success is remembered.** A failure is retried on the next call. The
  `sync.Once` existed to stop a full outage costing ~30 `usnoGet` call sites
  30 s each — fifteen minutes, past the CI binary timeout. Caching only the
  positive keeps that: an outage now costs one probe per *top-level test*,
  eleven times `ReachableTimeout`, under a minute.
- **The memo is separated from the probe**, so the thing that went wrong is
  testable without a network. `TestUSNOReachabilityDoesNotRememberAFailure`
  drives it through fail → fail → recover → cached, asserting the probe ran
  2, then 3, then still 3 times.
- **A docsguard check** so the next hand-rolled probe does not appear:
  `TestOnlyTestutilProbesReachability` fails on `net.Dial*` in any `_test.go`
  outside `testutil`. It would have caught both incidents.

## Result

```
--- PASS: TestUSNO_SunMoonOneDay (3.94s)     --- PASS: TestUSNO_Eclipses (0.39s)
--- PASS: TestUSNO_CelNav (0.63s)            --- PASS: TestUSNO_PolarSun (1.82s)
--- PASS: TestUSNO_MoonPhases (0.57s)        --- PASS: TestUSNO_HighAltitude (2.30s)
--- PASS: TestUSNO_Seasons (0.68s)           --- PASS: TestUSNO_Equator (1.09s)
--- PASS: TestUSNO_JulianDate (0.00s)        --- PASS: TestUSNO_PolarMoon (1.85s)
--- PASS: TestUSNO_SiderealTime (0.00s)      --- PASS: TestUSNO_CelNav_EdgeCases (2.69s)
--- PASS: TestUSNO_Apsides (0.68s)           --- PASS: TestUSNO_AltitudeShift (0.38s)
```

All fourteen, against the live service, in 17 seconds.

## Mutants

| mutant | killed by |
| --- | --- |
| cache the negative again | `DoesNotRememberAFailure` |
| remember nothing (probe every call) | `DoesNotRememberAFailure` |
| a hand-rolled `net.DialTimeout` in a test file | `OnlyTestutilProbesReachability` |

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation" ./...`,
`go test ./...`, `go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go -C examples build ./...`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.
