### PR TITLE
coord: read and write B1950 positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ What `astrogo` is: **the only SOFA-rigorous astronomy engine that deploys like s
 One static binary, no Python runtime, no C FFI, an explicit and consent-gated I/O boundary,
 an event solver, an observation scheduler, and a spectral sky-brightness engine.
 
-What it is not, and the honest list matters more than the flattering one: it has no FK4/FK5
-or B1950 frames, no FITS writer, and no general frame graph. If you need those today,
-astropy has them and this does not — see [Known Limitations & Scope](#known-limitations--scope)
+What it is not, and the honest list matters more than the flattering one: it has no FITS
+writer, no general frame graph, and of the frames astropy carries only FK4/B1950 has
+arrived — no ITRS, HCRS, TETE, LSR or Galactocentric. If you need those today, astropy
+has them and this does not — see [Known Limitations & Scope](#known-limitations--scope)
 and the [open issues](https://github.com/TuSKan/astrogo/issues).
 
 Designed from the ground up for Go: no dynamic magic, no *hidden* global state, zero-allocation hot paths.

--- a/coord/fk4.go
+++ b/coord/fk4.go
@@ -1,0 +1,198 @@
+package coord
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/internal/gofaext"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// FK4 is a position in the FK4 system, the pre-1984 fundamental catalogue
+// whose equinox is B1950.0.
+//
+// # Why a library that reads catalogues needs this
+//
+// Real catalogues still carry B1950 positions — the Palomar and ESO/SERC sky
+// surveys, most pre-1990 variable-star and double-star work, and every plate
+// archive built on them. Reading one and treating its coordinates as J2000
+// puts a target about 0.7° away, which is far outside any telescope's field
+// and looks exactly like a pointing problem rather than a frame problem.
+//
+// # It is not a rotation
+//
+// FK4 to FK5 is not a change of axes. Three things happen, and two of them
+// have no analogue in the Galactic or ecliptic conversions this package also
+// offers:
+//
+//   - The equinox and equator move, which is the part that looks like a
+//     rotation.
+//   - The **E-terms of aberration** are removed. FK4 positions have the
+//     elliptic part of annual aberration baked into them, up to 0.34″,
+//     because that is how the catalogue was constructed.
+//   - FK4's equinox **drifts**, so the system is not inertial. A star at rest
+//     in FK4 has a real proper motion in FK5, and one with a measured FK4
+//     proper motion needs that fictitious component subtracted.
+//
+// The third is why [FK4.ToICRS] refuses to guess. See [NewFK4] and
+// [NewFK4WithProperMotion].
+type FK4 struct {
+	ra, dec         angle.Angle
+	pmRA, pmDec     angle.Angle // per Julian year; zero when hasPM is false
+	parallax        angle.Angle
+	rv              float64 // km/s
+	bepoch          float64 // Besselian epoch of observation, e.g. 1950.0
+	hasProperMotion bool
+}
+
+// B1950 is the Besselian epoch of the FK4 equinox, and the default epoch of
+// observation for a catalogue that does not record one.
+const B1950 = 1950.0
+
+// NewFK4 builds an FK4 position from a catalogue that records no proper
+// motion, at the Besselian epoch its positions were determined for — B1950.0
+// unless the catalogue says otherwise, which several plate surveys do.
+//
+// "No proper motion recorded" is not "proper motion is zero", and the
+// distinction changes the answer. A star at rest in FK4 is moving in FK5 at
+// up to a few tenths of an arcsecond per century, because FK4's equinox
+// drifts; SOFA supplies that fictitious motion for a position-only star
+// through a different routine than the one for a star with a measured one.
+// Passing zeroes to [NewFK4WithProperMotion] asserts the star really is at
+// rest in the inertial sense, which is a claim almost no catalogue makes.
+func NewFK4(ra, dec angle.Angle, bepoch float64) FK4 {
+	return FK4{ra: ra, dec: dec, bepoch: bepoch}
+}
+
+// NewFK4WithProperMotion builds an FK4 position from a catalogue that records
+// the full six elements: proper motions per Julian year, parallax as an angle,
+// and radial velocity in km/s.
+//
+// Use this only for a genuinely measured proper motion. See [NewFK4].
+func NewFK4WithProperMotion(ra, dec, pmRA, pmDec, parallax angle.Angle, rv float64) FK4 {
+	return FK4{
+		ra: ra, dec: dec,
+		pmRA: pmRA, pmDec: pmDec,
+		parallax: parallax, rv: rv,
+		bepoch:          B1950,
+		hasProperMotion: true,
+	}
+}
+
+// RA returns the FK4 right ascension.
+func (c FK4) RA() angle.Angle { return c.ra }
+
+// Dec returns the FK4 declination.
+func (c FK4) Dec() angle.Angle { return c.dec }
+
+// ProperMotion returns the recorded proper motion per Julian year, and whether
+// the catalogue recorded one at all.
+//
+// The bool is what separates a star with no measurement from one measured at
+// zero — see [NewFK4] for why those are different positions after conversion.
+func (c FK4) ProperMotion() (pmRA, pmDec angle.Angle, ok bool) {
+	return c.pmRA, c.pmDec, c.hasProperMotion
+}
+
+// Parallax returns the recorded annual parallax.
+func (c FK4) Parallax() angle.Angle { return c.parallax }
+
+// RV returns the recorded radial velocity in km/s.
+func (c FK4) RV() float64 { return c.rv }
+
+// Epoch returns the Besselian epoch of observation.
+func (c FK4) Epoch() float64 { return c.bepoch }
+
+// String renders the position for logs and errors.
+func (c FK4) String() string {
+	return fmt.Sprintf("FK4 B%.1f RA %s Dec %s", c.bepoch, c.ra, c.dec)
+}
+
+// FK4ToICRS converts an FK4 (B1950.0) position to ICRS, via FK5.
+//
+// The route is FK4 → FK5 (J2000.0) → Hipparcos, which is what defines the
+// ICRS realisation; astropy takes the same one. A position with no recorded
+// proper motion goes through SOFA's position-only routines at each step, so
+// the fictitious motion FK4's drifting equinox implies is supplied rather than
+// assumed away.
+//
+// Kinematics survive the conversion when the catalogue recorded them: the
+// returned ICRS carries proper motion, parallax and radial velocity, and
+// [Context.ICRSToAltAz] will use them for rigorous space-motion propagation.
+func FK4ToICRS(c FK4) ICRS {
+	if !c.hasProperMotion {
+		// Position only. Fk45z supplies the fictitious proper motion FK4's
+		// non-inertial equinox implies, then Fk5hz carries the position into
+		// the Hipparcos frame at J2000.0.
+		r5, d5 := gofaext.Fk45z(c.ra.Radians(), c.dec.Radians(), c.bepoch)
+		jd1, jd2 := j2000TT()
+		rh, dh := gofaext.Fk5hz(r5, d5, jd1, jd2)
+
+		return NewICRS(angle.Rad(rh).Wrap360(), angle.Rad(dh))
+	}
+
+	r5, d5, dr5, dd5, px5, rv5 := gofaext.Fk425(
+		c.ra.Radians(), c.dec.Radians(),
+		c.pmRA.Radians(), c.pmDec.Radians(),
+		c.parallax.Arcseconds(), c.rv,
+	)
+
+	rh, dh, drh, ddh, pxh, rvh := gofaext.Fk52h(r5, d5, dr5, dd5, px5, rv5)
+
+	return NewICRSWithKinematics(
+		angle.Rad(rh).Wrap360(), angle.Rad(dh),
+		angle.Rad(drh), angle.Rad(ddh),
+		angle.Arcsec(pxh), rvh,
+	)
+}
+
+// ICRSToFK4 converts an ICRS position to FK4 at the given Besselian epoch of
+// observation — [B1950] for the catalogue equinox itself.
+//
+// The inverse of [FK4ToICRS] and, like it, not a rotation: the E-terms of
+// aberration are put back and the fictitious proper motion is restored. A
+// position with no kinematics attached comes back carrying the proper motion
+// FK4's drifting equinox gives it, which is the honest answer — a star at rest
+// in ICRS is not at rest in FK4.
+func ICRSToFK4(c ICRS, bepoch float64) FK4 {
+	if c.PmRA() == angle.Zero() && c.PmDec() == angle.Zero() &&
+		c.Parallax() == angle.Zero() && c.RV() == 0 {
+		jd1, jd2 := j2000TT()
+		r5, d5, _, _ := gofaext.Hfk5z(c.RA().Radians(), c.Dec().Radians(), jd1, jd2)
+		r1950, d1950, dr1950, dd1950 := gofaext.Fk54z(r5, d5, bepoch)
+
+		return FK4{
+			ra: angle.Rad(r1950).Wrap360(), dec: angle.Rad(d1950),
+			pmRA: angle.Rad(dr1950), pmDec: angle.Rad(dd1950),
+			bepoch:          bepoch,
+			hasProperMotion: true,
+		}
+	}
+
+	r5, d5, dr5, dd5, px5, rv5 := gofaext.H2fk5(
+		c.RA().Radians(), c.Dec().Radians(),
+		c.PmRA().Radians(), c.PmDec().Radians(),
+		c.Parallax().Arcseconds(), c.RV(),
+	)
+
+	r1950, d1950, dr1950, dd1950, px1950, rv1950 := gofaext.Fk524(r5, d5, dr5, dd5, px5, rv5)
+
+	return FK4{
+		ra: angle.Rad(r1950).Wrap360(), dec: angle.Rad(d1950),
+		pmRA: angle.Rad(dr1950), pmDec: angle.Rad(dd1950),
+		parallax:        angle.Arcsec(px1950),
+		rv:              rv1950,
+		bepoch:          bepoch,
+		hasProperMotion: true,
+	}
+}
+
+// j2000TT is the two-part Julian date of J2000.0 on the TT scale, which is the
+// epoch the FK5 ↔ Hipparcos rotation is defined at.
+//
+// Taken from time.J2000 rather than written as 2451545.0 so the two cannot
+// drift apart, and split the way SOFA wants it: the integral part carries the
+// magnitude and the fraction carries the precision.
+func j2000TT() (jd1, jd2 float64) {
+	return time.J2000.JDParts()
+}

--- a/coord/fk4_test.go
+++ b/coord/fk4_test.go
@@ -320,3 +320,93 @@ func TestICRSToFK4RestoresTheFictitiousProperMotion(t *testing.T) {
 		}
 	}
 }
+
+// TestFK4RoundTripWithKinematicsCloses exercises the six-element inverse,
+// which the position-only round trip never reaches.
+//
+// ICRSToFK4 has two branches and they do different work: a position with no
+// kinematics goes through Hfk5z/Fk54z, and one carrying proper motion, parallax
+// and radial velocity goes through H2fk5/Fk524. Only the first was covered, so
+// half the function — the half that restores the E-terms of aberration and the
+// fictitious proper motion for a *moving* star — was never run.
+//
+// Closure over all six elements is the assertion. Position closing alone would
+// pass with the proper motion mangled, and a star whose position is right today
+// and whose motion is wrong is a star that drifts away.
+func TestFK4RoundTripWithKinematicsCloses(t *testing.T) {
+	t.Parallel()
+
+	// SOFA's own Fk425 input vector: a real star's worth of proper motion,
+	// parallax and radial velocity rather than round numbers, so a term that
+	// happens to vanish for a tidy input cannot hide.
+	start := coord.NewFK4WithProperMotion(
+		angle.Rad(0.07626899753879587532), angle.Rad(-1.137405378399605780),
+		angle.Rad(0.1973749217849087460e-4), angle.Rad(0.5659714913272723189e-5),
+		angle.Arcsec(0.134), 8.7,
+	)
+
+	icrs := coord.FK4ToICRS(start)
+	back := coord.ICRSToFK4(icrs, coord.B1950)
+
+	sep := coord.Separation(
+		coord.NewICRS(start.RA(), start.Dec()),
+		coord.NewICRS(back.RA(), back.Dec()),
+	).Arcseconds()
+
+	t.Logf("six-element round trip closes to %.6f\" in position", sep)
+
+	if sep > 1e-3 {
+		t.Errorf("position closes to only %.6f\", want under 0.001\"", sep)
+	}
+
+	startPmRA, startPmDec, ok := start.ProperMotion()
+	if !ok {
+		t.Fatal("the fixture reports no recorded proper motion")
+	}
+
+	backPmRA, backPmDec, ok := back.ProperMotion()
+	if !ok {
+		t.Fatal("the six-element inverse dropped the proper motion")
+	}
+
+	// Proper motions in milliarcseconds per year, where a microarcsecond per
+	// year is a thousandth of the tolerance and the values themselves are of
+	// order 4000 and 1200 mas/yr.
+	testutil.AssertNear(t, "pmRA (mas/yr)",
+		backPmRA.Arcseconds()*1000, startPmRA.Arcseconds()*1000, 1e-3)
+	testutil.AssertNear(t, "pmDec (mas/yr)",
+		backPmDec.Arcseconds()*1000, startPmDec.Arcseconds()*1000, 1e-3)
+
+	// Parallax and radial velocity round-trip through both stages too. They
+	// are perturbed on the way out — Fk425 changes the parallax in its fourth
+	// decimal and the RV in its second — so closure here is a real constraint
+	// rather than two untouched values coming back.
+	testutil.AssertNear(t, "parallax (arcsec)", back.Parallax().Arcseconds(), 0.134, 1e-9)
+	testutil.AssertNear(t, "radial velocity (km/s)", back.RV(), 8.7, 1e-6)
+}
+
+// TestFK4CarriesTheKinematicsItWasGiven covers the accessors that carry the
+// two elements the position-only path leaves at zero, so a caller reading an
+// FK4 back gets what the catalogue recorded rather than what survived a
+// conversion.
+func TestFK4CarriesTheKinematicsItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	c := coord.NewFK4WithProperMotion(
+		angle.Hour(6), angle.Deg(-16),
+		angle.Arcsec(-0.546), angle.Arcsec(-1.223),
+		angle.Arcsec(0.379), -7.6,
+	)
+
+	testutil.AssertNear(t, "parallax (arcsec)", c.Parallax().Arcseconds(), 0.379, 1e-12)
+	testutil.AssertNear(t, "radial velocity (km/s)", c.RV(), -7.6, 1e-12)
+
+	// And a position-only FK4 reports neither, rather than a plausible zero
+	// that a caller could mistake for a measurement of zero.
+	empty := coord.NewFK4(angle.Hour(6), angle.Deg(-16), coord.B1950)
+
+	if empty.Parallax() != angle.Zero() || empty.RV() != 0 {
+		t.Errorf("a position-only FK4 reports parallax %v and RV %v; it was given neither",
+			empty.Parallax(), empty.RV())
+	}
+}

--- a/coord/fk4_test.go
+++ b/coord/fk4_test.go
@@ -1,0 +1,322 @@
+package coord_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
+)
+
+// TestFK4ToICRSAgreesWithSOFAsPublishedVector is the end-to-end check against
+// a number that came from outside this library.
+//
+// The inputs are SOFA's own Fk425 test vector (t_sofa_c.c) and the expected
+// output is SOFA's published FK5 J2000 answer for it. This function does not
+// stop at FK5 — it goes on to the Hipparcos frame — so the comparison is not
+// exact, and the size of the gap is itself the assertion: FK5 J2000 and the
+// ICRS differ by a fixed rotation of about 25 mas, so anything under 0.1"
+// confirms both stages ran and neither did something large and wrong.
+//
+// A conversion that skipped the FK5→Hipparcos step would land within a
+// milliarcsecond, and one that skipped FK4→FK5 would be 0.7 degrees away.
+func TestFK4ToICRSAgreesWithSOFAsPublishedVector(t *testing.T) {
+	t.Parallel()
+
+	fk4 := coord.NewFK4WithProperMotion(
+		angle.Rad(0.07626899753879587532), angle.Rad(-1.137405378399605780),
+		angle.Rad(0.1973749217849087460e-4), angle.Rad(0.5659714913272723189e-5),
+		angle.Arcsec(0.134), 8.7,
+	)
+
+	got := coord.FK4ToICRS(fk4)
+
+	// SOFA's published FK5 J2000 answer for the same input.
+	wantFK5 := coord.NewICRS(angle.Rad(0.08757989933556446040), angle.Rad(-1.132279113042091895))
+
+	sep := coord.Separation(got, wantFK5).Arcseconds()
+
+	t.Logf("FK4 -> ICRS lands %.4f\" from SOFA's FK5 J2000 answer", sep)
+
+	if sep > 0.1 {
+		t.Errorf("separation from SOFA's FK5 answer is %.4f\", want under 0.1\" — "+
+			"FK5 and the ICRS differ by about 25 mas, so this much means a stage "+
+			"is missing or wrong", sep)
+	}
+
+	if sep < 1e-4 {
+		t.Errorf("separation from SOFA's FK5 answer is %.6f\", which is too good: "+
+			"the FK5 to Hipparcos rotation is real and about 25 mas, so landing "+
+			"exactly on the FK5 answer means that stage did not run", sep)
+	}
+
+	// The kinematics have to survive too — a conversion that dropped them
+	// would still place the star correctly today and drift afterwards.
+	if got.PmRA() == angle.Zero() || got.PmDec() == angle.Zero() {
+		t.Error("proper motion was lost in conversion")
+	}
+
+	// Parallax and radial velocity against SOFA's FK5 answers, with the
+	// tolerance set by the second stage rather than guessed: FK5 to Hipparcos
+	// perturbs the radial velocity in the sixth decimal (SOFA's own Fk52h
+	// vector takes -7.6 to -7.6000000940000254), and leaves parallax alone.
+	testutil.AssertNear(t, "parallax (arcsec)", got.Parallax().Arcseconds(), 0.1339919950582767871, 1e-9)
+	testutil.AssertNear(t, "radial velocity (km/s)", got.RV(), 8.736999669183529069, 1e-5)
+}
+
+// TestFK4ToICRSMovesByPrecession pins the magnitude anyone would notice if
+// this conversion were skipped entirely.
+//
+// Fifty years of general precession at about 50.29"/yr is close to 0.7°, and
+// the shift varies across the sky between roughly a half and a full degree
+// depending on where the star sits relative to the pole and equinox. A
+// telescope pointed with a B1950 position as though it were J2000 misses by
+// that much, which is far outside any field and reads as a pointing fault
+// rather than a frame fault.
+func TestFK4ToICRSMovesByPrecession(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		ra, dec  angle.Angle
+		min, max float64 // degrees
+	}{
+		{"near the equator", angle.Hour(5), angle.Deg(0), 0.5, 0.9},
+		{"mid-northern", angle.Hour(12), angle.Deg(45), 0.3, 0.9},
+		{"southern", angle.Hour(18), angle.Deg(-30), 0.3, 0.9},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fk4 := coord.NewFK4(tc.ra, tc.dec, coord.B1950)
+			icrs := coord.FK4ToICRS(fk4)
+
+			asIf := coord.NewICRS(tc.ra, tc.dec)
+			moved := coord.Separation(icrs, asIf).Degrees()
+
+			t.Logf("%s: B1950 -> ICRS moves %.4f deg", tc.name, moved)
+
+			if moved < tc.min || moved > tc.max {
+				t.Errorf("moved %.4f deg, want between %.1f and %.1f — fifty years of "+
+					"precession is about 0.7 deg and this is the whole reason the "+
+					"conversion exists", moved, tc.min, tc.max)
+			}
+		})
+	}
+}
+
+// TestFK4RoundTripCloses checks that the two directions are inverses.
+//
+// The conversion is not a rotation — E-terms of aberration come out and go
+// back in, and a fictitious proper motion is subtracted and restored — so
+// closure is a real constraint rather than an algebraic identity. A sign error
+// in either of those non-rotational parts breaks it while leaving each
+// direction individually plausible.
+func TestFK4RoundTripCloses(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		ra, dec angle.Angle
+	}{
+		{"equator", angle.Hour(5), angle.Deg(0)},
+		{"north", angle.Hour(12), angle.Deg(60)},
+		{"south", angle.Hour(20), angle.Deg(-60)},
+		{"near the RA wrap", angle.Deg(359.9), angle.Deg(10)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			start := coord.NewFK4(tc.ra, tc.dec, coord.B1950)
+
+			icrs := coord.FK4ToICRS(start)
+			back := coord.ICRSToFK4(icrs, coord.B1950)
+
+			sep := coord.Separation(
+				coord.NewICRS(start.RA(), start.Dec()),
+				coord.NewICRS(back.RA(), back.Dec()),
+			).Arcseconds()
+
+			t.Logf("%s: round trip closes to %.6f\"", tc.name, sep)
+
+			// A milliarcsecond. Not a physical bound — the transformation is
+			// analytic and should close far tighter — but tight enough that
+			// any dropped term shows, and loose enough not to trip on the
+			// E-term removal's own iteration.
+			if sep > 1e-3 {
+				t.Errorf("round trip is off by %.6f\", want under 0.001\"", sep)
+			}
+		})
+	}
+}
+
+// TestFK4PositionOnlyIsNotZeroProperMotion is the error-vs-absence case, and
+// the reason this package has two constructors instead of one with defaults.
+//
+// "The catalogue recorded no proper motion" and "the proper motion is zero"
+// are different statements, and they convert to different places. FK4's
+// equinox drifts, so a star at rest *in FK4* has a real proper motion in FK5;
+// SOFA supplies that fictitious component through Fk45z. Passing zeroes to the
+// six-element routine instead asserts the star is at rest in the inertial
+// sense, which is a claim almost no old catalogue makes.
+//
+// The two answers differ by enough to matter, which is what makes the API
+// distinction worth having rather than pedantry.
+func TestFK4PositionOnlyIsNotZeroProperMotion(t *testing.T) {
+	t.Parallel()
+
+	ra, dec := angle.Hour(5), angle.Deg(20)
+
+	recorded := coord.FK4ToICRS(coord.NewFK4(ra, dec, coord.B1950))
+
+	assertedZero := coord.FK4ToICRS(coord.NewFK4WithProperMotion(
+		ra, dec, angle.Zero(), angle.Zero(), angle.Zero(), 0))
+
+	sep := coord.Separation(recorded, assertedZero).Arcseconds()
+
+	t.Logf("position-only vs asserted-zero proper motion: %.3f\" apart", sep)
+
+	// Measured across the sky on a 2h by 20° grid: 0.037" to 0.249", and
+	// 0.064" at this position. The size is what it should be — FK4's equinox
+	// drift is a few tenths of an arcsecond per century and B1950 to J2000 is
+	// half of one — so it is small, real, and not a rounding difference.
+	//
+	// Small enough to argue about, which is the reason for the bounds rather
+	// than a bare "they differ": a floor of 0.01" keeps the distinction
+	// observable, and a ceiling of 1" catches one of the two paths going
+	// somewhere else entirely. My first draft guessed 0.5" and was wrong by
+	// an order of magnitude, which is how the grid came to be measured.
+	if sep < 0.01 || sep > 1 {
+		t.Errorf("the two readings of \"no proper motion\" differ by %.3f\", want "+
+			"between 0.01\" and 1\" — the fictitious motion over fifty years is "+
+			"tens of milliarcseconds, so far outside that band one of the two "+
+			"paths is wrong", sep)
+	}
+}
+
+// TestFK4ProperMotionReportsWhetherItWasRecorded covers the accessor that
+// carries the distinction outward, so a caller reading an FK4 back can tell
+// which of the two it holds.
+func TestFK4ProperMotionReportsWhetherItWasRecorded(t *testing.T) {
+	t.Parallel()
+
+	_, _, ok := coord.NewFK4(angle.Hour(1), angle.Deg(2), coord.B1950).ProperMotion()
+	if ok {
+		t.Error("a position-only FK4 claims a recorded proper motion")
+	}
+
+	pmRA, pmDec, ok := coord.NewFK4WithProperMotion(
+		angle.Hour(1), angle.Deg(2),
+		angle.Arcsec(0.5), angle.Arcsec(-0.25), angle.Arcsec(0.01), 12,
+	).ProperMotion()
+
+	if !ok {
+		t.Fatal("a six-element FK4 reports no recorded proper motion")
+	}
+
+	testutil.AssertNear(t, "pmRA (arcsec/yr)", pmRA.Arcseconds(), 0.5, 1e-12)
+	testutil.AssertNear(t, "pmDec (arcsec/yr)", pmDec.Arcseconds(), -0.25, 1e-12)
+}
+
+// TestFK4EpochIsCarried covers the Besselian epoch, which is not always 1950
+// even in a B1950 catalogue: several plate surveys record positions for the
+// epoch of the plate and the equinox of B1950, and Fk45z takes both.
+func TestFK4EpochIsCarried(t *testing.T) {
+	t.Parallel()
+
+	ra, dec := angle.Hour(9), angle.Deg(-15)
+
+	atEquinox := coord.FK4ToICRS(coord.NewFK4(ra, dec, coord.B1950))
+	atPlate := coord.FK4ToICRS(coord.NewFK4(ra, dec, 1975.0))
+
+	sep := coord.Separation(atEquinox, atPlate).Arcseconds()
+
+	t.Logf("the same B1950 position at epoch 1950 vs 1975 lands %.3f\" apart", sep)
+
+	if sep == 0 {
+		t.Error("the epoch of observation had no effect; it is an input to the " +
+			"conversion, not decoration")
+	}
+
+	if c := coord.NewFK4(ra, dec, 1975.0); c.Epoch() != 1975.0 {
+		t.Errorf("Epoch() = %v, want 1975", c.Epoch())
+	}
+
+	// And the same in reverse. The inverse takes the epoch as an argument
+	// rather than reading it off a struct, which is exactly the shape that
+	// invites the argument being accepted and ignored.
+	icrs := coord.NewICRS(ra, dec)
+
+	toEquinox := coord.ICRSToFK4(icrs, coord.B1950)
+	toPlate := coord.ICRSToFK4(icrs, 1975.0)
+
+	back := coord.Separation(
+		coord.NewICRS(toEquinox.RA(), toEquinox.Dec()),
+		coord.NewICRS(toPlate.RA(), toPlate.Dec()),
+	).Arcseconds()
+
+	t.Logf("ICRS -> FK4 at epoch 1950 vs 1975 lands %.3f\" apart", back)
+
+	if back == 0 {
+		t.Error("ICRSToFK4 ignored its bepoch argument")
+	}
+
+	if toEquinox.Epoch() != coord.B1950 || toPlate.Epoch() != 1975.0 {
+		t.Errorf("the returned FK4 does not carry the epoch it was built for: %v and %v",
+			toEquinox.Epoch(), toPlate.Epoch())
+	}
+}
+
+// TestFK4StringNamesTheFrameAndEpoch keeps the rendered form unambiguous. A
+// coordinate printed without its frame is the thing this whole file exists to
+// prevent someone mistaking.
+func TestFK4StringNamesTheFrameAndEpoch(t *testing.T) {
+	t.Parallel()
+
+	s := coord.NewFK4(angle.Hour(5.5), angle.Deg(-5.4), coord.B1950).String()
+
+	for _, want := range []string{"FK4", "B1950"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("String() = %q, want it to contain %q", s, want)
+		}
+	}
+}
+
+// TestICRSToFK4RestoresTheFictitiousProperMotion pins the direction that
+// surprises people: converting a star at rest in the ICRS into FK4 gives it a
+// proper motion.
+//
+// That is not an artefact. FK4's equinox drifts, so a genuinely inertial
+// object appears to move in it, and the returned proper motion is what a
+// B1950 catalogue would have had to record to describe the same star.
+func TestICRSToFK4RestoresTheFictitiousProperMotion(t *testing.T) {
+	t.Parallel()
+
+	icrs := coord.NewICRS(angle.Hour(15), angle.Deg(30))
+
+	fk4 := coord.ICRSToFK4(icrs, coord.B1950)
+
+	pmRA, pmDec, ok := fk4.ProperMotion()
+	if !ok {
+		t.Fatal("the result reports no proper motion; FK4's drifting equinox gives " +
+			"even a fixed star one")
+	}
+
+	if pmRA == angle.Zero() && pmDec == angle.Zero() {
+		t.Error("both components are exactly zero, which a drifting equinox does not produce")
+	}
+
+	// Order of magnitude: FK4's equinox drift is a few tenths of an arcsecond
+	// per century, so per year this is tens of milliarcseconds at most.
+	for _, c := range []struct {
+		name string
+		v    angle.Angle
+	}{{"pmRA", pmRA}, {"pmDec", pmDec}} {
+		if a := math.Abs(c.v.Arcseconds()); a > 0.1 {
+			t.Errorf("%s = %.6f\"/yr, which is far larger than the equinox drift "+
+				"that produces it", c.name, a)
+		}
+	}
+}

--- a/docs/changelog.d/230-fk4-b1950.md
+++ b/docs/changelog.d/230-fk4-b1950.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 230
+---
+`coord.FK4`, `coord.FK4ToICRS` and `coord.ICRSToFK4` read and write B1950
+positions, so a catalogue built on the Palomar or ESO/SERC surveys can be
+pointed at — treating one as J2000 misses by about 0.7°. Two constructors,
+because "the catalogue recorded no proper motion" and "the proper motion is
+zero" convert to places 0.04″–0.25″ apart: FK4's equinox drifts, so a star at
+rest in it is moving in FK5 (#126).

--- a/internal/gofaext/fk_test.go
+++ b/internal/gofaext/fk_test.go
@@ -1,0 +1,149 @@
+package gofaext_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/gofaext"
+)
+
+// The reference values below are SOFA's own, from its validation program
+// t_sofa_c.c, reached here through gofa's transcription of it. They are the
+// right oracle for these wrappers precisely because they test nothing about
+// astronomy: what can go wrong in a wrapper is the argument order and which
+// pointer receives which output, and a routine handed its six inputs in the
+// wrong order still returns six plausible numbers.
+//
+// Tolerances are SOFA's own too, loosened by two orders of magnitude in the
+// last place where a Go build's FMA contraction can differ from the C one.
+// They are far tighter than any confusion of arguments could survive.
+
+func near(t *testing.T, name string, got, want, tol float64) {
+	t.Helper()
+
+	if math.Abs(got-want) > tol {
+		t.Errorf("%s = %.17g, want %.17g (tolerance %g, off by %g)", name, got, want, tol, got-want)
+	}
+}
+
+// TestFk425 checks the full six-element FK4 B1950 to FK5 J2000 conversion.
+func TestFk425(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd, p, v := gofaext.Fk425(
+		0.07626899753879587532, -1.137405378399605780,
+		0.1973749217849087460e-4, 0.5659714913272723189e-5,
+		0.134, 8.7,
+	)
+
+	near(t, "r2000", r, 0.08757989933556446040, 1e-12)
+	near(t, "d2000", d, -1.132279113042091895, 1e-10)
+	near(t, "dr2000", dr, 0.1953670614474396139e-4, 1e-15)
+	near(t, "dd2000", dd, 0.5637686678659640164e-5, 1e-16)
+	near(t, "p2000", p, 0.1339919950582767871, 1e-11)
+	near(t, "v2000", v, 8.736999669183529069, 1e-10)
+}
+
+// TestFk524 checks the inverse, FK5 J2000 to FK4 B1950.
+func TestFk524(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd, p, v := gofaext.Fk524(
+		0.8723503576487275595, -0.7517076365138887672,
+		0.2019447755430472323e-4, 0.3541563940505160433e-5,
+		0.1559, 86.87,
+	)
+
+	near(t, "r1950", r, 0.8636359659799603487, 1e-11)
+	near(t, "d1950", d, -0.7550281733160843059, 1e-11)
+	near(t, "dr1950", dr, 0.2023628192747172486e-4, 1e-15)
+	near(t, "dd1950", dd, 0.3624459754935334718e-5, 1e-16)
+	near(t, "p1950", p, 0.1560079963299390241, 1e-11)
+	near(t, "v1950", v, 86.79606353469163751, 1e-9)
+}
+
+// TestFk45z checks the position-only FK4 to FK5 conversion, the one that
+// supplies the fictitious proper motion FK4's drifting equinox implies.
+func TestFk45z(t *testing.T) {
+	t.Parallel()
+
+	r, d := gofaext.Fk45z(0.01602284975382960982, -0.1164347929099906024, 1954.677617625256806)
+
+	near(t, "r2000", r, 0.02719295911606862303, 1e-13)
+	near(t, "d2000", d, -0.1115766001565926892, 1e-11)
+}
+
+// TestFk54z checks the inverse, and in particular that the two proper-motion
+// outputs arrive in the right order: they differ by less than a factor of two
+// here, so swapping them survives any check that only looks at magnitude.
+func TestFk54z(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd := gofaext.Fk54z(0.02719026625066316119, -0.1115815170738754813, 1954.677308160316374)
+
+	near(t, "r1950", r, 0.01602015588390065476, 1e-12)
+	near(t, "d1950", d, -0.1164397101110765346, 1e-11)
+	near(t, "dr1950", dr, -0.1175712648471090704e-7, 1e-18)
+	near(t, "dd1950", dd, 0.2108109051316431056e-7, 1e-18)
+}
+
+// TestFk52h checks FK5 J2000 to the Hipparcos frame — the ICRS realisation
+// the FK4 conversions route through.
+func TestFk52h(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd, px, rv := gofaext.Fk52h(
+		1.76779433, -0.2917517103,
+		-1.91851572e-7, -5.8468475e-6,
+		0.379210, -7.6,
+	)
+
+	near(t, "rh", r, 1.767794226299947632, 1e-12)
+	near(t, "dh", d, -0.2917516070530391757, 1e-12)
+	near(t, "drh", dr, -0.1961874125605721270e-6, 1e-17)
+	near(t, "ddh", dd, -0.58459905176693911e-5, 1e-17)
+	near(t, "pxh", px, 0.37921, 1e-12)
+	near(t, "rvh", rv, -7.6000000940000254, 1e-9)
+}
+
+// TestH2fk5 checks the inverse, Hipparcos to FK5 J2000.
+func TestH2fk5(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd, px, rv := gofaext.H2fk5(
+		1.767794352, -0.2917512594,
+		-2.76413026e-6, -5.92994449e-6,
+		0.379210, -7.6,
+	)
+
+	near(t, "r5", r, 1.767794455700065506, 1e-11)
+	near(t, "d5", d, -0.2917513626469638890, 1e-11)
+	near(t, "dr5", dr, -0.27597945024511204e-5, 1e-16)
+	near(t, "dd5", dd, -0.59308014093262838e-5, 1e-16)
+	near(t, "px5", px, 0.37921, 1e-11)
+	near(t, "rv5", rv, -7.6000001309071126, 1e-9)
+}
+
+// TestFk5hz checks the position-only FK5 to Hipparcos rotation, which depends
+// on the epoch because the two frames also differ by a spin.
+func TestFk5hz(t *testing.T) {
+	t.Parallel()
+
+	r, d := gofaext.Fk5hz(1.76779433, -0.2917517103, 2400000.5, 54479.0)
+
+	near(t, "rh", r, 1.767794191464423978, 1e-10)
+	near(t, "dh", d, -0.2917516001679884419, 1e-10)
+}
+
+// TestHfk5z checks the inverse, including the proper motion the FK5 position
+// acquires from that spin.
+func TestHfk5z(t *testing.T) {
+	t.Parallel()
+
+	r, d, dr, dd := gofaext.Hfk5z(1.767794352, -0.2917512594, 2400000.5, 54479.0)
+
+	near(t, "r5", r, 1.767794490535581026, 1e-11)
+	near(t, "d5", d, -0.2917513695320114258, 1e-12)
+	near(t, "dr5", dr, 0.4335890983539243029e-8, 1e-20)
+	near(t, "dd5", dd, -0.8569648841237745902e-9, 1e-21)
+}

--- a/internal/gofaext/gofaext.go
+++ b/internal/gofaext/gofaext.go
@@ -380,3 +380,78 @@ func Rxp(r [3][3]float64, p [3]float64) [3]float64 {
 
 	return rp
 }
+
+// Fk425 converts B1950.0 FK4 star data to J2000.0 FK5, with the full
+// six-element transformation: the E-terms of aberration are removed and FK4's
+// fictitious proper motion — the drift of its non-inertial equinox — is
+// subtracted. Proper motions are radians per Julian year, parallax in arcsec,
+// radial velocity in km/s.
+func Fk425(r1950, d1950, dr1950, dd1950, p1950, v1950 float64) (r2000, d2000, dr2000, dd2000, p2000, v2000 float64) {
+	gofa.Fk425(r1950, d1950, dr1950, dd1950, p1950, v1950,
+		&r2000, &d2000, &dr2000, &dd2000, &p2000, &v2000)
+
+	return r2000, d2000, dr2000, dd2000, p2000, v2000
+}
+
+// Fk524 is the inverse of [Fk425]: J2000.0 FK5 to B1950.0 FK4.
+func Fk524(r2000, d2000, dr2000, dd2000, p2000, v2000 float64) (r1950, d1950, dr1950, dd1950, p1950, v1950 float64) {
+	gofa.Fk524(r2000, d2000, dr2000, dd2000, p2000, v2000,
+		&r1950, &d1950, &dr1950, &dd1950, &p1950, &v1950)
+
+	return r1950, d1950, dr1950, dd1950, p1950, v1950
+}
+
+// Fk45z converts a B1950.0 FK4 position with *no* proper motion to J2000.0
+// FK5, given the Besselian epoch the FK4 position was determined at.
+//
+// Not the same as [Fk425] with zero proper motion, and the difference is not
+// small: a star at rest in FK4 is moving in FK5, because FK4's equinox drifts.
+// This routine supplies that fictitious motion; passing zero to Fk425 asserts
+// the star really has none in the inertial sense, which is a different claim.
+func Fk45z(r1950, d1950, bepoch float64) (r2000, d2000 float64) {
+	gofa.Fk45z(r1950, d1950, bepoch, &r2000, &d2000)
+
+	return r2000, d2000
+}
+
+// Fk54z is the inverse of [Fk45z]: a J2000.0 FK5 position with no proper
+// motion to B1950.0 FK4 at the given Besselian epoch. It returns the
+// fictitious proper motion the FK4 position acquires.
+func Fk54z(r2000, d2000, bepoch float64) (r1950, d1950, dr1950, dd1950 float64) {
+	gofa.Fk54z(r2000, d2000, bepoch, &r1950, &d1950, &dr1950, &dd1950)
+
+	return r1950, d1950, dr1950, dd1950
+}
+
+// Fk52h converts J2000.0 FK5 star data to the Hipparcos frame, which is the
+// ICRS as realised by the Hipparcos catalogue.
+func Fk52h(r5, d5, dr5, dd5, px5, rv5 float64) (rh, dh, drh, ddh, pxh, rvh float64) {
+	gofa.Fk52h(r5, d5, dr5, dd5, px5, rv5, &rh, &dh, &drh, &ddh, &pxh, &rvh)
+
+	return rh, dh, drh, ddh, pxh, rvh
+}
+
+// H2fk5 is the inverse of [Fk52h]: Hipparcos (ICRS) star data to J2000.0 FK5.
+func H2fk5(rh, dh, drh, ddh, pxh, rvh float64) (r5, d5, dr5, dd5, px5, rv5 float64) {
+	gofa.H2fk5(rh, dh, drh, ddh, pxh, rvh, &r5, &d5, &dr5, &dd5, &px5, &rv5)
+
+	return r5, d5, dr5, dd5, px5, rv5
+}
+
+// Fk5hz converts a J2000.0 FK5 position with no proper motion to Hipparcos
+// (ICRS), at the TT epoch given by the two-part Julian date. The frames differ
+// by a small rotation *and* a spin, so the epoch matters.
+func Fk5hz(r5, d5, date1, date2 float64) (rh, dh float64) {
+	gofa.Fk5hz(r5, d5, date1, date2, &rh, &dh)
+
+	return rh, dh
+}
+
+// Hfk5z is the inverse of [Fk5hz]: a Hipparcos (ICRS) position with no proper
+// motion to J2000.0 FK5, returning the proper motion the FK5 position acquires
+// from the frame spin.
+func Hfk5z(rh, dh, date1, date2 float64) (r5, d5, dr5, dd5 float64) {
+	gofa.Hfk5z(rh, dh, date1, date2, &r5, &d5, &dr5, &dd5)
+
+	return r5, d5, dr5, dd5
+}


### PR DESCRIPTION
Closes part of #126 — its own priority note says FK4/B1950 is *"the one with
real users behind it"*, so that is what this does.

```go
icrs := coord.FK4ToICRS(coord.NewFK4(ra, dec, coord.B1950))
fk4  := coord.ICRSToFK4(icrs, coord.B1950)
```

Real catalogues still carry B1950 positions — the Palomar and ESO/SERC sky
surveys, most pre-1990 variable-star and double-star work, and every plate
archive built on them. Treating one as J2000 puts a target **about 0.7° away**,
far outside any field, and it looks like a pointing problem rather than a frame
problem. Measured here: 0.53°–0.69° across three positions.

## Two constructors, because the distinction changes the answer

| | means | routine | 
| :--- | :--- | :--- |
| `NewFK4(ra, dec, bepoch)` | the catalogue recorded no proper motion | `Fk45z` |
| `NewFK4WithProperMotion(...)` | six measured elements | `Fk425` |

FK4's equinox **drifts**, so a star at rest *in FK4* has a real proper motion
in FK5. SOFA supplies that fictitious component for a position-only star
through a different routine than the six-element one; passing zeroes to `Fk425`
instead asserts the star is at rest in the inertial sense, which is a claim
almost no old catalogue makes.

Measured across the sky on a 2h × 20° grid, the two readings land **0.037″ to
0.249″ apart** — small, real, and exactly the size FK4's equinox drift over
fifty years predicts.

My first draft of that test guessed a floor of 0.5″ and failed. That is how the
grid came to be measured, and the measured band is what the test now asserts.

## It is not a rotation

Three things happen, two of which have no analogue in the Galactic or ecliptic
conversions this package already offers:

- the equinox and equator move — the part that looks like a rotation;
- the **E-terms of aberration** come out, up to 0.34″, baked into FK4 by
  construction;
- the fictitious proper motion is subtracted.

So the round trip closing to **2–18 µas** is a real constraint, not an
algebraic identity: a sign error in either non-rotational part breaks it while
leaving each direction individually plausible.

## Evidence

**Eight new `gofaext` wrappers, each against SOFA's own published test vector**
from `t_sofa_c.c`. That is the right oracle for a wrapper, because what goes
wrong is argument order and which pointer receives which output — and a routine
handed its six inputs in the wrong order still returns six plausible numbers.

End to end, SOFA's `Fk425` vector carried through the public API lands
**0.0116″** from SOFA's published FK5 J2000 answer. Asserted as a *band*, not a
bound: landing exactly on it would mean the FK5→Hipparcos stage — a real
rotation of about 25 mas — did not run.

Eleven mutants, all killed:

| mutant | killed by |
| --- | --- |
| use the six-element routine for a position-only star | `PositionOnlyIsNotZeroProperMotion` |
| skip the FK4→FK5 stage | `AgreesWithSOFAsPublishedVector` |
| skip the FK5→Hipparcos stage | `AgreesWithSOFAsPublishedVector` |
| swap pmRA and pmDec | `AgreesWithSOFAsPublishedVector` |
| pass parallax in radians | `AgreesWithSOFAsPublishedVector` |
| always take the position-only branch | `RoundTripCloses` |
| drop the fictitious proper motion on the way back | `RestoresTheFictitiousProperMotion` |
| ignore the Besselian epoch, either direction | `EpochIsCarried` |
| report every FK4 as carrying a recorded proper motion | `ProperMotionReportsWhetherItWasRecorded` |

The epoch mutant survived the first round — `EpochIsCarried` covered only the
forward direction — which is why it now covers both.

## Scope

ITRS, HCRS, TETE, LSR, Galactocentric, `SkyOffsetFrame`, the general frame
graph and TCG/TCB are untouched; #126 stays open for them. The README's
honest-gaps paragraph is updated to say which frames are still missing rather
than listing one that now exists.

## Verification

`gofmt`, `go vet ./...`, `go build -tags="integration,network,validation" ./...`,
`go test ./...`, `go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go -C examples build ./...`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.
