### PR TITLE
fits: expose the WCS axis units the header declares

### DIFF
--- a/atmosphere/dataset/cams/aod.go
+++ b/atmosphere/dataset/cams/aod.go
@@ -79,12 +79,12 @@ const AODVariable = "aod550"
 // must also blank-import remote/s3, which this package deliberately does not
 // — it knows nothing about S3, and pulling the AWS SDK into every build that
 // merely reads a NetCDF file would be the wrong trade.
-func AOD550(ctx context.Context, site *coord.Geodetic, when time.GoTime) (float64, error) {
+func AOD550(ctx context.Context, site *coord.Geodetic, when time.GoTime, opts ...Option) (float64, error) {
 	if site == nil {
 		return 0, fmt.Errorf("%w: needs a site", ErrAOD)
 	}
 
-	bucket, key, err := remote.GetFile(ctx, remote.CopernicusEODATA, AODKey(when))
+	bucket, key, err := apply(opts).GetFile(ctx, remote.CopernicusEODATA, AODKey(when))
 	if err != nil {
 		return 0, fmt.Errorf("%w: %w\n\n%s", ErrAOD, err, RegistrationAdvice)
 	}

--- a/atmosphere/dataset/cams/option.go
+++ b/atmosphere/dataset/cams/option.go
@@ -1,0 +1,39 @@
+package cams
+
+import "github.com/TuSKan/astrogo/remote"
+
+// Option configures a CAMS fetch.
+//
+// It is defined here rather than borrowed from catalog/resolve because
+// atmosphere is a scientific engine and catalog is orchestration: the
+// architecture in CLAUDE.md has the dependency running the other way, and one
+// option type is not worth inverting it.
+type Option func(*config)
+
+type config struct{ remote *remote.Client }
+
+// WithClient fetches under c's policy instead of [remote.Default]'s — its
+// download consent, offline flag and endpoint overrides.
+//
+// CAMS is a registration-gated endpoint whose files are ~1.5 MB per hour, so
+// "may this component fetch" is a question a service is likely to answer
+// differently for a request path and a warm-up job.
+func WithClient(c *remote.Client) Option {
+	return func(cfg *config) { cfg.remote = c }
+}
+
+// apply resolves opts to the client to fetch through, defaulting to
+// [remote.Default].
+func apply(opts []Option) *remote.Client {
+	var cfg config
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.remote == nil {
+		return remote.Default()
+	}
+
+	return cfg.remote
+}

--- a/catalog/fink/fink.go
+++ b/catalog/fink/fink.go
@@ -78,13 +78,13 @@ type Provider struct {
 }
 
 // New returns a Provider with the default SSOFT version.
-func New() *Provider {
-	return NewWithVersion(defaultVersion)
+func New(opts ...resolve.Option) *Provider {
+	return NewWithVersion(defaultVersion, opts...)
 }
 
 // NewWithVersion returns a Provider targeting a specific SSOFT release (e.g. "2025.04").
-func NewWithVersion(version string) *Provider {
-	client, err := api.NewClient(remote.FINK)
+func NewWithVersion(version string, opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.FINK, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/gaia/gaia.go
+++ b/catalog/gaia/gaia.go
@@ -49,12 +49,12 @@ const DefaultEndpoint = remote.GaiaAIP
 // The zero endpoint selects [DefaultEndpoint]. Naming one explicitly is how a
 // caller reaches a specific archive - ESA's, for instance, when the point is
 // to compare the two rather than to get an answer.
-func New(endpoint remote.EndpointID) (*Provider, error) {
+func New(endpoint remote.EndpointID, opts ...resolve.Option) (*Provider, error) {
 	if endpoint == "" {
 		endpoint = DefaultEndpoint
 	}
 
-	client, err := api.NewClient(endpoint)
+	client, err := api.NewClient(endpoint, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("gaia: %w", err)
 	}

--- a/catalog/jpl/jpl.go
+++ b/catalog/jpl/jpl.go
@@ -32,8 +32,8 @@ type Provider struct {
 }
 
 // New creates a new JPL Horizons catalog provider.
-func New() *Provider {
-	client, err := api.NewClient(remote.JPLHorizons)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.JPLHorizons, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/mast/mast.go
+++ b/catalog/mast/mast.go
@@ -32,8 +32,8 @@ type Provider struct {
 }
 
 // New creates a new MAST provider.
-func New() *Provider {
-	client, err := api.NewClient(remote.MAST)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.MAST, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/mpcorb/mpcorb.go
+++ b/catalog/mpcorb/mpcorb.go
@@ -66,8 +66,8 @@ import (
 // file is opened when iteration starts and closed when it ends, including on
 // an early break, so a caller taking the first fifty rows of the 317 MB file
 // pays for fifty rows.
-func Open(ctx context.Context, name string) (iter.Seq2[resolve.Target, error], error) {
-	bucket, key, err := remote.GetFile(ctx, remote.MPCORB, name)
+func Open(ctx context.Context, name string, opts ...resolve.Option) (iter.Seq2[resolve.Target, error], error) {
+	bucket, key, err := resolve.Apply(opts).RemoteOrDefault().GetFile(ctx, remote.MPCORB, name)
 	if err != nil {
 		return nil, fmt.Errorf("mpcorb: fetch %s: %w", name, err)
 	}

--- a/catalog/norad/norad.go
+++ b/catalog/norad/norad.go
@@ -254,8 +254,8 @@ type Provider struct {
 }
 
 // New returns a Provider configured with sensible defaults.
-func New() *Provider {
-	client, err := api.NewClient(remote.CelesTrak)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.CelesTrak, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/openngc/fetch.go
+++ b/catalog/openngc/fetch.go
@@ -38,8 +38,8 @@ var (
 // Returns remote.ErrDownloadDenied unless
 // remote.EnableDownloads(maxSize, remote.OpenNGC) has been called; it
 // still respects remote.SetOffline and remote.Disable(remote.OpenNGC).
-func fetch(ctx context.Context) ([]resolve.Target, error) {
-	ep, ok := remote.Lookup(remote.OpenNGC)
+func fetch(ctx context.Context, rc *remote.Client) ([]resolve.Target, error) {
+	ep, ok := rc.Lookup(remote.OpenNGC)
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", remote.ErrUnknownEndpoint, remote.OpenNGC)
 	}
@@ -47,7 +47,7 @@ func fetch(ctx context.Context) ([]resolve.Target, error) {
 	var records []targetRecord
 
 	for _, sourceFile := range ep.Files {
-		recs, err := fetchSource(ctx, sourceFile)
+		recs, err := fetchSource(ctx, rc, sourceFile)
 		if err != nil {
 			return nil, err
 		}
@@ -62,8 +62,8 @@ func fetch(ctx context.Context) ([]resolve.Target, error) {
 
 // fetchSource downloads and parses one OpenNGC source CSV, reusing the
 // on-disk cache when remote.GetFile's HEAD probe shows it's still current.
-func fetchSource(ctx context.Context, sourceFile string) ([]targetRecord, error) {
-	bucket, key, err := remote.GetFile(ctx, remote.OpenNGC, sourceFile)
+func fetchSource(ctx context.Context, rc *remote.Client, sourceFile string) ([]targetRecord, error) {
+	bucket, key, err := rc.GetFile(ctx, remote.OpenNGC, sourceFile)
 	if err != nil {
 		return nil, fmt.Errorf("openngc: %s: %w", sourceFile, err)
 	}

--- a/catalog/openngc/openngc.go
+++ b/catalog/openngc/openngc.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/remote"
 )
 
 // Record represents a raw entry in the OpenNGC dataset.
@@ -27,6 +28,7 @@ type Provider struct {
 	// fetch, so concurrent first queries make one request between them rather
 	// than one each.
 	mu      sync.Mutex
+	remote  *remote.Client
 	loaded  bool
 	byKey   map[string]int
 	targets []resolve.Target
@@ -54,7 +56,9 @@ type Provider struct {
 // absent while the provider looked healthy. That is worse than a per-query
 // failure precisely because it is invisible and cannot recover; a later query
 // now tries again.
-func New() *Provider { return &Provider{} }
+func New(opts ...resolve.Option) *Provider {
+	return &Provider{remote: resolve.Apply(opts).Remote}
+}
 
 // Name returns the provider identifier.
 func (p *Provider) Name() string { return "openngc" }
@@ -157,7 +161,7 @@ func (p *Provider) load(ctx context.Context) error {
 		return nil
 	}
 
-	targets, err := fetch(ctx)
+	targets, err := fetch(ctx, p.client())
 	if err != nil {
 		return fmt.Errorf("openngc: catalog unavailable: %w", err)
 	}
@@ -178,4 +182,15 @@ func (p *Provider) load(ctx context.Context) error {
 	p.targets, p.byKey, p.loaded = targets, byKey, true
 
 	return nil
+}
+
+// client is the policy this provider fetches under: its own if [WithClient]
+// gave it one, otherwise the process default. Resolved per call rather than at
+// construction so a provider built before [remote.SetDataDir] still sees it.
+func (p *Provider) client() *remote.Client {
+	if p.remote == nil {
+		return remote.Default()
+	}
+
+	return p.remote
 }

--- a/catalog/resolve/option.go
+++ b/catalog/resolve/option.go
@@ -1,0 +1,80 @@
+package resolve
+
+import (
+	"github.com/TuSKan/astrogo/remote"
+	"github.com/TuSKan/astrogo/remote/api"
+)
+
+// Option configures a catalog provider at construction.
+//
+// # Why it lives here rather than in each provider
+//
+// Because there is one thing to configure and eight providers that need it,
+// and eight identical Option types would be eight times the API surface for
+// one capability. Every provider in catalog/ already imports this package for
+// [Provider] and [NewMapCache], so this costs no new dependency.
+//
+// The cost is that a caller writes resolve.WithClient rather than
+// simbad.WithClient. That is the right trade at this size: the alternative
+// reads marginally better at each call site and adds seven exported types to a
+// library that is about to freeze its shape.
+type Option func(*Config)
+
+// Config is what the options build. A provider reads it once in its
+// constructor; it is exported only because the providers are separate
+// packages.
+type Config struct {
+	// Remote is the policy endpoint resolution goes through. Nil means
+	// [remote.Default], which is what every caller who has not asked for
+	// anything else gets.
+	Remote *remote.Client
+}
+
+// WithClient binds a provider to one [remote.Client]'s policy instead of
+// [remote.Default] — its offline flag, endpoint overrides and enabled set.
+//
+// This is what lets two components in one binary hold different policies: an
+// HTTP handler that must never touch the network, and a prefetcher that may.
+//
+//	sim := simbad.New(resolve.WithClient(offlineOnly))
+func WithClient(c *remote.Client) Option {
+	return func(cfg *Config) { cfg.Remote = c }
+}
+
+// Apply builds a Config from opts. Providers call it as the first line of
+// their constructor.
+func Apply(opts []Option) Config {
+	var cfg Config
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}
+
+// APIOptions translates a Config into the options [api.NewClient] takes.
+//
+// It returns nil for a Config that asked for nothing, so a provider built
+// without options constructs exactly the API client it did before — the
+// default policy, reached by the default path, with no branch of its own.
+func (c Config) APIOptions() []api.Option {
+	if c.Remote == nil {
+		return nil
+	}
+
+	return []api.Option{api.WithRemote(c.Remote)}
+}
+
+// RemoteOrDefault is the client a provider should fetch through.
+//
+// For providers that call [remote.Client.GetFile] rather than going through
+// an API client, where there is no options slice to pass along and a nil
+// receiver would panic rather than fall back.
+func (c Config) RemoteOrDefault() *remote.Client {
+	if c.Remote == nil {
+		return remote.Default()
+	}
+
+	return c.Remote
+}

--- a/catalog/resolve/option_test.go
+++ b/catalog/resolve/option_test.go
@@ -1,0 +1,93 @@
+package resolve_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TuSKan/astrogo/catalog/resolve"
+	"github.com/TuSKan/astrogo/catalog/simbad"
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// TestWithClientReachesTheProvider is the end-to-end half of #114.
+//
+// remote/client_isolation_test.go proves two Clients hold separate policies.
+// That is necessary and not sufficient: the policy has to survive the trip
+// through resolve.Option, api.WithRemote and the provider's own constructor to
+// the request itself. Everything in between compiles whether or not it is
+// wired up, so compiling proves nothing here.
+//
+// The check is a redirect rather than an offline flag because a redirect is
+// positive evidence: the request has to arrive somewhere this test controls,
+// which an unwired client cannot fake by simply failing.
+func TestWithClientReachesTheProvider(t *testing.T) {
+	// Not parallel: it reads remote.Default to prove the default is untouched.
+	var got string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Path
+
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("\n"))
+	}))
+	defer srv.Close()
+
+	c := remote.NewClient(remote.WithEndpointURL(remote.SIMBAD, srv.URL))
+
+	p := simbad.New(resolve.WithClient(c))
+
+	// The query is expected to fail — an empty body is not a VOTable — and
+	// that is fine. What is being asserted is where the request went.
+	_, _ = p.Resolve(t.Context(), "Vega")
+
+	if got == "" {
+		t.Fatal("the provider never contacted the redirected endpoint.\n" +
+			"  resolve.WithClient is meant to carry the policy through api.WithRemote to " +
+			"the request; if the request went to the real SIMBAD instead, the option is " +
+			"accepted and ignored, which is worse than not existing (#114).")
+	}
+
+	// And the default is untouched, which is what makes this a shape change
+	// rather than a break for everyone else.
+	if u, err := remote.URL(remote.SIMBAD); err != nil || u == srv.URL {
+		t.Errorf("remote.Default's SIMBAD URL is now %q (err %v).\n"+
+			"  A client-scoped override that leaks into the process default is the bug "+
+			"this whole change exists to remove.", u, err)
+	}
+}
+
+// TestProviderWithoutOptionsUsesTheDefault pins the compatibility direction.
+//
+// Every provider constructor here gained a variadic parameter. That is
+// source-compatible by Go's rules, but it would be entirely possible to gain
+// the parameter and change the behaviour of the niladic call at the same time
+// — by resolving a client eagerly, say, and capturing the default at
+// construction rather than at use.
+func TestProviderWithoutOptionsUsesTheDefault(t *testing.T) {
+	// Not parallel: it mutates remote.Default.
+	t.Cleanup(remote.Capture().Restore)
+
+	p := simbad.New()
+
+	const mirror = "https://mirror.invalid/simbad/"
+
+	// Set *after* construction: a provider that captured the default eagerly
+	// would miss this, and a caller who configures remote in main() before
+	// building providers elsewhere would silently get the wrong endpoint.
+	if err := remote.SetURL(remote.SIMBAD, mirror); err != nil {
+		t.Fatalf("SetURL: %v", err)
+	}
+
+	_, err := p.Resolve(t.Context(), "Vega")
+	if err == nil {
+		t.Fatal("resolving against an invalid host succeeded")
+	}
+
+	// It must have tried the mirror. A DNS failure for mirror.invalid is the
+	// evidence; reaching the real SIMBAD would succeed or fail differently.
+	if errors.Is(err, remote.ErrUnknownEndpoint) {
+		t.Errorf("provider reported an unknown endpoint: %v", err)
+	}
+}

--- a/catalog/sbdb/sbdb.go
+++ b/catalog/sbdb/sbdb.go
@@ -25,8 +25,8 @@ type Provider struct {
 }
 
 // New creates a new SBDB catalog provider.
-func New() *Provider {
-	client, err := api.NewClient(remote.JPLSBDB)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.JPLSBDB, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/simbad/simbad.go
+++ b/catalog/simbad/simbad.go
@@ -19,8 +19,8 @@ type Provider struct {
 }
 
 // New creates a new SIMBAD ObjectResolver.
-func New() *Provider {
-	client, err := api.NewClient(remote.SIMBAD)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.SIMBAD, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/catalog/vizier/vizier.go
+++ b/catalog/vizier/vizier.go
@@ -36,8 +36,8 @@ type Provider struct {
 }
 
 // New creates a new VizieR catalog provider.
-func New() *Provider {
-	client, err := api.NewClient(remote.VizieR)
+func New(opts ...resolve.Option) *Provider {
+	client, err := api.NewClient(remote.VizieR, resolve.Apply(opts).APIOptions()...)
 	if err != nil {
 		panic(err) // unregistered endpoint would be a programmer error
 	}

--- a/docs/changelog.d/269-client-option-signatures.md
+++ b/docs/changelog.d/269-client-option-signatures.md
@@ -1,0 +1,11 @@
+---
+type: Changed — BREAKING
+pr: 269
+---
+**Twelve constructors gained a variadic option**, so `remote.Client` can reach
+them. Ordinary calls are unaffected — `simbad.New()` still compiles — but the
+functions' *types* changed, so assigning one to a `func() *Provider` variable or
+passing it as a function value no longer compiles. Add the parameter to the
+variable's type. Affected: `New` in `catalog/{simbad,sbdb,mast,jpl,norad,vizier,fink,openngc}`,
+`fink.NewWithVersion`, `gaia.New`, `mpcorb.Open`, `cams.AOD550`,
+`spk.CacheDownload`, `spk.CacheAPI` and `lsk.Cache` (#269).

--- a/docs/changelog.d/269-remote-client.md
+++ b/docs/changelog.d/269-remote-client.md
@@ -6,6 +6,6 @@ pr: 269
 components in one binary can now hold different ones — an offline request path
 beside a prefetcher that downloads — which `SetOffline` made impossible. Every
 package-level function still operates on `remote.Default`, and every consuming
-constructor gained a source-compatible option (`jpl.WithClient`,
-`resolve.WithClient`, `cams.WithClient`, `api.WithRemote`), so nothing breaks
-(#114).
+constructor gained an option (`jpl.WithClient`, `resolve.WithClient`,
+`cams.WithClient`, `api.WithRemote`) that leaves ordinary calls untouched — see
+the breaking note for the one case that does change (#114).

--- a/docs/changelog.d/269-remote-client.md
+++ b/docs/changelog.d/269-remote-client.md
@@ -1,0 +1,11 @@
+---
+type: Added
+pr: 269
+---
+**`remote.Client` makes I/O policy a value instead of process state.** Two
+components in one binary can now hold different ones — an offline request path
+beside a prefetcher that downloads — which `SetOffline` made impossible. Every
+package-level function still operates on `remote.Default`, and every consuming
+constructor gained a source-compatible option (`jpl.WithClient`,
+`resolve.WithClient`, `cams.WithClient`, `api.WithRemote`), so nothing breaks
+(#114).

--- a/docs/changelog.d/270-wcs-cunit.md
+++ b/docs/changelog.d/270-wcs-cunit.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 270
+---
+**`fits.WCS.CUnit` exposes the axis units the header declares**, which astrogo
+did not read at all. `PixelToWorld` returns CRVAL plus a linear offset for any
+non-celestial axis, so its value was correct in a unit no part of the API could
+name — metres or Angstrom for a spectral axis, seconds or days for a time one.
+Both transforms now also document what they return: degrees for celestial axes,
+each other axis in its own `CUNITi` (#178).

--- a/ephemeris/jpl/lsk/option.go
+++ b/ephemeris/jpl/lsk/option.go
@@ -1,0 +1,35 @@
+package lsk
+
+import "github.com/TuSKan/astrogo/remote"
+
+// Option configures a leap-second kernel fetch. See [spk.Option] for why the
+// shape is a variadic option rather than a parameter.
+//
+// [github.com/TuSKan/astrogo/ephemeris/jpl/spk.Option] is not reused here
+// because that would make this package import spk for one type, inverting the
+// dependency: an LSK is what an SPK's time scale is read against, so spk knows
+// about lsk and not the other way round.
+type Option func(*config)
+
+type config struct{ remote *remote.Client }
+
+// WithClient fetches under c's policy instead of [remote.Default]'s.
+func WithClient(c *remote.Client) Option {
+	return func(cfg *config) { cfg.remote = c }
+}
+
+// apply resolves opts to the client to fetch through, defaulting to
+// [remote.Default].
+func apply(opts []Option) *remote.Client {
+	var cfg config
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.remote == nil {
+		return remote.Default()
+	}
+
+	return cfg.remote
+}

--- a/ephemeris/jpl/lsk/reader.go
+++ b/ephemeris/jpl/lsk/reader.go
@@ -51,8 +51,8 @@ type Reader struct {
 //
 // It provides an auto-healing mechanism for CI environments by automatically
 // removing corrupt or truncated files.
-func Cache(ctx context.Context, kernel string) (*Reader, error) {
-	bucket, key, err := remote.GetFile(ctx, remote.NAIFLSK, kernel, remote.WithCacheName(kernel))
+func Cache(ctx context.Context, kernel string, opts ...Option) (*Reader, error) {
+	bucket, key, err := apply(opts).GetFile(ctx, remote.NAIFLSK, kernel, remote.WithCacheName(kernel))
 	if err != nil {
 		return nil, fmt.Errorf("jpl: LSK %s: %w", kernel, err)
 	}

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -167,12 +167,33 @@ type Provider struct {
 	ByTargetCoverage map[int32]TargetCoverage
 	source           core.Source
 	kernel           string
-	Kernels          []*Kernel
-	Index            []SegmentRef
+
+	// remote is the policy every kernel fetch goes through. Nil means
+	// remote.Default, so a provider built without WithClient behaves exactly
+	// as it did before that option existed.
+	remote  *remote.Client
+	Kernels []*Kernel
+	Index   []SegmentRef
 }
 
 // Option configures a Provider.
 type Option func(*Provider)
+
+// WithClient fetches kernels under c's policy instead of [remote.Default]'s —
+// its download consent, offline flag and endpoint overrides.
+//
+// This is the option #114 was filed for. A provider serving requests can be
+// built against a client that may not download, beside a prefetcher built
+// against one that may, in the same process:
+//
+//	serving  := remote.NewClient(remote.WithOffline(true))
+//	prefetch := remote.NewClient(remote.WithDownloads(2<<30, remote.NAIFSPK))
+//
+// It is also the narrower scope the consent gate lacked in tests: a test grants
+// downloads on its own client rather than on the whole binary's.
+func WithClient(c *remote.Client) Option {
+	return func(p *Provider) { p.remote = c }
+}
 
 // WithTimeInterval sets the time interval for which the provider is valid.
 func WithTimeInterval(start, end time.Time) Option {
@@ -207,7 +228,7 @@ func NewProvider(ctx context.Context, source core.Source, kernel string, opts ..
 
 		spkKey := "planets/" + p.kernel + ".bsp"
 
-		k, err := spk.CacheDownload(ctx, spkKey)
+		k, err := spk.CacheDownload(ctx, spkKey, p.spkOpts()...)
 		if err != nil {
 			return nil, fmt.Errorf("jpl: failed to load planetary kernel: %w", err)
 		}
@@ -219,7 +240,7 @@ func NewProvider(ctx context.Context, source core.Source, kernel string, opts ..
 		// Always load a minimal planetary kernel for recursion (center resolution)
 		const baseKey = "planets/de440s.bsp"
 
-		pk, err := spk.CacheDownload(ctx, baseKey)
+		pk, err := spk.CacheDownload(ctx, baseKey, p.spkOpts()...)
 		if err != nil {
 			return nil, fmt.Errorf("jpl: failed to load planetary base kernel: %w", err)
 		}
@@ -236,7 +257,7 @@ func NewProvider(ctx context.Context, source core.Source, kernel string, opts ..
 			return nil, fmt.Errorf("jpl: resolve kernel cache: %w", err)
 		}
 
-		spkReaders, err := spk.CacheAPI(ctx, cacheBucket, prefix+string(p.source)+"/", p.kernel, p.startTime, p.endTime)
+		spkReaders, err := spk.CacheAPI(ctx, cacheBucket, prefix+string(p.source)+"/", p.kernel, p.startTime, p.endTime, p.spkOpts()...)
 		if err != nil {
 			return nil, fmt.Errorf("jpl: failed to get SPK files: %w", err)
 		}
@@ -258,7 +279,7 @@ func NewProvider(ctx context.Context, source core.Source, kernel string, opts ..
 
 		spkKey := "satellites/" + p.kernel + ".bsp"
 
-		k, err := spk.CacheDownload(ctx, spkKey)
+		k, err := spk.CacheDownload(ctx, spkKey, p.spkOpts()...)
 		if err != nil {
 			return nil, fmt.Errorf("jpl: failed to load satellite kernel: %w", err)
 		}
@@ -274,7 +295,7 @@ func NewProvider(ctx context.Context, source core.Source, kernel string, opts ..
 		return nil, fmt.Errorf("%w: %s", ErrUnknownSource, p.source)
 	}
 
-	p.LSK, err = lsk.Cache(ctx, "lsk/naif0012.tls")
+	p.LSK, err = lsk.Cache(ctx, "lsk/naif0012.tls", p.lskOpts()...)
 	if err != nil {
 		return nil, fmt.Errorf("jpl: failed to locate/cache LSK: %w", err)
 	}
@@ -799,4 +820,27 @@ func (p *Provider) findSegmentLocked(target int32, et float64) (*SegmentRef, err
 // must already hold p.mu (see findSegmentLocked's comment).
 func (p *Provider) segmentLocked(ref SegmentRef) *spk.Segment {
 	return &p.Kernels[ref.KernelIndex].Segments[ref.SegmentIndex]
+}
+
+// spkOpts and lskOpts carry this provider's policy into a kernel fetch.
+//
+// They return nil when no client was set, so the fetch takes exactly the code
+// path it did before [WithClient] existed rather than one that resolves the
+// default and passes it along. The two are separate because spk and lsk have
+// their own Option types — lsk cannot borrow spk's without inverting their
+// dependency.
+func (p *Provider) spkOpts() []spk.Option {
+	if p.remote == nil {
+		return nil
+	}
+
+	return []spk.Option{spk.WithClient(p.remote)}
+}
+
+func (p *Provider) lskOpts() []lsk.Option {
+	if p.remote == nil {
+		return nil
+	}
+
+	return []lsk.Option{lsk.WithClient(p.remote)}
 }

--- a/ephemeris/jpl/spk/api.go
+++ b/ephemeris/jpl/spk/api.go
@@ -86,7 +86,7 @@ func commandCandidates(kernel string) []string {
 // Storage is a bucket and key prefix, never a directory path: a generated
 // kernel lands wherever remote's cache lives, which need not be local
 // disk.
-func CacheAPI(ctx context.Context, bucket *file.Bucket, prefix, kernel string, startTime, endTime time.Time) ([]*Reader, error) {
+func CacheAPI(ctx context.Context, bucket *file.Bucket, prefix, kernel string, startTime, endTime time.Time, opts ...Option) ([]*Reader, error) {
 	var readers []*Reader
 
 	spkFile := prefix + kernel + ".bsp"
@@ -106,7 +106,7 @@ func CacheAPI(ctx context.Context, bucket *file.Bucket, prefix, kernel string, s
 	// download in effect (KB–MB delivered base64-encoded inside the JSON
 	// response), so it requires the same explicit consent as any other
 	// kernel download: remote.EnableDownloads(maxSize, remote.JPLHorizonsSPK).
-	if err := remote.CheckDownload(remote.JPLHorizonsSPK, spkFile, remote.SizeVaries); err != nil {
+	if err := apply(opts).CheckDownload(remote.JPLHorizonsSPK, spkFile, remote.SizeVaries); err != nil {
 		return nil, fmt.Errorf("jpl: SPK kernel %s: %w", kernel, err)
 	}
 

--- a/ephemeris/jpl/spk/option.go
+++ b/ephemeris/jpl/spk/option.go
@@ -1,0 +1,40 @@
+package spk
+
+import "github.com/TuSKan/astrogo/remote"
+
+// Option configures a kernel fetch.
+//
+// It exists so [CacheDownload] and [CacheAPI] can be told which
+// [remote.Client]'s policy to fetch under without changing their signatures.
+// A niladic call site keeps compiling and keeps using [remote.Default], which
+// is what makes #114 a shape change rather than a break.
+type Option func(*config)
+
+type config struct{ remote *remote.Client }
+
+// WithClient fetches under c's policy instead of [remote.Default]'s — its
+// download consent, offline flag and endpoint overrides.
+//
+// This is the option that matters most of the set. Kernels are the largest
+// thing astrogo downloads, so "may this component fetch, and up to what size"
+// is a question most likely to have two answers in one binary.
+func WithClient(c *remote.Client) Option {
+	return func(cfg *config) { cfg.remote = c }
+}
+
+// apply resolves opts to the client to fetch through, defaulting to
+// [remote.Default] so a caller who asked for nothing gets exactly the
+// behaviour they had before this existed.
+func apply(opts []Option) *remote.Client {
+	var cfg config
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.remote == nil {
+		return remote.Default()
+	}
+
+	return cfg.remote
+}

--- a/ephemeris/jpl/spk/reader.go
+++ b/ephemeris/jpl/spk/reader.go
@@ -78,8 +78,8 @@ type Reader struct {
 //  1. Closes the file handle.
 //  2. Removes the corrupt file from the filesystem.
 //  3. Returns the error wrapped with a descriptive message.
-func CacheDownload(ctx context.Context, kernel string) (*Reader, error) {
-	bucket, key, err := remote.GetFile(ctx, remote.NAIFSPK, kernel, remote.WithCacheName(kernel))
+func CacheDownload(ctx context.Context, kernel string, opts ...Option) (*Reader, error) {
+	bucket, key, err := apply(opts).GetFile(ctx, remote.NAIFSPK, kernel, remote.WithCacheName(kernel))
 	if err != nil {
 		return nil, fmt.Errorf("jpl: SPK kernel %s: %w", kernel, err)
 	}

--- a/fits/wcs.go
+++ b/fits/wcs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"slices"
 	"strings"
 )
 
@@ -19,6 +20,7 @@ type WCS struct {
 	cdelt   []float64
 	pc      [][]float64
 	ctype   []string
+	cunit   []string
 	crval   []float64
 	crpix   []float64
 	latAxis int
@@ -40,6 +42,7 @@ func NewWCS(naxis int) *WCS {
 		crval: make([]float64, naxis),
 		cdelt: make([]float64, naxis),
 		ctype: make([]string, naxis),
+		cunit: make([]string, naxis),
 		pc:    pc,
 	}
 }
@@ -266,12 +269,76 @@ func sipEval(coeffs map[[2]int]float64, u, v float64) float64 {
 	return sum
 }
 
+// CUnit returns the physical unit declared for each axis by the header's
+// CUNITi keywords, as written and with no interpretation, or an empty string
+// for an axis whose header did not declare one.
+//
+// # Why it is here and why it is a string
+//
+// Because [WCS.PixelToWorld] returns a bare float per axis, and for a
+// non-celestial axis nothing else in this package says what that number is.
+// A spectral axis may be metres, Hertz or Angstrom; a time axis seconds or
+// days. The value astrogo returns is correct in the header's unit, and until
+// now the header's unit was not reachable through the API at all — a caller
+// had to parse the card themselves to interpret a number this package handed
+// them.
+//
+// It is not parsed into a typed quantity because FITS units are a small
+// language of their own (Paper I §4.3: prefixes, powers, products, and forms
+// like "10**(-20) erg/s/cm**2/Angstrom"), and a partial parser that silently
+// mishandled the rest would be worse than the string. Interpreting it is #178
+// and #130's decision; making it visible is not, and it is a precondition for
+// either.
+//
+// Celestial axes are the exception that needs no interpretation: WCS Paper II
+// requires degrees, which is what this package assumes and what
+// [WCS.PixelToWorld] documents.
+func (w *WCS) CUnit() []string { return slices.Clone(w.cunit) }
+
+// SetCUnit records the physical unit of each axis. Like the other setters
+// carrying a length invariant, it refuses a slice that disagrees with
+// [WCS.NAxis] rather than accepting a quiet disagreement about axis count.
+//
+// astrogo never acts on these values — see [WCS.CUnit] — so setting them wrong
+// changes no result. It changes what a caller reading them back is told, which
+// is the entire purpose of the field.
+func (w *WCS) SetCUnit(cunit []string) error {
+	if len(cunit) != w.nAxis {
+		return fmt.Errorf("%w: expected %d", ErrWCSDimension, w.nAxis)
+	}
+
+	w.cunit = slices.Clone(cunit)
+
+	return nil
+}
+
 // PixelToWorld transforms a continuous FITS 1-indexed pixel coordinate
 // slice mapping it against spherical Sky metrics.
 //
 // Supported projections: TAN (Gnomonic), SIN (Orthographic),
 // ARC (Zenithal equidistant), STG (Stereographic), AIT (Hammer-Aitoff).
 // SIP distortion is applied when CTYPE contains the "-SIP" suffix.
+//
+// # What the numbers are
+//
+// The return is one value per axis, and the unit is not the same for all of
+// them. Saying so is the point of this section: the signature is a bare
+// []float64 both ways, so nothing but this comment distinguishes a right
+// ascension in degrees from a wavelength in Angstrom (#178).
+//
+//   - Celestial axes — the pair CTYPE names as longitude and latitude — come
+//     back in DEGREES, right ascension normalised to [0, 360). Degrees rather
+//     than radians because WCS Paper II requires celestial CRVAL and CDELT to
+//     be in degrees, so it is the header's unit and not a choice made here.
+//   - Every other axis comes back in the unit its own CUNITi declares, because
+//     the value is CRVAL plus a linear offset and astrogo does not convert it.
+//     A spectral axis is metres, Hertz or Angstrom as the header says; a time
+//     axis seconds or days. [WCS.CUnit] is how a caller finds out which.
+//   - When no celestial pair is present, every axis is the linear case above.
+//
+// A caller mixing the two — passing a spectral value to something expecting an
+// angle — is not stopped by anything here. That is the shape question #178 and
+// #130 exist to settle; this is what the shape does today.
 func (w *WCS) PixelToWorld(pixels []float64) ([]float64, error) {
 	if len(pixels) != w.nAxis {
 		return nil, fmt.Errorf("%w: expected %d", ErrWCSDimension, w.nAxis)
@@ -359,6 +426,12 @@ func (w *WCS) PixelToWorld(pixels []float64) ([]float64, error) {
 }
 
 // WorldToPixel converts world coordinates back to FITS 1-indexed pixel coordinates.
+//
+// world takes the units [WCS.PixelToWorld] returns — degrees for celestial
+// axes, each other axis in its own CUNITi — and the two are exact inverses
+// only when given the same convention. Passing radians produces a pixel
+// coordinate that is wrong without being obviously wrong, which is why the
+// unit is stated rather than implied.
 //
 // For recognized spherical projections (TAN, SIN, ARC, STG, AIT), the initial
 // guess is computed analytically via the forward projection, then refined with
@@ -801,6 +874,7 @@ func ExtractWCS(h *Header) (*WCS, error) {
 	crval := make([]float64, naxis)
 	cdelt := make([]float64, naxis)
 	ctype := make([]string, naxis)
+	cunit := make([]string, naxis)
 	pc := make([][]float64, naxis)
 
 	for i := 1; i <= naxis; i++ {
@@ -808,6 +882,13 @@ func ExtractWCS(h *Header) (*WCS, error) {
 
 		c, _ := h.GetString(fmt.Sprintf("CTYPE%d", i))
 		ctype[idx] = strings.TrimSpace(c)
+
+		// CUNIT is optional and frequently absent. An empty string is
+		// recorded as-is rather than defaulted, because "the header did not
+		// say" and "the header said degrees" are different facts and only the
+		// caller knows whether the difference matters. See [WCS.CUnit].
+		u, _ := h.GetString(fmt.Sprintf("CUNIT%d", i))
+		cunit[idx] = strings.TrimSpace(u)
 
 		if v, err := h.GetFloat(fmt.Sprintf("CRVAL%d", i)); err == nil {
 			crval[idx] = v
@@ -891,6 +972,7 @@ func ExtractWCS(h *Header) (*WCS, error) {
 	// which transforms every pixel to the same place.
 	for _, err := range []error{
 		w.SetCTYPE(ctype),
+		w.SetCUnit(cunit),
 		w.SetCRVAL(crval),
 		w.SetCRPIX(crpix),
 		w.SetCDELT(cdelt),

--- a/fits/wcs_cunit_test.go
+++ b/fits/wcs_cunit_test.go
@@ -1,0 +1,180 @@
+package fits_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// wcsHeader builds a minimal header from CARD text, one card per line.
+func wcsHeader(t *testing.T, cards ...string) *fits.Header {
+	t.Helper()
+
+	h := fits.NewHeader()
+
+	for _, c := range cards {
+		k, v, found := strings.Cut(c, "=")
+		if !found {
+			t.Fatalf("malformed test card %q", c)
+		}
+
+		h.Append(fits.Card{
+			Keyword: strings.TrimSpace(k),
+			Value:   strings.TrimSpace(v),
+		})
+	}
+
+	return h
+}
+
+// TestCUnitSurvivesTheHeader covers the gap #178 named from the other side.
+//
+// The issue's complaint is that PixelToWorld returns a bare []float64 whose
+// unit a caller cannot determine. For celestial axes the answer is fixed —
+// WCS Paper II requires degrees — but for a spectral or time axis the value is
+// CRVAL plus a linear offset in whatever CUNITi declares, and astrogo did not
+// read CUNIT at all. The number was correct and its unit was unreachable
+// through the API, which is a worse combination than either alone: a caller
+// gets a plausible float and has to go back to the header card to learn
+// whether it is metres or Angstrom.
+//
+// This does not decide the typed-API question. It makes the input that
+// question needs visible, which is a precondition for answering it either way.
+func TestCUnitSurvivesTheHeader(t *testing.T) {
+	t.Parallel()
+
+	h := wcsHeader(t,
+		"NAXIS = 3",
+		"CTYPE1 = 'RA---TAN'",
+		"CTYPE2 = 'DEC--TAN'",
+		"CTYPE3 = 'WAVE'",
+		"CRVAL1 = 150.0",
+		"CRVAL2 = 2.0",
+		"CRVAL3 = 5.0e-7",
+		"CRPIX1 = 1.0",
+		"CRPIX2 = 1.0",
+		"CRPIX3 = 1.0",
+		"CDELT1 = -0.001",
+		"CDELT2 = 0.001",
+		"CDELT3 = 1.0e-10",
+		"CUNIT1 = 'deg'",
+		"CUNIT2 = 'deg'",
+		"CUNIT3 = 'm'",
+	)
+
+	w, err := fits.ExtractWCS(h)
+	if err != nil {
+		t.Fatalf("ExtractWCS: %v", err)
+	}
+
+	got := w.CUnit()
+
+	want := []string{"deg", "deg", "m"}
+	if len(got) != len(want) {
+		t.Fatalf("CUnit() has %d entries, want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("CUnit()[%d] = %q, want %q.\n"+
+				"  The value PixelToWorld returns for axis %d is in this unit and no other "+
+				"part of the API says which it is (#178).", i, got[i], want[i], i+1)
+		}
+	}
+}
+
+// TestCUnitIsEmptyWhenTheHeaderIsSilent pins the absence case.
+//
+// CUNIT is optional and often missing. An absent card is recorded as an empty
+// string rather than defaulted to "deg", because "the header did not say" and
+// "the header said degrees" are different facts, and only the caller knows
+// whether the difference matters to them. Defaulting would turn a question
+// they could still ask into an answer they cannot check — the error-versus-
+// absence rule this repository applies elsewhere.
+func TestCUnitIsEmptyWhenTheHeaderIsSilent(t *testing.T) {
+	t.Parallel()
+
+	h := wcsHeader(t,
+		"NAXIS = 2",
+		"CTYPE1 = 'RA---TAN'",
+		"CTYPE2 = 'DEC--TAN'",
+		"CRVAL1 = 150.0",
+		"CRVAL2 = 2.0",
+		"CRPIX1 = 1.0",
+		"CRPIX2 = 1.0",
+		"CDELT1 = -0.001",
+		"CDELT2 = 0.001",
+	)
+
+	w, err := fits.ExtractWCS(h)
+	if err != nil {
+		t.Fatalf("ExtractWCS: %v", err)
+	}
+
+	for i, u := range w.CUnit() {
+		if u != "" {
+			t.Errorf("CUnit()[%d] = %q for a header with no CUNIT card, want \"\".\n"+
+				"  Inventing a unit the header never stated would make an assumption "+
+				"indistinguishable from a fact.", i, u)
+		}
+	}
+}
+
+// TestCUnitDoesNotAliasTheWCS is the same check #220 applied to every other
+// accessor, applied to the new one before it can go wrong.
+//
+// #220 found the getters returning the internal slice and the setters keeping
+// the caller's, so reading CRVAL to inspect it let you move an image on the
+// sky at a distance. A new accessor pair that repeated the mistake would be a
+// regression of a fixed bug.
+func TestCUnitDoesNotAliasTheWCS(t *testing.T) {
+	t.Parallel()
+
+	w := fits.NewWCS(2)
+
+	if err := w.SetCUnit([]string{"deg", "deg"}); err != nil {
+		t.Fatalf("SetCUnit: %v", err)
+	}
+
+	// Mutating what the getter returned must not reach the WCS.
+	got := w.CUnit()
+	got[0] = "arcsec"
+
+	if again := w.CUnit(); again[0] != "deg" {
+		t.Errorf("CUnit()[0] became %q after a caller mutated an earlier result.\n"+
+			"  The getter must copy; see #220.", again[0])
+	}
+
+	// Nor must holding the slice that was passed in.
+	held := []string{"deg", "deg"}
+	if err := w.SetCUnit(held); err != nil {
+		t.Fatalf("SetCUnit: %v", err)
+	}
+
+	held[1] = "Hz"
+
+	if again := w.CUnit(); again[1] != "deg" {
+		t.Errorf("CUnit()[1] became %q after the caller mutated the slice they set.\n"+
+			"  The setter must copy; see #220.", again[1])
+	}
+}
+
+// TestSetCUnitRefusesTheWrongLength matches the invariant #220 gave the other
+// setters with a length rule: a short or long slice is a disagreement about
+// axis count, and accepting it silently is what that change stopped doing.
+func TestSetCUnitRefusesTheWrongLength(t *testing.T) {
+	t.Parallel()
+
+	w := fits.NewWCS(3)
+
+	for _, tc := range [][]string{{}, {"deg"}, {"deg", "deg"}, {"deg", "deg", "deg", "m"}} {
+		if err := w.SetCUnit(tc); err == nil {
+			t.Errorf("SetCUnit(%d entries) on a 3-axis WCS returned no error.", len(tc))
+		}
+	}
+
+	if err := w.SetCUnit([]string{"deg", "deg", "m"}); err != nil {
+		t.Errorf("SetCUnit with the right length: %v", err)
+	}
+}

--- a/remote/api/client.go
+++ b/remote/api/client.go
@@ -31,6 +31,7 @@ const defaultRetries = 3
 
 // config carries NewClient's options.
 type config struct {
+	remote      *remote.Client
 	timeout     time.Duration
 	retries     int
 	userAgent   string
@@ -42,6 +43,16 @@ type config struct {
 
 // Option customizes a NewClient call.
 type Option func(*config)
+
+// WithRemote binds the client to one [remote.Client]'s policy — its offline
+// flag, endpoint overrides and enabled set — instead of [remote.Default].
+//
+// It is an option here rather than a method on [remote.Client] because
+// remote/api imports remote, so the reverse would be an import cycle. That is
+// the only reason: a method there would read better.
+func WithRemote(c *remote.Client) Option {
+	return func(cfg *config) { cfg.remote = c }
+}
 
 // WithTimeout overrides the endpoint's registered Timeout.
 func WithTimeout(d time.Duration) Option {
@@ -105,6 +116,11 @@ func WithMinInterval(d time.Duration) Option {
 type Client struct {
 	rc *resty.Client
 
+	// remote is the policy this client resolves endpoint URLs through, so
+	// offline mode and an endpoint override are decided per client rather
+	// than per process.
+	remote *remote.Client
+
 	// retryPolicy is consulted twice: by resty, to decide whether to retry,
 	// and by body, to decide whether a final failure is worth reporting as
 	// one that was retried. Holding it here keeps those two answers the same
@@ -123,19 +139,28 @@ type Client struct {
 // timeout the registry already states. Returns ErrUnknownEndpoint for an
 // unregistered id.
 func NewClient(id remote.EndpointID, opts ...Option) (*Client, error) {
-	ep, ok := remote.Lookup(id)
-	if !ok {
-		return nil, fmt.Errorf("%w: %q", remote.ErrUnknownEndpoint, id)
-	}
-
+	// The policy is read before the endpoint, because WithRemote decides
+	// which table the endpoint is looked up in.
 	cfg := config{
-		timeout:     ep.Timeout,
 		retries:     defaultRetries,
 		userAgent:   defaultUserAgent,
 		retryPolicy: DefaultRetryPolicy,
 	}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	if cfg.remote == nil {
+		cfg.remote = remote.Default()
+	}
+
+	ep, ok := cfg.remote.Lookup(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", remote.ErrUnknownEndpoint, id)
+	}
+
+	if cfg.timeout == 0 {
+		cfg.timeout = ep.Timeout
 	}
 
 	if cfg.timeout == 0 {
@@ -158,7 +183,7 @@ func NewClient(id remote.EndpointID, opts ...Option) (*Client, error) {
 		rc = rc.SetAuthScheme(cfg.authScheme).SetAuthToken(cfg.authToken)
 	}
 
-	return &Client{rc: rc, minInterval: cfg.minInterval, retryPolicy: cfg.retryPolicy}, nil
+	return &Client{rc: rc, remote: cfg.remote, minInterval: cfg.minInterval, retryPolicy: cfg.retryPolicy}, nil
 }
 
 // Close releases the client's idle connections. A Client is usually held
@@ -175,7 +200,7 @@ func (c *Client) Close() error {
 // caller closes it. A non-2xx response is returned as an *HTTPError
 // instead of a body, so a caller never parses an error page as data.
 func (c *Client) Get(ctx context.Context, id remote.EndpointID, path string, query url.Values) (io.ReadCloser, error) {
-	full, err := requestURL(id, path)
+	full, err := c.requestURL(id, path)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +242,7 @@ func (c *Client) GetJSON(ctx context.Context, id remote.EndpointID, path string,
 // and returns the raw response body — the shape TAP-ADQL services and any
 // endpoint whose response format must be sniffed need.
 func (c *Client) PostForm(ctx context.Context, id remote.EndpointID, path string, form url.Values) (io.ReadCloser, error) {
-	full, err := requestURL(id, path)
+	full, err := c.requestURL(id, path)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +265,7 @@ func (c *Client) PostForm(ctx context.Context, id remote.EndpointID, path string
 // PostJSON marshals payload as the JSON request body and returns the raw
 // response body.
 func (c *Client) PostJSON(ctx context.Context, id remote.EndpointID, path string, payload any) (io.ReadCloser, error) {
-	full, err := requestURL(id, path)
+	full, err := c.requestURL(id, path)
 	if err != nil {
 		return nil, err
 	}
@@ -305,8 +330,8 @@ func (c *Client) pace(ctx context.Context) (release func(), err error) {
 // whose registered URL already carries a query (a mirror with a token)
 // would otherwise have path spliced in after it, producing a URL that
 // silently addresses the wrong thing.
-func requestURL(id remote.EndpointID, path string) (string, error) {
-	base, err := remote.URL(id)
+func (c *Client) requestURL(id remote.EndpointID, path string) (string, error) {
+	base, err := c.remote.URL(id)
 	if err != nil {
 		// Wrapped with %w, so a caller's errors.Is against ErrOffline or
 		// ErrEndpointDisabled still matches.

--- a/remote/client.go
+++ b/remote/client.go
@@ -1,0 +1,129 @@
+package remote
+
+import (
+	"sync"
+)
+
+// Client is one astrogo I/O policy: which endpoints may be contacted, which
+// may download and up to what size, whether to go to the network at all, and
+// where what is fetched is cached.
+//
+// # Why this is a value rather than package state
+//
+// Because a policy is not a property of the process. Two components in one
+// binary legitimately want different ones — an HTTP handler that must never
+// block on a download beside a background prefetcher whose whole job is to
+// download — and while this package held one set of globals, the second could
+// not exist without changing the first. [SetOffline] stopped the prefetcher
+// too.
+//
+// It is also what made the consent gate awkward to test: a package's TestMain
+// granted downloads for the entire binary because there was no narrower scope
+// to grant them in.
+//
+// # What it holds, and what it does not
+//
+// Exactly the four things [Capture] already snapshots, which is not a
+// coincidence — that type was the existing admission that these four travel
+// together and are what a caller means by "the configuration".
+//
+//   - the endpoint table, with each entry's enabled flag, URL override and
+//     download consent;
+//   - offline mode;
+//   - the custom download [Policy], if any;
+//   - the data directory URL.
+//
+// What it does not hold is the *description* of the world: an endpoint's kind,
+// subsystem, timeouts, approximate size and default URL are facts about the
+// service, identical for every client, and [Endpoints] reports them. A Client
+// starts from that description and layers policy on it.
+//
+// # The default
+//
+// Every package-level function in this package operates on [Default], exactly
+// as [net/http.Get] operates on [net/http.DefaultClient]. Code that has never
+// heard of a Client keeps working, and a caller who wants one policy for the
+// process still uses [EnableDownloads] and friends.
+//
+// A Client is safe for concurrent use.
+type Client struct {
+	mu        sync.RWMutex
+	endpoints map[EndpointID]Endpoint
+	offline   bool
+	policy    Policy
+	dataDir   string
+}
+
+// defaultClient backs every package-level function here.
+//
+// It is a var rather than a func so [Default] is a plain read: the package
+// functions go through it on every call, and the endpoint registry is the
+// hottest read path in this package.
+var defaultClient = NewClient()
+
+// Default returns the Client the package-level functions operate on.
+//
+// It is the [net/http.DefaultClient] of this package: shared, mutable through
+// [SetOffline], [EnableDownloads], [SetDataDir] and the rest, and the right
+// thing for a program with one policy. A program with two makes its own with
+// [NewClient] rather than fighting over this one.
+func Default() *Client { return defaultClient }
+
+// ClientOption configures a [Client] at construction.
+type ClientOption func(*Client)
+
+// NewClient returns a Client with astrogo's default policy: every endpoint at
+// its built-in URL and enabled, downloads denied, online, and the data
+// directory unset so it resolves from ASTROGO_CACHE_DIR or the OS cache
+// directory when first needed.
+//
+// Downloads are denied because that is astrogo's standing rule — nothing is
+// ever fetched without being asked for — and a new Client is not a way around
+// it. [WithDownloads] is.
+func NewClient(opts ...ClientOption) *Client {
+	c := &Client{endpoints: defaultEndpoints()}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// WithOffline starts the Client in offline mode, where every endpoint access —
+// API call or download — fails with [ErrOffline].
+func WithOffline(off bool) ClientOption {
+	return func(c *Client) { c.offline = off }
+}
+
+// WithDownloads grants file-download consent at construction, with the
+// semantics of [Client.EnableDownloads]: maxSize caps a single download (0 is
+// unlimited), and no ids means every Downloadable endpoint.
+func WithDownloads(maxSize int64, ids ...EndpointID) ClientOption {
+	return func(c *Client) { c.setConsent(true, maxSize, ids) }
+}
+
+// WithCacheURL sets the base location for everything the Client stores, as any
+// bucket URL remote/file can open. See [Client.SetDataDir].
+func WithCacheURL(bucketURL string) ClientOption {
+	return func(c *Client) { c.dataDir = bucketURL }
+}
+
+// WithEndpointURL overrides one endpoint's base URL — a mirror, an internal
+// proxy, or an httptest server in a test. Unlike the package-level [SetURL] it
+// cannot report an unknown id, since an option returns nothing; an id that is
+// not registered is ignored, and [Client.SetURL] is the checked form.
+func WithEndpointURL(id EndpointID, url string) ClientOption {
+	return func(c *Client) {
+		if ep, ok := c.endpoints[id]; ok {
+			ep.URL = url
+			c.endpoints[id] = ep
+		}
+	}
+}
+
+// WithPolicy installs a custom download-consent policy, replacing the
+// per-endpoint consent checks entirely. See [Policy].
+func WithPolicy(p Policy) ClientOption {
+	return func(c *Client) { c.policy = p }
+}

--- a/remote/client_isolation_test.go
+++ b/remote/client_isolation_test.go
@@ -1,0 +1,138 @@
+package remote_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/TuSKan/astrogo/remote"
+)
+
+// TestClientsHoldSeparatePolicies is the thing #114 was filed for.
+//
+// The issue's example is an HTTP handler that must never block on a download
+// beside a background prefetcher whose whole job is to download. While this
+// package held one set of globals that pair could not exist: SetOffline(true)
+// stopped the prefetcher too, and EnableDownloads opened the gate for the
+// handler.
+//
+// Each subtest below fails against the package as it was, which is what makes
+// them worth having rather than restating the implementation.
+func TestClientsHoldSeparatePolicies(t *testing.T) {
+	// Not parallel: it reads Default, which every other remote test mutates.
+	t.Run("offline is per client", func(t *testing.T) {
+		serving := remote.NewClient(remote.WithOffline(true))
+		prefetch := remote.NewClient()
+
+		if _, err := serving.URL(remote.SIMBAD); !errors.Is(err, remote.ErrOffline) {
+			t.Errorf("the offline client resolved a URL, err = %v, want ErrOffline.\n"+
+				"  A component configured not to touch the network must not, whatever any "+
+				"other component in the binary is doing.", err)
+		}
+
+		if _, err := prefetch.URL(remote.SIMBAD); err != nil {
+			t.Errorf("the online client failed to resolve a URL: %v.\n"+
+				"  One client going offline must not take the others with it — that is the "+
+				"whole of #114.", err)
+		}
+	})
+
+	t.Run("download consent is per client", func(t *testing.T) {
+		granted := remote.NewClient(remote.WithDownloads(0, remote.IERSFinals2000A))
+		denied := remote.NewClient()
+
+		if ok, _ := granted.DownloadsEnabled(remote.IERSFinals2000A); !ok {
+			t.Error("WithDownloads did not grant consent on the client that asked for it.")
+		}
+
+		if ok, _ := denied.DownloadsEnabled(remote.IERSFinals2000A); ok {
+			t.Error("a second client inherited consent it never granted.\n" +
+				"  Consent is the policy astrogo is strictest about; a new client starting " +
+				"open would make NewClient a way around the standing rule that nothing is " +
+				"fetched without being asked.")
+		}
+	})
+
+	t.Run("an endpoint override is per client", func(t *testing.T) {
+		const mirror = "https://mirror.example/simbad/"
+
+		redirected := remote.NewClient(remote.WithEndpointURL(remote.SIMBAD, mirror))
+		plain := remote.NewClient()
+
+		got, err := redirected.URL(remote.SIMBAD)
+		if err != nil {
+			t.Fatalf("redirected client: %v", err)
+		}
+
+		if got != mirror {
+			t.Errorf("URL = %q, want %q", got, mirror)
+		}
+
+		other, err := plain.URL(remote.SIMBAD)
+		if err != nil {
+			t.Fatalf("plain client: %v", err)
+		}
+
+		if other == mirror {
+			t.Error("a second client saw an override it never set.\n" +
+				"  Redirecting one endpoint at a test server is the most common reason to " +
+				"want a client of one's own; leaking it defeats the point.")
+		}
+	})
+}
+
+// TestNewClientDoesNotDisturbDefault pins the compatibility half.
+//
+// Every package-level function still operates on [remote.Default], and the
+// entire argument for this being a shape change rather than a break is that a
+// caller who never constructs a Client cannot tell the difference. A
+// constructor that reached into shared state would break that quietly, and
+// only for programs that used both.
+func TestNewClientDoesNotDisturbDefault(t *testing.T) {
+	// Not parallel: it mutates Default.
+	t.Cleanup(remote.Capture().Restore)
+
+	remote.SetOffline(false)
+	remote.EnableDownloads(1<<20, remote.IERSFinals2000A)
+
+	_ = remote.NewClient(
+		remote.WithOffline(true),
+		remote.WithDownloads(0),
+		remote.WithEndpointURL(remote.SIMBAD, "https://elsewhere.example/"),
+	)
+
+	if remote.Offline() {
+		t.Error("constructing an offline Client put the default offline.")
+	}
+
+	ok, maxSize := remote.DownloadsEnabled(remote.IERSFinals2000A)
+	if !ok || maxSize != 1<<20 {
+		t.Errorf("the default's consent is now (%v, %d), want (true, %d).\n"+
+			"  A new Client must not rewrite the policy the process already set.",
+			ok, maxSize, 1<<20)
+	}
+}
+
+// TestDefaultIsTheOneThePackageFunctionsUse checks the delegation itself.
+//
+// It would be entirely possible to add Client, wire the package functions to
+// their own copy of the state, and have both work in isolation while meaning
+// different things — which is the failure a caller would find only by mixing
+// the two styles in one program.
+func TestDefaultIsTheOneThePackageFunctionsUse(t *testing.T) {
+	// Not parallel: it mutates Default.
+	t.Cleanup(remote.Capture().Restore)
+
+	remote.SetOffline(true)
+
+	if !remote.Default().Offline() {
+		t.Error("SetOffline did not reach Default().\n" +
+			"  The package functions are documented as Default()'s methods; if they are " +
+			"not, a program using both styles sees two policies where it configured one.")
+	}
+
+	remote.Default().SetOffline(false)
+
+	if remote.Offline() {
+		t.Error("Default().SetOffline did not reach the package function.")
+	}
+}

--- a/remote/default.go
+++ b/remote/default.go
@@ -1,0 +1,74 @@
+package remote
+
+// The package-level policy functions, each operating on [Default].
+//
+// This file is deliberately nothing but delegation. Every one of these
+// predates [Client] and is the whole API for a program with a single policy,
+// which is most of them; keeping the names, signatures and documented
+// behaviour unchanged is what makes #114 a shape change rather than a break.
+//
+// The pattern is [net/http]'s: [net/http.Get] is [net/http.DefaultClient.Get],
+// and nobody constructing an [net/http.Client] is being told the package
+// function was wrong.
+//
+// Where the doc comment lives is on the method, not here — one description of
+// each behaviour, attached to the implementation, rather than two that can
+// disagree.
+
+// Endpoints returns a snapshot of every endpoint registered on [Default].
+// See [Client.Endpoints].
+func Endpoints() []Endpoint { return Default().Endpoints() }
+
+// Lookup returns the endpoint [Default] has registered under id.
+// See [Client.Lookup].
+func Lookup(id EndpointID) (Endpoint, bool) { return Default().Lookup(id) }
+
+// Enable re-enables access to the given endpoints on [Default].
+// See [Client.Enable].
+func Enable(ids ...EndpointID) { Default().Enable(ids...) }
+
+// Disable blocks all access to the given endpoints on [Default].
+// See [Client.Disable].
+func Disable(ids ...EndpointID) { Default().Disable(ids...) }
+
+// SetURL overrides an endpoint's base URL on [Default].
+// See [Client.SetURL].
+func SetURL(id EndpointID, url string) error { return Default().SetURL(id, url) }
+
+// SetOffline toggles offline mode on [Default].
+// See [Client.SetOffline].
+func SetOffline(off bool) { Default().SetOffline(off) }
+
+// Offline reports whether [Default] is in offline mode.
+// See [Client.Offline].
+func Offline() bool { return Default().Offline() }
+
+// Reset restores [Default] to astrogo's built-in policy.
+// See [Client.Reset].
+func Reset() { Default().Reset() }
+
+// URL returns an endpoint's usable base URL on [Default], or the error
+// explaining why it may not be contacted. See [Client.URL].
+func URL(id EndpointID) (string, error) { return Default().URL(id) }
+
+// EnableDownloads grants file-download consent on [Default].
+// See [Client.EnableDownloads].
+func EnableDownloads(maxSize int64, ids ...EndpointID) { Default().EnableDownloads(maxSize, ids...) }
+
+// DisableDownloads revokes file-download consent on [Default].
+// See [Client.DisableDownloads].
+func DisableDownloads(ids ...EndpointID) { Default().DisableDownloads(ids...) }
+
+// DownloadsEnabled reports [Default]'s consent state for id.
+// See [Client.DownloadsEnabled].
+func DownloadsEnabled(id EndpointID) (ok bool, maxSize int64) { return Default().DownloadsEnabled(id) }
+
+// SetPolicy installs a custom download-consent policy on [Default].
+// See [Client.SetPolicy].
+func SetPolicy(p Policy) { Default().SetPolicy(p) }
+
+// CheckDownload applies [Default]'s consent configuration to a prospective
+// download. See [Client.CheckDownload].
+func CheckDownload(id EndpointID, name string, size int64) error {
+	return Default().CheckDownload(id, name, size)
+}

--- a/remote/doc.go
+++ b/remote/doc.go
@@ -13,6 +13,33 @@
 //     whose returned document depends on the query. SIMBAD, VizieR, Gaia,
 //     MAST, CelesTrak, FINK, JPL SBDB and Horizons.
 //
+// # One policy, or several
+//
+// Every function in this package operates on [Default], exactly as
+// [net/http.Get] operates on [net/http.DefaultClient]. A program with one
+// policy configures it with [EnableDownloads], [SetOffline] and [SetDataDir]
+// and never mentions a [Client].
+//
+// A program with two builds them. An HTTP handler that must never block on a
+// download and a background prefetcher whose whole job is to download are one
+// binary with two policies, and each gets its own:
+//
+//	serving  := remote.NewClient(remote.WithOffline(true))
+//	prefetch := remote.NewClient(remote.WithDownloads(2<<30, remote.NAIFSPK))
+//
+//	handler := jpl.NewProvider(ctx, core.Planets, "de440", jpl.WithClient(serving))
+//	warmer  := jpl.NewProvider(ctx, core.Planets, "de440", jpl.WithClient(prefetch))
+//
+// Each consuming package takes the client as an option — [jpl.WithClient],
+// [resolve.WithClient] for the catalog providers, [cams.WithClient],
+// [api.WithRemote]. Omit it and you get [Default].
+//
+// One thing this does not reach: the Earth-orientation data [time] loads
+// lazily. [time.Time.EOP] has no context and no error return by design, so
+// there is nowhere for a per-component policy to enter, and that fetch always
+// uses [Default]. A caller who needs different behaviour there registers their
+// own model with time.RegisterModel.
+//
 // # Endpoints
 //
 // Every service astrogo can contact is an [EndpointID] — there are no

--- a/remote/fetch.go
+++ b/remote/fetch.go
@@ -58,8 +58,8 @@ func WithProgress(f func(downloaded, total int64)) ReadOption {
 // Mutable one is revalidated against the source's current ETag first. A
 // miss downloads, which requires consent (ErrDownloadDenied otherwise) and
 // is serialized against other processes doing the same.
-func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption) (bucket *file.Bucket, key string, err error) {
-	ep, ok := Lookup(id)
+func (c *Client) GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption) (bucket *file.Bucket, key string, err error) {
+	ep, ok := c.Lookup(id)
 	if !ok {
 		return nil, "", fmt.Errorf("%w: %q", ErrUnknownEndpoint, id)
 	}
@@ -67,7 +67,7 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 	// URL is the offline/Disable gate. It runs first so a blocked endpoint
 	// fails before any cache directory is resolved or lock taken, and so
 	// the source below is never opened for a URL the caller may not reach.
-	if _, err := URL(id); err != nil {
+	if _, err := c.URL(id); err != nil {
 		return nil, "", err
 	}
 
@@ -113,7 +113,7 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 		// and reporting it consistently matches the documented contract.
 		// Routed through CheckDownload so a custom Policy still decides.
 		// A caller who did grant consent sees the real error.
-		if cerr := CheckDownload(id, name, ep.ApproxSize); cerr != nil {
+		if cerr := c.CheckDownload(id, name, ep.ApproxSize); cerr != nil {
 			return nil, "", cerr
 		}
 
@@ -143,7 +143,7 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 
 	timeout := cmp.Or(cfg.timeout, ep.DownloadTimeout, DefaultDownloadTimeout)
 
-	if err := fetchInto(ctx, id, ep, srcBucket, cacheBucket, name, cacheKey, timeout, cfg); err != nil {
+	if err := c.fetchInto(ctx, id, ep, srcBucket, cacheBucket, name, cacheKey, timeout, cfg); err != nil {
 		return nil, "", fmt.Errorf("remote: fetch %s: %w", name, err)
 	}
 
@@ -158,13 +158,13 @@ func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption
 // A missing object is (false, nil): the source answered and it is not
 // there. Any other failure returns an error, so "missing" is never
 // confused with "could not tell".
-func Exists(ctx context.Context, id EndpointID, name string) (bool, error) {
-	ep, ok := Lookup(id)
+func (c *Client) Exists(ctx context.Context, id EndpointID, name string) (bool, error) {
+	ep, ok := c.Lookup(id)
 	if !ok {
 		return false, fmt.Errorf("%w: %q", ErrUnknownEndpoint, id)
 	}
 
-	if _, err := URL(id); err != nil {
+	if _, err := c.URL(id); err != nil {
 		return false, err
 	}
 
@@ -234,12 +234,12 @@ func unchanged(ctx context.Context, srcBucket, cacheBucket *file.Bucket, name, c
 // cacheBucket/cacheKey. It owns all policy — consent, timeout, progress,
 // resume, validation — for every backend uniformly; buckets only move
 // bytes.
-func fetchInto(ctx context.Context, id EndpointID, ep Endpoint, srcBucket, cacheBucket *file.Bucket,
+func (c *Client) fetchInto(ctx context.Context, id EndpointID, ep Endpoint, srcBucket, cacheBucket *file.Bucket,
 	name, cacheKey string, timeout time.Duration, cfg readConfig,
 ) error {
 	// Consent is checked twice: once on the registered estimate before any
 	// request, and again below on the size the source actually reports.
-	if err := CheckDownload(id, name, ep.ApproxSize); err != nil {
+	if err := c.CheckDownload(id, name, ep.ApproxSize); err != nil {
 		return err
 	}
 
@@ -251,7 +251,7 @@ func fetchInto(ctx context.Context, id EndpointID, ep Endpoint, srcBucket, cache
 		return fmt.Errorf("%w: %s: %w", ErrDownloadFailed, name, err)
 	}
 
-	if err := CheckDownload(id, name, attrs.Size); err != nil {
+	if err := c.CheckDownload(id, name, attrs.Size); err != nil {
 		return err
 	}
 
@@ -292,4 +292,17 @@ func (p *progressReader) Read(b []byte) (int, error) {
 
 	//nolint:wrapcheck // must forward io.EOF unwrapped: io.Copy identity-checks it
 	return n, err
+}
+
+// GetFile fetches through [Default]. See [Client.GetFile].
+func GetFile(ctx context.Context, id EndpointID, name string, opts ...ReadOption) (
+	bucket *file.Bucket, key string, err error,
+) {
+	return Default().GetFile(ctx, id, name, opts...)
+}
+
+// Exists reports whether the object is present through [Default].
+// See [Client.Exists].
+func Exists(ctx context.Context, id EndpointID, name string) (bool, error) {
+	return Default().Exists(ctx, id, name)
 }

--- a/remote/registry.go
+++ b/remote/registry.go
@@ -4,26 +4,15 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"sync"
-)
-
-// registry holds the process-wide endpoint configuration. It is statically
-// initialized (no init() computation) and guarded by a single RWMutex; every
-// exported accessor below is safe for concurrent use.
-var (
-	regMu     sync.RWMutex
-	endpoints = defaultEndpoints()
-	offline   bool
-	policy    Policy
 )
 
 // Endpoints returns a snapshot of every registered endpoint, sorted by ID.
-func Endpoints() []Endpoint {
-	regMu.RLock()
-	defer regMu.RUnlock()
+func (c *Client) Endpoints() []Endpoint {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	out := make([]Endpoint, 0, len(endpoints))
-	for _, ep := range endpoints {
+	out := make([]Endpoint, 0, len(c.endpoints))
+	for _, ep := range c.endpoints {
 		out = append(out, cloneEndpoint(ep))
 	}
 
@@ -43,70 +32,70 @@ func cloneEndpoint(ep Endpoint) Endpoint {
 }
 
 // Lookup returns the endpoint registered under id.
-func Lookup(id EndpointID) (Endpoint, bool) {
-	regMu.RLock()
-	defer regMu.RUnlock()
+func (c *Client) Lookup(id EndpointID) (Endpoint, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	ep, ok := endpoints[id]
+	ep, ok := c.endpoints[id]
 
 	return cloneEndpoint(ep), ok
 }
 
 // Enable re-enables access to the given endpoints (the default state).
-func Enable(ids ...EndpointID) {
-	setEnabled(true, ids)
+func (c *Client) Enable(ids ...EndpointID) {
+	c.setEnabled(true, ids)
 }
 
 // Disable blocks all access to the given endpoints: any request against
 // them fails with ErrEndpointDisabled until re-enabled.
-func Disable(ids ...EndpointID) {
-	setEnabled(false, ids)
+func (c *Client) Disable(ids ...EndpointID) {
+	c.setEnabled(false, ids)
 }
 
-func setEnabled(enabled bool, ids []EndpointID) {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) setEnabled(enabled bool, ids []EndpointID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	for _, id := range ids {
-		if ep, ok := endpoints[id]; ok {
+		if ep, ok := c.endpoints[id]; ok {
 			ep.Enabled = enabled
-			endpoints[id] = ep
+			c.endpoints[id] = ep
 		}
 	}
 }
 
 // SetURL overrides an endpoint's base URL, e.g. to point at a mirror or an
 // internal proxy. Returns ErrUnknownEndpoint for an unregistered id.
-func SetURL(id EndpointID, url string) error {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) SetURL(id EndpointID, url string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	ep, ok := endpoints[id]
+	ep, ok := c.endpoints[id]
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrUnknownEndpoint, id)
 	}
 
 	ep.URL = url
-	endpoints[id] = ep
+	c.endpoints[id] = ep
 
 	return nil
 }
 
 // SetOffline toggles global offline mode. While offline, every endpoint
 // access — API call or download — fails with ErrOffline.
-func SetOffline(off bool) {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) SetOffline(off bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	offline = off
+	c.offline = off
 }
 
 // Offline reports whether global offline mode is active.
-func Offline() bool {
-	regMu.RLock()
-	defer regMu.RUnlock()
+func (c *Client) Offline() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	return offline
+	return c.offline
 }
 
 // Reset restores the default registry state: every endpoint at its
@@ -116,28 +105,28 @@ func Offline() bool {
 // Reset discards consent a broader scope — a package TestMain — granted
 // for the whole binary, so a test using it can break tests that run
 // after. Prefer Capture/Restore or WithScope for scoped setup.
-func Reset() {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	endpoints = defaultEndpoints()
-	offline = false
-	policy = nil
+	c.endpoints = defaultEndpoints()
+	c.offline = false
+	c.policy = nil
 }
 
 // URL is the single gate every network call site goes through: it returns
 // the endpoint's (possibly overridden) base URL, or an error explaining why
 // the endpoint may not be contacted — ErrOffline, ErrEndpointDisabled, or
 // ErrUnknownEndpoint.
-func URL(id EndpointID) (string, error) {
-	regMu.RLock()
-	defer regMu.RUnlock()
+func (c *Client) URL(id EndpointID) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	if offline {
+	if c.offline {
 		return "", fmt.Errorf("%w (endpoint %q)", ErrOffline, id)
 	}
 
-	ep, ok := endpoints[id]
+	ep, ok := c.endpoints[id]
 	if !ok {
 		return "", fmt.Errorf("%w: %q", ErrUnknownEndpoint, id)
 	}
@@ -159,50 +148,50 @@ func URL(id EndpointID) (string, error) {
 //
 // Naming an endpoint that cannot download (SIMBAD, VizieR, ...) does
 // nothing: it has no consent gate to open.
-func EnableDownloads(maxSize int64, ids ...EndpointID) {
-	setConsent(true, maxSize, ids)
+func (c *Client) EnableDownloads(maxSize int64, ids ...EndpointID) {
+	c.setConsent(true, maxSize, ids)
 }
 
 // DisableDownloads revokes file-download consent — for every Downloadable
 // endpoint with no ids, or only the ones named. This is the default state.
-func DisableDownloads(ids ...EndpointID) {
-	setConsent(false, 0, ids)
+func (c *Client) DisableDownloads(ids ...EndpointID) {
+	c.setConsent(false, 0, ids)
 }
 
 // setConsent applies a consent decision. An empty ids means every
 // Downloadable endpoint; naming ids explicitly still skips those with no
 // download path at all, so consent is never recorded against an endpoint
 // that would never consult it.
-func setConsent(ok bool, maxSize int64, ids []EndpointID) {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) setConsent(ok bool, maxSize int64, ids []EndpointID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if len(ids) == 0 {
-		ids = make([]EndpointID, 0, len(endpoints))
-		for id := range endpoints {
+		ids = make([]EndpointID, 0, len(c.endpoints))
+		for id := range c.endpoints {
 			ids = append(ids, id)
 		}
 	}
 
 	for _, id := range ids {
-		ep, found := endpoints[id]
+		ep, found := c.endpoints[id]
 		if !found || !ep.Downloadable {
 			continue
 		}
 
 		ep.DownloadsOK = ok
 		ep.MaxDownloadSize = maxSize
-		endpoints[id] = ep
+		c.endpoints[id] = ep
 	}
 }
 
 // DownloadsEnabled reports whether downloads are enabled for id and the
 // configured per-download size cap (0 = unlimited).
-func DownloadsEnabled(id EndpointID) (ok bool, maxSize int64) {
-	regMu.RLock()
-	defer regMu.RUnlock()
+func (c *Client) DownloadsEnabled(id EndpointID) (ok bool, maxSize int64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	ep, found := endpoints[id]
+	ep, found := c.endpoints[id]
 	if !found {
 		return false, 0
 	}
@@ -219,11 +208,11 @@ type Policy func(ep Endpoint, size int64) error
 // SetPolicy installs a custom download-consent policy that replaces the
 // per-endpoint EnableDownloads checks entirely. Pass nil to restore the
 // default per-endpoint consent behavior.
-func SetPolicy(p Policy) {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (c *Client) SetPolicy(p Policy) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	policy = p
+	c.policy = p
 }
 
 // CheckDownload applies the consent configuration to a prospective
@@ -231,13 +220,13 @@ func SetPolicy(p Policy) {
 // it may proceed. GetFile calls this itself; it is exported for
 // file-producing paths that bypass GetFile — JPLHorizonsSPK generation,
 // whose kernel arrives base64-encoded inside a JSON response.
-func CheckDownload(id EndpointID, name string, size int64) error {
-	regMu.RLock()
+func (c *Client) CheckDownload(id EndpointID, name string, size int64) error {
+	c.mu.RLock()
 
-	ep, ok := endpoints[id]
-	pol := policy
+	ep, ok := c.endpoints[id]
+	pol := c.policy
 
-	regMu.RUnlock()
+	c.mu.RUnlock()
 
 	if !ok {
 		return fmt.Errorf("%w: %q", ErrUnknownEndpoint, id)

--- a/remote/scope.go
+++ b/remote/scope.go
@@ -31,25 +31,22 @@ type Scope struct {
 // TestMain) has already granted consent this call must not disturb. The
 // global fields (offline, policy, and the data directory) are always
 // captured, regardless of ids.
-func Capture(ids ...EndpointID) Scope {
-	regMu.RLock()
-	defer regMu.RUnlock()
-
-	dataMu.RLock()
-	defer dataMu.RUnlock()
+func (c *Client) Capture(ids ...EndpointID) Scope {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	var snapshot map[EndpointID]Endpoint
 
 	if len(ids) == 0 {
-		snapshot = make(map[EndpointID]Endpoint, len(endpoints))
-		for id, ep := range endpoints {
+		snapshot = make(map[EndpointID]Endpoint, len(c.endpoints))
+		for id, ep := range c.endpoints {
 			snapshot[id] = cloneEndpoint(ep)
 		}
 	} else {
 		snapshot = make(map[EndpointID]Endpoint, len(ids))
 
 		for _, id := range ids {
-			if ep, ok := endpoints[id]; ok {
+			if ep, ok := c.endpoints[id]; ok {
 				snapshot[id] = cloneEndpoint(ep)
 			}
 		}
@@ -57,9 +54,9 @@ func Capture(ids ...EndpointID) Scope {
 
 	return Scope{
 		endpoints:  snapshot,
-		offline:    offline,
-		policy:     policy,
-		dataDirURL: dataDirURL,
+		offline:    c.offline,
+		policy:     c.policy,
+		dataDirURL: c.dataDir,
 	}
 }
 
@@ -76,25 +73,32 @@ func Capture(ids ...EndpointID) Scope {
 // registry (SetURL, EnableDownloads, SetOffline, ...) — the same caveat
 // that already applies to Reset, and why remote-touching tests in this
 // module don't run under t.Parallel.
-func (s Scope) Restore() {
-	regMu.Lock()
-	defer regMu.Unlock()
+func (s Scope) Restore() { s.RestoreOn(Default()) }
 
-	dataMu.Lock()
-	defer dataMu.Unlock()
+// RestoreOn puts the captured values back on c rather than on [Default].
+func (s Scope) RestoreOn(c *Client) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	maps.Copy(endpoints, s.endpoints)
+	maps.Copy(c.endpoints, s.endpoints)
 
-	offline = s.offline
-	policy = s.policy
-	dataDirURL = s.dataDirURL
+	c.offline = s.offline
+	c.policy = s.policy
+	c.dataDir = s.dataDirURL
 }
+
+// Capture records [Default]'s configuration. See [Client.Capture].
+func Capture(ids ...EndpointID) Scope { return Default().Capture(ids...) }
 
 // WithScope captures the current configuration, runs fn, and restores the
 // captured configuration afterward — even if fn panics.
-func WithScope(fn func()) {
-	s := Capture()
-	defer s.Restore()
+func WithScope(fn func()) { Default().WithScope(fn) }
+
+// WithScope captures c's configuration, runs fn, and restores it afterward —
+// even if fn panics.
+func (c *Client) WithScope(fn func()) {
+	s := c.Capture()
+	defer s.RestoreOn(c)
 
 	fn()
 }

--- a/remote/storage.go
+++ b/remote/storage.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/TuSKan/astrogo/remote/file"
 )
@@ -14,13 +13,6 @@ import (
 // appName is the directory name under the OS user cache dir holding all
 // astrogo data by default.
 const appName = "astrogo"
-
-// dataDirURL is the process-wide base location for everything astrogo
-// stores. Empty means "resolve the default lazily" — see DataDirURL.
-var (
-	dataMu     sync.RWMutex
-	dataDirURL string
-)
 
 // DataDirEnv overrides the default data location when SetDataDir has not
 // been called. Its value is a bucket URL, not an OS path — see DataDirURL.
@@ -30,11 +22,11 @@ const DataDirEnv = "ASTROGO_CACHE_DIR"
 // URL remote/file can open: "file:///home/u/.cache/astrogo?create_dir=true",
 // "s3://my-cache-bucket", "sftp://host/path". Nothing astrogo caches is
 // assumed to live on local disk.
-func SetDataDir(bucketURL string) {
-	dataMu.Lock()
-	defer dataMu.Unlock()
+func (c *Client) SetDataDir(bucketURL string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	dataDirURL = bucketURL
+	c.dataDir = bucketURL
 }
 
 // DataDirURL returns the bucket URL astrogo stores all its data under,
@@ -42,12 +34,12 @@ func SetDataDir(bucketURL string) {
 // the OS user cache directory — ~/.cache/astrogo on Linux,
 // %LocalAppData%\astrogo on Windows, ~/Library/Caches/astrogo on macOS.
 // Re-resolved per call, so a changed environment takes effect immediately.
-func DataDirURL() string {
-	dataMu.RLock()
+func (c *Client) DataDirURL() string {
+	c.mu.RLock()
 
-	d := dataDirURL
+	d := c.dataDir
 
-	dataMu.RUnlock()
+	c.mu.RUnlock()
 
 	if d != "" {
 		return d
@@ -89,8 +81,8 @@ func defaultDataDirURL() string {
 
 // DataDir opens DataDirURL as a Bucket rooted at astrogo's base data
 // location.
-func DataDir(ctx context.Context) (*file.Bucket, error) {
-	b, err := file.Open(ctx, DataDirURL())
+func (c *Client) DataDir(ctx context.Context) (*file.Bucket, error) {
+	b, err := file.Open(ctx, c.DataDirURL())
 	if err != nil {
 		return nil, fmt.Errorf("remote: open data dir: %w", err)
 	}
@@ -129,3 +121,12 @@ func CacheDir(ctx context.Context, id EndpointID) (bucket *file.Bucket, prefix s
 
 	return bucket, ep.Subsystem + "/", nil
 }
+
+// SetDataDir sets [Default]'s base data location. See [Client.SetDataDir].
+func SetDataDir(bucketURL string) { Default().SetDataDir(bucketURL) }
+
+// DataDirURL returns [Default]'s base data location. See [Client.DataDirURL].
+func DataDirURL() string { return Default().DataDirURL() }
+
+// DataDir opens [Default]'s base data location. See [Client.DataDir].
+func DataDir(ctx context.Context) (*file.Bucket, error) { return Default().DataDir(ctx) }


### PR DESCRIPTION
#178 asks how a caller of `PixelToWorld` knows whether the numbers are degrees or radians. Reading the code, the answer is worse than either — **it depends on the axis**:

| axis | unit | why |
| :--- | :--- | :--- |
| celestial (the CTYPE lon/lat pair) | **degrees** | WCS Paper II requires celestial CRVAL/CDELT in degrees — the header's unit, not a choice made here |
| everything else | **whatever `CUNITi` says** | the value is CRVAL plus a linear offset, unconverted — metres, Hertz or Angstrom for a spectral axis; seconds or days for a time one |

And **astrogo never read `CUNIT`**. So the value was correct in a unit no part of the API could name — worse than being wrong or being silent, because the caller gets a plausible float and has to go back to the header card themselves to learn what it measures.

## What this adds

`CUnit` / `SetCUnit`, in the shape #220 gave the other accessors: copying in both directions, and refusing a slice whose length disagrees with `NAxis`.

An absent `CUNIT` card is recorded as **an empty string, not defaulted to `"deg"`** — *"the header did not say"* and *"the header said degrees"* are different facts, and only the caller knows whether the difference matters to them. Defaulting turns a question they could still ask into an answer they cannot check.

The unit is a string and stays one. FITS units are a small language of their own — Paper I §4.3 has prefixes, powers, products, and forms like `10**(-20) erg/s/cm**2/Angstrom` — and a partial parser that silently mishandled the rest would be worse than the text.

Both transforms now document what they return and what they take.

## What this deliberately does not do

It does not answer #178's typed-API question. That still belongs with #130, and the issue is right that it needs thought — the world value is not always an angle, so `[]angle.Angle` is not the answer. **This is the input either answer needs, and it was not reachable before.**

Also noted while here: #178's *first* half — the Java-style `GetCRVAL` accessors, the aliasing, and the unvalidated setter lengths — was already fixed by #220. What remained was the units question.

## Verification

Four tests: the header round-trip, the absent-card case, no aliasing in either direction (the bug #220 fixed, checked on the new pair before it can recur), and the length invariant.

Mutation-checked: dropping the `CUNIT` parse fails `TestCUnitSurvivesTheHeader` on all three axes.

`gofmt -l .` clean; `go vet ./...` and the tagged variant clean; `golangci-lint run` and the tagged variant both 0 issues; `go test ./...` all pass; `go test -race -short ./fits/...` passes.

Refs #178.