### PR TITLE
ephemeris: say which bodies are barycentres, and pin it

### DIFF
--- a/docs/changelog.d/258-barycentre-semantics.md
+++ b/docs/changelog.d/258-barycentre-semantics.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 258
+---
+`core.ID` and `jpl.NAIFFor` now document which bodies are system barycentres
+rather than planets — the giant planets are, and the gap is 0.03–0.05″ against
+a reference that defaults to the body centre. A test pins the numbers and the
+centre-versus-barycentre split (#258).

--- a/ephemeris/core/core.go
+++ b/ephemeris/core/core.go
@@ -209,30 +209,72 @@ const (
 // ─── Body ID ─────────────────────────────────────────────────────────────────
 
 // ID identifies a major Solar System body or a generic celestial object.
+//
+// # For the outer planets this is the system barycentre, not the planet
+//
+// A planetary kernel — de440, de441 — contains barycentres for the giant
+// planets, because their satellite systems live in separate kernels
+// (jup365, sat441, ura184, nep097). So a provider backed by one resolves
+// [Mars], [Jupiter], [Saturn], [Uranus] and [Neptune] to NAIF 4, 5, 6, 7 and
+// 8: the barycentre of the planet and its moons. [Mercury], [Venus] and
+// [Earth] resolve to 199, 299 and 399, the body centres, because a planet
+// with no significant moons *is* its own barycentre.
+//
+// One identifier space therefore holds two kinds of point, and which one you
+// get depends on the body. The difference is small and not negligible —
+// measured against JPL Horizons' body-centre commands over 2026:
+//
+//	Uranus    0.0497 arcsec
+//	Jupiter   0.0324 arcsec
+//	Saturn    0.0288 arcsec
+//	Neptune   0.0093 arcsec
+//	Mars      0.0000 arcsec   (Phobos and Deimos displace it by centimetres)
+//
+// That is far inside every tolerance astrogo publishes, and far outside what
+// someone checking Jupiter against Horizons' default `599` would expect: it
+// reads as an astrogo error and is not one. Ask Horizons for `5` to compare
+// like for like (#253).
+//
+// Getting the body centre needs the satellite kernel loaded, which is a
+// different provider and a multi-gigabyte download; see
+// [github.com/TuSKan/astrogo/ephemeris.Moons].
 type ID uint32
 
 const (
-	// Mercury is the identifier for Mercury.
+	// Mercury is the identifier for Mercury. Body centre, NAIF 199 — Mercury
+	// has no moons, so its barycentre is itself.
 	Mercury ID = iota + 1
-	// Venus is the identifier for Venus.
+	// Venus is the identifier for Venus. Body centre, NAIF 299, for the same
+	// reason as Mercury.
 	Venus
-	// Earth is the identifier for Earth.
+	// Earth is the identifier for Earth. Body centre, NAIF 399 — distinct
+	// from the Earth-Moon barycentre, which is 4,671 km away.
 	Earth
-	// Mars is the identifier for Mars.
+	// Mars is the identifier for the Mars system barycentre, NAIF 4. Phobos
+	// and Deimos displace it from the planet by centimetres, so the
+	// distinction is unobservable here.
 	Mars
-	// Jupiter is the identifier for Jupiter.
+	// Jupiter is the identifier for the Jupiter system barycentre, NAIF 5 —
+	// about 0.03 arcsec from the planet as seen from Earth. See [ID].
 	Jupiter
-	// Saturn is the identifier for Saturn.
+	// Saturn is the identifier for the Saturn system barycentre, NAIF 6 —
+	// about 0.03 arcsec from the planet as seen from Earth. See [ID].
 	Saturn
-	// Uranus is the identifier for Uranus.
+	// Uranus is the identifier for the Uranus system barycentre, NAIF 7 —
+	// about 0.05 arcsec from the planet as seen from Earth. See [ID].
 	Uranus
-	// Neptune is the identifier for Neptune.
+	// Neptune is the identifier for the Neptune system barycentre, NAIF 8 —
+	// about 0.01 arcsec from the planet as seen from Earth. See [ID].
 	Neptune
-	// Pluto is the identifier for Pluto.
+	// Pluto is the identifier for Pluto. Unlike every other body here it has
+	// no NAIF mapping in the JPL provider at all — NAIFFor reports false —
+	// so a kernel-backed provider cannot serve it and eph.Default answers
+	// with a Kepler two-body propagation instead, worth 0.138 AU at worst.
+	// See docs/VALIDATION.md's `ephemeris.kepler.pluto` row.
 	Pluto
-	// Moon is the identifier for the Moon.
+	// Moon is the identifier for the Moon. Body centre, NAIF 301.
 	Moon
-	// Sun is the identifier for the Sun.
+	// Sun is the identifier for the Sun. Body centre, NAIF 10.
 	Sun
 	// SolarSystemBarycenter is the identifier for the solar system barycenter.
 	SolarSystemBarycenter

--- a/ephemeris/jpl/naifsemantics_test.go
+++ b/ephemeris/jpl/naifsemantics_test.go
@@ -1,0 +1,93 @@
+package jpl_test
+
+import (
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+)
+
+// TestNAIFMappingIsTheDocumentedMixOfCentresAndBarycentres pins which kind of
+// point each body identifier means.
+//
+// The mapping holds two kinds of point at once: 199, 299 and 399 are body
+// centres, while 4, 5, 6, 7 and 8 are system barycentres. That is not a
+// mistake — a planetary kernel contains only barycentres for the giant
+// planets, because their satellite systems live in separate kernels — but it
+// is invisible from the identifier, and it is worth tens of milliarcseconds.
+//
+// Measured against Horizons' body-centre commands over 2026: 0.0497 arcsec at
+// Uranus, 0.0324 at Jupiter, 0.0288 at Saturn, 0.0093 at Neptune, and zero at
+// Mars. Far inside every tolerance astrogo publishes, and far outside what
+// someone comparing Jupiter against Horizons' default `599` expects — it reads
+// as an astrogo error and is not one (#253).
+//
+// This is a documentation guard as much as a behavioural one. The doc comments
+// on core.ID and NAIFFor state these numbers; if the mapping moves, they
+// become wrong silently, and a wrong statement about which point a coordinate
+// refers to is worse than no statement.
+func TestNAIFMappingIsTheDocumentedMixOfCentresAndBarycentres(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		body       core.ID
+		naif       int
+		barycentre bool
+	}{
+		{core.Sun, 10, false},
+		{core.Moon, 301, false},
+		{core.Mercury, 199, false},
+		{core.Venus, 299, false},
+		{core.Earth, 399, false},
+
+		{core.Mars, 4, true},
+		{core.Jupiter, 5, true},
+		{core.Saturn, 6, true},
+		{core.Uranus, 7, true},
+		{core.Neptune, 8, true},
+	} {
+		t.Run(tc.body.String(), func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := jpl.NAIFFor(tc.body)
+			if !ok {
+				t.Fatalf("NAIFFor(%s) reports no mapping", tc.body)
+			}
+
+			if got != tc.naif {
+				t.Errorf("NAIFFor(%s) = %d, want %d; the doc comments on core.ID and "+
+					"NAIFFor name this number and would now be wrong", tc.body, got, tc.naif)
+			}
+
+			// NAIF's own convention: a bare 1-9 is a system barycentre, and
+			// the body centre is that number times 100 plus the same digit.
+			// So the kind of point is readable from the identifier itself,
+			// which is what makes this checkable rather than a matter of
+			// remembering.
+			if isBarycentre := got < 10; isBarycentre != tc.barycentre {
+				kind := map[bool]string{true: "a system barycentre", false: "a body centre"}
+
+				t.Errorf("NAIFFor(%s) = %d, which is %s; the documentation says %s",
+					tc.body, got, kind[isBarycentre], kind[tc.barycentre])
+			}
+		})
+	}
+}
+
+// TestPlutoHasNoNAIFMapping pins the one body that is absent, because absent
+// is easy to mistake for an oversight.
+//
+// A kernel-backed provider cannot serve Pluto, so eph.Default answers with a
+// Kepler two-body propagation — worth 0.138 AU at worst, which is four orders
+// of magnitude looser than anything else in this mapping. Anyone adding a
+// NAIF number here should know they are also changing which of those two
+// answers a caller gets.
+func TestPlutoHasNoNAIFMapping(t *testing.T) {
+	t.Parallel()
+
+	if naif, ok := jpl.NAIFFor(core.Pluto); ok {
+		t.Errorf("NAIFFor(Pluto) = %d, but this package has no Pluto kernel mapping; "+
+			"adding one changes eph.Default from a Kepler propagation to an SPK lookup "+
+			"and the 0.138 AU contract in docs/VALIDATION.md with it", naif)
+	}
+}

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -75,6 +75,24 @@ var kmPerAU = constants.IAU.AstronomicalUnit.Value / 1e3
 // exported map. A caller that assigns to BodyIDToNAIF changes which SPK
 // segment every other caller in the binary resolves to — silently, and with
 // no way for a later reader to see it happened.
+//
+// # The mapping mixes body centres and system barycentres
+//
+// 199, 299 and 399 are body centres; 4, 5, 6, 7 and 8 are system
+// barycentres. That is not an inconsistency to fix but what a planetary
+// kernel contains — the giant planets' satellite systems live in separate
+// kernels, so de440 and de441 can only offer the barycentre, while Mercury
+// and Venus have no moons and so *are* their own barycentres.
+//
+// It does mean two kinds of point share one identifier space. Measured
+// against Horizons' body-centre commands over 2026, the gap is 0.0497 arcsec
+// at Uranus, 0.0324 at Jupiter, 0.0288 at Saturn, 0.0093 at Neptune and zero
+// at Mars. Small, systematic, and easy to mistake for an astrogo error when
+// comparing against a reference that defaults to the body centre — see
+// [github.com/TuSKan/astrogo/ephemeris/core.ID] (#253).
+//
+// core.Pluto is deliberately absent: there is no NAIF mapping for it here,
+// so this reports false and a kernel-backed provider cannot serve it.
 func NAIFFor(id core.ID) (int, bool) {
 	naif, ok := BodyIDToNAIF[id]
 


### PR DESCRIPTION
Closes #253.

`core.Jupiter` is not Jupiter. It is the Jupiter *system barycentre*, and nothing in the API or the documentation said so.

## The mapping holds two kinds of point

```go
core.Sun: 10, core.Moon: 301, core.Mercury: 199, core.Venus: 299,
core.Earth: 399, core.Mars: 4, core.Jupiter: 5, core.Saturn: 6,
core.Uranus: 7, core.Neptune: 8,
```

199, 299 and 399 are **body centres**. 4 through 8 are **system barycentres**.

That is not a mistake to fix. A planetary kernel contains only barycentres for the giant planets, because their satellite systems live in separate kernels (`jup365`, `sat441`, …); Mercury and Venus have no moons, so they *are* their own barycentres. The problem is that it is invisible from the identifier.

## What it costs

Measured against Horizons' body-centre commands over 2026:

| planet | median offset |
| :--- | ---: |
| Uranus | 0.0497″ |
| Jupiter | 0.0324″ |
| Saturn | 0.0288″ |
| Neptune | 0.0093″ |
| Mars | 0.0000″ — Phobos and Deimos displace it by centimetres |

Far inside every tolerance astrogo publishes, and far outside what someone checking Jupiter against Horizons' default `599` would expect. **It reads as an astrogo error and is not one** — which is exactly how it was found, while building the geocentric astrometric comparison in #254: Sun, Venus and Mars matched exactly while Jupiter and Saturn did not.

## What this changes

Documentation on the three places a caller actually reads — `core.ID`, each affected constant, and `jpl.NAIFFor` — plus a test that pins the numbers and the centre-versus-barycentre split.

The test is the point. A doc comment that names a number becomes wrong *silently* when the number moves, and a wrong statement about which point a coordinate refers to is worse than no statement. It also reads the kind of point out of the identifier itself — NAIF's convention is that a bare 1–9 is a barycentre and the body centre is that digit times 100 plus itself — so the check is structural rather than a matter of remembering.

Confirmed to fire: changing `core.Jupiter: 5` to `599` reports both that the number moved *and* that it is now a body centre where the documentation says barycentre.

## Pluto, found while writing it

`core.Pluto` has no NAIF mapping here at all. `NAIFFor` reports false, a kernel-backed provider cannot serve it, and `eph.Default` answers with a Kepler two-body propagation — **0.138 AU at worst**, four orders of magnitude looser than anything else in this mapping.

Absence is easy to read as an oversight, so it is documented and pinned too, with a note that adding a NAIF number there also changes which of those two answers a caller gets, and the 0.138 AU contract in `docs/VALIDATION.md` with it.

## Not in scope

#253's second suggestion — distinguishing the two kinds of point in the ID space — is a design change, not a documentation fix, and would need a body-centre provider backed by satellite kernels to be worth anything. Its third asks whether `plan`'s event solving cares: tens of milliarcseconds is far inside rise/set and conjunction tolerances, so not today. Occultation work (#131) would.

`docs/VALIDATION.md` already carries this under Known Incomplete Areas, added in #254.

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.
