### PR TITLE
remote: stage cache writes beside the object, not in the shared temp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,9 +576,16 @@ It is a **bucket URL, not a filesystem path** — nothing in astrogo assumes the
 local disk:
 
 ```go
-remote.SetDataDir("file:///data/astrogo-cache?create_dir=true")
+remote.SetDataDir("file:///data/astrogo-cache?create_dir=true&no_tmp_dir=1")
 remote.SetDataDir("s3://my-cache-bucket") // needs: import _ "github.com/TuSKan/astrogo/remote/s3"
 ```
+
+For a `file://` cache, pass **`no_tmp_dir=1`** as shown. Without it every write is staged in
+the shared `os.TempDir()` under a name derived from the key's basename, so two goroutines
+caching the same kernel name collide on one staging path (measured on Windows: 49 failures
+in 320 concurrent writes, 0 with the parameter), and a cache on a different volume from
+`os.TempDir` pays a full extra copy of every multi-gigabyte kernel. astrogo's own default
+cache URL carries it; a URL you supply is used exactly as written.
 
 The `ASTROGO_CACHE_DIR` environment variable sets the same thing, and also takes a URL.
 `remote.CacheDir(ctx, id)` reports the bucket and key prefix an endpoint caches under, and

--- a/docs/changelog.d/242-no-tmp-dir.md
+++ b/docs/changelog.d/242-no-tmp-dir.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 242
+---
+Cache writes are staged beside the object rather than in the shared
+`os.TempDir()`, so two goroutines caching the same kernel name no longer
+collide on one staging path. Measured on Windows: 49 failures in 320
+concurrent same-key writes before, 0 after (#242).

--- a/internal/testutil/bucketurl.go
+++ b/internal/testutil/bucketurl.go
@@ -16,6 +16,13 @@ import (
 // exist yet. It is built through url.URL so a temp path containing '#' or a
 // stray '%' — which t.TempDir can produce from a test name — encodes
 // correctly instead of silently truncating.
+//
+// It also carries no_tmp_dir=1, matching remote's default cache URL. Without
+// it fileblob stages writes in the shared os.TempDir under a name built from
+// the key's basename and the current time, so parallel tests writing the same
+// key into their own t.TempDir buckets still collide on one staging path.
+// That is not hypothetical: it failed a different one of spk's three
+// TestDiscardIfCorrupt tests on each run, each of which passed alone (#241).
 func FileURL(tb testing.TB, dir string) string {
 	tb.Helper()
 
@@ -29,7 +36,7 @@ func FileURL(tb testing.TB, dir string) string {
 		slash = "/" + slash // Windows drive-letter paths are not "/"-rooted
 	}
 
-	u := url.URL{Scheme: "file", Path: slash, RawQuery: "create_dir=true"}
+	u := url.URL{Scheme: "file", Path: slash, RawQuery: "create_dir=true&no_tmp_dir=1"}
 
 	return u.String()
 }

--- a/remote/file/concurrentwrite_test.go
+++ b/remote/file/concurrentwrite_test.go
@@ -1,0 +1,92 @@
+package file_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/TuSKan/astrogo/remote/file"
+)
+
+// TestConcurrentWritesOfOneKeySucceed covers a failure that had been showing
+// up as three unrelated flaky tests.
+//
+// fileblob stages a write in the shared os.TempDir under a name built from
+// the key's *basename* and the current time, then renames it into the bucket.
+// So the staging path does not depend on which bucket is being written, and
+// two goroutines caching the same kernel name collide even when their buckets
+// are entirely separate — one's staging file gets renamed out from under the
+// other, and the loser reports "rename ...: The system cannot find the file
+// specified".
+//
+// The naming assumes nanosecond precision makes that unlikely. On Windows
+// time.Now().UnixNano returned one distinct value across 2000 consecutive
+// reads — a ~15.6 ms tick — so the assumption does not hold and the O_EXCL
+// retry re-reads the same frozen clock. Measured before the fix: 49 failures
+// in 320 writes. After: 0.
+//
+// astrogo does exactly this shape of write. plan's small-body fan-out has
+// many goroutines resolving bodies that all need the same base kernel, into
+// one cache directory.
+//
+// The fix is no_tmp_dir=1 in the bucket URL, which [testutil.FileURL] and
+// remote's default cache URL both carry, so this test is really asking
+// whether they still do.
+func TestConcurrentWritesOfOneKeySucceed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// The same basename every caller uses; that is the whole point.
+		key       = "jpl/planets/de440s.bsp"
+		writers   = 8
+		rounds    = 20
+		wantTotal = writers * rounds
+	)
+
+	ctx := context.Background()
+
+	var failures []error
+
+	for round := range rounds {
+		// A separate bucket per writer, so nothing but the shared staging
+		// directory can bring them into contact.
+		buckets := make([]*file.Bucket, writers)
+
+		for i := range writers {
+			b, err := file.Open(ctx, testutil.FileURL(t, t.TempDir()))
+			if err != nil {
+				t.Fatalf("open bucket %d: %v", i, err)
+			}
+
+			buckets[i] = b
+		}
+
+		errs := make([]error, writers)
+
+		var wg sync.WaitGroup
+
+		for i := range writers {
+			wg.Go(func() {
+				errs[i] = buckets[i].WriteAll(ctx, key, []byte("kernel bytes"), nil)
+			})
+		}
+
+		wg.Wait()
+
+		for i, err := range errs {
+			if err != nil {
+				failures = append(failures, fmt.Errorf("round %d writer %d: %w", round, i, err))
+			}
+		}
+	}
+
+	if len(failures) != 0 {
+		t.Errorf("%d of %d concurrent writes of %q failed; the bucket URL is most "+
+			"likely missing no_tmp_dir, which puts every writer's staging file in "+
+			"one shared directory under one name.\nfirst: %v",
+			len(failures), wantTotal, key, errors.Join(failures[:1]...))
+	}
+}

--- a/remote/storage.go
+++ b/remote/storage.go
@@ -71,6 +71,21 @@ func DataDirURL() string {
 // a cache directory that does not exist yet. It is built through url.URL
 // rather than concatenation: a '#' in the path would silently truncate it
 // and swallow the query, and a stray '%' would make it unparseable.
+//
+// It carries no_tmp_dir=1 for two reasons, both about where a write is
+// staged before it is renamed into place. Without it fileblob stages in the
+// shared os.TempDir under a name built from the key's basename and the
+// current time, so two goroutines caching the same kernel name — which is
+// what plan's small-body fan-out does on every query — compute the same
+// staging path even in different buckets. The comment behind that naming
+// says nanosecond precision makes a conflict unlikely; on Windows,
+// time.Now().UnixNano returned a single distinct value across 2000
+// consecutive reads, and 8 goroutines writing one key failed 49 times in
+// 320. With this parameter, 0 (#241).
+//
+// The second reason holds on every platform: os.TempDir is often on a
+// different volume from the cache, and a cross-volume rename is a whole
+// second copy of a multi-gigabyte kernel.
 func defaultDataDirURL() string {
 	base, err := os.UserCacheDir()
 	if err != nil {
@@ -82,7 +97,7 @@ func defaultDataDirURL() string {
 		slash = "/" + slash // Windows drive-letter paths are not "/"-rooted
 	}
 
-	u := url.URL{Scheme: "file", Path: slash, RawQuery: "create_dir=true"}
+	u := url.URL{Scheme: "file", Path: slash, RawQuery: "create_dir=true&no_tmp_dir=1"}
 
 	return u.String()
 }


### PR DESCRIPTION
Closes #241.

`fileblob` stages a write in the **shared** `os.TempDir()` under a name built from the key's *basename* and the current time, then renames it into the bucket. The staging path does not depend on which bucket is being written — so two goroutines caching the same kernel name collide even when their buckets are completely separate. One writer's staging file gets renamed out from under another:

```
blob (key "jpl/planets/de440s.bsp") (code=NotFound): rename
C:\...\Temp\de440s.bsp.18d3947f1dea1bb4.tmp  <bucket>\jpl\planets\de440s.bsp:
The system cannot find the file specified.
```

## Why it fires here

The naming rests on this, from `fileblob`'s `createTemp`:

> Nanosecond changes enough between each iteration to make a conflict unlikely.

Measured on this machine:

```
distinct UnixNano in 2000 consecutive reads: 1
```

**One.** Windows' clock granularity is ~15.6 ms, so the premise does not hold at all, and the `O_EXCL` retry loop re-reads the same frozen clock.

| bucket URL | failures out of 320 concurrent same-key writes |
| :--- | ---: |
| `?create_dir=true` (before) | **49** |
| `?create_dir=true&no_tmp_dir=1` (after) | **0** |

## The fix

`no_tmp_dir=1` on both places astrogo constructs a `file://` bucket URL — [`remote/storage.go`](../blob/main/remote/storage.go)'s default cache and [`internal/testutil.FileURL`](../blob/main/internal/testutil/bucketurl.go) — which stages next to the final object instead.

This follows the architecture rule rather than bending it: CLAUDE.md already says scheme-specific connection detail *"rides in the URL's query string, never in Go."* No branch in the fetch path, no new interface, nothing added to `remote/file`.

It is also correct on every platform independently of the race. `os.TempDir` is frequently on a different volume from the cache, and a cross-volume `rename` is a full copy — a second write of an entire multi-gigabyte kernel. `fileblob`'s own doc comment raises exactly this.

## What this was showing up as

Three unrelated-looking flaky tests, none of which pointed at the cause:

- **`ephemeris/jpl/spk`**: under `-race -short`, one of `TestDiscardIfCorruptDeletesAKernelThatIsWrong` / `TestDiscardIfCorruptReportsACloseFailure` / `TestDiscardIfCorruptRunsExtrasOnlyWhenItDeletes` failed on **every** run and a **different one each time**, while each passed alone. All three are `t.Parallel()` and all three seed the same key into their own `t.TempDir()` bucket. Now **5 runs out of 5 green**.
- **`plan`**, under the full tag set: the small-body fan-out was hitting the read side of the same shared staging — partial reads of a kernel another goroutine was still writing, `range read jpl/planets/de440s.bsp at 17104896: EOF`, plus Windows sharing violations. That one is the reason this matters beyond test hygiene: a truncated kernel read is a *wrong answer*, not an error, until the checksum happens to catch it.

## Verification

Nothing in the suite covered concurrent cache writes, which is exactly why this surfaced as flakiness elsewhere instead of as itself. `TestConcurrentWritesOfOneKeySucceed` in `remote/file` does now — 8 goroutines × 20 rounds, each into its own bucket, all writing one key.

It is not vacuous: with the parameter removed from `testutil.FileURL` it reports **18 of 160 failed**, and names the likely cause in the failure message. With the fix, 0.

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.

## Note

A caller-supplied `ASTROGO_CACHE_DIR` URL is still used exactly as written — consistent with how every other `fileblob` option is handled here — so the README's cache section now documents the parameter alongside `create_dir`, with the measured reason.
