### PR TITLE
remote: make the download lock exclusive within the process

### DIFF
--- a/docs/changelog.d/250-lock-exclusion.md
+++ b/docs/changelog.d/250-lock-exclusion.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 250
+---
+`remote`'s download lock is now genuinely exclusive within a process. It relied
+on `fileblob`'s `IfNotExist` being mutex-guarded, which the pinned driver does
+not do — measured, 8 goroutines on one bucket produced 51 rounds in 200 with
+two or more simultaneous holders (#250).

--- a/remote/file/file.go
+++ b/remote/file/file.go
@@ -50,12 +50,19 @@ type Bucket = blob.Bucket
 // verbatim; an unregistered scheme surfaces as that call's own error.
 //
 // One Bucket is opened per distinct URL and reused for the life of the
-// process. *blob.Bucket is safe for concurrent use, so sharing is free,
-// and reuse is what makes fileblob's IfNotExist precondition meaningful
-// within a process: that driver guards it with a per-Bucket mutex, so
-// separate Bucket values over the same directory would not exclude each
-// other. Buckets are never closed, matching their process-lifetime role as
-// astrogo's cache and source handles.
+// process. *blob.Bucket is safe for concurrent use, so sharing is free, and
+// one handle per URL avoids reopening a bucket on every fetch. Buckets are
+// never closed, matching their process-lifetime role as astrogo's cache and
+// source handles.
+//
+// This used to claim more: that sharing "is what makes fileblob's
+// IfNotExist precondition meaningful within a process", because "that
+// driver guards it with a per-Bucket mutex". It does not. In the pinned
+// driver fileblob's bucket struct holds no mutex, and the one that exists is
+// built per writer inside NewTypedWriter, so contenders never exclude each
+// other however many Buckets they share. Measured, 8 goroutines on one
+// Bucket over 200 rounds produced 51 rounds with two or more simultaneous
+// lock holders. remote.acquireLock now owns that exclusion itself (#245).
 func Open(ctx context.Context, bucketURL string) (*Bucket, error) {
 	bucketsMu.Lock()
 	defer bucketsMu.Unlock()

--- a/remote/lock_resume.go
+++ b/remote/lock_resume.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
@@ -33,20 +34,101 @@ const (
 	lockRetryDelayMax     = 2 * time.Second
 )
 
+// inProcess serialises lock acquisition within this process, one key at a
+// time.
+//
+// This used to be delegated to fileblob, and both this function and
+// [github.com/TuSKan/astrogo/remote/file.Open] documented that the driver
+// "guards it with a per-Bucket mutex" — which is why file.Open shares one
+// Bucket per URL for the life of the process.
+//
+// That is not true of the pinned driver and may never have been. fileblob's
+// bucket struct holds no mutex at all, and the mutex that does appear is
+// constructed per *writer*, inside NewTypedWriter, so each contender locks
+// its own. What IfNotExist actually performs is an os.Stat followed by an
+// os.Rename, with a window in between.
+//
+// Measured before this existed — 8 goroutines sharing one Bucket, 200
+// rounds: 51 rounds in which two or more contenders each believed they held
+// the lock, and 2 in which three did (#245).
+var inProcess = keyedSemaphore{held: make(map[string]chan struct{})}
+
+// keyedSemaphore hands out exclusive access per key, honouring a context
+// while waiting.
+//
+// A plain sync.Mutex would do the exclusion but not the waiting: a caller
+// blocked in Lock cannot notice its own deadline, and the thing being
+// waited for here is a download that may legitimately run for minutes.
+//
+// Entries are never removed. The keys are cache keys — a few dozen kernels
+// and bulletins across a process's life — so the map is bounded by what the
+// process actually fetches, and reclaiming entries would need reference
+// counting to no measurable end.
+type keyedSemaphore struct {
+	mu   sync.Mutex
+	held map[string]chan struct{}
+}
+
+// acquire blocks until key is free or ctx is done, returning the release
+// for the caller to run exactly once.
+func (k *keyedSemaphore) acquire(ctx context.Context, key string) (release func(), err error) {
+	k.mu.Lock()
+
+	ch, ok := k.held[key]
+	if !ok {
+		ch = make(chan struct{}, 1)
+		k.held[key] = ch
+	}
+
+	k.mu.Unlock()
+
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("remote: wait for in-process lock %s: %w", key, ctx.Err())
+	}
+}
+
 // acquireLock blocks until it holds an exclusive lock on cacheKey within
 // bucket, or ctx is done. Call the returned release exactly once — defer
 // it immediately, including on the caller's own error paths.
 //
-// It is built on WriterOptions.IfNotExist, the create-if-absent primitive
-// every Bucket exposes, so there is no backend-specific code here. On S3
-// that is a genuinely atomic conditional PUT. fileblob implements it as
-// Stat-then-Rename under a per-Bucket mutex, which is why remote/file.Open
-// returns one shared Bucket per URL: that makes the lock exclusive within
-// a process. Across processes on a local cache it remains best-effort,
-// bounded by the double-check GetFile performs after acquiring.
+// Exclusion is in two layers, because one of them is not reliable.
+//
+// Within this process it is [inProcess], an ordinary semaphore this package
+// owns and can therefore trust. Across processes it is
+// WriterOptions.IfNotExist, the create-if-absent primitive every Bucket
+// exposes, so there is no backend-specific code here: on S3 a genuinely
+// atomic conditional PUT, on fileblob a Stat-then-Rename that is best-effort
+// and can admit a second holder. That residual race is bounded by the
+// double-check GetFile performs after acquiring, and its consequences are
+// what #241 tracks.
+//
+// The layering matters for a reason beyond belt-and-braces: `go test ./...`
+// runs each package as its own process and several of them want the same JPL
+// kernel, so the cross-process case is the common one and the in-process case
+// is the one that used to be claimed and was not delivered.
 func acquireLock(ctx context.Context, bucket *file.Bucket, cacheKey string) (release func(), err error) {
 	lockKey := cacheKey + ".lock"
 	delay := lockRetryDelayInitial
+
+	// Not re-wrapped: acquire already names the key and what was being
+	// waited for, and a second layer saying the same thing makes the
+	// message longer without making it more specific.
+	releaseInProcess, err := inProcess.acquire(ctx, lockKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Every path out of the loop below that is not a successful acquire has
+	// to hand the in-process slot back, or the next caller for this key
+	// waits on a holder that no longer exists.
+	defer func() {
+		if err != nil {
+			releaseInProcess()
+		}
+	}()
 
 	// gcerrors.Unknown counts as contention alongside FailedPrecondition:
 	// a losing writer on Windows surfaces a raw "Access is denied", which
@@ -68,7 +150,16 @@ func acquireLock(ctx context.Context, bucket *file.Bucket, cacheKey string) (rel
 				// release runs from the caller's defer, possibly after ctx
 				// was cancelled, and must still delete the lock — otherwise
 				// it leaks until staleLockAge lets someone steal it.
-				return func() { _ = bucket.Delete(context.WithoutCancel(ctx), lockKey) }, nil
+				//
+				// The in-process slot is handed back after the object is
+				// gone, not before: releasing it first would let the next
+				// goroutine in this process reach IfNotExist while the lock
+				// object is still there, and spin until it is deleted.
+				return func() {
+					_ = bucket.Delete(context.WithoutCancel(ctx), lockKey)
+
+					releaseInProcess()
+				}, nil
 			case isContention(gcerrors.Code(closeErr)):
 				// Someone won the race between NewWriter and Close.
 			default:

--- a/remote/lockexclusion_test.go
+++ b/remote/lockexclusion_test.go
@@ -1,0 +1,191 @@
+package remote
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestAcquireLockAdmitsOneHolderAtATime is the regression.
+//
+// The existing contract test acquires, then starts a second contender, so
+// the second one genuinely finds the lock object already written and the
+// check-then-act window inside fileblob is never opened. Simultaneous
+// contenders are the case that failed, and nothing exercised it.
+//
+// acquireLock delegated exclusion to WriterOptions.IfNotExist, which this
+// package and remote/file both documented as being guarded by a per-Bucket
+// mutex. It is not: fileblob's bucket struct holds no mutex, and the mutex
+// that exists is constructed per writer, so IfNotExist is a bare os.Stat
+// followed by an os.Rename. Measured before the fix, 8 goroutines sharing
+// one Bucket over 200 rounds: 51 rounds with two or more holders, 2 with
+// three (#245).
+//
+// The assertion is on overlap rather than on a winner count, because
+// acquireLock is not a try-lock — every contender is supposed to get the
+// lock eventually. What must never happen is two of them holding it at the
+// same moment.
+func TestAcquireLockAdmitsOneHolderAtATime(t *testing.T) {
+	bucket, _ := openLocalBucket(t)
+
+	const (
+		cacheKey   = "exclusion-test.bin"
+		contenders = 8
+		rounds     = 25
+	)
+
+	var (
+		inside  atomic.Int32
+		overlap atomic.Int32
+		peak    atomic.Int32
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	for range rounds {
+		var wg sync.WaitGroup
+
+		for range contenders {
+			wg.Go(func() {
+				release, err := acquireLock(ctx, bucket, cacheKey)
+				if err != nil {
+					t.Errorf("acquireLock: %v", err)
+
+					return
+				}
+
+				defer release()
+
+				n := inside.Add(1)
+
+				for {
+					p := peak.Load()
+					if n <= p || peak.CompareAndSwap(p, n) {
+						break
+					}
+				}
+
+				if n > 1 {
+					overlap.Add(1)
+				}
+
+				// Long enough that a second holder would be inside this
+				// window rather than slipping through between two
+				// instructions.
+				time.Sleep(200 * time.Microsecond)
+
+				inside.Add(-1)
+			})
+		}
+
+		wg.Wait()
+	}
+
+	if got := overlap.Load(); got != 0 {
+		t.Errorf("%d of %d acquisitions found another holder already inside the lock "+
+			"(peak %d simultaneous); acquireLock is not excluding anyone",
+			got, contenders*rounds, peak.Load())
+	}
+}
+
+// TestAcquireLockReleasesTheInProcessSlotOnFailure covers the leak that
+// would turn one failed acquire into a permanently stuck key.
+//
+// The in-process semaphore is taken before the blob-level loop, so every
+// path out of that loop which is not a successful acquire has to hand the
+// slot back. If it does not, the next caller for that key waits forever on
+// a holder that no longer exists — and waits silently, which is the worst
+// version of it.
+func TestAcquireLockReleasesTheInProcessSlotOnFailure(t *testing.T) {
+	bucket, _ := openLocalBucket(t)
+
+	const cacheKey = "cancelled-acquire-test.bin"
+
+	// The lock object is written directly, standing in for a holder in
+	// another process. That is what reaches the path under test: this
+	// process takes the in-process slot, finds the object already there,
+	// and gives up on its own deadline — so the slot has to come back.
+	//
+	// Holding it with acquireLock instead would not do: the second caller
+	// would block on the semaphore and fail before ever taking the slot,
+	// which exercises nothing. That is exactly how this test first passed
+	// against a build that leaked the slot.
+	if err := bucket.WriteAll(context.Background(), cacheKey+".lock", []byte("locked"), nil); err != nil {
+		t.Fatalf("seed lock object: %v", err)
+	}
+
+	blocked, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	if _, err := acquireLock(blocked, bucket, cacheKey); err == nil {
+		t.Fatal("acquireLock succeeded while another holder's lock object was present")
+	}
+
+	if err := bucket.Delete(context.Background(), cacheKey+".lock"); err != nil {
+		t.Fatalf("clear lock object: %v", err)
+	}
+
+	// If the failed attempt kept the in-process slot, this blocks until the
+	// test's own deadline rather than returning.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		r, err := acquireLock(context.Background(), bucket, cacheKey)
+		if err != nil {
+			t.Errorf("third acquireLock: %v", err)
+
+			return
+		}
+
+		r()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("acquireLock blocked after an earlier attempt failed; the in-process " +
+			"slot was not handed back")
+	}
+}
+
+// TestAcquireLockDoesNotSerialiseDifferentKeys keeps the exclusion scoped.
+//
+// The in-process semaphore is keyed, and a single global one would pass
+// every other test here while making a multi-gigabyte kernel download block
+// an unrelated bulletin fetch behind it for minutes.
+func TestAcquireLockDoesNotSerialiseDifferentKeys(t *testing.T) {
+	bucket, _ := openLocalBucket(t)
+
+	first, err := acquireLock(context.Background(), bucket, "kernel-a.bin")
+	if err != nil {
+		t.Fatalf("acquireLock a: %v", err)
+	}
+
+	defer first()
+
+	done := make(chan error, 1)
+
+	go func() {
+		release, err := acquireLock(context.Background(), bucket, "kernel-b.bin")
+		if err == nil {
+			release()
+		}
+
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("acquireLock b: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a lock on one key blocked a lock on another; the exclusion is not keyed")
+	}
+}


### PR DESCRIPTION
Closes #245 for the in-process case. The cross-process half is unchanged and tracked by #241 — see below.

`acquireLock` delegated exclusion to `WriterOptions.IfNotExist`, and **two** doc comments explained why that was safe within a process:

> fileblob implements it as Stat-then-Rename under a per-Bucket mutex, which is why `remote/file.Open` returns one shared Bucket per URL: that makes the lock exclusive within a process.

and, in `remote/file.Open` itself, the reason it caches one Bucket per URL for the life of the process:

> reuse is what makes fileblob's IfNotExist precondition meaningful within a process: that driver guards it with a per-Bucket mutex

**The mutex does not exist.** In the pinned driver:

```go
type bucket struct {
	dir  string
	opts *Options
}
```

No mutex field. The `mu` that does appear is built inside `NewTypedWriter` — `mu: &sync.Mutex{}`, twice — so every contender locks a mutex of its own, which synchronises nothing. What `IfNotExist` actually performs is an `os.Stat` followed by an `os.Rename`, with a window in between.

So a design decision (process-wide Bucket sharing) rests on a property of a dependency that isn't there.

## Measured

Directly against `blob.Bucket`, 8 goroutines sharing **one** Bucket, 200 rounds:

```
rounds where MORE THAN ONE contender believed it held the lock: 51/200
  1 holder(s): 149 rounds
  2 holder(s):  49 rounds
  3 holder(s):   2 rounds
```

And through `acquireLock` itself, in the new test: **41 of 200 acquisitions found another holder already inside the lock**. After this change, 0.

## The fix

Exclusion in two layers, because one of them is not reliable:

- **Within the process** — a keyed semaphore this package owns and can therefore trust.
- **Across processes** — still `IfNotExist`: a genuinely atomic conditional PUT on S3, best-effort on fileblob. Unchanged, and its consequences are what #241 tracks.

The in-process half is the one that was claimed and not delivered, and it is the half several parallel tests in a single binary hit — `ephemeris/jpl/spk`'s three `TestDiscardIfCorrupt*` tests being the visible symptom.

Two properties the implementation is deliberate about:

- **Keyed, not global.** A single semaphore would pass every other test here while making a multi-gigabyte kernel download block an unrelated bulletin fetch behind it for minutes. `TestAcquireLockDoesNotSerialiseDifferentKeys` pins that.
- **Channel, not `sync.Mutex`.** A caller blocked in `Lock` cannot observe its own deadline, and what it is queued behind is a download that may legitimately run for minutes. The semaphore selects on `ctx.Done()`.

Map entries are never reclaimed. The keys are cache keys — a few dozen kernels and bulletins over a process's life — so the map is bounded by what the process actually fetches, and reference counting would buy nothing measurable.

## Verification

Three new tests. The existing `TestAcquireLockSerializesAndReleases` acquires *then* starts the second contender, so the second genuinely finds the lock object present and the check-then-act window never opens — simultaneous contention was the untested case.

- `TestAcquireLockAdmitsOneHolderAtATime` — 8 contenders × 25 rounds, asserting on *overlap* rather than a winner count, since `acquireLock` is not a try-lock and every contender should eventually get in. What must never happen is two inside at once.
- `TestAcquireLockReleasesTheInProcessSlotOnFailure` — the leak that would turn one failed acquire into a permanently, silently stuck key.
- `TestAcquireLockDoesNotSerialiseDifferentKeys` — the keying.

Mutation testing, 4 mutants, 3 killed:

| mutation | result |
| :--- | :--- |
| in-process exclusion removed | killed — `AdmitsOneHolderAtATime` (41/200 overlaps) |
| slot not returned when acquire fails | killed — `ReleasesTheInProcessSlotOnFailure` |
| one global key instead of per-cache-key | killed — `DoesNotSerialiseDifferentKeys` |
| slot returned *before* the lock object is deleted | **survived** |

The second of those initially **survived**, and the reason is worth recording: my first version of that test held the lock with `acquireLock`, so the second caller blocked on the semaphore and failed *before* ever taking the slot — exercising nothing. It now writes the lock object directly, standing in for a holder in another process, which is the only way to reach the path where the slot is held and the blob-level acquire then fails.

The surviving mutant is a latency difference, not a correctness one: releasing the slot first lets the next goroutine reach `IfNotExist` while the object is still there, costing it one 50 ms retry cycle. Both orderings are correct. I chose the faster one and said why in the code rather than contriving a timing-dependent test for it.

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.
