### PR TITLE
ephemeris/jpl: stop reporting correctly-loaded comets as the wrong body

### DIFF
--- a/docs/changelog.d/237-comet-spk-id.md
+++ b/docs/changelog.d/237-comet-spk-id.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 237
+---
+`ephemeris/jpl` no longer rejects every comet fetched by its Horizons SPK-ID as
+a substituted body. Those IDs sit outside NAIF's numbered-asteroid block, where
+`core.SmallBodyID` reports 0, and the substitution guard was comparing the
+loaded bodies against that zero rather than against the comet (#237).

--- a/ephemeris/core/core.go
+++ b/ephemeris/core/core.go
@@ -265,6 +265,13 @@ const smallBodySpan = 1000000
 //
 // Returns 0 for an n outside NAIF's small-body block, which is not a valid
 // body identifier and will fail to resolve rather than aliasing another body.
+//
+// That zero means "n is not a small-body number", not "body 0", and the two
+// are only interchangeable when the result is about to be resolved. Check it
+// before comparing: a comparison against it answers no for every body, so it
+// turns "the question could not be asked" into "the answer is different from
+// what you wanted" — which is how a Horizons comet SPK-ID, well outside this
+// block, was reported as the wrong object having loaded correctly.
 func SmallBodyID(n int) ID {
 	if n <= 0 || n >= smallBodySpan {
 		return 0

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -570,16 +570,26 @@ func (p *Provider) loadSmallBodyKernels(readers []*spk.Reader) error {
 	return p.verifyRequestedBodyLoaded(after)
 }
 
-// numberedAsteroid reports the asteroid number a designation names, and
-// whether it names one at all. "433" and "433;" both name 433; a provisional
+// numberedAsteroid reports the body a designation names, and whether it names
+// a predictable one at all. "433" and "433;" both name Eros; a provisional
 // designation or a comet fragment names nothing predictable.
-func numberedAsteroid(designation string) (int, bool) {
+//
+// A bare integer is not enough to make it an asteroid number. Horizons'
+// comet index issues SPK-IDs that are also bare integers — 1000390 for
+// C/2002 J5 (LINEAR) — and they sit outside NAIF's numbered-asteroid
+// allocation entirely. [core.SmallBodyID] is the authority on that bound and
+// reports 0 for anything beyond it, so it is asked rather than having its
+// constant copied here, where the two could drift apart without either side
+// noticing.
+func numberedAsteroid(designation string) (core.ID, bool) {
 	n, err := strconv.Atoi(strings.TrimSuffix(designation, ";"))
-	if err != nil || n <= 0 {
+	if err != nil {
 		return 0, false
 	}
 
-	return n, true
+	id := core.SmallBodyID(n)
+
+	return id, id != 0
 }
 
 // verifyRequestedBodyLoaded checks that the body loaded is the body asked
@@ -594,16 +604,23 @@ func numberedAsteroid(designation string) (int, bool) {
 //
 // A numbered asteroid has a knowable identifier, so this is checkable rather
 // than a matter of trusting the syntax: asteroid n must arrive as
-// [core.SmallBodyID](n). A designation that is not a bare number — a comet
-// fragment, a provisional designation — names nothing this can predict and
-// is left alone.
+// [core.SmallBodyID](n). A designation that does not name one — a comet
+// fragment, a provisional designation, or a Horizons SPK-ID from the comet
+// index — names nothing this can predict and is left alone.
+//
+// That last case is why the check asks [numberedAsteroid] for a body rather
+// than for a number. Composing the two by hand read as
+// slices.Contains(loaded, core.SmallBodyID(n)), which for a comet SPK-ID
+// compares against SmallBodyID's out-of-range zero: the body genuinely
+// requested is present, ID 0 is not, and the guard reported the loudest wrong
+// answer it has — that Horizons substituted a different object — for a load
+// that was entirely correct.
 func (p *Provider) verifyRequestedBodyLoaded(loaded []core.ID) error {
-	n, ok := numberedAsteroid(p.kernel)
+	want, ok := numberedAsteroid(p.kernel)
 	if !ok {
 		return nil
 	}
 
-	want := core.SmallBodyID(n)
 	if slices.Contains(loaded, want) {
 		return nil
 	}

--- a/ephemeris/jpl/smallbody_designation_classify_test.go
+++ b/ephemeris/jpl/smallbody_designation_classify_test.go
@@ -1,0 +1,117 @@
+package jpl
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+)
+
+// TestNumberedAsteroidClassifiesTheDesignation pins the boundary that decides
+// whether the substitution guard has a question it can ask at all.
+//
+// Everything at or above NAIF's numbered-asteroid allocation is some other
+// namespace — Horizons' comet index issues SPK-IDs there — and a designation
+// naming one of those predicts nothing about which body should arrive.
+func TestNumberedAsteroidClassifiesTheDesignation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		designation string
+		want        core.ID
+		wantOK      bool
+	}{
+		{"an asteroid number", "433", core.SmallBodyID(433), true},
+		{"the semicolon form Horizons prefers", "433;", core.SmallBodyID(433), true},
+		{"the ambiguous bare one", "1", core.SmallBodyID(1), true},
+		{"the last number in the block", "999999", core.SmallBodyID(999999), true},
+
+		{"the first number outside it", "1000000", 0, false},
+		{"a comet SPK-ID from Horizons", "1000390", 0, false},
+		{"another comet SPK-ID", "1003928", 0, false},
+
+		{"zero", "0", 0, false},
+		{"negative", "-5", 0, false},
+		{"a name", "Ceres", 0, false},
+		{"a provisional designation", "2019 M4", 0, false},
+		{"nothing", "", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := numberedAsteroid(tc.designation)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("numberedAsteroid(%q) = (%v, %v), want (%v, %v)",
+					tc.designation, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestVerifyRequestedBodyLoadedAcceptsACometSPKID is the regression.
+//
+// Every comet reached by its Horizons SPK-ID failed as ErrWrongSmallBody —
+// the loudest and most specific claim this package can make, that Horizons
+// substituted a different object — while the body requested was sitting in
+// the list. core.SmallBodyID reports 0 for a number outside its block, and
+// composing it into the check by hand asked whether the kernel contained
+// body 0. It never does, so the guard concluded substitution every time.
+//
+// Three of these turned up in one run of plan's network suite: C/2002 J5
+// (LINEAR), C/2000 A1 (Montani) and C/2019 M4 (TESS).
+func TestVerifyRequestedBodyLoadedAcceptsACometSPKID(t *testing.T) {
+	t.Parallel()
+
+	const comet = core.ID(1000390) // C/2002 J5 (LINEAR)
+
+	p := &Provider{kernel: "1000390"}
+
+	if err := p.verifyRequestedBodyLoaded([]core.ID{core.Earth, core.Sun, comet}); err != nil {
+		t.Fatalf("a comet that loaded correctly was rejected: %v", err)
+	}
+}
+
+// TestVerifyRequestedBodyLoadedStillCatchesTheSubstitution is the half that
+// must not be lost to the fix.
+//
+// Asking Horizons for "1" returns comet 1000036 rather than 1 Ceres, and
+// catching that is the whole reason this check exists.
+func TestVerifyRequestedBodyLoadedStillCatchesTheSubstitution(t *testing.T) {
+	t.Parallel()
+
+	const whatHorizonsActuallySends = core.ID(1000036)
+
+	p := &Provider{kernel: "1"}
+
+	err := p.verifyRequestedBodyLoaded([]core.ID{core.Earth, core.Sun, whatHorizonsActuallySends})
+	if !errors.Is(err, ErrWrongSmallBody) {
+		t.Fatalf("verifyRequestedBodyLoaded = %v, want ErrWrongSmallBody", err)
+	}
+
+	// The message has to name the body that was wanted, or a reader is told
+	// a substitution happened without being told what to look for.
+	if !strings.Contains(err.Error(), core.SmallBodyID(1).String()) {
+		t.Errorf("error does not name the requested body: %v", err)
+	}
+}
+
+// TestVerifyRequestedBodyLoadedAcceptsTheAsteroidItAskedFor keeps the ordinary
+// case honest: a numbered asteroid that arrives is not an error.
+func TestVerifyRequestedBodyLoadedAcceptsTheAsteroidItAskedFor(t *testing.T) {
+	t.Parallel()
+
+	for _, designation := range []string{"433", "433;"} {
+		t.Run(designation, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Provider{kernel: designation}
+
+			loaded := []core.ID{core.Earth, core.Sun, core.SmallBodyID(433)}
+			if err := p.verifyRequestedBodyLoaded(loaded); err != nil {
+				t.Fatalf("%q: %v", designation, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #236.

Every comet reached by its Horizons SPK-ID failed as `ErrWrongSmallBody` — the most specific and most alarming claim this package can make, that Horizons answered with a different object — while the object requested was sitting in the list the error printed:

```
jpl: horizons returned a different small body: asked for "1000390" and Horizons returned
[Earth Venus BodyID(1000390) Jupiter Saturn Uranus Sun Mercury Mars Neptune Pluto Moon],
which does not include BodyID(0)
```

`BodyID(1000390)` is right there. The check was looking for `BodyID(0)`.

## Mechanism

`core.SmallBodyID` returns `0` for a number outside NAIF's numbered-asteroid block, meaning *"n is not a small-body number"*. Horizons' comet index issues SPK-IDs well outside that block, and `verifyRequestedBodyLoaded` composed `SmallBodyID` into a `slices.Contains` by hand — so it asked whether the kernel contained body 0. It never does.

Measured across the boundary:

| n | `SmallBodyID(n)` |
| ---: | :--- |
| 433 | `SmallBody(433)` |
| 999999 | `SmallBody(999999)` |
| **1000000** | **`BodyID(0)`** |
| **1000390** | **`BodyID(0)`** — C/2002 J5 (LINEAR) |
| **1003928** | **`BodyID(0)`** — C/2019 M4 (TESS) |

An absence became a confident wrong answer — the same shape as #102 / #172 / #177 / #182, and worse than a plain false negative, because a reader following the message investigates designation syntax that was never wrong.

## Fix

`numberedAsteroid` now returns the *body* rather than the number, and asks `core.SmallBodyID` whether the designation names one at all:

```go
func numberedAsteroid(designation string) (core.ID, bool) {
	n, err := strconv.Atoi(strings.TrimSuffix(designation, ";"))
	if err != nil {
		return 0, false
	}

	id := core.SmallBodyID(n)

	return id, id != 0
}
```

The bound stays with `core` instead of being re-derived in `jpl`, where the two could drift apart without either side noticing. A designation naming nothing predictable is left alone — which is what `verifyRequestedBodyLoaded`'s doc comment already claimed it did for comet fragments and provisional designations.

`core.SmallBodyID`'s doc now says plainly that its zero must be checked before it is *compared*, not only before it is resolved. The existing wording covered resolution ("will fail to resolve rather than aliasing another body"), which is true and was not the way it got used.

## What is deliberately not changed

`SmallBodyID` keeps its `ID` return rather than becoming `(ID, bool)`, which #236 floated. The honest signature would prevent this class outright, but it is public API with 20 inline call sites in tests and an `Example` (`SmallBodyID(433).String()`), against exactly **one** production caller — the one fixed here. Not worth a breaking change; recorded here so the trade-off is on the record rather than silently taken. If `core` ever grows a second caller that compares rather than resolves, revisit it.

## Verification

The guard this check exists for is unchanged: asking Horizons for `"1"` still returns comet 1000036 rather than 1 Ceres, and is still refused.

New untagged tests, so they run in ordinary CI rather than only under `network`:

- `TestNumberedAsteroidClassifiesTheDesignation` — 12 cases pinning the boundary: `999999` classifies, `1000000` and two real comet SPK-IDs do not, alongside names, provisional designations, zero and negatives.
- `TestVerifyRequestedBodyLoadedAcceptsACometSPKID` — the regression.
- `TestVerifyRequestedBodyLoadedStillCatchesTheSubstitution` — the `"1"` → comet 1000036 case, asserting both the sentinel and that the message names the body wanted.
- `TestVerifyRequestedBodyLoadedAcceptsTheAsteroidItAskedFor` — `"433"` and `"433;"`.

Confirmed end to end against the suite that surfaced it. Before, `plan`'s run reported three comets as substituted bodies; after, `ErrWrongSmallBody` does not appear at all. (That test still fails on unrelated grounds — Horizons was returning 503 during the run, and there is a separate concurrent-cache problem on Windows worth its own issue.)

Mutation testing, 5 mutants, 5 killed:

| mutation | killed by |
| :--- | :--- |
| any bare integer counts as an asteroid number | `TestNumberedAsteroidClassifiesTheDesignation` |
| the semicolon form is not recognised | `the semicolon form Horizons prefers` |
| the guard checks exactly the wrong designations | `TestSmallBodyMultiMatch` |
| the block bound is off by one | `the first number outside it` |
| zero is a small-body number | `zero` |

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.
