### PR TITLE
time: stop re-parsing the whole IERS bulletin on every out-of-coverage lookup

### DIFF
--- a/docs/changelog.d/247-eop-coverage-throttle.md
+++ b/docs/changelog.d/247-eop-coverage-throttle.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 247
+---
+An EOP lookup outside the IERS bulletin's coverage no longer re-reads and
+re-parses the whole file on every call — 71 ns for a covered epoch against
+11 ms and 15.6 MB for one just outside. Scheduling more than a year ahead and
+historical work before 1973 were both on that path (#247).

--- a/plan/bench_test.go
+++ b/plan/bench_test.go
@@ -114,7 +114,18 @@ func benchScheduler(b *testing.B, n int, strategy Strategy) {
 	tm := &BasicTransitionModel{BaseSetup: 0}
 	blocks := makeBlocks(n)
 
-	start := time.ZeroTime()
+	// A real epoch, inside the EOP bulletin's coverage, rather than
+	// time.ZeroTime.
+	//
+	// ZeroTime is FromJD(0) — 4713 BC — where no Earth Orientation
+	// Parameters exist, and every constraint evaluation therefore took the
+	// out-of-coverage path. A heap profile put 99.88% of this benchmark's
+	// allocated bytes in time.Time.EOP rather than anywhere in scheduling,
+	// so what it reported was the cost of missing EOP data (#246).
+	//
+	// Fixed epoch, not time.NowUTC: a benchmark whose result depends on the
+	// day it is run cannot be compared with the one before it.
+	start := time.Date(2026, time.March, 20, 0, 0, 0, 0, time.LocationUTC)
 	window := Window{Start: start, End: start.Add(time.Duration(n*15) * time.Minute)}
 
 	for b.Loop() {

--- a/time/internal/iers/cachethrottle_test.go
+++ b/time/internal/iers/cachethrottle_test.go
@@ -1,0 +1,141 @@
+package iers
+
+import (
+	"testing"
+	"time"
+)
+
+// uncoveredMJD is far outside sampleFinals2000A's two days, so no amount of
+// loading will ever cover it — which is the whole point.
+const uncoveredMJD = 200000.0
+
+// bulletinModTime stands in for when the cached file was last written.
+//
+// Fixed rather than time.Now: nothing here depends on it being recent, and a
+// test that reads the wall clock drifts across the IERS measured/predicted
+// boundary and starts failing on a future date with no code change.
+var bulletinModTime = time.Date(2026, time.March, 20, 0, 0, 0, 0, time.UTC)
+
+// TestEnsureLoadedReadsTheCacheOnceForAnUncoveredEpoch is the regression.
+//
+// covered(mjd) was the only fast path, so an epoch the bulletin does not
+// cover fell through to Loader.Cached on *every* lookup and re-parsed the
+// whole file. Measured through Time.EOP: 71 ns for a covered epoch against
+// 11 ms allocating 15.6 MB for one just outside — a 150,000x cliff, silent,
+// on two ordinary requests (scheduling more than a year out, and history
+// before 1973).
+//
+// It also made this repository's own scheduler benchmarks meaningless: they
+// run at time.ZeroTime, and 99.88% of their allocated bytes were this.
+func TestEnsureLoadedReadsTheCacheOnceForAnUncoveredEpoch(t *testing.T) {
+	l := &fakeLoader{
+		cached:   Data{Raw: []byte(sampleFinals2000A), ModTime: bulletinModTime},
+		fetchErr: errUpstream,
+	}
+
+	installLoader(t, l)
+
+	const lookups = 50
+
+	for range lookups {
+		_ = EnsureLoaded(uncoveredMJD)
+	}
+
+	cached, _ := l.counts()
+	if cached != 1 {
+		t.Errorf("Loader.Cached called %d times for %d lookups of one uncovered epoch, want 1; "+
+			"re-reading the bulletin cannot change whether it covers an epoch it does not cover",
+			cached, lookups)
+	}
+}
+
+// TestEnsureLoadedStillReadsTheCacheForACoveredEpoch is the half the
+// throttle must not break: the first lookup still loads.
+func TestEnsureLoadedStillReadsTheCacheForACoveredEpoch(t *testing.T) {
+	l := &fakeLoader{
+		cached:   Data{Raw: []byte(sampleFinals2000A), ModTime: bulletinModTime},
+		fetchErr: errUpstream,
+	}
+
+	installLoader(t, l)
+
+	if err := EnsureLoaded(41684.5); err != nil {
+		t.Fatalf("EnsureLoaded for a covered epoch: %v", err)
+	}
+
+	cached, fetched := l.counts()
+	if cached != 1 {
+		t.Errorf("Loader.Cached called %d times, want 1", cached)
+	}
+
+	if fetched != 0 {
+		t.Errorf("Loader.Fetch called %d times for an epoch the cache covers, want 0", fetched)
+	}
+}
+
+// TestResetAllowsTheCacheToBeReadAgain covers the contract the throttle
+// could otherwise have broken quietly.
+//
+// Reset promises a caller can start over, and it is the cached read that
+// keeps that promise — a Reset followed by a lookup must not find the
+// throttle still closed and silently keep the zero model.
+func TestResetAllowsTheCacheToBeReadAgain(t *testing.T) {
+	l := &fakeLoader{
+		cached:   Data{Raw: []byte(sampleFinals2000A), ModTime: bulletinModTime},
+		fetchErr: errUpstream,
+	}
+
+	installLoader(t, l)
+
+	if err := EnsureLoaded(41684.5); err != nil {
+		t.Fatalf("first EnsureLoaded: %v", err)
+	}
+
+	Reset()
+
+	if err := EnsureLoaded(41684.5); err != nil {
+		t.Fatalf("EnsureLoaded after Reset: %v", err)
+	}
+
+	if cached, _ := l.counts(); cached != 2 {
+		t.Errorf("Loader.Cached called %d times across a Reset, want 2; Reset says a "+
+			"subsequent EnsureLoaded is free to load again", cached)
+	}
+}
+
+// TestZeroCooldownDisablesTheCacheThrottle keeps SetRetryCooldown meaning
+// what it says for both halves it now governs.
+func TestZeroCooldownDisablesTheCacheThrottle(t *testing.T) {
+	l := &fakeLoader{
+		cached:   Data{Raw: []byte(sampleFinals2000A), ModTime: bulletinModTime},
+		fetchErr: errUpstream,
+	}
+
+	installLoader(t, l)
+
+	previous := currentRetryCooldown()
+
+	SetRetryCooldown(0)
+
+	t.Cleanup(func() { SetRetryCooldown(previous) })
+
+	const lookups = 3
+
+	for range lookups {
+		_ = EnsureLoaded(uncoveredMJD)
+	}
+
+	if cached, _ := l.counts(); cached != lookups {
+		t.Errorf("Loader.Cached called %d times with the cooldown disabled, want %d",
+			cached, lookups)
+	}
+}
+
+// currentRetryCooldown reads the cooldown under the mutex that guards it,
+// so a test can put back whatever it found.
+func currentRetryCooldown() time.Duration {
+	fetchMu.Lock()
+	defer fetchMu.Unlock()
+
+	return retryCooldown
+}

--- a/time/internal/iers/eop.go
+++ b/time/internal/iers/eop.go
@@ -102,6 +102,11 @@ func registerModelInternal(m Model, source string) {
 // role in that package: primarily for tests, but not test-only — any
 // caller that wants a clean slate can use it.
 func Reset() {
+	// Before taking modelMu: starting over means the next lookup may read
+	// the cached bulletin again, which the read cooldown would otherwise
+	// hold closed.
+	forgetCacheRead()
+
 	modelMu.Lock()
 	defer modelMu.Unlock()
 

--- a/time/internal/iers/fetch.go
+++ b/time/internal/iers/fetch.go
@@ -13,6 +13,7 @@ import (
 var (
 	fetchMu       sync.Mutex
 	lastAttempt   time.Time         // wall-clock of last fetch attempt (success or failure)
+	lastCacheRead time.Time         // wall-clock of last Loader.Cached read
 	errLastFetch  error             // non-nil if the most recent attempt failed
 	retryCooldown = 5 * time.Minute // minimum interval between fetch attempts
 )
@@ -74,13 +75,34 @@ func EnsureLoaded(mjd float64) error {
 
 	ctx := context.Background()
 
-	if data, err := l.Cached(ctx); err == nil {
-		if lastAttempt.IsZero() {
-			lastAttempt = data.ModTime
-		}
+	// Reading the cache is throttled by the same window as fetching it.
+	//
+	// Without this, an epoch the bulletin does not cover re-read and
+	// re-parsed the whole file on *every* lookup, because covered(mjd) is
+	// the only fast path and no amount of loading makes finals2000A cover
+	// 1970 or 2035. Measured, Time.EOP was 71 ns for a covered epoch and
+	// 11 ms allocating 15.6 MB for one just outside — a 150,000x cliff that
+	// nothing reported, on two entirely ordinary requests: scheduling more
+	// than a year ahead, and historical work before 1973 (#246).
+	//
+	// The cooldown below already existed and already said "at most one
+	// attempt per cooldown window" in this function's own doc comment. It
+	// simply sat under the read rather than over it, so it throttled the
+	// network and not the local storm.
+	//
+	// Re-reading at all is what picks up a bulletin an operator dropped in
+	// by hand, so this bounds that rather than removing it.
+	if lastCacheRead.IsZero() || time.Since(lastCacheRead) >= retryCooldown {
+		lastCacheRead = time.Now()
 
-		if _, perr := parseAndRegister(data.Raw, SourceCache); perr == nil && covered(mjd) {
-			return nil
+		if data, err := l.Cached(ctx); err == nil {
+			if lastAttempt.IsZero() {
+				lastAttempt = data.ModTime
+			}
+
+			if _, perr := parseAndRegister(data.Raw, SourceCache); perr == nil && covered(mjd) {
+				return nil
+			}
 		}
 	}
 
@@ -93,6 +115,28 @@ func EnsureLoaded(mjd float64) error {
 	errLastFetch = fetch(ctx, l)
 
 	return errLastFetch
+}
+
+// forgetCacheRead lets the next EnsureLoaded read the cached bulletin
+// again rather than waiting out the cooldown.
+//
+// [Reset] calls it because it promises a caller can "start over", and that
+// promise is kept by the cached read: without this, a Reset followed by a
+// lookup would find the throttle still closed and silently keep the zero
+// model for up to a cooldown window.
+//
+// It deliberately leaves lastAttempt and errLastFetch alone, so Reset
+// still does not license an immediate network fetch — exactly as before
+// the read was throttled.
+//
+// Takes fetchMu on its own rather than being called with modelMu held:
+// EnsureLoaded holds fetchMu and then reads the model through covered, so
+// acquiring them the other way round would invert the order.
+func forgetCacheRead() {
+	fetchMu.Lock()
+	defer fetchMu.Unlock()
+
+	lastCacheRead = time.Time{}
 }
 
 // SetRetryCooldown sets the minimum interval EnsureLoaded waits between

--- a/time/internal/iers/fetch_test.go
+++ b/time/internal/iers/fetch_test.go
@@ -98,6 +98,7 @@ func clearCooldown() {
 	defer fetchMu.Unlock()
 
 	lastAttempt = time.Time{}
+	lastCacheRead = time.Time{}
 	errLastFetch = nil
 }
 


### PR DESCRIPTION
Closes #246. Found during the profiling pass over the `coord`/`plan`/`magnitude`/`time`/`atmosphere` benchmarks.

An EOP lookup for an epoch the bulletin does not cover re-read and re-parsed the **entire** finals2000A file — on every single call.

| epoch | ns/op | B/op | allocs/op |
| :--- | ---: | ---: | ---: |
| 2024 (covered) | **71** | 32 | 1 |
| 2026 (covered) | **95** | 32 | 1 |
| **2028** (past the predictions) | **10,994,652** | **15,610,455** | 20,609 |
| **1970** (before the bulletin) | **6,425,363** | 15,608,885 | 20,582 |

A **150,000× cliff**, silent — `Time.EOP` has no error return — on two entirely ordinary requests for an observatory-planning library: **scheduling more than about a year ahead**, and **historical work before 1973**.

## Mechanism

`covered(mjd)` was `EnsureLoaded`'s only fast path. For an epoch outside coverage it is false *permanently* — no amount of loading makes finals2000A cover 1970 — so every call fell through to `Loader.Cached`, which is a full `ReadAll` plus `ParseFinals2000A`.

The cooldown that throttles fetching was already there. This function's doc comment already promised *"at most one attempt per cooldown window"*. It simply sat **below** the cached read rather than above it, so it throttled the network and not the local storm. The read now sits inside the same window.

## After

- **1970**: 6,425,363 ns / 15.6 MB → **1,158 ns / 448 B**.
- **2028**: keeps one network fetch attempt, which the existing cooldown already bounded, then is free. Verified one-time rather than per-call by raising the iteration count — total time stays constant at ~1.18 s while ns/op falls 18.3 ms → 1.18 ms → 235 µs across 100/1000/5000 iterations.

`Reset` clears the read timestamp, because it promises a caller can "start over" and it is the cached read that keeps that promise — otherwise a `Reset` followed by a lookup would find the throttle closed and silently keep the zero model. It deliberately leaves `lastAttempt` alone, so `Reset` still does not license an immediate network fetch, exactly as before. `forgetCacheRead` takes `fetchMu` on its own rather than being called under `modelMu`, since `EnsureLoaded` holds `fetchMu` and then reads the model through `covered` — acquiring them the other way round would invert the order.

## It was distorting this repository's own benchmarks

`plan/bench_test.go` started every scheduler benchmark at `time.ZeroTime()` — `FromJD(0)`, **4713 BC**. A heap profile of `BenchmarkGreedyStrategy_10` put **99.88% of allocated bytes** in `time.Time.EOP` → `remote.eopLoader.Cached` → `io.ReadAll` / `ParseFinals2000A` / `bufio.Scanner.Text`. Nothing about scheduling appeared until below that. `BenchmarkSwapOptimized_100` was reporting **149 GB allocated and 197M allocs per op**; essentially all of it was this.

They now run at a fixed 2026 epoch — fixed rather than "now", so a result stays comparable with the one before it, and the repo's own `TestNoUndeclaredWallClockTests` guard enforces that.

Combined effect, benchmarks otherwise unchanged:

| benchmark | before | after | |
| :--- | ---: | ---: | ---: |
| `GreedyStrategy_10` time | 1,803 ms | **19.2 ms** | **94×** |
| `GreedyStrategy_10` alloc | 2.65 GB | **3.2 MB** | **826×** |
| `GreedyStrategy_10` allocs | 3,501,817 | **4,279** | **818×** |
| `SwapOptimized_10` time | 7,906 ms | **112 ms** | **71×** |
| `SwapOptimized_10` alloc | 16.98 GB | **549 KB** | **30,900×** |
| `SwapOptimized_10` allocs | 22,392,844 | **803** | **27,900×** |

## Verification

Four regression tests in `time/internal/iers`, using the package's existing counting fake loader:

- `TestEnsureLoadedReadsTheCacheOnceForAnUncoveredEpoch` — 50 lookups of one uncovered epoch must produce exactly **1** `Cached` call.
- `TestEnsureLoadedStillReadsTheCacheForACoveredEpoch` — the first lookup still loads, and does not fetch.
- `TestResetAllowsTheCacheToBeReadAgain` — `Reset` reopens the read.
- `TestZeroCooldownDisablesTheCacheThrottle` — `SetRetryCooldown(0)` still means what it says, now for both halves it governs.

Mutation testing, 5 mutants, 5 killed:

| mutation | killed by |
| :--- | :--- |
| throttle removed (the original bug) | `...ReadsTheCacheOnceForAnUncoveredEpoch` |
| read once ever, cooldown never reopens it | `TestZeroCooldownDisablesTheCacheThrottle` |
| the read timestamp is never recorded | `...ReadsTheCacheOnceForAnUncoveredEpoch` |
| `Reset` no longer reopens the read | `TestResetAllowsTheCacheToBeReadAgain` |
| cooldown comparison inverted | `...ReadsTheCacheOnceForAnUncoveredEpoch` |

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.

## Left for later, deliberately

`Time.EOP` warns once when EOP data is *unavailable* — the only signal a caller gets that accuracy silently degraded. An **out-of-coverage** epoch is the same class of silent degradation and still says nothing. It should warn once too, but that is a behaviour change with its own test surface rather than part of a performance fix, so it is noted on #246 rather than folded in here.

The one unrelated failure seen during the gate is `ephemeris/jpl/spk`'s `TestDiscardIfCorrupt*` under `-race` — a different one of the three each run, each passing alone. That is #245, pre-existing, and not touched by this.
