### PR TITLE
chore: bump resty to rc.4, and say why gocloud cannot leave its pseudo-version

### DIFF
--- a/docs/changelog.d/259-dependency-state.md
+++ b/docs/changelog.d/259-dependency-state.md
@@ -1,0 +1,7 @@
+---
+type: Changed
+pr: 259
+---
+`resty.dev/v3` moves to `rc.4`, and `go.mod` now records why `gocloud.dev`
+cannot leave its pseudo-version: `gocloud-ext`'s httpblob driver implements
+`blob/driver.DeleteOptions`, which was added after v0.46.0 (#259).

--- a/docs/changelog.d/259-examples-dependency-drift.md
+++ b/docs/changelog.d/259-examples-dependency-drift.md
@@ -1,0 +1,8 @@
+---
+type: Added
+pr: 259
+---
+`docsguard` now catches a dependency bumped in the root module but not mirrored
+into `examples/`. The examples module carries the library's dependencies as
+indirect requirements, and a stale copy makes `go build ./...` inside it refuse
+outright — previously visible only after a push, from CI (#259).

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -54,7 +54,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260724162435-b2f20204f0df // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	resty.dev/v3 v3.0.0-rc.3 // indirect
+	resty.dev/v3 v3.0.0-rc.4 // indirect
 )
 
 replace github.com/TuSKan/astrogo => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -201,5 +201,5 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-resty.dev/v3 v3.0.0-rc.3 h1:k24LZ03Cb4Ue5e6O/Pfxu5TQRBBYGES6wm2wceia+Io=
-resty.dev/v3 v3.0.0-rc.3/go.mod h1:NTOerrC/4T7/FE6tXIZGIysXXBdgNqwMZuKtxpea9NM=
+resty.dev/v3 v3.0.0-rc.4 h1:n3360yEcFiyrX5Vkc9XG3Y8kMM24alRBxJ9Ev1mLmqs=
+resty.dev/v3 v3.0.0-rc.4/go.mod h1:NTOerrC/4T7/FE6tXIZGIysXXBdgNqwMZuKtxpea9NM=

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,14 @@ require (
 	github.com/joshuaferrara/go-satellite v0.0.0-20220611180459-512638c64e5b
 	github.com/klauspost/pgzip v1.2.6
 	github.com/scigolib/hdf5 v0.14.0
+	// Pinned past v0.46.0 because gocloud-ext's httpblob driver implements
+	// blob/driver.DeleteOptions, which was added after that tag. Forcing the
+	// tag fails to build: "undefined: driver.DeleteOptions". It can move to a
+	// release as soon as gocloud.dev cuts one containing that type (#120).
 	gocloud.dev v0.46.1-0.20260810195832-b5401c07b5f1
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.22.0
-	resty.dev/v3 v3.0.0-rc.3
+	resty.dev/v3 v3.0.0-rc.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -208,5 +208,5 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-resty.dev/v3 v3.0.0-rc.3 h1:k24LZ03Cb4Ue5e6O/Pfxu5TQRBBYGES6wm2wceia+Io=
-resty.dev/v3 v3.0.0-rc.3/go.mod h1:NTOerrC/4T7/FE6tXIZGIysXXBdgNqwMZuKtxpea9NM=
+resty.dev/v3 v3.0.0-rc.4 h1:n3360yEcFiyrX5Vkc9XG3Y8kMM24alRBxJ9Ev1mLmqs=
+resty.dev/v3 v3.0.0-rc.4/go.mod h1:NTOerrC/4T7/FE6tXIZGIysXXBdgNqwMZuKtxpea9NM=

--- a/internal/docsguard/examplesmodule_test.go
+++ b/internal/docsguard/examplesmodule_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// examplesModule guards the three properties that make examples/ a separate
+// examplesModule guards the four properties that make examples/ a separate
 // module (#124) worth having rather than a place for code to rot.
 //
 // # Why a guard at all
@@ -16,7 +17,7 @@ import (
 // Before the split, `go build ./...` compiled the 32 example programs along
 // with everything else, so an API change that broke one failed immediately and
 // nobody had to remember anything. A module boundary ends that: `./...` stops
-// at it, and the examples are now verified only because three things stay
+// at it, and the examples are now verified only because several things stay
 // true at once. Each of them is one careless edit from being false, and none
 // of them fails loudly on its own.
 //
@@ -32,13 +33,85 @@ import (
 //  3. CI actually builds it. A perfectly correct module nothing compiles is
 //     the same as no module.
 //
+//  4. The versions the two modules share stay equal. examples/ requires only
+//     astrogo, so every other line in its require block is an indirect copy of
+//     one of the root's — a hand-maintained duplicate that drifts the moment a
+//     dependency is bumped in one file and not the other, and then refuses to
+//     build at all.
+//
 // The README's claim that every sample in it was compiled and run rests on
-// the same three facts, which is the other reason to assert them here rather
+// the same facts, which is the other reason to assert them here rather
 // than trust the workflow file to keep saying what it says today.
 var (
 	goDirectiveLine = regexp.MustCompile(`(?m)^go (\d+\.\d+(?:\.\d+)?)\s*$`)
 	localReplace    = regexp.MustCompile(`(?m)^replace\s+github\.com/TuSKan/astrogo\s+=>\s+\.\./\s*$`)
+
+	// A requirement in either of go.mod's two spellings: a tab-indented line
+	// inside a `require (…)` block, or a standalone `require path version`.
+	// Both forms appear in this repository — examples/go.mod states its one
+	// direct requirement on a single line — and matching only the block form
+	// would skip a requirement silently rather than report it, which is the
+	// failure mode a guard must not have.
+	//
+	// Comment-only lines and the block delimiters do not match, which is what
+	// keeps the gocloud pin's explanatory comment from being read as a
+	// requirement.
+	requireLine = regexp.MustCompile(`(?m)^(?:\t|require +)([^\s/][^\s]*) +(v[^\s]+)(?: +//.*)?$`)
 )
+
+// requires maps module path to version for every require line in a go.mod.
+func requires(mod []byte) map[string]string {
+	out := make(map[string]string)
+
+	for _, m := range requireLine.FindAllSubmatch(mod, -1) {
+		out[string(m[1])] = string(m[2])
+	}
+
+	return out
+}
+
+// TestRequiresReadsBothSpellings pins the parser the drift check is built on.
+// Its dangerous failure is not a wrong version but a missed line: a
+// requirement the regexp skips is a requirement the drift check reports as
+// absent rather than as unequal, and the guard passes while the two modules
+// disagree.
+func TestRequiresReadsBothSpellings(t *testing.T) {
+	t.Parallel()
+
+	const mod = "module example.com/m\n" +
+		"\n" +
+		"go 1.27\n" +
+		"\n" +
+		"require standalone.example/a v1.2.3\n" +
+		"\n" +
+		"require (\n" +
+		"\t// A comment inside the block, naming v9.9.9, is not a requirement.\n" +
+		"\tblocked.example/b v0.4.0\n" +
+		"\tindirect.example/c v1.0.0 // indirect\n" +
+		")\n" +
+		"\n" +
+		"replace replaced.example/d => ../d\n"
+
+	want := map[string]string{
+		"standalone.example/a": "v1.2.3",
+		"blocked.example/b":    "v0.4.0",
+		"indirect.example/c":   "v1.0.0",
+	}
+
+	got := requires([]byte(mod))
+
+	for path, ver := range want {
+		if got[path] != ver {
+			t.Errorf("requires()[%q] = %q, want %q", path, got[path], ver)
+		}
+	}
+
+	for path := range got {
+		if _, expected := want[path]; !expected {
+			t.Errorf("requires() reported %q = %q, which is not a requirement", path, got[path])
+		}
+	}
+}
 
 func TestExamplesModuleIsVerifiedAgainstTheWorkingTree(t *testing.T) {
 	t.Parallel()
@@ -84,6 +157,39 @@ func TestExamplesModuleIsVerifiedAgainstTheWorkingTree(t *testing.T) {
 			t.Errorf("examples/go.mod declares go %s, go.mod declares go %s.\n"+
 				"  Two modules in one repository on different toolchain minimums build "+
 				"differently depending on who ran them.", got[1], want[1])
+		}
+	})
+
+	t.Run("shared dependency versions have not drifted", func(t *testing.T) {
+		t.Parallel()
+
+		// examples/ requires astrogo and nothing else, so with the `replace`
+		// above its build list is the root's build list. Every other entry in
+		// its require block is therefore a copy, and a copy can go stale: a
+		// dependency bump in the root leaves examples/go.mod naming the old
+		// version, and `go build ./...` inside examples/ then refuses with
+		// "updates to go.mod needed" rather than building against the wrong
+		// one. CI's own `go mod tidy` check catches that, but only after a
+		// push; this catches it in `go test ./...`.
+		//
+		// The fix is always the same and is the missing half of any dependency
+		// bump here: `go mod tidy` in the root, then `go mod tidy` in
+		// examples/.
+		root := requires(rootMod)
+
+		var stale []string
+
+		for path, exVer := range requires(exMod) {
+			if rootVer, shared := root[path]; shared && rootVer != exVer {
+				stale = append(stale, path+": examples has "+exVer+", go.mod has "+rootVer)
+			}
+		}
+
+		sort.Strings(stale)
+
+		for _, s := range stale {
+			t.Errorf("examples/go.mod is behind the root module — %s.\n"+
+				"  Run `go mod tidy` in examples/ after every dependency bump.", s)
 		}
 	})
 


### PR DESCRIPTION
Partially addresses #120 — two of its four items, settled by measurement. The other two are recorded below rather than guessed at.

## 1. SGP4 against Vallado — already done

#120 calls this "the important half: it matters far more that the propagator is *proven correct* than that its module is tagged." It landed in #181: 588 states over 30 element sets, run by the `validation` tier, reported as a distribution — 22 cases at p50 35 m / max 289 m, 8 diverging by 0.6–3440 km and asserted from both sides.

## 4. Why gocloud.dev is on a pseudo-version — it cannot leave

The issue asks to document the reason or move to a tag. It cannot move.

`gocloud-ext/blob/httpblob@v0.1.1` implements `blob/driver.DeleteOptions`, which **does not exist in v0.46.0** — it was added after the tag. Forcing the tag:

```
# github.com/TuSKan/gocloud-ext/blob/httpblob
httpblob.go:1581:71: undefined: driver.DeleteOptions
```

astrogo does not choose the pin either. `go mod graph` shows `gocloud-ext/blob/httpblob@v0.1.1 -> gocloud.dev@v0.46.1-0.2026...`, and `go mod tidy` restores it if you edit it away.

The reason is now a comment on the `require` line — where someone tempted to tidy up a pseudo-version will actually read it — and it names the condition that would let it move: gocloud.dev cutting a release containing that type. Verified the comment survives `go mod tidy`.

## 3. resty — rc.3 → rc.4

Still a release candidate, so the issue's request to pin a GA before 1.0 stays open. But there is no reason to sit on the older candidate in the meantime.

No resty type escapes `remote/api` (CLAUDE.md's rule, and API Diff confirms), so this cannot move astrogo's own surface.

## 2. go-satellite — left alone deliberately

`go list -m -versions github.com/joshuaferrara/go-satellite` returns **no tags at all**, which is the issue's complaint rather than something a bump fixes. Whether to vendor it is a judgement call about maintenance burden and belongs with a reviewer, not with this change — and #181 already removed the sharpest edge by proving the propagator against reference vectors, which is what makes an untagged dependency defensible or not.

## Verification

Full gate: `gofmt`, `go vet`, `golangci-lint run --build-tags="integration,network,validation"` at 0 issues, `go test ./...`, `go test -race -short -count=1 ./...`.

Leaving #120 open — items 2 and 3 both need decisions rather than measurements.
