### PR TITLE
chore: require Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,28 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          # '1.25' rather than go-version-file: go.mod, deliberately.
+          # '1.27' rather than go-version-file: go.mod, still deliberately —
+          # though the reason is now insurance rather than a live problem.
           #
-          # go.mod declares `go 1.25.8` — a patch-level minimum astrogo does
-          # not need and does not set: `go mod tidy` raises the directive to
-          # the maximum any dependency declares, and gocloud-ext's seven
-          # modules declare 1.25.8 (see #109). Reading it here made setup-go
-          # demand that exact patch, and every observed job then logged
-          # "Attempting to download 1.25.8" — so the toolchain was fetched and
-          # extracted before the job could start. On PR #151 that step hung
-          # for 25 minutes without running a single test.
+          # go.mod used to declare `go 1.25.8`, a patch-level minimum astrogo
+          # never asked for: `go mod tidy` raises the directive to the maximum
+          # any dependency declares, and gocloud-ext's seven modules declare
+          # 1.25.8 (#109). Reading it here made setup-go demand that exact
+          # patch, and every observed job logged "Attempting to download
+          # 1.25.8" — the toolchain fetched and extracted before the job could
+          # start. On PR #151 that step hung for 25 minutes without running a
+          # single test.
           #
-          # A minor-version spec resolves to whatever 1.25.x the runner
-          # already has. It cannot silently diverge from go.mod: Go refuses to
-          # build below the declared directive and fetches the required
-          # toolchain itself, so a future bump past 1.25 degrades to today's
-          # behaviour (a download) rather than to a wrong result.
-          go-version: '1.25'
+          # The directive is now `go 1.27`, so that hazard is gone at its
+          # source and go-version-file would be safe today. The explicit pin
+          # stays because the hazard can come back the same way it arrived —
+          # one dependency declaring a patch-level version above ours and one
+          # `go mod tidy` — and it would come back silently. A minor-version
+          # spec cannot: Go refuses to build below the declared directive and
+          # fetches what it needs, so a divergence degrades to a download
+          # rather than to a wrong result, and internal/docsguard fails if
+          # these pins and go.mod ever disagree on the minor version.
+          go-version: '1.27'
           cache: true
 
       - name: Verify dependencies
@@ -221,7 +226,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       # Pinned, not @latest, for two reasons. x/exp raises its own go directive
@@ -250,7 +255,7 @@ jobs:
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Run tests with race detector
@@ -270,7 +275,7 @@ jobs:
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Run benchmarks
@@ -315,7 +320,7 @@ jobs:
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Trial-merge every open PR and build it
@@ -337,7 +342,7 @@ jobs:
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Run integration tests

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -56,7 +56,7 @@ jobs:
           # cannot drift onto a different toolchain from ci.yml.
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Prepare output directory
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.27'
           cache: true
 
       - name: Prepare output directory

--- a/catalog/fink/fink.go
+++ b/catalog/fink/fink.go
@@ -240,8 +240,7 @@ func (p *Provider) querySingle(ctx context.Context, number int64, name string) (
 
 	body, err := p.client.PostJSON(ctx, remote.FINK, "", payload)
 	if err != nil {
-		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) {
+		if httpErr, ok := errors.AsType[*api.HTTPError](err); ok {
 			return nil, fmt.Errorf("%w: %d: %s", ErrHTTPStatus, httpErr.StatusCode, httpErr.Body[:min(200, len(httpErr.Body))])
 		}
 
@@ -499,8 +498,7 @@ func (p *Provider) downloadSSOFT(ctx context.Context) (_ []ssoRecord, err error)
 
 	body, err := p.client.PostJSON(ctx, remote.FINK, "", payload)
 	if err != nil {
-		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) {
+		if httpErr, ok := errors.AsType[*api.HTTPError](err); ok {
 			return nil, fmt.Errorf("%w: %d: %s", ErrHTTPStatus, httpErr.StatusCode, httpErr.Body[:min(200, len(httpErr.Body))])
 		}
 

--- a/docs/changelog.d/231-go-1.27.md
+++ b/docs/changelog.d/231-go-1.27.md
@@ -1,0 +1,8 @@
+---
+type: Changed
+pr: 231
+---
+astrogo now requires Go 1.27. The module directive is `go 1.27` — a minor
+version, not the patch-level `1.25.8` it inherited from a dependency — so the
+forced per-job toolchain download that cost PR #151 twenty-five minutes cannot
+recur from our own go.mod (#109).

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -11,7 +11,7 @@
 // directly, where a replace directive is ignored.
 module github.com/TuSKan/astrogo/examples
 
-go 1.25.8
+go 1.27
 
 require github.com/TuSKan/astrogo v0.19.0
 

--- a/fits/asciitable.go
+++ b/fits/asciitable.go
@@ -27,10 +27,10 @@ func ReadASCIITable(h *Header, r io.Reader) (*ASCIITableHDU, error) {
 	rowSize, _ := h.GetInt("NAXIS1")
 
 	hdu := &ASCIITableHDU{
-		basicHDU: basicHDU{header: h, hType: HDUTypeASCII},
-		Rows:     rows,
-		Cols:     tfields,
-		RowSize:  rowSize,
+		header: h, hType: HDUTypeASCII,
+		Rows:    rows,
+		Cols:    tfields,
+		RowSize: rowSize,
 	}
 
 	if rows == 0 || tfields == 0 {

--- a/fits/bintable.go
+++ b/fits/bintable.go
@@ -175,10 +175,10 @@ func ReadBintable(h *Header, r io.Reader) (*BintableHDU, error) {
 	rowSize, _ := h.GetInt("NAXIS1")
 
 	hdu := &BintableHDU{
-		basicHDU: basicHDU{header: h, hType: HDUTypeBinary},
-		Rows:     rows,
-		Cols:     tfields,
-		RowSize:  rowSize,
+		header: h, hType: HDUTypeBinary,
+		Rows:    rows,
+		Cols:    tfields,
+		RowSize: rowSize,
 	}
 
 	if rows == 0 || tfields == 0 {

--- a/fits/image.go
+++ b/fits/image.go
@@ -88,7 +88,7 @@ func ReadImage(h *Header, r io.Reader) (*ImageHDU, error) {
 	}
 
 	hdu := &ImageHDU{
-		basicHDU: basicHDU{header: h, hType: HDUTypeImage},
+		header: h, hType: HDUTypeImage,
 		Bitpix:   bitpix,
 		Axes:     axes,
 		BScale:   bscale,

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,17 @@
 module github.com/TuSKan/astrogo
 
-go 1.25.8
+go 1.27
 
 require (
 	github.com/TuSKan/gocloud-ext/blob/httpblob v0.1.1
+	github.com/apache/arrow-go/v18 v18.6.0
 	github.com/hebl/gofa v1.19.1
 	github.com/joshuaferrara/go-satellite v0.0.0-20220611180459-512638c64e5b
 	github.com/klauspost/pgzip v1.2.6
 	github.com/scigolib/hdf5 v0.14.0
 	gocloud.dev v0.46.1-0.20260810195832-b5401c07b5f1
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+	golang.org/x/sync v0.22.0
 	resty.dev/v3 v3.0.0-rc.3
 )
 
@@ -38,6 +41,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/goccy/go-json v0.10.6 // indirect
+	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/google/wire v0.7.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.23.0 // indirect
@@ -53,6 +58,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/api v0.290.0 // indirect
@@ -60,13 +66,4 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
-)
-
-require (
-	github.com/apache/arrow-go/v18 v18.6.0
-	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/google/flatbuffers v25.12.19+incompatible // indirect
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
-	golang.org/x/sync v0.22.0
-	golang.org/x/sys v0.47.0 // indirect
 )

--- a/time/reexport_test.go
+++ b/time/reexport_test.go
@@ -81,8 +81,7 @@ func TestParseRoundTripsAndReportsFailure(t *testing.T) {
 		t.Fatal("Parse accepted a value that is not a time")
 	}
 
-	var perr *gotime.ParseError
-	if !errors.As(err, &perr) {
+	if _, ok := errors.AsType[*gotime.ParseError](err); !ok {
 		t.Errorf("Parse returned %T; a caller can no longer type-assert *time.ParseError.\n"+
 			"  That is what the //nolint:wrapcheck on this re-export exists to preserve.", err)
 	}


### PR DESCRIPTION
Refs #109.

Both modules move to `go 1.27`, and the eight hand-written `setup-go` pins with
them — `internal/docsguard` fails if those two ever disagree on the minor
version.

## `go 1.27`, not `go 1.27.1`

The directive was `go 1.25.8` — a **patch-level** minimum astrogo never asked
for. `go mod tidy` raises the directive to the maximum any dependency declares,
and gocloud-ext's seven modules declare 1.25.8, so it arrived by inheritance
(#109). The cost was real: `setup-go` demanded that exact patch, every job
logged *"Attempting to download 1.25.8"*, and on PR #151 that step hung for 25
minutes without running a single test.

Writing `1.27.1` would recreate exactly that, from our own `go.mod` this time.
`go 1.27` says what astrogo actually needs and leaves the runner free to use
the 1.27.x it already has.

Say the word if you want the exact patch pinned anyway and I'll change it — but
it would re-open #109 rather than close it, so I have not assumed it.

The `ci.yml` comment explaining the pins is rewritten rather than left stale:
the hazard is now gone at its source, so `go-version-file: go.mod` would be
safe today. The pins stay as insurance against it returning the same way it
arrived — one dependency declaring a patch-level version above ours, one
`go mod tidy`, silently.

## What 1.27 changed in the code

Six new `modernize` findings, all applied. The linter is `default: all` and
CLAUDE.md forbids turning one off to pass:

| change | where | why it is new |
| :--- | :--- | :--- |
| `errors.AsType[T]` replaces the var-plus-`errors.As` dance | `catalog/fink` ×2, `time/reexport_test.go` | `AsType` is new in Go 1.27 |
| embedded fields set directly in a composite literal, dropping the inner `basicHDU{...}` | `fits` ×3 | new in Go 1.27 |

The `fits` ones were applied with the modernize tool's own `-fix` rather than
by hand — my first attempt at that edit was `basicHDU: {…}`, which does not
compile, and letting the tool write it was faster than being wrong twice.

## The cost, stated plainly

**Consumers on Go 1.25 or 1.26 are dropped.** That is the point of the change,
not a side effect, and it is worth saying rather than leaving to be discovered
at someone's build.

`go mod tidy` also merged `go.mod`'s two `require` blocks into one under 1.27.
No dependency versions moved.

## Verification

Run on go1.27.1: `gofmt`, `go vet ./...`,
`go build -tags="integration,network,validation" ./...`, `go test ./...`,
`go test -race -short -count=1 ./...`, `go test -tags=validation`,
`go test -tags=integration`, `go -C examples build ./...`, and
`golangci-lint run --build-tags="integration,network,validation"` — all clean.
