### PR TITLE
plan: stop one test revoking the download consent the rest depend on

### DIFF
--- a/docs/changelog.d/240-consent-scope.md
+++ b/docs/changelog.d/240-consent-scope.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 240
+---
+`plan`'s tests no longer revoke the download consent their own `TestMain`
+grants: the four blanket `remote.Reset` cleanups are now scoped
+`remote.Capture(...).Restore`, and a new guard in `internal/docsguard` fails
+any consent-granting package that reintroduces one (#240).

--- a/internal/docsguard/consentscope_test.go
+++ b/internal/docsguard/consentscope_test.go
@@ -1,0 +1,164 @@
+package docsguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestConsentGrantingPackagesDoNotResetRemote stops one test in a package
+// from revoking the download consent every other test in it depends on.
+//
+// # Why
+//
+// remote's consent, offline flag and cache directory are process-wide, and
+// several packages grant consent once in TestMain for the whole test binary —
+// real DE441/DE442 fetches need it. remote.Reset restores the *process
+// default*, which is no consent at all, so a test that cleans up with
+// t.Cleanup(remote.Reset) does not undo itself: it undoes TestMain, for every
+// test that runs afterwards.
+//
+// Reset also does not touch the data directory, which is a separate global,
+// so a test that repoints the cache at an empty t.TempDir and then Resets
+// leaves it pointed there. A later test then finds neither consent nor cache
+// and fails instantly, in a package it has nothing to do with.
+//
+// This is not hypothetical and not new. It broke the same three eclipse and
+// moon-phase tests twice: once from plan/visible_tonight_internal_test.go,
+// whose doc comment records the diagnosis, and again from
+// plan/mpc_network_test.go (#239), written afterwards, which used the form
+// that comment warns about. remote.Reset's own doc comment says to prefer
+// Capture/Restore. The knowledge was written down three times and still did
+// not travel, so this checks instead.
+//
+// # Scope
+//
+// Only packages that grant consent in TestMain, because only they have
+// something for a Reset to destroy. remote's own tests Reset freely and
+// should — that is the package under test.
+//
+// The fix at any site this reports is remote.Capture(ids...).Restore, which
+// snapshots exactly what the test is about to change, the data directory
+// included, and puts back exactly that.
+func TestConsentGrantingPackagesDoNotResetRemote(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..")
+
+	granting := consentGrantingPackages(t, root)
+	if len(granting) < 3 {
+		t.Fatalf("only %d packages found granting download consent in TestMain; "+
+			"the walk is not reaching the module", len(granting))
+	}
+
+	var scanned, offenders int
+
+	for _, dir := range granting {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+
+			path := filepath.Join(dir, e.Name())
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+
+			scanned++
+
+			rel, _ := filepath.Rel(root, path)
+			rel = filepath.ToSlash(rel)
+
+			for n, line := range strings.Split(string(data), "\n") {
+				trimmed := strings.TrimSpace(line)
+
+				// A comment explaining why Reset is wrong is exactly the
+				// prose this guard wants to keep, so only code counts.
+				if strings.HasPrefix(trimmed, "//") || !strings.Contains(trimmed, "remote.Reset") {
+					continue
+				}
+
+				offenders++
+
+				t.Errorf("%s:%d uses remote.Reset in a package whose TestMain grants "+
+					"download consent.\n"+
+					"  Reset restores the process default — no consent — so this revokes "+
+					"TestMain's grant for every test running afterwards, and leaves any "+
+					"SetDataDir pointed at this test's temporary bucket. Use "+
+					"remote.Capture(ids...).Restore, which puts back exactly what was "+
+					"captured. See #239.", rel, n+1)
+			}
+		}
+	}
+
+	t.Logf("%d test files scanned across %d consent-granting packages, %d offending lines",
+		scanned, len(granting), offenders)
+}
+
+// consentGrantingPackages returns the directories holding a TestMain that
+// grants download consent — the only ones where a Reset has something to
+// destroy.
+//
+// Both markers must appear in the same file, so a package with an ordinary
+// TestMain and an unrelated EnableDownloads elsewhere is not swept in.
+func consentGrantingPackages(t *testing.T, root string) []string {
+	t.Helper()
+
+	var dirs []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // an unreadable path is skipped, not fatal
+		}
+
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an unreadable file is skipped, not fatal
+		}
+
+		// A declaration at column zero and a qualified call, rather than bare
+		// substrings: this file names both markers in its own strings and doc
+		// comment, and a guard that reports itself reports nothing useful.
+		src := string(data)
+		if !strings.HasPrefix(src, "func TestMain(") && !strings.Contains(src, "\nfunc TestMain(") {
+			return nil
+		}
+
+		if !strings.Contains(src, "remote.EnableDownloads(") {
+			return nil
+		}
+
+		dir := filepath.Dir(path)
+		if !slices.Contains(dirs, dir) {
+			dirs = append(dirs, dir)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	return dirs
+}

--- a/plan/mpc_network_test.go
+++ b/plan/mpc_network_test.go
@@ -21,7 +21,7 @@ func requireMPCList(t *testing.T) []MPCObservatory {
 
 	testutil.RequireReachable(t, "www.minorplanetcenter.net:443")
 
-	t.Cleanup(remote.Reset)
+	t.Cleanup(remote.Capture(remote.MPCObsCodes).Restore)
 	remote.EnableDownloads(0, remote.MPCObsCodes)
 
 	list, err := MPCObservatories(context.Background())
@@ -210,8 +210,16 @@ func TestNewMPCSiteRejectsCodesWithNoGroundPosition(t *testing.T) {
 func TestMPCObservatoriesNeedsDownloadConsent(t *testing.T) {
 	testutil.RequireReachable(t, "www.minorplanetcenter.net:443")
 
-	t.Cleanup(remote.Reset)
-	remote.Reset() // no EnableDownloads
+	// Scoped to this one endpoint rather than remote.Reset, which restores
+	// the process default — no consent — and so revokes what
+	// integration_main_test.go's TestMain granted for the whole binary.
+	// Reset also leaves the data directory alone, so the empty bucket below
+	// would stay pointed there afterwards: a later test would find neither
+	// consent nor cache. That combination failed three unrelated eclipse and
+	// moon-phase tests (#239), which is the second time the same three have
+	// been broken this way — see visible_tonight_internal_test.go's note.
+	t.Cleanup(remote.Capture(remote.MPCObsCodes).Restore)
+	remote.DisableDownloads(remote.MPCObsCodes)
 
 	remote.SetDataDir("file:///" + filepath.ToSlash(t.TempDir()) + "?create_dir=true")
 

--- a/plan/visible_tonight_network_test.go
+++ b/plan/visible_tonight_network_test.go
@@ -39,7 +39,7 @@ func requireJPL(t *testing.T) {
 func TestVisibleTonight_MinorBodiesRespectMagLimit(t *testing.T) {
 	requireJPL(t)
 
-	t.Cleanup(remote.Reset)
+	t.Cleanup(remote.Capture(remote.NAIFSPK, remote.NAIFLSK, remote.JPLHorizonsSPK).Restore)
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	remote.EnableDownloads(0, remote.NAIFSPK)
 	remote.EnableDownloads(0, remote.NAIFLSK)
@@ -112,7 +112,7 @@ func TestVisibleTonight_MinorBodiesRespectMagLimit(t *testing.T) {
 func TestVisibleTonight_PlanetaryMoons(t *testing.T) {
 	requireJPL(t)
 
-	t.Cleanup(remote.Reset)
+	t.Cleanup(remote.Capture(remote.NAIFSPK, remote.NAIFLSK).Restore)
 	remote.SetDataDir(testutil.FileURL(t, t.TempDir()))
 	remote.EnableDownloads(110<<20, remote.NAIFSPK)
 	remote.EnableDownloads(0, remote.NAIFLSK)


### PR DESCRIPTION
Closes #239.

Three tests failed on every full-gate run:

```
--- FAIL: TestAstroPixels_MoonPhases (0.00s)
--- FAIL: TestNASA_LunarEclipses_Historical (0.16s)
--- FAIL: TestNASA_SolarEclipses_Historical (0.14s)
    remote: download denied: planets/de441_part-1.bsp ... call remote.EnableDownloads(...)
```

`plan/integration_main_test.go`'s `TestMain` grants unlimited `NAIFSPK` consent for the whole binary. It was being thrown away by an earlier test.

## Isolated

```
-run 'TestAstroPixels_MoonPhases'                                              ok
-run 'TestGatherPlanetaryMoonsSkipsWithoutDownloadConsent|TestAstroPixels_...'  ok
-run 'TestMPCObservatoriesNeedsDownloadConsent|TestAstroPixels_MoonPhases'    FAIL
```

`TestMPCObservatoriesNeedsDownloadConsent` cleans up with `t.Cleanup(remote.Reset)`. Two things leak forward:

- **`Reset` restores the process default, which is no consent** — so it does not undo the test, it undoes `TestMain`.
- **`Reset` does not touch the data directory**, a separate global, so the empty `t.TempDir()` bucket the test points the cache at stays pointed there.

Neither consent nor cache. That is why the failures were instant — 0.00s, before any network call.

## The fix

All four blanket `Reset` cleanups in `plan` now use `remote.Capture(ids...).Restore`, which snapshots exactly what the test is about to change — the data directory included — and puts back exactly that:

```go
t.Cleanup(remote.Capture(remote.MPCObsCodes).Restore)
remote.DisableDownloads(remote.MPCObsCodes)
```

`remote.Capture` already existed for precisely this; `plan/visible_tonight_internal_test.go:50` is the worked example.

## Why this needed a guard, not just a fix

This is the **second** time these same three tests have broken this way.

`plan/visible_tonight_internal_test.go:40` records the first, in detail:

> a plain `remote.Reset()` here would revoke that for every test running afterward in the same binary, not just this one (confirmed: it did, breaking three otherwise unrelated eclipse/moon-phase tests)

`remote.Reset`'s own doc comment says:

> Reset discards consent a broader scope — a package TestMain — granted for the whole binary ... Prefer Capture/Restore or WithScope for scoped setup.

`ephemeris/jpl/spk` avoids it correctly and says why, in three separate comments. The knowledge was written down in five places and still did not reach `mpc_network_test.go`, which was added afterwards. So `internal/docsguard/consentscope_test.go` now checks it instead: in any package whose `TestMain` grants download consent, `remote.Reset` appearing in test code is an error naming file and line.

It is untagged, so it runs in ordinary CI. It scans 105 test files across the 5 consent-granting packages, and it only looks at code — a comment explaining why `Reset` is wrong is exactly the prose worth keeping, and several exist.

Detection is by a `func TestMain(` declaration at column zero plus a qualified `remote.EnableDownloads(` call, rather than bare substrings, because the first version reported *itself*: its own doc comment and match strings name both markers.

## Verification

- **The three tests now pass.** Full `plan` suite under `-tags="integration,network,validation"`: `TestAstroPixels_MoonPhases`, `TestNASA_LunarEclipses_Historical` and `TestNASA_SolarEclipses_Historical` are all green.
- **The guard fires.** Reintroducing the exact line that caused this produces `plan/mpc_network_test.go:24 uses remote.Reset in a package whose TestMain grants download consent`, and removing it again passes.
- Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.

## Still failing, unrelated

Two `plan` tests still fail under the full tag set, for reasons this PR does not touch and does not introduce:

- `horizons service unavailable (503): temporary overload/maintenance` — external.
- Concurrent fan-out over small bodies has many goroutines opening the same `de440s.bsp` in one cache directory while it is still being written: partial reads (`range read ... at 17104896: EOF`) and, on Windows, `The process cannot access the file because it is being used by another process`. The same shape reproduces in `ephemeris/jpl/spk`'s three `TestDiscardIfCorrupt*` tests under `-race`, where a different one fails on each run. Filed separately.
