### PR TITLE
plan: stop two network tests failing on the incompleteness they cause

### DIFF
--- a/docs/changelog.d/251-incomplete-expected.md
+++ b/docs/changelog.d/251-incomplete-expected.md
@@ -1,0 +1,8 @@
+---
+type: Fixed
+pr: 251
+---
+`ephemeris/jpl/spk`'s Horizons status sentinels now wrap the HTTP error rather
+than replacing it, so a 503 is recognisable as upstream downtime by anything
+matching `HTTPStatus() int` — previously a service outage was indistinguishable
+from a bad request (#251).

--- a/ephemeris/jpl/spk/api.go
+++ b/ephemeris/jpl/spk/api.go
@@ -281,15 +281,28 @@ func mapHorizonsStatus(err error) error {
 		return fmt.Errorf("jpl: horizons request: %w", err)
 	}
 
+	// Each sentinel keeps the HTTP error rather than replacing it.
+	//
+	// Returning the sentinel alone discarded the status, which broke a rule
+	// this repository states elsewhere: a network-tagged test skips on
+	// external downtime rather than failing CI, and
+	// internal/testutil.SkipOnUpstreamFailure decides that by looking for an
+	// error carrying HTTPStatus() int. *api.HTTPError has one; a bare
+	// sentinel does not, so a Horizons 503 — downtime by definition — failed
+	// tests that were written to tolerate exactly that (#244).
+	//
+	// testutil matches through the interface rather than importing this
+	// package, so wrapping is all that is needed here and nothing has to
+	// learn about Horizons in particular.
 	switch httpErr.StatusCode {
 	case http.StatusBadRequest:
-		return ErrHorizonsBadRequest
+		return fmt.Errorf("%w: %w", ErrHorizonsBadRequest, httpErr)
 	case http.StatusMethodNotAllowed:
-		return ErrHorizonsMethodNA
+		return fmt.Errorf("%w: %w", ErrHorizonsMethodNA, httpErr)
 	case http.StatusInternalServerError:
-		return ErrHorizonsServerError
+		return fmt.Errorf("%w: %w", ErrHorizonsServerError, httpErr)
 	case http.StatusServiceUnavailable:
-		return ErrHorizonsUnavailable
+		return fmt.Errorf("%w: %w", ErrHorizonsUnavailable, httpErr)
 	default:
 		return fmt.Errorf("%w: %d", ErrHorizonsUnexpected, httpErr.StatusCode)
 	}

--- a/ephemeris/jpl/spk/api_test.go
+++ b/ephemeris/jpl/spk/api_test.go
@@ -90,6 +90,34 @@ func TestMapHorizonsStatus(t *testing.T) {
 		}
 	}
 
+	// The status has to survive the mapping, not just the sentinel.
+	//
+	// internal/testutil.SkipOnUpstreamFailure decides "this is the remote end
+	// failing, skip rather than fail CI" by looking for an error carrying
+	// HTTPStatus() int. When these sentinels replaced the HTTP error instead
+	// of wrapping it, a Horizons 503 could not be recognised as downtime and
+	// failed tests written to tolerate it (#244).
+	for _, status := range []int{
+		http.StatusBadRequest,
+		http.StatusMethodNotAllowed,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	} {
+		mapped := mapHorizonsStatus(&api.HTTPError{StatusCode: status})
+
+		var carrier interface{ HTTPStatus() int }
+		if !errors.As(mapped, &carrier) {
+			t.Errorf("mapHorizonsStatus(%d) = %v, which carries no HTTP status; "+
+				"upstream downtime becomes indistinguishable from a bad request", status, mapped)
+
+			continue
+		}
+
+		if got := carrier.HTTPStatus(); got != status {
+			t.Errorf("mapHorizonsStatus(%d) carries status %d", status, got)
+		}
+	}
+
 	unexpected := mapHorizonsStatus(&api.HTTPError{StatusCode: http.StatusTeapot})
 	if unexpected == nil {
 		t.Error("mapHorizonsStatus(teapot) = nil, want ErrHorizonsUnexpected-wrapped error")

--- a/plan/incomplete_reasons_test.go
+++ b/plan/incomplete_reasons_test.go
@@ -1,0 +1,134 @@
+package plan_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/TuSKan/astrogo/plan"
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// Stand-ins for failures this test did not cause: a kernel that would not
+// parse, and a query that failed outright rather than coming back short.
+var (
+	errCorruptKernel  = errors.New("moon kernel \"plu060\": spk: bad file record")
+	errSiteUnresolved = errors.New("plan: site could not be resolved")
+)
+
+// flattenReasons returns the individual skip reasons under an ErrIncomplete.
+//
+// skips.err joins one error per dropped candidate, so errors.Is over the whole
+// thing answers "was anything denied", not "was everything denied" — and only
+// the second question separates a limit a caller set for itself from a real
+// failure sitting alongside it. TestVisibleTonight_PlanetaryMoons caps
+// downloads on purpose and needs exactly that distinction (#244).
+//
+// ErrIncomplete is dropped rather than returned as a reason: skips.err builds
+// its result as fmt.Errorf("%w: %w", ErrIncomplete, joined), so the sentinel
+// is a sibling of the reasons in the tree rather than one of them. Returning
+// it would make every caller reject its own expected incompleteness.
+//
+// This lives in an untagged file so it is exercised by the ordinary test run
+// rather than only under -tags=network, where the one caller is.
+func flattenReasons(err error) []error {
+	// A structural walk, so errors.As on the interface rather than on a
+	// concrete type: nothing here looks for a particular error, only for the
+	// shape that has children.
+	var multi interface{ Unwrap() []error }
+	if !errors.As(err, &multi) {
+		if errors.Is(err, plan.ErrIncomplete) {
+			return nil
+		}
+
+		return []error{err}
+	}
+
+	children := multi.Unwrap()
+	out := make([]error, 0, len(children))
+
+	for _, child := range children {
+		out = append(out, flattenReasons(child)...)
+	}
+
+	return out
+}
+
+// incompleteLike rebuilds the error shape plan's unexported skips.err
+// produces: the sentinel and the joined reasons as siblings.
+//
+// The coupling is deliberate and is this test's one weakness — if skips.err
+// changes shape, this keeps passing while flattenReasons stops matching
+// reality. It is called out here so the next reader checks both together.
+func incompleteLike(reasons ...error) error {
+	return fmt.Errorf("%w: %w", plan.ErrIncomplete, errors.Join(reasons...))
+}
+
+// TestFlattenReasonsSeparatesTheSentinelFromTheReasons is the test that makes
+// the helper worth trusting.
+//
+// Its whole job is to answer "was *everything* skipped for the reason I
+// caused", and the two ways it can be wrong are both silent: returning
+// ErrIncomplete as a reason makes a caller reject its own expected
+// incompleteness, and returning nothing makes the check vacuous — it would
+// accept any failure at all.
+func TestFlattenReasonsSeparatesTheSentinelFromTheReasons(t *testing.T) {
+	t.Parallel()
+
+	denied := fmt.Errorf("moon kernel %q: %w", "sat441", remote.ErrDownloadDenied)
+	deniedToo := fmt.Errorf("moon kernel %q: %w", "jup365", remote.ErrDownloadDenied)
+	corrupt := errCorruptKernel
+
+	for _, tc := range []struct {
+		name       string
+		err        error
+		wantCount  int
+		allDenials bool
+	}{
+		{"one denial", incompleteLike(denied), 1, true},
+		{"several denials", incompleteLike(denied, deniedToo), 2, true},
+		{"a denial and a real failure", incompleteLike(denied, corrupt), 2, false},
+		{"only a real failure", incompleteLike(corrupt), 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flattenReasons(tc.err)
+			if len(got) != tc.wantCount {
+				t.Fatalf("flattenReasons returned %d reasons, want %d: %v",
+					len(got), tc.wantCount, got)
+			}
+
+			all := true
+
+			for _, r := range got {
+				if errors.Is(r, plan.ErrIncomplete) {
+					t.Errorf("ErrIncomplete came back as a reason; a caller checking its "+
+						"own expected incompleteness would reject it: %v", r)
+				}
+
+				if !errors.Is(r, remote.ErrDownloadDenied) {
+					all = false
+				}
+			}
+
+			if all != tc.allDenials {
+				t.Errorf("every reason a download denial = %v, want %v (%v)",
+					all, tc.allDenials, got)
+			}
+		})
+	}
+}
+
+// TestFlattenReasonsOnAPlainError covers the shape a caller gets when the
+// query failed outright rather than coming back short.
+func TestFlattenReasonsOnAPlainError(t *testing.T) {
+	t.Parallel()
+
+	plain := errSiteUnresolved
+
+	got := flattenReasons(plain)
+	if len(got) != 1 || !errors.Is(got[0], plain) {
+		t.Errorf("flattenReasons(plain) = %v, want the error itself", got)
+	}
+}

--- a/plan/visible_tonight_network_test.go
+++ b/plan/visible_tonight_network_test.go
@@ -4,6 +4,7 @@ package plan_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
@@ -53,6 +54,13 @@ func TestVisibleTonight_MinorBodiesRespectMagLimit(t *testing.T) {
 
 	tight, err := plan.VisibleTonight(ctx, site, testNight, 2, sources, ephemeris.Default())
 	if err != nil {
+		// A skipped candidate is reported, not swallowed — that is what
+		// ErrIncomplete is for — so an unreachable or overloaded Horizons
+		// arrives here rather than as a missing row. CLAUDE.md's rule for
+		// this tier is to skip on external downtime and never fail CI for
+		// it; the TCP pre-check in requireJPL cannot see a 503, which
+		// happens one layer deeper (#244).
+		testutil.SkipOnUpstreamFailure(t, err)
 		t.Fatalf("VisibleTonight (magLimit=2): %v", err)
 	}
 
@@ -64,6 +72,7 @@ func TestVisibleTonight_MinorBodiesRespectMagLimit(t *testing.T) {
 
 	loose, err := plan.VisibleTonight(ctx, site, testNight, 5, sources, ephemeris.Default())
 	if err != nil {
+		testutil.SkipOnUpstreamFailure(t, err)
 		t.Fatalf("VisibleTonight (magLimit=5): %v", err)
 	}
 
@@ -96,10 +105,18 @@ func TestVisibleTonight_MinorBodiesRespectMagLimit(t *testing.T) {
 // (~32 MB), the full planetaryMoons set spans six kernels totaling ~2.4 GB
 // (Jupiter's alone is ~1.1 GB), which would make this an unreasonably
 // expensive test to run routinely. Denied-by-cap kernels are skipped by
-// gatherPlanetaryMoons exactly like a denied-by-policy one — not a test
-// failure — so this still exercises the real fetch-and-compute path for
-// Phobos/Deimos/Triton without paying for Jupiter/Saturn/Uranus/Pluto's
-// far larger kernels every run.
+// gatherPlanetaryMoons exactly like a denied-by-policy one, so this still
+// exercises the real fetch-and-compute path for Phobos/Deimos/Triton
+// without paying for Jupiter/Saturn/Uranus/Pluto's far larger kernels every
+// run.
+//
+// Those skips are reported, though. This comment used to add "not a test
+// failure", and that stopped being true when VisibleTonight began returning
+// ErrIncomplete for anything it dropped — correctly, since a caller who
+// cannot tell a short list from a short list plus an unreachable JPL is the
+// defect ErrIncomplete exists to fix. So this test induces four denials on
+// purpose and then has to accept the report of them, while still failing on
+// any reason that is not the cap it set itself (#244).
 //
 // magLimit=16 is loose enough for Triton (~mag 13.5) and Phobos/Deimos
 // (~mag 11-13 from Earth, effectively never actually visible at Mars's
@@ -124,7 +141,22 @@ func TestVisibleTonight_PlanetaryMoons(t *testing.T) {
 
 	results, err := plan.VisibleTonight(ctx, site, testNight, 16, nil, ephemeris.Default(), plan.WithPlanetaryMoons())
 	if err != nil {
-		t.Fatalf("VisibleTonight with WithPlanetaryMoons: %v", err)
+		testutil.SkipOnUpstreamFailure(t, err)
+
+		if !errors.Is(err, plan.ErrIncomplete) {
+			t.Fatalf("VisibleTonight with WithPlanetaryMoons: %v", err)
+		}
+
+		// Every reason has to be the cap this test set. A kernel that failed
+		// to parse, or a site that could not be resolved, is precisely what
+		// this test would otherwise stop reporting.
+		for _, reason := range flattenReasons(err) {
+			if !errors.Is(reason, remote.ErrDownloadDenied) {
+				t.Fatalf("VisibleTonight reported a skip this test did not cause: %v", reason)
+			}
+		}
+
+		t.Logf("expected incompleteness from this test's own download cap: %v", err)
 	}
 
 	for _, r := range results {


### PR DESCRIPTION
Closes #244.

`VisibleTonight` returns `ErrIncomplete` alongside a perfectly good result whenever it skipped a candidate — deliberately, so a caller can tell a short list from a short list plus an unreachable JPL. Both of these tests **arrange skips on purpose** and then called `t.Fatalf` on any non-nil error, so each failed on the outcome it was written to produce.

## PlanetaryMoons — accepting the incompleteness it causes

The test caps `NAIFSPK` downloads at ~110 MB on purpose: the full moon-kernel set is ~2.4 GB and Jupiter's alone is ~1.1 GB. Its doc comment claimed denied-by-cap kernels were *"not a test failure"*, which stopped being true when skips began to be reported — correctly, since that reporting is what #177's follow-up was for.

It now accepts `ErrIncomplete` **only when every reason is `remote.ErrDownloadDenied`**, and fails on anything else. A kernel that would not parse is still caught, which is the part that matters — ignoring the error entirely would have been the easy fix and the wrong one.

Verified live: passes, reports the `plu060` denial it caused, and finds **Triton at mag 13.87** — the real fetch-and-compute path the test exists for.

## MinorBodies — and the reason it *couldn't* skip

This one failed whenever Horizons returned 503. CLAUDE.md's rule for the tier is explicit: *"These tests do a TCP pre-check and `t.Skipf` when the endpoint is unreachable (never fail CI for external downtime)."* A 503 is downtime arriving one layer deeper than a TCP pre-check can see, and `testutil.SkipOnUpstreamFailure` exists for exactly this.

It could not work. `SkipOnUpstreamFailure` decides by looking for an error carrying `HTTPStatus() int` — matched through the interface, deliberately, so `testutil` need not import `remote`. And `spk.mapHorizonsStatus` was **replacing** the HTTP error with a bare sentinel:

```go
case http.StatusServiceUnavailable:
	return ErrHorizonsUnavailable
```

`*api.HTTPError` has `HTTPStatus()`. A bare sentinel does not. So two mechanisms that both mean "the service is having a problem" could not see each other, and downtime was indistinguishable from a bad request.

Each sentinel now wraps the HTTP error instead of dropping it. `errors.Is` on the sentinels is unaffected, `testutil` still imports nothing new, and **every** caller gains the distinction — not just this test.

Verified live: the test now skips with `upstream service failure, not verified: server error (... jpl: horizons service unavailable (503) ...: remote/api: http 503 ...)` instead of failing.

## The helper, and why it is tested

Distinguishing "was *anything* denied" from "was *everything* denied" needs a walk of the joined error tree, because `errors.Is` over the whole thing only answers the first question — and only the second separates a cap a test set for itself from a real failure sitting alongside it.

That walk has two silent failure modes, so it lives in an **untagged** file with its own table test and runs in the ordinary suite rather than only under `-tags=network`:

- Returning `ErrIncomplete` as a reason makes a caller reject its own expected incompleteness. It is a *sibling* of the reasons in the tree (`fmt.Errorf("%w: %w", ErrIncomplete, joined)`), not one of them — easy to get wrong, and I did get it wrong first time.
- Returning nothing makes the check vacuous: it would accept any failure at all.

The test's one weakness is called out in its own comment: it rebuilds the shape `skips.err` produces, so if that shape changes the test keeps passing while the helper stops matching reality. Flagged there so the next reader checks both together.

## Verification

Mutation testing, 3 mutants, 3 killed:

| mutation | killed by |
| :--- | :--- |
| 503 sentinel drops the HTTP status again | `TestMapHorizonsStatus` |
| `ErrIncomplete` returned as a reason | `TestFlattenReasonsSeparatesTheSentinelFromTheReasons` |
| flatten returns nothing (vacuous check) | `TestFlattenReasonsSeparatesTheSentinelFromTheReasons` |

Plus a new assertion in `TestMapHorizonsStatus` that the status survives the mapping for all four mapped codes, not only that the sentinel matches.

Both network tests run live against JPL, one passing and one skipping for the right reason. Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.
