### PR TITLE
ephemeris/jpl: refuse a body id that cannot be a NAIF id (CodeQL alert 1)

### DIFF
--- a/docs/changelog.d/273-naif-id-range.md
+++ b/docs/changelog.d/273-naif-id-range.md
@@ -1,0 +1,10 @@
+---
+type: Fixed
+pr: 273
+---
+**A body id above `MaxInt32` was converted rather than refused.** `core.ID` is
+unsigned and a NAIF id is signed 32-bit, so the top half of the range wrapped to
+a *negative* id — which is meaningful, since that is how NAIF numbers
+spacecraft. `core.ID(0xFFFFFFFF)` was looked up as −1 and answered for a body
+the caller never named. `jpl.Provider.State` now returns `ErrBodyIDOutOfRange`,
+and `plan`'s designation parser bounds to 31 bits (#273).

--- a/ephemeris/jpl/bodyid_range_test.go
+++ b/ephemeris/jpl/bodyid_range_test.go
@@ -1,0 +1,72 @@
+package jpl_test
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/ephemeris/core"
+	"github.com/TuSKan/astrogo/ephemeris/jpl"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TestBodyIDAboveInt32IsRefused covers the conversion CodeQL flagged as
+// go/incorrect-integer-conversion, and the reason it is worth more than a
+// bounds check.
+//
+// [core.ID] is uint32. A NAIF id is signed 32-bit. So the top half of the
+// unsigned range is not a large id — it is not an id at all, and converting it
+// does not lose information in the usual harmless way. It *wraps to a negative
+// number*, and negative NAIF ids are meaningful: that is how spacecraft are
+// numbered, Cassini being -82.
+//
+// The failure mode is therefore not a crash or a zero. core.ID(0xFFFFFFFF)
+// becomes -1, which is a syntactically valid id, and the provider goes looking
+// for it. A caller's typo or a bad designation from a catalogue arrives as a
+// different real body, or as "no coverage" for one — an answer, not an error.
+// That is the class this repository keeps finding and refusing to ship.
+//
+// Reported rather than clamped, because there is no id to fall back to:
+// clamping to MaxInt32 would invent a body the caller never asked for.
+func TestBodyIDAboveInt32IsRefused(t *testing.T) {
+	t.Parallel()
+
+	// No kernel is needed: the guard runs before any segment lookup, which is
+	// itself worth pinning — an id that cannot be represented should not first
+	// cost a download.
+	p := &jpl.Provider{}
+
+	epoch := time.Date(2026, time.June, 21, 0, 0, 0, 0, time.LocationUTC)
+
+	for _, id := range []core.ID{
+		math.MaxInt32 + 1, // the first value that wraps, to -2147483648
+		math.MaxUint32,    // wraps to -1
+		math.MaxUint32 - 81,
+	} {
+		_, err := p.State(id, epoch)
+		if !errors.Is(err, jpl.ErrBodyIDOutOfRange) {
+			t.Errorf("State(%d) returned %v, want ErrBodyIDOutOfRange.\n"+
+				"  Converted rather than refused, this id becomes a negative NAIF number — "+
+				"a spacecraft — and the caller gets a body they never named.", id, err)
+		}
+	}
+}
+
+// TestBodyIDAtTheBoundaryIsAccepted checks the guard did not move the edge.
+//
+// MaxInt32 is representable and must stay usable; a guard that rejected it
+// would be trading one silent wrong answer for a loud wrong refusal. It fails
+// later for want of a kernel, which is the right reason.
+func TestBodyIDAtTheBoundaryIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	p := &jpl.Provider{}
+	epoch := time.Date(2026, time.June, 21, 0, 0, 0, 0, time.LocationUTC)
+
+	_, err := p.State(core.ID(math.MaxInt32), epoch)
+	if errors.Is(err, jpl.ErrBodyIDOutOfRange) {
+		t.Error("State(MaxInt32) was refused as out of range.\n" +
+			"  It is the largest id that survives the conversion intact and has to " +
+			"remain askable.")
+	}
+}

--- a/ephemeris/jpl/provider.go
+++ b/ephemeris/jpl/provider.go
@@ -26,6 +26,7 @@ var (
 	ErrUnknownSource         = errors.New("jpl: unknown source")
 	ErrRecursionDepth        = errors.New("jpl: recursion depth exceeded")
 	ErrNilKernel             = errors.New("jpl: kernel is nil")
+	ErrBodyIDOutOfRange      = errors.New("jpl: body id outside the signed 32-bit NAIF range")
 	ErrKernelIndexOutOfRange = errors.New("jpl: kernel index out of range")
 
 	// ErrNoSmallBodyKernel indicates Horizons matched no small body for the
@@ -327,6 +328,19 @@ func (p *Provider) State(id core.ID, t time.Time) (core.State, error) {
 
 	naif, ok := NAIFFor(id)
 	if !ok {
+		// core.ID is uint32; a NAIF id is signed 32-bit. The top half of the
+		// unsigned range therefore has no meaning as an id, and converting it
+		// does not merely lose information — it wraps to a NEGATIVE id, which
+		// is meaningful, because that is how NAIF numbers spacecraft. Cassini
+		// is -82. So core.ID(4294967295) would quietly be looked up as -1
+		// rather than refused, and the answer would be a real body's state
+		// under a caller's typo.
+		//
+		// Reported rather than clamped: there is no id here to fall back to.
+		if id > math.MaxInt32 {
+			return core.State{}, fmt.Errorf("%w: %d", ErrBodyIDOutOfRange, id)
+		}
+
 		naif = int(id)
 	}
 

--- a/plan/factory.go
+++ b/plan/factory.go
@@ -219,8 +219,14 @@ func asteroidOptsFrom(c catalog.Target) []AsteroidOption {
 }
 
 // parseEphID converts a string ID to an eph.ID, returning 0 on failure.
+//
+// Bounded to 31 bits, not 32. eph.ID is unsigned and a NAIF id is signed
+// 32-bit, so anything above MaxInt32 is not an id at all — and converting one
+// wraps it to a negative value, which NAIF uses for spacecraft. Parsing it as
+// a failure keeps a garbage designation from arriving downstream as a
+// plausible different body.
 func parseEphID(id string) eph.ID {
-	n, err := strconv.ParseUint(id, 10, 32)
+	n, err := strconv.ParseUint(id, 10, 31)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Closes the `go/incorrect-integer-conversion` alert at `ephemeris/jpl/provider.go:330`.

The interesting part is why it matters here rather than being a routine bounds check.

`core.ID` is **unsigned** 32-bit. A NAIF id is **signed** 32-bit. So the top half of the unsigned range is not a large id — it is not an id at all — and converting it does not lose information in the usual harmless way. **It wraps to a negative number, and negative NAIF ids are meaningful**: that is how spacecraft are numbered, Cassini being −82.

So `core.ID(0xFFFFFFFF)` became `-1`, a syntactically valid id, and the provider went looking for it. A caller's typo, or a bad designation from a catalogue, arrived as a different real body — or as "no coverage" for one.

Measured with the guard removed, all three test ids come back as `ErrNoSegment`:

```
State(2147483648) returned jpl: no coverage for target at requested epoch
State(4294967295) returned jpl: no coverage for target at requested epoch
State(4294967214) returned jpl: no coverage for target at requested epoch
```

That reads like a data gap and is not one. It is the error-versus-absence class this repository keeps refusing to ship.

## The fix

`State` refuses it with `ErrBodyIDOutOfRange`, **before any segment lookup**, so an id that cannot be represented does not first cost a kernel download.

Refused rather than clamped: there is no id to fall back to, and clamping to `MaxInt32` would invent a body the caller never asked for.

`plan`'s `parseEphID` bounds to **31 bits rather than 32**, which removes the same mismatch at the source CodeQL traced from — a designation above `MaxInt32` is a parse failure, not a value to be wrapped later.

`MaxInt32` itself stays askable. A guard that moved that edge would trade a silent wrong answer for a loud wrong refusal, and it is pinned by its own test.

## Verification

Mutation-checked: removing the guard fails `TestBodyIDAboveInt32IsRefused` on all three ids, with the `ErrNoSegment` output above.

`gofmt -l .` clean; `go vet ./...` and the tagged variant clean; `golangci-lint run` and the tagged variant both 0 issues; `go test ./...` all pass.
