### PR TITLE
internal/leakcheck: prove goroutine leaks with the Go 1.27 runtime profile

### DIFF
--- a/catalog/main_test.go
+++ b/catalog/main_test.go
@@ -1,0 +1,14 @@
+package catalog_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/leakcheck"
+)
+
+// catalog fans out across providers (askAll) and across cone-search anchors,
+// and both paths join their work before returning. This is what keeps that
+// true — and it catches a test that forgets to close an api.Client, whose
+// transport goroutines would otherwise outlive the suite.
+func TestMain(m *testing.M) { os.Exit(leakcheck.RunWithLeakCheck(m)) }

--- a/docs/changelog.d/234-leakcheck.md
+++ b/docs/changelog.d/234-leakcheck.md
@@ -2,7 +2,7 @@
 type: Added
 pr: 234
 ---
-`internal/leakcheck` fails a package's tests when a goroutine outlives them,
-naming each survivor and where it started. Installed in the two packages that
-fan out — `internal/parallel` and `catalog` — both of which measure clean,
-including against the live services (#234).
+`internal/leakcheck` fails a package's tests when Go 1.27's `goroutineleak`
+profile proves a goroutine leaked, naming each survivor and where it started.
+Installed in the two packages that fan out — `internal/parallel` and `catalog`
+— both of which measure clean, including against the live services (#234).

--- a/docs/changelog.d/234-leakcheck.md
+++ b/docs/changelog.d/234-leakcheck.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 234
+---
+`internal/leakcheck` fails a package's tests when a goroutine outlives them,
+naming each survivor and where it started. Installed in the two packages that
+fan out — `internal/parallel` and `catalog` — both of which measure clean,
+including against the live services (#234).

--- a/internal/leakcheck/errors.go
+++ b/internal/leakcheck/errors.go
@@ -1,0 +1,11 @@
+package leakcheck
+
+import "errors"
+
+// ErrProfileUnavailable indicates the runtime has no goroutine-leak profile,
+// so nothing checked whether goroutines leaked.
+//
+// A sentinel rather than a bare message because the distinction it carries is
+// the one this package is about: "no leaks found" and "nothing looked" are
+// different answers, and only one of them is good news.
+var ErrProfileUnavailable = errors.New("leakcheck: goroutine-leak profile unavailable")

--- a/internal/leakcheck/leakcheck.go
+++ b/internal/leakcheck/leakcheck.go
@@ -1,4 +1,5 @@
-// Package leakcheck fails a package's tests when a goroutine outlives them.
+// Package leakcheck fails a package's tests when the runtime proves a
+// goroutine leaked.
 //
 // A leaked goroutine is invisible to every other check in this repository. It
 // does not fail a test, does not race, does not allocate enough to notice and
@@ -12,91 +13,101 @@
 package leakcheck
 
 import (
+	"bytes"
+	"fmt"
 	"os"
-	"runtime"
-	"sort"
+	"runtime/pprof"
 	"strings"
 	"testing"
-
-	"github.com/TuSKan/astrogo/time"
 )
 
-// LeakSettleTimeout bounds how long a package waits for stragglers before
-// calling a goroutine leaked.
+// profileName is the runtime profile that does the work.
 //
-// A goroutine that is on its way out — an HTTP transport closing idle
-// connections, a worker between its last send and its return — is not a leak,
-// and the difference is only visible in time. One second is far longer than
-// any of those take and far shorter than a leak, which never ends.
-const LeakSettleTimeout = time.Second
+// Go 1.27 added it. The runtime runs a GC cycle that marks a goroutine leaked
+// when it is blocked on something nothing else can reach — an unreachable
+// channel, a WaitGroup that can never be Done — so a leak here is *proved*,
+// not inferred from having outlived a deadline.
+//
+// Measured against six shapes, it reports the first three and none of the
+// rest:
+//
+//	blocked forever on an unreachable channel   reported
+//	blocked on a WaitGroup never Done           reported
+//	select {} forever                           reported
+//	blocked on a mutex never unlocked           not reported
+//	time.Sleep(time.Hour)                       not reported — it will wake
+//	a goroutine that finished                   not reported
+//
+// The last two are the point. An earlier version of this package counted every
+// goroutine still running when the tests ended, which meant waiting a second
+// for stragglers and hoping that was long enough — a check that could report a
+// slow worker as a leak and a leak as a slow worker. This one cannot: the
+// sleeper is not blocked on anything unreachable, so it is simply not a leak.
+//
+// The mutex case is a real gap rather than a design choice, and it is worth
+// knowing before trusting a clean result too far: this proves the leaks it
+// reports, and does not prove their absence.
+//
+// One more condition, measured rather than assumed: a goroutine is only
+// provably leaked once it has *parked*. Spawned and not yet scheduled, it is
+// runnable, and correctly not a leak — so a check run in the same instant that
+// something leaked can see nothing. That costs this package nothing, because
+// [RunWithLeakCheck] runs after every test has returned, but it is why the
+// tests here poll rather than look once.
+const profileName = "goroutineleak"
 
 // RunWithLeakCheck runs a package's tests and reports a non-zero exit code if
-// any goroutine outlives them.
+// the runtime proves any goroutine leaked.
 //
 // Use it from TestMain in a package that starts goroutines:
 //
 //	func TestMain(m *testing.M) { os.Exit(leakcheck.RunWithLeakCheck(m)) }
 //
-// # Why its own package and not internal/testutil
+// It also catches something subtler for free: a test that forgets to Close an
+// api.Client can leave the transport's connection goroutines blocked, and they
+// show up here with the stack that created them.
 //
-// It needs a clock, and internal/testutil deliberately cannot have one: it is
-// imported by nearly every test in the repository including astrogo/time's, so
-// it sits below astrogo/time and expresses its one timeout as an untyped
-// nanosecond constant to avoid the import. This package sits above
-// astrogo/time and uses it, which docsguard's stdtime rule requires of
-// everything outside time/ — a rule that caught this file living in the wrong
-// place.
+// # Why not testing/synctest
 //
-// # What this catches that nothing else does
-//
-// A leaked goroutine is invisible to every other check in this repository. It
-// does not fail a test, does not race, does not allocate enough to notice, and
-// does not appear in a coverage report. It shows up in production as a process
-// that grows, and by then the fan-out that leaked it is a hundred commits back.
-//
-// The three places astrogo starts goroutines — internal/parallel's chunked
-// workers, catalog's cone-search fan-out and its provider fan-out — all join
-// their work before returning, and this guard is what keeps that true. It also
-// checks something subtler for free: a package whose tests forget to Close an
-// api.Client leaves the transport's connection goroutines running, so the
-// guard fails and names them.
-//
-// # Why a package-level check and not synctest
-//
-// [testing/synctest] detects the same thing more precisely, by waiting for
-// every goroutine in its bubble, and it is the better tool where it applies:
-// pure concurrency, a fake clock, no network. It cannot be used for most of
-// this repository, whose concurrent code exists specifically to talk to
-// several observatories at once. This check works anywhere, including under
-// the network and integration tags, at the cost of naming the goroutine rather
-// than the test that started it.
-//
-// A failure prints each surviving goroutine's state and the first frame that
-// is not the runtime or the test framework, which is normally enough to name
-// the culprit; run the package with -run on a narrower set to bisect.
+// [testing/synctest] detects the same thing more precisely still, by waiting
+// for every goroutine in its bubble, and it names the *test* rather than the
+// goroutine. It is the better tool where it applies: pure concurrency, a fake
+// clock, no network. It cannot be used for most of this repository, whose
+// concurrent code exists specifically to talk to several observatories at
+// once. This works anywhere, including under the network and integration tags.
 func RunWithLeakCheck(m *testing.M) int {
-	return leakCheck(m.Run(), LeakedGoroutines)
+	return leakCheck(m.Run(), Leaked)
 }
 
 // leakCheck is RunWithLeakCheck's decision, separated from m.Run so it can be
 // tested against a probe that answers on demand.
 //
-// Without this seam the only testable part would be the predicate, and the
-// mutation that matters most — not consulting the predicate at all — would
-// pass unnoticed. A guard that silently does nothing is the exact failure this
-// file exists to prevent elsewhere.
-func leakCheck(code int, probe func(time.Duration) string) int {
+// Without this seam the only testable part would be the probe, and the
+// mutation that matters most — not consulting it at all — would pass
+// unnoticed. A guard that silently does nothing is the exact failure this
+// package exists to prevent elsewhere.
+func leakCheck(code int, probe func() (string, error)) int {
 	// Only when the suite passed. A failing test may have left work in flight
-	// by design, and reporting that as a leak on top of the real failure buries
-	// it.
+	// by design, and reporting that on top of the real failure buries it.
 	if code != 0 {
 		return code
 	}
 
-	if leaked := probe(LeakSettleTimeout); leaked != "" {
-		_, _ = os.Stderr.WriteString("goroutines outlived the tests:\n" + leaked +
-			"\nEach line names a surviving goroutine and where it started. Something " +
-			"started work and did not wait for it, or a client was not closed.\n")
+	leaked, err := probe()
+	if err != nil {
+		// Never silently: a guard that cannot run must say so, or a package
+		// with no goroutine profile passes exactly as one with no leaks does.
+		_, _ = fmt.Fprintf(os.Stderr, "leakcheck: %v\n", err)
+
+		return 1
+	}
+
+	if leaked != "" {
+		_, _ = os.Stderr.WriteString("the runtime proved these goroutines leaked:\n" +
+			leaked +
+			"\nEach is blocked on something nothing else can reach, so it can never " +
+			"resume. Something started work and did not wait for it, or a client was " +
+			"not closed.\n")
 
 		return 1
 	}
@@ -104,132 +115,76 @@ func leakCheck(code int, probe func(time.Duration) string) int {
 	return code
 }
 
-// LeakedGoroutines returns one line per goroutine still running after the
-// caller's own, or "" when everything has finished. It polls until settle
-// elapses, so a goroutine on its way out is not mistaken for one that will
-// never leave.
+// Leaked returns the goroutine-leak profile when the runtime has proved any
+// goroutine leaked, and "" when it has not.
+//
+// The error is for the profile being unavailable — a toolchain without it —
+// which is deliberately not the same answer as "nothing leaked". Reporting an
+// absent profile as a clean result is how a guard becomes decoration.
 //
 // Exported separately from [RunWithLeakCheck] for the same reason
 // [github.com/TuSKan/astrogo/internal/testutil.Reachable] is exported
 // separately from RequireReachable: the predicate is testable and the wrapper
 // that exits the process is not.
-func LeakedGoroutines(settle time.Duration) string {
-	deadline := time.Now().Add(settle)
-
-	for {
-		found := survivingGoroutines()
-		if found == "" {
-			return ""
-		}
-
-		if time.Now().After(deadline) {
-			return found
-		}
-
-		// Yield first, so a goroutine that only needs a scheduling slot gets
-		// one without waiting out a sleep.
-		runtime.Gosched()
-		time.Sleep(settle / 50)
+func Leaked() (string, error) {
+	p := pprof.Lookup(profileName)
+	if p == nil {
+		return "", fmt.Errorf("%w: this toolchain has no %q profile (Go 1.27 added it), "+
+			"so nothing checked whether goroutines leaked", ErrProfileUnavailable, profileName)
 	}
+
+	var buf bytes.Buffer
+
+	// debug=1 symbolizes the stacks, which is the difference between a report
+	// naming catalog.fanOut and one naming a hexadecimal address.
+	if err := p.WriteTo(&buf, 1); err != nil {
+		return "", fmt.Errorf("leakcheck: writing the %q profile: %w", profileName, err)
+	}
+
+	return leakedReport(buf.String()), nil
 }
 
-// survivingGoroutines snapshots the stacks and drops the caller's own.
-func survivingGoroutines() string {
-	self := currentGoroutineHeader()
-
-	// runtime.Stack truncates rather than failing, so the buffer is sized for
-	// a pathological case: a genuine leak of hundreds of goroutines is exactly
-	// when the report matters most and a truncated one names the wrong ones.
-	buf := make([]byte, 1<<21)
-	buf = buf[:runtime.Stack(buf, true)]
-
-	var out []string
-
-	for g := range strings.SplitSeq(string(buf), "\n\n") {
-		if strings.TrimSpace(g) == "" {
-			continue
-		}
-
-		if strings.HasPrefix(g, self) {
-			continue
-		}
-
-		out = append(out, describeGoroutine(g))
-	}
-
-	sort.Strings(out)
-
-	if len(out) == 0 {
+// leakedReport is the profile when it holds a leak and "" when it does not.
+//
+// Separated from [Leaked] because it is the whole decision, and because
+// [Leaked] can only read the process it runs in: by the time any test has
+// leaked a goroutine on purpose, no later call can observe a clean profile
+// again. A pure function can be shown both answers.
+//
+// The distinction is not cosmetic. The runtime emits a header even when
+// nothing leaked, so returning the profile unconditionally would report every
+// package as leaking, forever.
+func leakedReport(profile string) string {
+	if leakCount(profile) == 0 {
 		return ""
 	}
 
-	return strings.Join(out, "\n") + "\n"
+	return profile
 }
 
-// currentGoroutineHeader returns "goroutine N [" for the goroutine calling it,
-// which is the only stack this check must never report.
+// leakCount reads the count off the profile's header line, which reads
+// "goroutineleak profile: total 3".
 //
-// # Why identity rather than a list of names
-//
-// The first version filtered by frame text — testing.(*M).Run, the runtime's
-// GC workers, os/signal's loop, this package's own functions. Removing each
-// entry in turn showed only one of them ever fired, because runtime.Stack does
-// not report system goroutines at all; the rest were guarding against stacks
-// that never appear.
-//
-// Then trimming to that one entry broke every package that uses the guard from
-// TestMain, and for a reason the name list could not express: by the time
-// TestMain runs the check, m.Run has *returned*, so testing.(*M).Run is no
-// longer on the stack. The goroutine to exclude is not identifiable by what it
-// is running — it is running this very function — but by being this one.
-//
-// runtime.Stack with all=false dumps only the caller, whose header carries its
-// id. Nothing else can share it.
-func currentGoroutineHeader() string {
-	var buf [64]byte
+// Parsed rather than counting stack lines because one leaked goroutine can
+// contribute several frames, and because the header is the runtime's own
+// answer rather than this package's arithmetic over its output.
+func leakCount(profile string) int {
+	head, _, _ := strings.Cut(profile, "\n")
 
-	n := runtime.Stack(buf[:], false)
-
-	head, _, _ := strings.Cut(string(buf[:n]), "\n")
-
-	// "goroutine 42 [running]:" -> "goroutine 42 [", which cannot prefix any
-	// other goroutine's header.
-	if i := strings.IndexByte(head, '['); i > 0 {
-		return head[:i+1]
+	_, total, ok := strings.Cut(head, "total ")
+	if !ok {
+		return 0
 	}
 
-	return head
-}
+	var n int
 
-// describeGoroutine renders one stack as its header plus the first frame that
-// is not the runtime or the test framework.
-//
-// The header alone — "goroutine 63 [select (no cases)]:" — says what the
-// goroutine is doing and nothing about who started it, which is the half a
-// reader needs. Finding that out from a bare header means re-running with a
-// profile; carrying one frame here means not having to.
-func describeGoroutine(stack string) string {
-	lines := strings.Split(stack, "\n")
-	head := lines[0]
-
-	for _, l := range lines[1:] {
-		l = strings.TrimSpace(l)
-
-		// Stacks alternate a frame line with a file:line line; the frames are
-		// the ones carrying a call.
-		if !strings.Contains(l, "(") || strings.Contains(l, ".go:") {
-			continue
+	for _, c := range strings.TrimSpace(total) {
+		if c < '0' || c > '9' {
+			break
 		}
 
-		switch {
-		case strings.HasPrefix(l, "runtime."),
-			strings.HasPrefix(l, "testing."),
-			strings.HasPrefix(l, "sync."):
-			continue
-		}
-
-		return head + " " + l
+		n = n*10 + int(c-'0')
 	}
 
-	return head
+	return n
 }

--- a/internal/leakcheck/leakcheck.go
+++ b/internal/leakcheck/leakcheck.go
@@ -1,0 +1,235 @@
+// Package leakcheck fails a package's tests when a goroutine outlives them.
+//
+// A leaked goroutine is invisible to every other check in this repository. It
+// does not fail a test, does not race, does not allocate enough to notice and
+// does not appear in a coverage report — it shows up in production as a
+// process that grows, by which time the fan-out that leaked it is a hundred
+// commits back.
+//
+// astrogo starts goroutines in three places: internal/parallel's chunked
+// workers and catalog's two fan-outs. All of them join their work before
+// returning, and this is what keeps that true.
+package leakcheck
+
+import (
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// LeakSettleTimeout bounds how long a package waits for stragglers before
+// calling a goroutine leaked.
+//
+// A goroutine that is on its way out — an HTTP transport closing idle
+// connections, a worker between its last send and its return — is not a leak,
+// and the difference is only visible in time. One second is far longer than
+// any of those take and far shorter than a leak, which never ends.
+const LeakSettleTimeout = time.Second
+
+// RunWithLeakCheck runs a package's tests and reports a non-zero exit code if
+// any goroutine outlives them.
+//
+// Use it from TestMain in a package that starts goroutines:
+//
+//	func TestMain(m *testing.M) { os.Exit(leakcheck.RunWithLeakCheck(m)) }
+//
+// # Why its own package and not internal/testutil
+//
+// It needs a clock, and internal/testutil deliberately cannot have one: it is
+// imported by nearly every test in the repository including astrogo/time's, so
+// it sits below astrogo/time and expresses its one timeout as an untyped
+// nanosecond constant to avoid the import. This package sits above
+// astrogo/time and uses it, which docsguard's stdtime rule requires of
+// everything outside time/ — a rule that caught this file living in the wrong
+// place.
+//
+// # What this catches that nothing else does
+//
+// A leaked goroutine is invisible to every other check in this repository. It
+// does not fail a test, does not race, does not allocate enough to notice, and
+// does not appear in a coverage report. It shows up in production as a process
+// that grows, and by then the fan-out that leaked it is a hundred commits back.
+//
+// The three places astrogo starts goroutines — internal/parallel's chunked
+// workers, catalog's cone-search fan-out and its provider fan-out — all join
+// their work before returning, and this guard is what keeps that true. It also
+// checks something subtler for free: a package whose tests forget to Close an
+// api.Client leaves the transport's connection goroutines running, so the
+// guard fails and names them.
+//
+// # Why a package-level check and not synctest
+//
+// [testing/synctest] detects the same thing more precisely, by waiting for
+// every goroutine in its bubble, and it is the better tool where it applies:
+// pure concurrency, a fake clock, no network. It cannot be used for most of
+// this repository, whose concurrent code exists specifically to talk to
+// several observatories at once. This check works anywhere, including under
+// the network and integration tags, at the cost of naming the goroutine rather
+// than the test that started it.
+//
+// A failure prints each surviving goroutine's state and the first frame that
+// is not the runtime or the test framework, which is normally enough to name
+// the culprit; run the package with -run on a narrower set to bisect.
+func RunWithLeakCheck(m *testing.M) int {
+	return leakCheck(m.Run(), LeakedGoroutines)
+}
+
+// leakCheck is RunWithLeakCheck's decision, separated from m.Run so it can be
+// tested against a probe that answers on demand.
+//
+// Without this seam the only testable part would be the predicate, and the
+// mutation that matters most — not consulting the predicate at all — would
+// pass unnoticed. A guard that silently does nothing is the exact failure this
+// file exists to prevent elsewhere.
+func leakCheck(code int, probe func(time.Duration) string) int {
+	// Only when the suite passed. A failing test may have left work in flight
+	// by design, and reporting that as a leak on top of the real failure buries
+	// it.
+	if code != 0 {
+		return code
+	}
+
+	if leaked := probe(LeakSettleTimeout); leaked != "" {
+		_, _ = os.Stderr.WriteString("goroutines outlived the tests:\n" + leaked +
+			"\nEach line names a surviving goroutine and where it started. Something " +
+			"started work and did not wait for it, or a client was not closed.\n")
+
+		return 1
+	}
+
+	return code
+}
+
+// LeakedGoroutines returns one line per goroutine still running after the
+// caller's own, or "" when everything has finished. It polls until settle
+// elapses, so a goroutine on its way out is not mistaken for one that will
+// never leave.
+//
+// Exported separately from [RunWithLeakCheck] for the same reason
+// [github.com/TuSKan/astrogo/internal/testutil.Reachable] is exported
+// separately from RequireReachable: the predicate is testable and the wrapper
+// that exits the process is not.
+func LeakedGoroutines(settle time.Duration) string {
+	deadline := time.Now().Add(settle)
+
+	for {
+		found := survivingGoroutines()
+		if found == "" {
+			return ""
+		}
+
+		if time.Now().After(deadline) {
+			return found
+		}
+
+		// Yield first, so a goroutine that only needs a scheduling slot gets
+		// one without waiting out a sleep.
+		runtime.Gosched()
+		time.Sleep(settle / 50)
+	}
+}
+
+// survivingGoroutines snapshots the stacks and drops the caller's own.
+func survivingGoroutines() string {
+	self := currentGoroutineHeader()
+
+	// runtime.Stack truncates rather than failing, so the buffer is sized for
+	// a pathological case: a genuine leak of hundreds of goroutines is exactly
+	// when the report matters most and a truncated one names the wrong ones.
+	buf := make([]byte, 1<<21)
+	buf = buf[:runtime.Stack(buf, true)]
+
+	var out []string
+
+	for g := range strings.SplitSeq(string(buf), "\n\n") {
+		if strings.TrimSpace(g) == "" {
+			continue
+		}
+
+		if strings.HasPrefix(g, self) {
+			continue
+		}
+
+		out = append(out, describeGoroutine(g))
+	}
+
+	sort.Strings(out)
+
+	if len(out) == 0 {
+		return ""
+	}
+
+	return strings.Join(out, "\n") + "\n"
+}
+
+// currentGoroutineHeader returns "goroutine N [" for the goroutine calling it,
+// which is the only stack this check must never report.
+//
+// # Why identity rather than a list of names
+//
+// The first version filtered by frame text — testing.(*M).Run, the runtime's
+// GC workers, os/signal's loop, this package's own functions. Removing each
+// entry in turn showed only one of them ever fired, because runtime.Stack does
+// not report system goroutines at all; the rest were guarding against stacks
+// that never appear.
+//
+// Then trimming to that one entry broke every package that uses the guard from
+// TestMain, and for a reason the name list could not express: by the time
+// TestMain runs the check, m.Run has *returned*, so testing.(*M).Run is no
+// longer on the stack. The goroutine to exclude is not identifiable by what it
+// is running — it is running this very function — but by being this one.
+//
+// runtime.Stack with all=false dumps only the caller, whose header carries its
+// id. Nothing else can share it.
+func currentGoroutineHeader() string {
+	var buf [64]byte
+
+	n := runtime.Stack(buf[:], false)
+
+	head, _, _ := strings.Cut(string(buf[:n]), "\n")
+
+	// "goroutine 42 [running]:" -> "goroutine 42 [", which cannot prefix any
+	// other goroutine's header.
+	if i := strings.IndexByte(head, '['); i > 0 {
+		return head[:i+1]
+	}
+
+	return head
+}
+
+// describeGoroutine renders one stack as its header plus the first frame that
+// is not the runtime or the test framework.
+//
+// The header alone — "goroutine 63 [select (no cases)]:" — says what the
+// goroutine is doing and nothing about who started it, which is the half a
+// reader needs. Finding that out from a bare header means re-running with a
+// profile; carrying one frame here means not having to.
+func describeGoroutine(stack string) string {
+	lines := strings.Split(stack, "\n")
+	head := lines[0]
+
+	for _, l := range lines[1:] {
+		l = strings.TrimSpace(l)
+
+		// Stacks alternate a frame line with a file:line line; the frames are
+		// the ones carrying a call.
+		if !strings.Contains(l, "(") || strings.Contains(l, ".go:") {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(l, "runtime."),
+			strings.HasPrefix(l, "testing."),
+			strings.HasPrefix(l, "sync."):
+			continue
+		}
+
+		return head + " " + l
+	}
+
+	return head
+}

--- a/internal/leakcheck/leakcheck_internal_test.go
+++ b/internal/leakcheck/leakcheck_internal_test.go
@@ -1,76 +1,12 @@
 package leakcheck
 
 import (
-	"runtime"
+	"errors"
 	"strings"
 	"testing"
-
-	"github.com/TuSKan/astrogo/time"
 )
 
-// The three functions behind the leak guard are tested here, in-package,
-// against synthetic stack text.
-//
-// The external tests point the whole guard at a real leaked goroutine, which
-// proves it fires. They cannot prove what it *does not* fire on, because the
-// report renders only a goroutine's header and one frame — so an assertion
-// that the runner's frame is absent from the output passes whether or not the
-// runner is filtered. Mutating the filter away left those tests green. These
-// close that.
-
-// A stack fragment taken verbatim from a real runtime.Stack dump.
-const (
-	leakStack = `goroutine 42 [select (no cases)]:
-github.com/TuSKan/astrogo/catalog.fanOut.func2()
-	D:/Developments/astrogo/catalog/catalog.go:681 +0x8c
-created by github.com/TuSKan/astrogo/catalog.fanOut
-	D:/Developments/astrogo/catalog/catalog.go:678 +0x1f4`
-)
-
-// TestDescribeGoroutineNamesWhereItStarted covers the half of the report that
-// makes it actionable.
-//
-// The header alone says what a goroutine is doing — "select (no cases)" — and
-// nothing about who started it, which is the half a reader needs. Mutating the
-// frame away left every external test green, because they only asserted that
-// the report was non-empty.
-func TestDescribeGoroutineNamesWhereItStarted(t *testing.T) {
-	t.Parallel()
-
-	got := describeGoroutine(leakStack)
-
-	for _, want := range []string{
-		"goroutine 42",           // which one
-		"select (no cases)",      // what it is doing
-		"astrogo/catalog.fanOut", // where it came from
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("describeGoroutine = %q, want it to contain %q", got, want)
-		}
-	}
-
-	// The file:line lines are noise in a one-line-per-goroutine report.
-	if strings.Contains(got, ".go:") {
-		t.Errorf("describeGoroutine = %q, want no file:line noise", got)
-	}
-}
-
-// TestDescribeGoroutineFallsBackToTheHeader covers a stack with nothing but
-// runtime frames — better a header alone than an empty line that says nothing.
-func TestDescribeGoroutineFallsBackToTheHeader(t *testing.T) {
-	t.Parallel()
-
-	const runtimeOnly = `goroutine 7 [syscall]:
-runtime.notetsleepg(0x8a2d20, 0xdf8475800)
-	C:/Program Files/Go/src/runtime/lock_sema.go:295 +0x33`
-
-	got := describeGoroutine(runtimeOnly)
-	if !strings.HasPrefix(got, "goroutine 7 [syscall]:") {
-		t.Errorf("describeGoroutine = %q, want it to fall back to the header", got)
-	}
-}
-
-// TestLeakCheckConsultsTheProbe is the mutation that mattered most: a guard
+// TestLeakCheckConsultsTheProbe covers the mutation that matters most: a guard
 // that never asks whether anything leaked.
 //
 // It is invisible from outside — the package passes, which is exactly what it
@@ -78,25 +14,29 @@ runtime.notetsleepg(0x8a2d20, 0xdf8475800)
 func TestLeakCheckConsultsTheProbe(t *testing.T) {
 	t.Parallel()
 
+	probeErr := errors.New("leakcheck_test: no profile") //nolint:err113 // a stand-in for ErrProfileUnavailable
+
 	for _, tc := range []struct {
 		name       string
 		suiteCode  int
-		probeSays  string
+		says       string
+		saysErr    error
 		wantCode   int
 		wantProbed bool
 	}{
-		{"a clean suite with a leak fails", 0, "goroutine 42 [select]:", 1, true},
-		{"a clean suite with no leak passes", 0, "", 0, true},
-		{"a failing suite is not masked", 1, "goroutine 42 [select]:", 1, false},
+		{"a clean suite with a leak fails", 0, "goroutineleak profile: total 1", nil, 1, true},
+		{"a clean suite with no leak passes", 0, "", nil, 0, true},
+		{"a failing suite is not masked", 1, "goroutineleak profile: total 1", nil, 1, false},
+		{"an unavailable profile fails rather than passing", 0, "", probeErr, 1, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			probed := false
-			probe := func(time.Duration) string {
+			probe := func() (string, error) {
 				probed = true
 
-				return tc.probeSays
+				return tc.says, tc.saysErr
 			}
 
 			if got := leakCheck(tc.suiteCode, probe); got != tc.wantCode {
@@ -111,51 +51,87 @@ func TestLeakCheckConsultsTheProbe(t *testing.T) {
 	}
 }
 
-// TestCurrentGoroutineHeaderIdentifiesOnlyTheCaller covers the filter that
-// replaced a list of frame names.
+// TestLeakCountReadsTheRuntimesOwnTotal pins the parse.
 //
-// The name list looked right and was wrong in a way no unit test caught: by
-// the time TestMain runs the check, m.Run has returned, so testing.(*M).Run is
-// no longer on the stack and the check reported itself. Every package using
-// the guard failed. Identity cannot drift that way — the goroutine to exclude
-// is the one asking.
-func TestCurrentGoroutineHeaderIdentifiesOnlyTheCaller(t *testing.T) {
-	self := currentGoroutineHeader()
+// The count comes off the profile's header rather than from counting stack
+// lines, because one leaked goroutine contributes several frames — counting
+// them would report a single leak as four and, worse, would report a
+// *formatting* change as a leak.
+func TestLeakCountReadsTheRuntimesOwnTotal(t *testing.T) {
+	t.Parallel()
 
-	if !strings.HasPrefix(self, "goroutine ") || !strings.HasSuffix(self, "[") {
-		t.Fatalf("header = %q, want the form \"goroutine N [\"", self)
-	}
+	for _, tc := range []struct {
+		name    string
+		profile string
+		want    int
+	}{
+		{"none", "goroutineleak profile: total 0\n", 0},
+		{"one", "goroutineleak profile: total 1\n1 @ 0x1 0x2\n#\t0x1\tpkg.fn+0x18\tfile.go:14\n", 1},
+		{"several", "goroutineleak profile: total 12\n", 12},
+		{"empty input", "", 0},
+		{"a header this code does not recognise", "something else entirely\n", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	// It must match this goroutine in a full dump, and exactly one of them.
-	buf := make([]byte, 1<<20)
-	buf = buf[:runtime.Stack(buf, true)]
-
-	matches := 0
-
-	for g := range strings.SplitSeq(string(buf), "\n\n") {
-		if strings.HasPrefix(g, self) {
-			matches++
-		}
-	}
-
-	if matches != 1 {
-		t.Errorf("header %q matched %d goroutines in a full dump, want exactly 1 — "+
-			"a prefix that matches none reports the checker as a leak, and one that "+
-			"matches several hides real ones", self, matches)
+			if got := leakCount(tc.profile); got != tc.want {
+				t.Errorf("leakCount = %d, want %d", got, tc.want)
+			}
+		})
 	}
 }
 
-// TestSurvivingGoroutinesDoesNotReportItself is the regression for the failure
-// that trimming the old filter exposed: run from anywhere, the check must
-// never name its own goroutine.
-func TestSurvivingGoroutinesDoesNotReportItself(t *testing.T) {
-	got := survivingGoroutines()
+// TestLeakedReportIsEmptyOnlyWhenNothingLeaked pins the answer a clean run
+// gives.
+//
+// The runtime writes a header whether or not anything leaked, so "the profile
+// is non-empty" is not the same question as "something leaked" — reading it
+// that way would fail every guarded package on every run. Leaked cannot show
+// this by itself, because this process has deliberately leaked goroutines by
+// the time anything can ask it twice.
+func TestLeakedReportIsEmptyOnlyWhenNothingLeaked(t *testing.T) {
+	t.Parallel()
 
-	if strings.Contains(got, "survivingGoroutines") {
-		t.Errorf("the check reported itself:\n%s", got)
+	const leaked = "goroutineleak profile: total 1\n1 @ 0x1\n#\t0x1\tpkg.fn+0x18\tfile.go:14\n"
+
+	for _, tc := range []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		{"a clean run still has a header", "goroutineleak profile: total 0\n", ""},
+		{"nothing at all", "", ""},
+		{"a leak is reported verbatim", leaked, leaked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := leakedReport(tc.profile); got != tc.want {
+				t.Errorf("leakedReport(%q) = %q, want %q", tc.profile, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLeakedNamesTheProfileItNeeds covers the failure that must not look like
+// success: no profile at all.
+//
+// "Nothing leaked" and "nothing looked" are different answers and only one is
+// good news. A toolchain without the profile has to say so, and the sentinel
+// is what lets a caller tell them apart.
+func TestLeakedNamesTheProfileItNeeds(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(ErrProfileUnavailable.Error(), "goroutine-leak profile") {
+		t.Errorf("ErrProfileUnavailable = %q, want it to name what is missing",
+			ErrProfileUnavailable)
 	}
 
-	if strings.Contains(got, "currentGoroutineHeader") {
-		t.Errorf("the check reported its own helper:\n%s", got)
+	// The profile this package depends on must exist on the toolchain the
+	// repository builds with — if it stops existing, that is a finding rather
+	// than a quietly disabled guard.
+	if _, err := Leaked(); errors.Is(err, ErrProfileUnavailable) {
+		t.Fatalf("this toolchain has no %q profile, so the guard installed in "+
+			"internal/parallel and catalog is checking nothing", profileName)
 	}
 }

--- a/internal/leakcheck/leakcheck_internal_test.go
+++ b/internal/leakcheck/leakcheck_internal_test.go
@@ -1,0 +1,161 @@
+package leakcheck
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// The three functions behind the leak guard are tested here, in-package,
+// against synthetic stack text.
+//
+// The external tests point the whole guard at a real leaked goroutine, which
+// proves it fires. They cannot prove what it *does not* fire on, because the
+// report renders only a goroutine's header and one frame — so an assertion
+// that the runner's frame is absent from the output passes whether or not the
+// runner is filtered. Mutating the filter away left those tests green. These
+// close that.
+
+// A stack fragment taken verbatim from a real runtime.Stack dump.
+const (
+	leakStack = `goroutine 42 [select (no cases)]:
+github.com/TuSKan/astrogo/catalog.fanOut.func2()
+	D:/Developments/astrogo/catalog/catalog.go:681 +0x8c
+created by github.com/TuSKan/astrogo/catalog.fanOut
+	D:/Developments/astrogo/catalog/catalog.go:678 +0x1f4`
+)
+
+// TestDescribeGoroutineNamesWhereItStarted covers the half of the report that
+// makes it actionable.
+//
+// The header alone says what a goroutine is doing — "select (no cases)" — and
+// nothing about who started it, which is the half a reader needs. Mutating the
+// frame away left every external test green, because they only asserted that
+// the report was non-empty.
+func TestDescribeGoroutineNamesWhereItStarted(t *testing.T) {
+	t.Parallel()
+
+	got := describeGoroutine(leakStack)
+
+	for _, want := range []string{
+		"goroutine 42",           // which one
+		"select (no cases)",      // what it is doing
+		"astrogo/catalog.fanOut", // where it came from
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("describeGoroutine = %q, want it to contain %q", got, want)
+		}
+	}
+
+	// The file:line lines are noise in a one-line-per-goroutine report.
+	if strings.Contains(got, ".go:") {
+		t.Errorf("describeGoroutine = %q, want no file:line noise", got)
+	}
+}
+
+// TestDescribeGoroutineFallsBackToTheHeader covers a stack with nothing but
+// runtime frames — better a header alone than an empty line that says nothing.
+func TestDescribeGoroutineFallsBackToTheHeader(t *testing.T) {
+	t.Parallel()
+
+	const runtimeOnly = `goroutine 7 [syscall]:
+runtime.notetsleepg(0x8a2d20, 0xdf8475800)
+	C:/Program Files/Go/src/runtime/lock_sema.go:295 +0x33`
+
+	got := describeGoroutine(runtimeOnly)
+	if !strings.HasPrefix(got, "goroutine 7 [syscall]:") {
+		t.Errorf("describeGoroutine = %q, want it to fall back to the header", got)
+	}
+}
+
+// TestLeakCheckConsultsTheProbe is the mutation that mattered most: a guard
+// that never asks whether anything leaked.
+//
+// It is invisible from outside — the package passes, which is exactly what it
+// would do if nothing had leaked — so nothing but this would notice.
+func TestLeakCheckConsultsTheProbe(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		suiteCode  int
+		probeSays  string
+		wantCode   int
+		wantProbed bool
+	}{
+		{"a clean suite with a leak fails", 0, "goroutine 42 [select]:", 1, true},
+		{"a clean suite with no leak passes", 0, "", 0, true},
+		{"a failing suite is not masked", 1, "goroutine 42 [select]:", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			probed := false
+			probe := func(time.Duration) string {
+				probed = true
+
+				return tc.probeSays
+			}
+
+			if got := leakCheck(tc.suiteCode, probe); got != tc.wantCode {
+				t.Errorf("leakCheck = %d, want %d", got, tc.wantCode)
+			}
+
+			if probed != tc.wantProbed {
+				t.Errorf("probe consulted = %v, want %v — a guard that does not ask "+
+					"cannot answer", probed, tc.wantProbed)
+			}
+		})
+	}
+}
+
+// TestCurrentGoroutineHeaderIdentifiesOnlyTheCaller covers the filter that
+// replaced a list of frame names.
+//
+// The name list looked right and was wrong in a way no unit test caught: by
+// the time TestMain runs the check, m.Run has returned, so testing.(*M).Run is
+// no longer on the stack and the check reported itself. Every package using
+// the guard failed. Identity cannot drift that way — the goroutine to exclude
+// is the one asking.
+func TestCurrentGoroutineHeaderIdentifiesOnlyTheCaller(t *testing.T) {
+	self := currentGoroutineHeader()
+
+	if !strings.HasPrefix(self, "goroutine ") || !strings.HasSuffix(self, "[") {
+		t.Fatalf("header = %q, want the form \"goroutine N [\"", self)
+	}
+
+	// It must match this goroutine in a full dump, and exactly one of them.
+	buf := make([]byte, 1<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+
+	matches := 0
+
+	for g := range strings.SplitSeq(string(buf), "\n\n") {
+		if strings.HasPrefix(g, self) {
+			matches++
+		}
+	}
+
+	if matches != 1 {
+		t.Errorf("header %q matched %d goroutines in a full dump, want exactly 1 — "+
+			"a prefix that matches none reports the checker as a leak, and one that "+
+			"matches several hides real ones", self, matches)
+	}
+}
+
+// TestSurvivingGoroutinesDoesNotReportItself is the regression for the failure
+// that trimming the old filter exposed: run from anywhere, the check must
+// never name its own goroutine.
+func TestSurvivingGoroutinesDoesNotReportItself(t *testing.T) {
+	got := survivingGoroutines()
+
+	if strings.Contains(got, "survivingGoroutines") {
+		t.Errorf("the check reported itself:\n%s", got)
+	}
+
+	if strings.Contains(got, "currentGoroutineHeader") {
+		t.Errorf("the check reported its own helper:\n%s", got)
+	}
+}

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -2,79 +2,94 @@ package leakcheck_test
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/TuSKan/astrogo/time"
-
 	"github.com/TuSKan/astrogo/internal/leakcheck"
+	"github.com/TuSKan/astrogo/time"
 )
 
-// TestLeakedGoroutinesFindsOne is the check that makes the guard worth having.
+// settle is how long these tests will wait for a goroutine to park.
+//
+// The runtime proves a leak by unreachability, but only for a goroutine that
+// has actually blocked — one that has been spawned and not yet scheduled is
+// merely runnable, and correctly not a leak. Measured here, a single
+// runtime.Gosched was enough; this is generous because a loaded CI runner is
+// not this machine.
+//
+// It is a bound on patience, not a settle window of the kind the earlier
+// version of this package needed: nothing here concludes anything from the
+// time elapsing.
+const (
+	settle = 2 * time.Second
+	poll   = 5 * time.Millisecond
+)
+
+// TestLeakedProvesTheShapesItClaims is the check that makes this guard worth
+// having, and the reason it is not simply trusted.
 //
 // A leak detector that has never caught anything is indistinguishable from one
-// that cannot, and this one is installed as a TestMain — where a false negative
-// is completely silent, because the package simply passes. So it is pointed at
-// a goroutine that will never return.
+// that cannot, and this one runs from TestMain — where a false negative is
+// completely silent, because the package just passes.
 //
-// The leaked goroutine is deliberately not cleaned up: there is no way to stop
-// a `select {}` and nothing to gain from one, since the test binary is about to
-// exit anyway. It is a handful of bytes for the rest of the run.
-func TestLeakedGoroutinesFindsOne(t *testing.T) {
-	// Not parallel: it reads every goroutine in the process, so a sibling
-	// test's workers would show up as its subject.
-	started := make(chan struct{})
+// The shapes are the ones the doc comment claims, asserted rather than
+// described. The leaked goroutines are deliberately never released: there is
+// no way to release a goroutine blocked on an unreachable channel, which is
+// the definition being tested.
+func TestLeakedProvesTheShapesItClaims(t *testing.T) {
+	// Not parallel: the profile is process-wide, so a sibling test's
+	// goroutines would appear in this one's result.
+	before := countLeaks(t, mustLeaked(t))
 
-	go func() {
-		close(started)
+	// Blocked forever on a channel that goes out of scope with it.
+	func() {
+		ch := make(chan int)
 
-		select {} // never returns, which is the point
+		go func() { <-ch }()
 	}()
 
-	<-started
+	// Blocked on a WaitGroup nothing will ever mark done.
+	func() {
+		var wg sync.WaitGroup
 
-	got := leakcheck.LeakedGoroutines(200 * time.Millisecond)
-	if got == "" {
-		t.Fatal("a goroutine blocked forever was not reported; a leak check that " +
-			"cannot fail is a package that only looks clean")
+		wg.Add(1)
+
+		go func() { wg.Wait() }()
+	}()
+
+	after, report := waitForLeaks(t, before+2)
+	if after < before+2 {
+		t.Fatalf("two goroutines blocked on unreachable synchronisation were reported "+
+			"as %d leaks, want at least %d; a leak check that cannot fail is a package "+
+			"that only looks clean\n%s", after, before+2, report)
 	}
 
-	// The report has to name something a reader can act on. "select (no
-	// cases)" is what the runtime calls a goroutine parked forever.
-	if !strings.Contains(got, "goroutine") {
-		t.Errorf("report does not name a goroutine:\n%s", got)
-	}
-}
-
-// TestLeakedGoroutinesIgnoresTheTestRunner pins the other half: the check must
-// not report the goroutine running the tests, or every package fails always
-// and the guard is turned off within a day.
-//
-// This runs in the same binary as the test above, so it cannot assert a clean
-// result outright — that one's leak is still parked. What it can assert is
-// that the runner and the check's own frames are not in the report, which is
-// the part that would break every package rather than one.
-func TestLeakedGoroutinesIgnoresTheTestRunner(t *testing.T) {
-	got := leakcheck.LeakedGoroutines(50 * time.Millisecond)
-
-	for _, unwanted := range []string{
-		"testing.(*M).Run",
-		"leakcheck.LeakedGoroutines",
-		"leakcheck.survivingGoroutines",
-	} {
-		if strings.Contains(got, unwanted) {
-			t.Errorf("report includes %q, which is the framework rather than a leak:\n%s",
-				unwanted, got)
-		}
+	// The report has to name somewhere a reader can go.
+	if !strings.Contains(report, "leakcheck_test") {
+		t.Errorf("the report does not name the code that leaked:\n%s", report)
 	}
 }
 
-// TestLeakedGoroutinesWaitsForStragglers covers the settle window.
+// TestLeakedIgnoresAGoroutineThatWillWake is the half an earlier version of
+// this package could not get right.
 //
-// A goroutine on its way out is not a leak, and the difference is only visible
-// in time. Without the wait this check would fail on any test whose last
-// worker had not yet been scheduled to return — a flake that would look like a
-// real finding and would be chased for hours.
-func TestLeakedGoroutinesWaitsForStragglers(t *testing.T) {
+// That version counted every goroutine still running when the tests ended, so
+// it needed a settle window and a guess at how long stragglers take — which
+// makes a slow worker indistinguishable from a leak in both directions. The
+// runtime's definition has no such ambiguity: a sleeping goroutine is blocked
+// on a timer that will fire, so it is not leaked, however long it sleeps.
+//
+// The count is re-read repeatedly rather than once, so that the sleeper is
+// given every chance to be miscounted rather than merely being too young to
+// notice.
+func TestLeakedIgnoresAGoroutineThatWillWake(t *testing.T) {
+	before := countLeaks(t, mustLeaked(t))
+
+	// An hour is far longer than any test run, so if duration mattered this
+	// would be reported.
+	go func() { time.Sleep(time.Hour) }()
+
+	// And one that is merely slow rather than stuck.
 	done := make(chan struct{})
 
 	go func() {
@@ -82,12 +97,84 @@ func TestLeakedGoroutinesWaitsForStragglers(t *testing.T) {
 		close(done)
 	}()
 
-	// Long enough to outlast the sleeper, so it must not be reported.
-	got := leakcheck.LeakedGoroutines(2 * time.Second)
+	for range 20 {
+		report := mustLeaked(t)
+		if got := countLeaks(t, report); got != before {
+			t.Fatalf("a goroutine that will wake was reported as leaked: %d, want %d\n%s",
+				got, before, report)
+		}
+
+		time.Sleep(poll)
+	}
 
 	<-done
+}
 
-	if strings.Contains(got, "TestLeakedGoroutinesWaitsForStragglers") {
-		t.Errorf("a goroutine that finished within the settle window was reported:\n%s", got)
+// mustLeaked reads the profile, failing the test rather than the package if it
+// is unavailable.
+func mustLeaked(t *testing.T) string {
+	t.Helper()
+
+	report, err := leakcheck.Leaked()
+	if err != nil {
+		t.Fatalf("Leaked: %v", err)
 	}
+
+	return report
+}
+
+// waitForLeaks polls until the profile reports at least want leaks, and
+// returns what it last saw either way.
+//
+// Polling is for the goroutines to park, not for a leak to develop: a parked
+// goroutine's unreachability is decided by the GC cycle the profile runs, and
+// that answer does not change with more waiting.
+func waitForLeaks(t *testing.T, want int) (int, string) {
+	t.Helper()
+
+	var (
+		report string
+		got    int
+	)
+
+	for waited := time.Duration(0); waited < settle; waited += poll {
+		report = mustLeaked(t)
+
+		if got = countLeaks(t, report); got >= want {
+			return got, report
+		}
+
+		time.Sleep(poll)
+	}
+
+	return got, report
+}
+
+// countLeaks reads the count off the profile header, or 0 when the profile is
+// empty.
+func countLeaks(t *testing.T, profile string) int {
+	t.Helper()
+
+	if profile == "" {
+		return 0
+	}
+
+	head, _, _ := strings.Cut(profile, "\n")
+
+	_, total, ok := strings.Cut(head, "total ")
+	if !ok {
+		t.Fatalf("profile header has no total: %q", head)
+	}
+
+	n := 0
+
+	for _, c := range strings.TrimSpace(total) {
+		if c < '0' || c > '9' {
+			break
+		}
+
+		n = n*10 + int(c-'0')
+	}
+
+	return n
 }

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -1,0 +1,93 @@
+package leakcheck_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+
+	"github.com/TuSKan/astrogo/internal/leakcheck"
+)
+
+// TestLeakedGoroutinesFindsOne is the check that makes the guard worth having.
+//
+// A leak detector that has never caught anything is indistinguishable from one
+// that cannot, and this one is installed as a TestMain — where a false negative
+// is completely silent, because the package simply passes. So it is pointed at
+// a goroutine that will never return.
+//
+// The leaked goroutine is deliberately not cleaned up: there is no way to stop
+// a `select {}` and nothing to gain from one, since the test binary is about to
+// exit anyway. It is a handful of bytes for the rest of the run.
+func TestLeakedGoroutinesFindsOne(t *testing.T) {
+	// Not parallel: it reads every goroutine in the process, so a sibling
+	// test's workers would show up as its subject.
+	started := make(chan struct{})
+
+	go func() {
+		close(started)
+
+		select {} // never returns, which is the point
+	}()
+
+	<-started
+
+	got := leakcheck.LeakedGoroutines(200 * time.Millisecond)
+	if got == "" {
+		t.Fatal("a goroutine blocked forever was not reported; a leak check that " +
+			"cannot fail is a package that only looks clean")
+	}
+
+	// The report has to name something a reader can act on. "select (no
+	// cases)" is what the runtime calls a goroutine parked forever.
+	if !strings.Contains(got, "goroutine") {
+		t.Errorf("report does not name a goroutine:\n%s", got)
+	}
+}
+
+// TestLeakedGoroutinesIgnoresTheTestRunner pins the other half: the check must
+// not report the goroutine running the tests, or every package fails always
+// and the guard is turned off within a day.
+//
+// This runs in the same binary as the test above, so it cannot assert a clean
+// result outright — that one's leak is still parked. What it can assert is
+// that the runner and the check's own frames are not in the report, which is
+// the part that would break every package rather than one.
+func TestLeakedGoroutinesIgnoresTheTestRunner(t *testing.T) {
+	got := leakcheck.LeakedGoroutines(50 * time.Millisecond)
+
+	for _, unwanted := range []string{
+		"testing.(*M).Run",
+		"leakcheck.LeakedGoroutines",
+		"leakcheck.survivingGoroutines",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("report includes %q, which is the framework rather than a leak:\n%s",
+				unwanted, got)
+		}
+	}
+}
+
+// TestLeakedGoroutinesWaitsForStragglers covers the settle window.
+//
+// A goroutine on its way out is not a leak, and the difference is only visible
+// in time. Without the wait this check would fail on any test whose last
+// worker had not yet been scheduled to return — a flake that would look like a
+// real finding and would be chased for hours.
+func TestLeakedGoroutinesWaitsForStragglers(t *testing.T) {
+	done := make(chan struct{})
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(done)
+	}()
+
+	// Long enough to outlast the sleeper, so it must not be reported.
+	got := leakcheck.LeakedGoroutines(2 * time.Second)
+
+	<-done
+
+	if strings.Contains(got, "TestLeakedGoroutinesWaitsForStragglers") {
+		t.Errorf("a goroutine that finished within the settle window was reported:\n%s", got)
+	}
+}

--- a/internal/parallel/main_test.go
+++ b/internal/parallel/main_test.go
@@ -1,0 +1,12 @@
+package parallel_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/leakcheck"
+)
+
+// This package's whole purpose is starting goroutines, so it is the first
+// place a leak would appear. See leakcheck.RunWithLeakCheck.
+func TestMain(m *testing.M) { os.Exit(leakcheck.RunWithLeakCheck(m)) }


### PR DESCRIPTION
A leaked goroutine is invisible to every other check in this repository. It does not fail a test, does not race, does not allocate enough to notice and does not appear in a coverage report. It shows up in production as a process that grows, by which time the fan-out that leaked it is a hundred commits back.

`internal/leakcheck` closes that gap for the two packages that start goroutines — `internal/parallel`'s chunked workers and `catalog`'s two fan-outs — with one line in each `TestMain`:

```go
func TestMain(m *testing.M) { os.Exit(leakcheck.RunWithLeakCheck(m)) }
```

## What changed since the first push of this branch

The first two commits counted goroutines still running when the tests ended. That needs a settle window and a guess at how long a straggler takes, which makes a slow worker and a leak the same observation — in both directions. It was a heuristic wearing a guard's clothes.

Go 1.27 added a `goroutineleak` pprof profile. `WriteTo` runs a GC cycle that marks a goroutine leaked when it is blocked on something **nothing else can reach**, so a leak is *proved* rather than inferred from having outlived a timer. The third commit rewrites the package on it and deletes the settle window entirely.

## Measured boundary

Six shapes, run against the profile rather than described from the release notes:

| shape | reported |
| :--- | :--- |
| blocked forever on an unreachable channel | yes |
| blocked on a `WaitGroup` never `Done` | yes |
| `select {}` forever | yes |
| blocked on a mutex never unlocked | **no** |
| `time.Sleep(time.Hour)` | no — it will wake |
| a goroutine that finished | no |

The last two are the point: zero false positives, which is exactly what the settle window existed to paper over.

Two limits are recorded in the package doc rather than assumed away, because a clean result is only worth what its limits are:

- **The mutex case is a real gap.** This proves the leaks it reports; it does not prove their absence.
- **A goroutine is only provably leaked once it has parked.** Measured: spawned-and-not-yet-scheduled reports 0, one `runtime.Gosched` later it reports 1. This costs the guard nothing — it runs after every test has returned — but it is why the tests here poll instead of looking once. My first version of the test did look once, and failed for exactly this reason.

## Verification

Proved end to end rather than in isolation. A deliberate leak added to `internal/parallel`:

```
PASS
the runtime proved these goroutines leaked:
goroutineleak profile: total 1
1 @ ...
#	0x...	...parallel_test.TestTemporarilyLeaksToProveTheGuardFires.func1+0x18	internal/parallel/zz_leakproof_test.go:8
FAIL	github.com/TuSKan/astrogo/internal/parallel
```

The suite passes and the guard then fails the package, naming the file and line that started it. The probe was removed again before committing.

Mutation testing, 7 mutants, 7 killed:

| mutation | killed by |
| :--- | :--- |
| never short-circuits on a failing suite | `a failing suite is not masked` |
| an unavailable profile passes | `an unavailable profile fails rather than passing` |
| a leak is not acted on | `a clean suite with a leak fails` |
| a clean profile reported as a leak | `a clean run still has a header` |
| an unrecognised header counts as one leak | `empty input` |
| `debug=2` instead of `1` | `TestLeakedProvesTheShapesItClaims` |
| looks up the wrong profile | `TestLeakedIgnoresAGoroutineThatWillWake` |

The fourth of those was a survivor found by inspection, not by the tests as first written: the runtime emits a header even when nothing leaked, so returning the profile unconditionally would fail every guarded package forever — and `total 0` parses to 0 either way, so nothing noticed. `Leaked` cannot demonstrate this itself, because by the time any test has leaked a goroutine on purpose no later call in that process can observe a clean profile again. The decision is now a pure function, `leakedReport`, which can be shown both answers.

Full gate on the rebased branch: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`, and both guarded packages clean under `-tags=network` against the live services.

## Notes

- Requires Go 1.27 for the profile, so this was rebased onto `main` after #231 landed. On an older toolchain `pprof.Lookup` returns nil and the guard reports `ErrProfileUnavailable` rather than passing — an absent profile is deliberately not the same answer as no leaks.
- The package lives in `internal/leakcheck` rather than `internal/testutil` because `docsguard`'s stdtime rule exempts only `logging` and `time/`, and `testutil` sits below `astrogo/time`. Worth noting separately: that rule's *comment* claims `testutil` is exempt while its *code* does not.
- Not `testing/synctest`, which is more precise but requires a bubble with a fake clock and no network — most concurrency here exists specifically to talk to several observatories at once. That reasoning is in the doc comment so the next reader does not re-derive it.
