### PR TITLE
perf: assert allocation contracts, and make the Benchmarks job report a delta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,28 @@ jobs:
       - name: Run tests with race detector
         run: go test -race -short -count=1 ./...
 
+  # These numbers are recorded and compared, but nothing here fails a build.
+  #
+  # ns/op on a shared runner is too noisy to gate on, and a noisy gate gets
+  # muted — this repository already had one job failing every run for an
+  # unrelated reason, which is how it went unread (#238). The hard guarantees
+  # live in the allocation contracts (coord/allocs_test.go and its siblings):
+  # deterministic, and in the ordinary test job where they block a merge.
+  #
+  # What this job owes its reader is a delta, on the run page. Before #248 it
+  # uploaded an artifact nothing opened, so it faithfully recorded
+  # "BenchmarkSwapOptimized_100 ... 149427883656 B/op" — 149 GB per operation —
+  # on every merge for months while #246 was live, and reported nothing.
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+
+    permissions:
+      contents: read
+      # Listing this workflow's earlier runs and downloading their artifacts,
+      # which is what the comparison below is built on.
+      actions: read
 
     steps:
       - name: Checkout code
@@ -278,16 +296,73 @@ jobs:
           go-version: '1.27'
           cache: true
 
+      - name: Install benchstat
+        # Pinned, like apidiff above: a comparison tool that moves under you
+        # turns a real delta and a tooling change into the same diff.
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260908200009-22c9c6c9d4da
+
       - name: Run benchmarks
+        # ./... on its own, deliberately. This used to name ./... *and* five
+        # packages, which reads as "just these five" while in fact benchmarking
+        # the whole module, since ./... already covers them. The whole module
+        # is the right scope: remote/file's ReadAt strategy benchmark is one
+        # CLAUDE.md explicitly says not to lose.
+        #
+        # -count=6 rather than 3, so benchstat has the samples to say anything
+        # other than "~". Affordable now: fixing #246 took the worst plan
+        # benchmark from ~68 s to ~1.5 s.
         run: |
           go test ./... \
             -run=^$ \
             -bench=. \
             -benchmem \
-            -count=3 \
+            -count=6 \
             -timeout=30m \
-            ./coord/... ./plan/... ./magnitude/... ./time/... ./atmosphere/... \
             | tee bench.txt
+
+      - name: Compare against the previous run on this branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          summary() { cat >> "$GITHUB_STEP_SUMMARY"; }
+
+          previous=$(gh run list \
+            --workflow ci.yml \
+            --branch "$GITHUB_REF_NAME" \
+            --status success \
+            --limit 20 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.headSha != \"$GITHUB_SHA\")][0].databaseId // empty")
+
+          if [ -z "$previous" ]; then
+            echo '_No earlier successful run on this branch to compare against._' | summary
+            exit 0
+          fi
+
+          # A missing artifact is the ordinary case once retention lapses, so
+          # this reports and moves on rather than failing the job.
+          if ! gh run download "$previous" --dir previous 2>/dev/null; then
+            echo "_Run $previous kept no downloadable benchmark artifact (90-day retention)._" | summary
+            exit 0
+          fi
+
+          baseline=$(find previous -name bench.txt -print -quit)
+          if [ -z "$baseline" ]; then
+            echo "_Run $previous uploaded no bench.txt._" | summary
+            exit 0
+          fi
+
+          {
+            echo "## Benchmark delta"
+            echo
+            echo "Against run [$previous](https://github.com/$GITHUB_REPOSITORY/actions/runs/$previous)."
+            echo
+            echo '```'
+            benchstat "$baseline" bench.txt || echo 'benchstat failed; the raw results are attached as an artifact.'
+            echo '```'
+          } | summary
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,30 @@ The low `fits` figures are minimization, not a slow parser: those two targets fi
 
 Any crasher Go writes to `testdata/fuzz/` should be committed — that's the one place a small binary fixture is legitimate here, since it's a regression test for a bug the fuzzer found, not a data source. Two are checked in: an out-of-range TLE epoch day that panicked inside the SGP4 backend, and a VOTable with rows but no field declarations.
 
+## Performance
+
+Three layers, and only one of them can fail a build. That split is deliberate.
+
+**Allocation contracts are the gate** (`coord/allocs_test.go`, `time/allocs_test.go`, `atmosphere/allocs_test.go`). Plain `testing.AllocsPerRun` assertions on paths where zero-allocation is a design claim: a cached `Context` transform, an EOP-free scale conversion, a refraction evaluation. They assert exact `0` where zero is the claim and a bound where a bound is the honest statement — `NewContext` allocates 1 and is contracted at ≤ 8, because the risk is not that it costs one allocation but that it quietly starts costing many.
+
+They are ordinary untagged tests, so they run in every CI job and block a merge. `allocs/op` is what makes that safe: it is deterministic across machines and — measured, not assumed — **unchanged under `-race`**, so no build tag and no short-mode skip are needed. `ns/op` on a shared runner is not, which is why nothing here gates on time.
+
+Add a contract when you can state *why* a path must not allocate, not merely that it currently doesn't.
+
+**The Benchmarks CI job reports, and never fails.** It runs on push to main and posts a `benchstat` delta against the previous successful run into the job summary. `-count=6`, not 3: with three samples benchstat cannot compute a confidence interval and prints `± ∞` for every row.
+
+**Profiling is a manual, periodic step, not a CI gate** — the same rule as extended fuzzing above, for the same reason. A flame graph cannot be usefully diffed by a machine, and the finding that motivated all of this came from *reading* `pprof -top` and noticing that `io.ReadAll` had no business appearing in a scheduler. What automates is the scalar assertion you write afterwards, once you know what the number should be.
+
+```bash
+go test -run=^$ -bench=. -benchmem -cpuprofile=cpu.out -memprofile=mem.out -o pkg.test ./plan/
+go tool pprof -top -nodecount=15 pkg.test cpu.out
+go tool pprof -sample_index=alloc_space -top -nodecount=15 pkg.test mem.out
+```
+
+**Two ways to read a benchmark wrong, both of which happened here.** A low `-benchtime` charges a one-time lazy load to every iteration: at `-benchtime=1x`, `BenchmarkUTCToUT1` reported 8.6 ms and 15.6 MB for a conversion that actually costs 67 ns and allocates nothing — that was the EOP file loading once. The same illusion appears on any path that touches the network once. Before believing a per-op cost, raise the iteration count and check the *total* stays proportional; if total time is flat while ns/op falls, it is a fixed cost, not a per-call one.
+
+And a benchmark's epoch is part of its subject. `plan`'s scheduler benchmarks ran at `time.ZeroTime()` — JD 0, 4713 BC — where no Earth Orientation Parameters exist, so 99.88% of their allocated bytes were EOP handling rather than scheduling (#246). Benchmark a realistic epoch, and a fixed one: a result that depends on the day it was run cannot be compared with the one before it.
+
 ## Embedded data
 
 There is no `go:generate` step in this codebase — it was removed deliberately. No package uses `go:embed` either — every data source is obtained at runtime through `remote.GetFile`, on a lazy, on-first-query load: `catalog/openngc`'s two CSVs (see [catalog/openngc/openngc.go](catalog/openngc/openngc.go)) and `time`'s Earth Orientation Parameters (see [time/eop.go](time/eop.go) and the unexported `time/internal/iers`). A constructor performs no I/O; the first query that needs the data fetches it under that caller's context.

--- a/atmosphere/allocs_test.go
+++ b/atmosphere/allocs_test.go
@@ -1,0 +1,62 @@
+package atmosphere
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+)
+
+// TestRefractionAndAirmassDoNotAllocate pins the zero-allocation claim on the
+// per-direction calls a sky map repeats.
+//
+// # Why this is a test and not a benchmark
+//
+// Every benchmark in this repository already runs on every push to main and
+// its numbers are uploaded as an artifact. That caught nothing, because a
+// number in an artifact cannot be wrong — CI recorded 149 GB/op for a
+// scheduler benchmark on every merge for months while #246 was live, and a
+// benchmark-diffing gate would have stayed green too, since the defect was
+// there at the baseline. An absolute claim about a named path is what catches
+// that class (#248).
+//
+// allocs/op is what to assert: it is deterministic where ns/op on a shared
+// runner is not, and — measured, not assumed — unchanged under -race.
+//
+// # Why zero
+//
+// These are closed-form evaluations over scalars. skybrightness walks a whole
+// hemisphere through them (129,600 points in the largest map here), so an
+// allocation per call is an allocation per pixel, which is the difference
+// between a sky map that fits in cache and one that keeps the collector busy.
+//
+// Not parallel: testing.AllocsPerRun measures the whole process, so a sibling
+// test allocating concurrently would be counted here.
+func TestRefractionAndAirmassDoNotAllocate(t *testing.T) {
+	var (
+		rigorous    = RefractionRigorous{}
+		approximate = RefractionApproximate{}
+		env         = StandardRefraction
+		alt         = angle.Deg(30)
+		horizon     = angle.Deg(0.5)
+	)
+
+	for _, tc := range []struct {
+		name string
+		f    func()
+	}{
+		{"RefractionRigorous.RefractFromTrue", func() { _ = rigorous.RefractFromTrue(alt, env) }},
+		{"RefractionRigorous.RefractFromApparent", func() { _ = rigorous.RefractFromApparent(alt, env) }},
+		{"RefractionRigorous near the horizon", func() { _ = rigorous.RefractFromTrue(horizon, env) }},
+		{"RefractionApproximate.RefractFromTrue", func() { _ = approximate.RefractFromTrue(alt, env) }},
+		{"Airmass", func() { _, _ = Airmass(alt) }},
+		{"AtAltitude", func() { _ = AtAltitude(2635) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testing.AllocsPerRun(1000, tc.f); got != 0 {
+				t.Errorf("%s allocates %v times per call, want 0.\n"+
+					"  A hemisphere walk evaluates this once per direction, so an "+
+					"allocation here is an allocation per pixel.", tc.name, got)
+			}
+		})
+	}
+}

--- a/coord/allocs_test.go
+++ b/coord/allocs_test.go
@@ -1,0 +1,130 @@
+package coord_test
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/atmosphere"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/time"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// Allocation contracts for coord's hot path.
+//
+// # Why these are tests and not benchmarks
+//
+// This repository already runs every benchmark on every push to main and
+// uploads the numbers as an artifact. That found nothing: a number in an
+// artifact cannot be wrong. #246 was a defect that made an EOP lookup
+// allocate 15.6 MB, and CI recorded 149 GB/op for the scheduler benchmark on
+// every merge for months without failing (#248).
+//
+// A benchmark-diffing gate would not have caught it either, because the
+// defect was present at the baseline — every run agreed with the one before
+// it. What catches that class is an *absolute* claim about a specific path.
+//
+// # Why allocations rather than time
+//
+// ns/op on a shared CI runner is noisy, and a noisy gate gets muted. allocs/op
+// is deterministic: the figures below are identical on Windows and Linux and,
+// checked rather than assumed, unchanged under -race — so these need no build
+// tag and no short-mode skip.
+//
+// # Why zero, specifically
+//
+// coord.Context exists so that the expensive per-epoch setup happens once and
+// each subsequent transform is cheap. "Cheap" here means it touches no heap at
+// all, which is what lets a scheduler run one Context over thousands of
+// targets without giving the collector anything to do. If a transform starts
+// allocating, that property is gone whether or not the wall clock notices.
+//
+// None of these use t.Parallel: testing.AllocsPerRun measures the whole
+// process, so a sibling test allocating concurrently would be counted here.
+
+// TestCachedContextTransformsDoNotAllocate pins the zero-allocation claim on
+// the transforms a hot loop repeats.
+func TestCachedContextTransformsDoNotAllocate(t *testing.T) {
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4), angle.Deg(-24.6), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	atm := atmosphere.AtAltitude(2635)
+	epoch := time.FromJD(2460000.5, time.UTC)
+	ctx := coord.NewContext(epoch, loc, atm)
+
+	pos := coord.NewICRS(angle.Hour(5.5), angle.Deg(-5.4))
+	vec := vector.Vec3{X: 0.5, Y: 0.5, Z: 0.7071}
+
+	for _, tc := range []struct {
+		name string
+		f    func()
+	}{
+		{"ICRSToAltAz", func() { _, _ = ctx.ICRSToAltAz(pos) }},
+		{"GeocentricToObserved", func() { _ = ctx.GeocentricToObserved(vec) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testing.AllocsPerRun(1000, tc.f); got != 0 {
+				t.Errorf("%s allocates %v times per call, want 0.\n"+
+					"  A cached Context transform touching the heap costs a scheduler "+
+					"one allocation per target per time step, which is the reason the "+
+					"Context cache exists.", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestBatchTransformDoesNotAllocate covers the batch API's whole reason for
+// existing: the caller supplies the output slice, so the transform itself has
+// nothing to allocate however many targets it is given.
+func TestBatchTransformDoesNotAllocate(t *testing.T) {
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4), angle.Deg(-24.6), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	ctx := coord.NewContext(time.FromJD(2460000.5, time.UTC), loc, atmosphere.AtAltitude(2635))
+
+	const n = 512
+
+	stars := make([]coord.ICRS, n)
+	for i := range stars {
+		stars[i] = coord.NewICRS(angle.Hour(float64(i)*24.0/n), angle.Deg(float64(i%80)-40))
+	}
+
+	out := make([]coord.AltAz, n)
+
+	if got := testing.AllocsPerRun(100, func() { ctx.ICRSBatchToAltAz(stars, out) }); got != 0 {
+		t.Errorf("ICRSBatchToAltAz allocates %v times per call over %d targets, want 0; "+
+			"the caller already supplied the destination", got, n)
+	}
+}
+
+// TestNewContextAllocationIsBounded states a bound rather than zero, because
+// zero would be a false claim: Context holds the SOFA astrometry parameters
+// and one allocation is what materialises them.
+//
+// The bound is what matters. NewContext is the expensive call — measured
+// ~137 us against ~293 ns for a cached transform — and the risk is not that it
+// costs one allocation but that it quietly starts costing many, which is how
+// a per-epoch cost turns into a per-target one.
+func TestNewContextAllocationIsBounded(t *testing.T) {
+	loc, err := coord.NewGeodetic(angle.Deg(-70.4), angle.Deg(-24.6), 2635)
+	if err != nil {
+		t.Fatalf("NewGeodetic: %v", err)
+	}
+
+	atm := atmosphere.AtAltitude(2635)
+	epoch := time.FromJD(2460000.5, time.UTC)
+
+	// Measured: 1. The headroom is for an implementation that legitimately
+	// splits that one structure, not for a regression — 8 is still far below
+	// anything that would make per-epoch setup look like per-target work.
+	const maxAllocs = 8
+
+	if got := testing.AllocsPerRun(200, func() { _ = coord.NewContext(epoch, loc, atm) }); got > maxAllocs {
+		t.Errorf("NewContext allocates %v times per call, want at most %d (measured 1)",
+			got, maxAllocs)
+	}
+}

--- a/docs/changelog.d/249-perf-contracts.md
+++ b/docs/changelog.d/249-perf-contracts.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 249
+---
+Allocation contracts for `coord`, `time` and `atmosphere`'s hot paths, as
+ordinary tests that fail a build — `allocs/op` is deterministic where `ns/op`
+on a shared runner is not. The Benchmarks CI job now reports a `benchstat`
+delta in its job summary instead of uploading numbers nothing reads (#249).

--- a/time/allocs_test.go
+++ b/time/allocs_test.go
@@ -1,0 +1,80 @@
+package time
+
+import "testing"
+
+// TestScaleConversionsDoNotAllocate pins the zero-allocation claim on the
+// conversions that carry no Earth Orientation Parameters.
+//
+// # Why this is a test and not a benchmark
+//
+// This repository runs every benchmark on every push to main and uploads the
+// numbers as an artifact. That found nothing, because a number in an artifact
+// cannot be wrong: CI recorded 149 GB/op for a scheduler benchmark on every
+// merge for months while #246 was live. A benchmark-diffing gate would not
+// have caught it either — the defect was present at the baseline, so every run
+// agreed with the one before it. What catches that class is an absolute claim
+// about a named path (#248).
+//
+// allocs/op is the right thing to assert because it is deterministic, unlike
+// ns/op on a shared runner. Checked rather than assumed: these counts are
+// unchanged under -race, so this needs no build tag and no short-mode skip.
+//
+// # Scope
+//
+// TAI, TT, TDB and MJD are pure arithmetic over the epoch: no table lookup, no
+// EOP, no I/O. Zero is therefore the honest claim and not merely the current
+// measurement.
+//
+// UT1 is deliberately absent. It consults the EOP model, so what it costs
+// depends on data this test would have to install, and the path that actually
+// went wrong there is guarded far more precisely in
+// time/internal/iers by counting Loader.Cached calls (#247). A weaker
+// duplicate here would add noise rather than coverage.
+//
+// Not parallel: testing.AllocsPerRun measures the whole process, so a sibling
+// test allocating concurrently would be counted here.
+func TestScaleConversionsDoNotAllocate(t *testing.T) {
+	epoch := FromJD(2460000.5, UTC)
+
+	for _, tc := range []struct {
+		name string
+		f    func()
+	}{
+		{"TAI", func() { _ = epoch.TAI() }},
+		{"TT", func() { _ = epoch.TT() }},
+		{"TDB", func() { _ = epoch.TDB() }},
+		{"MJD", func() { _ = epoch.MJD() }},
+		{"JD", func() { _ = epoch.JD() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testing.AllocsPerRun(1000, tc.f); got != 0 {
+				t.Errorf("%s allocates %v times per call, want 0; it is arithmetic over "+
+					"the epoch and has nothing to put on the heap", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestEpochArithmeticDoesNotAllocate covers the comparison and difference
+// operations, which a solver runs at every step of every bisection.
+func TestEpochArithmeticDoesNotAllocate(t *testing.T) {
+	a := FromJD(2460000.5, UTC)
+	b := FromJD(2460001.5, UTC)
+	tt := a.TT()
+
+	for _, tc := range []struct {
+		name string
+		f    func()
+	}{
+		{"Sub same scale", func() { _ = b.Sub(a) }},
+		{"Sub cross scale", func() { _ = b.Sub(tt) }},
+		{"Equal same scale", func() { _ = a.Equal(b) }},
+		{"Add", func() { _ = a.Add(Hour) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testing.AllocsPerRun(1000, tc.f); got != 0 {
+				t.Errorf("%s allocates %v times per call, want 0", tc.name, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #248.

CI has run benchmarks on every push to main for months and uploaded the numbers as a 90-day artifact. It caught nothing — because **a number in an artifact cannot be wrong**. It faithfully recorded `BenchmarkSwapOptimized_100 ... 149427883656 B/op` — 149 GB per operation — on every merge while #246 was live.

A benchmark-diffing gate would not have caught that one either: the defect was present *at the baseline*, so every run agreed with the one before it. Relative detection finds what you introduce. This was there from the start.

Three changes, in decreasing order of how much they can fail.

## 1. Allocation contracts — these gate

Ordinary untagged unit tests in `coord`, `time` and `atmosphere`. Exact `0` where zero-allocation is a design claim the repo already makes in prose, and a **bound** where a bound is the honest statement:

| path | contract | measured |
| :--- | :--- | ---: |
| cached `Context.ICRSToAltAz` / `GeocentricToObserved` | `== 0` | 0 |
| `ICRSBatchToAltAz` over 512 targets | `== 0` | 0 |
| `Time.TAI/TT/TDB/MJD/JD`, `Sub`, `Equal`, `Add` | `== 0` | 0 |
| `atmosphere` refraction (3 forms), `Airmass`, `AtAltitude` | `== 0` | 0 |
| `coord.NewContext` | `<= 8` | 1 |

`NewContext` gets a bound rather than an equality because zero would be a false claim — it materialises the SOFA astrometry parameters. The risk there isn't that it costs one allocation; it's that it quietly starts costing many, which is how a per-epoch cost becomes a per-target one.

**Why `allocs/op` is safe to gate on and `ns/op` is not.** `allocs/op` is deterministic across machines, and — measured rather than assumed — **unchanged under `-race`**, so these need no build tag and no short-mode skip. Timing on a shared runner is noisy, and a noisy gate gets muted; this repo already had one job failing every run for an unrelated reason, which is exactly how it went unread (#238).

**They are not vacuous.** Injecting a single allocation into `Airmass`, `Context.ICRSToAltAz` and `Time.TT` makes each contract fail, naming the path and the count:

```
allocs_test.go:56: Airmass allocates 1 times per call, want 0.
allocs_test.go:69: ICRSToAltAz allocates 1 times per call, want 0.
allocs_test.go:51: TT allocates 1 times per call, want 0; it is arithmetic over the epoch...
```

Deliberately **not** an alloc contract on the out-of-coverage EOP path: #247 already guards that more precisely by counting `Loader.Cached` calls, and a weaker duplicate would add noise rather than coverage.

## 2. The Benchmarks job now reports a delta

It installs a pinned `benchstat` and posts a comparison against the previous successful run into the **job summary**, where a reader sees it on the run page, instead of into an artifact nobody opens. It still cannot fail a build — that split is the whole point.

Verified end to end against the real API rather than written hopefully: the `gh run list --jq` query returns a run id, `gh run download` retrieves a real artifact, `find previous -name bench.txt -print -quit` locates it inside the `benchmarks-<sha>/` directory, and the pinned `benchstat` produces a table from it. Missing previous run, missing artifact and missing `bench.txt` each report into the summary and exit 0, since expired retention is the ordinary case.

Two corrections come with it:

- The package list read `./... ./coord/... ./plan/... ...`, which *looks* like "just these five" while actually benchmarking the whole module, since `./...` already covers them. Now `./...` alone, with a comment — whole-module is the right scope, since `remote/file`'s ReadAt strategy benchmark is one CLAUDE.md explicitly says not to lose.
- `-count` 3 → 6. With three samples benchstat cannot compute a confidence interval and prints `± ∞` for every row — observed on the real artifact, not assumed. Affordable now that #247 took the worst `plan` benchmark from ~68 s to ~1.5 s.

## 3. CLAUDE.md gains a Performance section

Recording the three-layer split and, importantly, **the two ways to misread a benchmark that both happened during this work**:

- A low `-benchtime` charges a one-time lazy load to every iteration. At `-benchtime=1x`, `BenchmarkUTCToUT1` reported 8.6 ms and 15.6 MB for a conversion that actually costs 67 ns and allocates nothing. The check is to raise the iteration count and confirm the *total* stays proportional; flat total with falling ns/op means a fixed cost.
- A benchmark's epoch is part of its subject. `plan`'s schedulers ran at `time.ZeroTime()` — JD 0, 4713 BC — so 99.88% of their allocated bytes were EOP handling (#246).

Profiling itself stays a **manual, periodic step, not a CI gate** — the same rule the Fuzzing section already sets, for the same reason: a flame graph can't be usefully diffed by a machine, and #246 was found by *reading* `pprof -top` and noticing `io.ReadAll` had no business appearing in a scheduler.

## Verification

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...` — all clean, including the new contracts under the race detector.

The workflow YAML was parsed and its `benchmarks` job inspected programmatically (6 steps, in order) rather than trusted to review.
