### PR TITLE
fits: write images and binary tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ be able to break an API until 1.0 says otherwise.
 | `magnitude` | Apparent magnitude (planets, asteroids, comets, satellites, stars) |
 | `constellation` | IAU constellation lookup from an ICRS position (official 1930 boundaries), `List`/`Centroid` enumeration |
 | `optics` | Equipment-optics arithmetic (`Telescope`/`Eyepiece`/`Sensor`) — magnification, FOV, exit pupil, Dawes limit, pixel scale |
-| `fits` | FITS **reading**, WCS (TAN projection), mmap, Arrow export — read-only, no writer yet ([#127](https://github.com/TuSKan/astrogo/issues/127)) |
+| `fits` | FITS **reading and writing**, WCS (TAN projection), mmap, Arrow export. Writes images (every BITPIX) and binary tables from Arrow batches via `fits.Write` |
 | `fits/plan` | FITS↔plan bridge (`SiteFromFITS`, `TargetFromFITS`) |
 | `plan` | Observability, constraints, events, scheduling, satellite passes |
 | `skybrightness` | Spectral all-sky radiance engine (`Scene`/`Component`/`Model`/`Estimate`, all-sky ops, uncertainty, provenance) — seven components, Phases 0–5, natural sky validated to 0.05 mag against GAMBONS |

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ be able to break an API until 1.0 says otherwise.
 | `magnitude` | Apparent magnitude (planets, asteroids, comets, satellites, stars) |
 | `constellation` | IAU constellation lookup from an ICRS position (official 1930 boundaries), `List`/`Centroid` enumeration |
 | `optics` | Equipment-optics arithmetic (`Telescope`/`Eyepiece`/`Sensor`) — magnification, FOV, exit pupil, Dawes limit, pixel scale |
-| `fits` | FITS **reading and writing**, WCS (TAN projection), mmap, Arrow export. Writes images (every BITPIX) and binary tables from Arrow batches via `fits.Write` |
+| `fits` | FITS **reading and writing**, WCS (TAN projection), mmap, Arrow export. `fits.Write` produces images (every BITPIX, signed and unsigned), binary tables and ASCII tables from Arrow batches, with HIERARCH, CONTINUE long strings, TNULL, vector columns and CHECKSUM/DATASUM |
 | `fits/plan` | FITS↔plan bridge (`SiteFromFITS`, `TargetFromFITS`) |
 | `plan` | Observability, constraints, events, scheduling, satellite passes |
 | `skybrightness` | Spectral all-sky radiance engine (`Scene`/`Component`/`Model`/`Estimate`, all-sky ops, uncertainty, provenance) — seven components, Phases 0–5, natural sky validated to 0.05 mag against GAMBONS |

--- a/docs/changelog.d/275-fits-conventions.md
+++ b/docs/changelog.d/275-fits-conventions.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 275
+---
+**The FITS conventions real files use, in both directions.** HIERARCH keywords and CONTINUE
+long strings (previously mangled and truncated on *read*, not merely unwritten); unsigned
+images through BZERO; DATASUM and CHECKSUM on every HDU, satisfying the sum-to-all-ones test
+cfitsio and astropy apply; TNULL and NaN so a missing table value stays missing; vector
+columns, which used to decode as nulls and discard every value; and ASCII tables, whose
+reader consumed the payload without decoding it (#127).

--- a/docs/changelog.d/275-fits-writer.md
+++ b/docs/changelog.d/275-fits-writer.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 275
+---
+**`fits.Write` — the package writes FITS as well as reading it.** Images at every BITPIX
+(uint8, int16/32/64, float32/64) and binary tables built from an Arrow batch, to any
+`io.Writer`. Structural keywords are derived from the data rather than copied from the
+stored header, so a filtered table or a replaced image cannot produce a file whose header
+describes something it does not contain. A card that will not fit the 80-byte record is an
+error rather than a truncation, since an over-long card shifts every card after it (#127).

--- a/docs/changelog.d/275-fits-writer.md
+++ b/docs/changelog.d/275-fits-writer.md
@@ -7,4 +7,4 @@ pr: 275
 `io.Writer`. Structural keywords are derived from the data rather than copied from the
 stored header, so a filtered table or a replaced image cannot produce a file whose header
 describes something it does not contain. A card that will not fit the 80-byte record is an
-error rather than a truncation, since an over-long card shifts every card after it (#127).
+error rather than a truncation, since an over-long card shifts every card after it. The primary header carries `EXTEND` when extensions follow, and a non-finite `BSCALE`/`BZERO` is refused rather than written as text no reader can parse (#127).

--- a/docs/changelog.d/275-null-not-zero.md
+++ b/docs/changelog.d/275-null-not-zero.md
@@ -1,0 +1,9 @@
+---
+type: Fixed
+pr: 275
+---
+**A null table value read as 0.0.** `fits.BintableHDU`'s float-column accessor — and a
+second copy of the same logic in `skybrightness/dataset/solar` — returned zero for an absent
+value, so a missing flux became a flux of nothing and a missing magnitude became magnitude 0,
+which is a very bright star. Nulls read as NaN now, which is what every consumer already
+screens for.

--- a/fits/asciiformat.go
+++ b/fits/asciiformat.go
@@ -1,0 +1,154 @@
+package fits
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// An ASCII table (XTENSION = 'TABLE') stores its values as text, one
+// fixed-width field per column, laid out by TBCOLn and formatted by TFORMn.
+//
+// It is the older of the two table extensions and BINTABLE superseded it, but
+// archives are full of them and a library that cannot read one cannot read
+// those archives. FITS 4.0 §7.2 is the reference.
+//
+// The formats are a small Fortran subset:
+//
+//	Iw      integer, right-justified in w columns
+//	Fw.d    fixed-point, d digits after the decimal point
+//	Ew.d    exponential, d digits of mantissa
+//	Dw.d    exponential, double precision, the same layout as E
+//	Aw      character, w columns
+//
+// A field of all blanks is undefined, which is the format's way of saying null
+// — there is no TNULL here, and a blank is not zero.
+
+// asciiForm is one parsed TFORMn of an ASCII table.
+type asciiForm struct {
+	code      byte
+	width     int
+	precision int
+}
+
+// parseASCIIForm reads a TFORMn such as "I10", "F12.5" or "A20".
+func parseASCIIForm(tform string) (asciiForm, error) {
+	t := strings.TrimSpace(tform)
+	if t == "" {
+		return asciiForm{}, fmt.Errorf("%w: empty TFORM", ErrBadTForm)
+	}
+
+	code := t[0]
+
+	switch code {
+	case 'I', 'F', 'E', 'D', 'A':
+	default:
+		return asciiForm{}, fmt.Errorf("%w: %q is not an ASCII table format", ErrBadTForm, tform)
+	}
+
+	rest := t[1:]
+
+	widthText, precisionText, hasPrecision := strings.Cut(rest, ".")
+
+	width, err := strconv.Atoi(strings.TrimSpace(widthText))
+	if err != nil || width <= 0 {
+		return asciiForm{}, fmt.Errorf("%w: width in %q", ErrBadTForm, tform)
+	}
+
+	form := asciiForm{code: code, width: width}
+
+	if hasPrecision {
+		p, err := strconv.Atoi(strings.TrimSpace(precisionText))
+		if err != nil || p < 0 {
+			return asciiForm{}, fmt.Errorf("%w: precision in %q", ErrBadTForm, tform)
+		}
+
+		form.precision = p
+	}
+
+	return form, nil
+}
+
+// String renders the form back as a TFORM value.
+func (f asciiForm) String() string {
+	if f.code == 'I' || f.code == 'A' {
+		return string(f.code) + strconv.Itoa(f.width)
+	}
+
+	return string(f.code) + strconv.Itoa(f.width) + "." + strconv.Itoa(f.precision)
+}
+
+// parseCell decodes one field's text.
+//
+// blank reports a field of all spaces, which is how an ASCII table says the
+// value is undefined. It is returned separately from the zero value because
+// they are different things, and conflating them is how a missing measurement
+// becomes a real one.
+func (f asciiForm) parseCell(text string) (value float64, str string, blank bool, err error) {
+	trimmed := strings.TrimSpace(text)
+
+	if trimmed == "" {
+		return 0, "", true, nil
+	}
+
+	if f.code == 'A' {
+		return 0, strings.TrimRight(text, " "), false, nil
+	}
+
+	// FITS permits a D exponent where Go expects E, since Fortran wrote
+	// double-precision literals that way.
+	normalised := strings.Map(func(r rune) rune {
+		if r == 'D' || r == 'd' {
+			return 'E'
+		}
+
+		return r
+	}, trimmed)
+
+	v, err := strconv.ParseFloat(normalised, 64)
+	if err != nil {
+		return 0, "", false, fmt.Errorf("%w: %q is not a number", ErrBadTForm, trimmed)
+	}
+
+	return v, "", false, nil
+}
+
+// formatCell renders a value into its fixed-width field.
+//
+// A value too wide for its field is an error rather than a truncation: the
+// columns are positional, so an overflowing field runs into its neighbour and
+// every column after it is misread.
+func (f asciiForm) formatCell(value float64, str string, null bool) (string, error) {
+	if null {
+		return strings.Repeat(" ", f.width), nil
+	}
+
+	var out string
+
+	switch f.code {
+	case 'A':
+		out = str
+	case 'I':
+		out = strconv.FormatInt(int64(value), 10)
+	case 'F':
+		out = strconv.FormatFloat(value, 'f', f.precision, 64)
+	case 'E', 'D':
+		out = strconv.FormatFloat(value, 'E', f.precision, 64)
+	default:
+		return "", fmt.Errorf("%w: format %q", ErrBadTForm, string(f.code))
+	}
+
+	if len(out) > f.width {
+		return "", fmt.Errorf("%w: %q needs %d columns, TFORM allows %d",
+			ErrCardTooLong, out, len(out), f.width)
+	}
+
+	// Character fields are left-justified; everything else is right-justified,
+	// which is what the format's Fortran ancestry prescribes and what a reader
+	// aligning columns expects.
+	if f.code == 'A' {
+		return out + strings.Repeat(" ", f.width-len(out)), nil
+	}
+
+	return strings.Repeat(" ", f.width-len(out)) + out, nil
+}

--- a/fits/asciitable.go
+++ b/fits/asciitable.go
@@ -3,20 +3,37 @@ package fits
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 )
 
 // ASCIITableHDU represents a FITS ASCII Table extension (TABLE).
-// ASCII Tables use string formatting natively.
+//
+// The older of the two table extensions: values are stored as text in
+// fixed-width columns, positioned by TBCOLn and formatted by TFORMn. BINTABLE
+// superseded it and is what modern pipelines write, but archives are full of
+// these and a reader that skips them cannot read those archives.
 type ASCIITableHDU struct {
 	basicHDU
+
+	// Batch holds the decoded columns, in the same shape a BintableHDU uses,
+	// so a caller reading one kind of table reads the other the same way.
+	Batch arrow.RecordBatch
 
 	Rows    int // NAXIS2
 	Cols    int // TFIELDS
 	RowSize int // NAXIS1
 }
 
-// ReadASCIITable scaffolds the ingestion of ASCII TABLE payloads.
-// Because it is lower priority than BINTABLE, it currently returns standard unloaded frames.
+// ReadASCIITable decodes an ASCII TABLE extension into an Arrow record batch.
+//
+// Numeric columns become float64 and character columns become strings. A field
+// of all blanks is undefined — the format's own way of saying "no value", with
+// no TNULL involved — and becomes a null rather than a zero.
 func ReadASCIITable(h *Header, r io.Reader) (*ASCIITableHDU, error) {
 	tfields, err := h.GetInt("TFIELDS")
 	if err != nil {
@@ -34,29 +51,137 @@ func ReadASCIITable(h *Header, r io.Reader) (*ASCIITableHDU, error) {
 	}
 
 	if rows == 0 || tfields == 0 {
-		return hdu, nil
+		return hdu, discardPadding(r, int64(rowSize)*int64(rows))
 	}
 
-	// ASCII Tables don't have PCOUNT, but standard rules apply for trailing skips.
-	totalPayloadBytes := int64(rowSize) * int64(rows)
+	forms, starts, fields, err := asciiColumns(h, tfields, rowSize)
+	if err != nil {
+		return nil, err
+	}
 
-	// In the P1 prototype, we assume it's read lazily or skipped over by fits.go
-	// However, if we're forced to consume it here:
-	skipBuf := make([]byte, totalPayloadBytes)
-	if _, err := io.ReadFull(r, skipBuf); err != nil {
+	payload := make([]byte, int64(rowSize)*int64(rows))
+	if _, err := io.ReadFull(r, payload); err != nil {
 		return nil, fmt.Errorf("fits: failed reading asciitable payload: %w", err)
 	}
 
-	// Consume padding
-	paddingBytes := int(totalPayloadBytes) % BlockSize
-	if paddingBytes != 0 {
-		padLen := BlockSize - paddingBytes
+	bldr := array.NewRecordBuilder(memory.NewGoAllocator(), arrow.NewSchema(fields, nil))
+	defer bldr.Release()
 
-		padBuf := make([]byte, padLen)
-		if _, err := io.ReadFull(r, padBuf); err != nil {
-			return nil, fmt.Errorf("fits: failed reading asciitable padding: %w", err)
+	for row := range rows {
+		line := payload[row*rowSize : (row+1)*rowSize]
+
+		for i, form := range forms {
+			end := min(starts[i]+form.width, len(line))
+			if starts[i] >= len(line) {
+				bldr.Field(i).AppendNull()
+
+				continue
+			}
+
+			if err := appendASCIICell(bldr.Field(i), form, string(line[starts[i]:end])); err != nil {
+				return nil, fmt.Errorf("fits: row %d column %d: %w", row+1, i+1, err)
+			}
 		}
 	}
 
-	return hdu, nil
+	hdu.Batch = bldr.NewRecordBatch()
+
+	return hdu, discardPadding(r, int64(rowSize)*int64(rows))
 }
+
+// asciiColumns reads the per-column keywords: where each field starts, how it
+// is formatted, and what to call it.
+func asciiColumns(h *Header, tfields, rowSize int) (forms []asciiForm, starts []int, fields []arrow.Field, err error) {
+	forms = make([]asciiForm, tfields)
+	starts = make([]int, tfields)
+	fields = make([]arrow.Field, tfields)
+
+	for i := range tfields {
+		n := strconv.Itoa(i + 1)
+
+		tform, err := h.GetString("TFORM" + n)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("fits: missing TFORM%s: %w", n, err)
+		}
+
+		form, err := parseASCIIForm(tform)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("fits: column %s: %w", n, err)
+		}
+
+		// TBCOLn is 1-based, and is the only statement of where a field sits:
+		// ASCII table columns may have gaps between them.
+		tbcol, err := h.GetInt("TBCOL" + n)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("fits: missing TBCOL%s: %w", n, err)
+		}
+
+		if tbcol < 1 || tbcol+form.width-1 > rowSize {
+			return nil, nil, nil, fmt.Errorf("%w: column %s starts at %d and is %d wide, "+
+				"which does not fit a row of %d", ErrBadTForm, n, tbcol, form.width, rowSize)
+		}
+
+		name, _ := h.GetString("TTYPE" + n)
+		if strings.TrimSpace(name) == "" {
+			name = "COL" + n
+		}
+
+		forms[i] = form
+		starts[i] = tbcol - 1
+		fields[i] = arrow.Field{Name: strings.TrimSpace(name), Type: form.arrowType(), Nullable: true}
+	}
+
+	return forms, starts, fields, nil
+}
+
+// arrowType is the Arrow type an ASCII column decodes into.
+func (f asciiForm) arrowType() arrow.DataType {
+	if f.code == 'A' {
+		return arrow.BinaryTypes.String
+	}
+
+	// Every numeric format becomes float64. The format writes text, so an I
+	// column's values are exact integers either way, and one type keeps the
+	// caller from having to branch on TFORM to read a number.
+	return arrow.PrimitiveTypes.Float64
+}
+
+// appendASCIICell decodes one field and appends it.
+func appendASCIICell(bldr array.Builder, form asciiForm, text string) error {
+	value, str, blank, err := form.parseCell(text)
+	if err != nil {
+		return err
+	}
+
+	if blank {
+		bldr.AppendNull()
+
+		return nil
+	}
+
+	switch b := bldr.(type) {
+	case *array.StringBuilder:
+		b.Append(str)
+	case *array.Float64Builder:
+		b.Append(value)
+	default:
+		bldr.AppendNull()
+	}
+
+	return nil
+}
+
+// discardPadding consumes an extension's trailing block padding.
+func discardPadding(r io.Reader, consumed int64) error {
+	if pad := consumed % int64(BlockSize); pad != 0 {
+		if _, err := io.CopyN(io.Discard, r, int64(BlockSize)-pad); err != nil {
+			return fmt.Errorf("fits: failed reading asciitable padding: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Type reports that this is an ASCII table HDU. See [ImageHDU.Type] for why it
+// is declared here rather than left to the embedded basicHDU.
+func (*ASCIITableHDU) Type() HDUType { return HDUTypeASCII }

--- a/fits/asciitable_test.go
+++ b/fits/asciitable_test.go
@@ -2,34 +2,199 @@ package fits
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
-	"github.com/TuSKan/astrogo/internal/testutil"
+	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-func TestReadASCIITable(t *testing.T) {
+// An ASCII table stores values as text in fixed-width columns positioned by
+// TBCOLn. These tests read the layout FITS 4.0 §7.2 prescribes, written out as
+// bytes, rather than only round-tripping through this package's own writer.
+
+// asciiTableHeader builds a TABLE header for the fixtures below.
+func asciiTableHeader(rowSize int, columns ...[3]string) *Header {
 	h := NewHeader()
-	h.Append(Card{Keyword: "TFIELDS", Value: "1"})
-	h.Append(Card{Keyword: "NAXIS2", Value: "1"})
-	h.Append(Card{Keyword: "NAXIS1", Value: "10"})
+	h.Append(Card{Keyword: "XTENSION", Value: "'TABLE   '"})
+	h.Append(Card{Keyword: "BITPIX", Value: "8"})
+	h.Append(Card{Keyword: "NAXIS", Value: "2"})
+	h.Append(Card{Keyword: "NAXIS1", Value: itoa(rowSize)})
+	h.Append(Card{Keyword: "NAXIS2", Value: "2"})
+	h.Append(Card{Keyword: "PCOUNT", Value: "0"})
+	h.Append(Card{Keyword: "GCOUNT", Value: "1"})
+	h.Append(Card{Keyword: "TFIELDS", Value: itoa(len(columns))})
 
-	payload := []byte("0123456789")
-	padded := make([]byte, 2880)
-	copy(padded, payload)
-
-	r := bytes.NewReader(padded)
-	hdu, err := ReadASCIITable(h, r)
-	testutil.AssertNoError(t, err)
-
-	if hdu.Cols != 1 || hdu.Rows != 1 || hdu.RowSize != 10 {
-		t.Errorf("expected 1,1,10 got %d,%d,%d", hdu.Cols, hdu.Rows, hdu.RowSize)
+	for i, c := range columns {
+		n := itoa(i + 1)
+		h.Append(Card{Keyword: "TTYPE" + n, Value: "'" + c[0] + "'"})
+		h.Append(Card{Keyword: "TBCOL" + n, Value: c[1]})
+		h.Append(Card{Keyword: "TFORM" + n, Value: "'" + c[2] + "'"})
 	}
 
-	// Error missing TFIELDS
-	h2 := NewHeader()
+	return h
+}
 
-	_, err = ReadASCIITable(h2, bytes.NewReader(nil))
-	if err == nil {
-		t.Errorf("expected error missing TFIELDS")
+// itoa is strconv.Itoa, spelled short because these fixtures use it a lot.
+func itoa(v int) string {
+	return string(appendInt(nil, v))
+}
+
+// appendInt renders v without importing strconv into a test file that needs
+// nothing else from it.
+func appendInt(dst []byte, v int) []byte {
+	if v == 0 {
+		return append(dst, '0')
 	}
+
+	var digits [20]byte
+
+	i := len(digits)
+
+	for v > 0 {
+		i--
+		digits[i] = byte('0' + v%10)
+		v /= 10
+	}
+
+	return append(dst, digits[i:]...)
+}
+
+// TestReadASCIITableDecodesItsColumns is the behaviour that was missing: the
+// reader used to consume the payload and return a header, so every ASCII table
+// in every archive arrived empty.
+func TestReadASCIITableDecodesItsColumns(t *testing.T) {
+	t.Parallel()
+
+	h := asciiTableHeader(28,
+		[3]string{"NAME", "1", "A8"},
+		[3]string{"RA", "10", "F9.4"},
+		[3]string{"COUNT", "20", "I9"},
+	)
+
+	// Columns at 1, 10 and 20, one-based, exactly as TBCOLn declares: an
+	// eight-column name, a gap, nine columns of RA, a gap, nine of count.
+	rows := "Vega    " + " " + " 279.2347" + " " + "    91262" +
+		"Betelgeu" + " " + "  88.7929" + " " + "    27989"
+
+	payload := blankPayload(rows)
+
+	hdu, err := ReadASCIITable(h, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("ReadASCIITable: %v", err)
+	}
+
+	if hdu.Batch == nil {
+		t.Fatal("no batch decoded; the reader is still a stub")
+	}
+
+	names, ok := hdu.Batch.Column(0).(*array.String)
+	if !ok {
+		t.Fatalf("NAME is %T, want *array.String", hdu.Batch.Column(0))
+	}
+
+	if got := names.Value(0); got != "Vega" {
+		t.Errorf("NAME row 0 = %q, want Vega", got)
+	}
+
+	ra, ok := hdu.Batch.Column(1).(*array.Float64)
+	if !ok {
+		t.Fatalf("RA is %T, want *array.Float64", hdu.Batch.Column(1))
+	}
+
+	if got := ra.Value(0); math.Abs(got-279.2347) > 1e-9 {
+		t.Errorf("RA row 0 = %v, want 279.2347", got)
+	}
+
+	counts, ok := hdu.Batch.Column(2).(*array.Float64)
+	if !ok {
+		t.Fatalf("COUNT is %T, want *array.Float64", hdu.Batch.Column(2))
+	}
+
+	if got := counts.Value(0); got != 91262 {
+		t.Errorf("COUNT row 0 = %v, want 91262", got)
+	}
+}
+
+// TestASCIIBlankFieldIsNullNotZero covers the format's own way of saying "no
+// value".
+//
+// There is no TNULL in an ASCII table: a field of all blanks is undefined. A
+// reader that parses it as zero turns a missing measurement into a real one,
+// which is the same failure the binary table's TNULL handling exists to avoid.
+func TestASCIIBlankFieldIsNullNotZero(t *testing.T) {
+	t.Parallel()
+
+	h := asciiTableHeader(18,
+		[3]string{"NAME", "1", "A8"},
+		[3]string{"FLUX", "10", "F9.3"},
+	)
+
+	// Eight columns of name, a gap, nine of flux. The second row's flux field
+	// is blank, which is how the format says the value is undefined.
+	rows := "Vega    " + " " + "    1.234" +
+		"Unknown " + " " + "         "
+
+	payload := blankPayload(rows)
+
+	hdu, err := ReadASCIITable(h, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("ReadASCIITable: %v", err)
+	}
+
+	flux := hdu.Batch.Column(1)
+
+	if flux.IsNull(0) {
+		t.Error("row 0 has a value and came back null")
+	}
+
+	if !flux.IsNull(1) {
+		t.Errorf("a blank field read as %s, want null — a blank is undefined, not zero",
+			flux.ValueStr(1))
+	}
+}
+
+// TestReadASCIITableRefusesAMalformedHeader keeps the reader from guessing at
+// a layout it was not given. Column positions are the only thing separating
+// one field from the next.
+func TestReadASCIITableRefusesAMalformedHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		header *Header
+		name   string
+	}{
+		{
+			name:   "no TFIELDS",
+			header: NewHeader(),
+		},
+		{
+			name: "column runs past the row",
+			header: asciiTableHeader(10,
+				[3]string{"NAME", "1", "A20"},
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ReadASCIITable(tc.header, bytes.NewReader(make([]byte, 2880))); err == nil {
+				t.Error("a malformed TABLE header was accepted")
+			}
+		})
+	}
+}
+
+// blankPayload puts rows into a block padded with spaces.
+//
+// Spaces, not zeros: an ASCII table's padding is blank text, and a NUL byte in
+// a numeric field is not a blank — it is a character that will not parse.
+func blankPayload(rows string) []byte {
+	payload := make([]byte, 2880)
+	for i := range payload {
+		payload[i] = ' '
+	}
+
+	copy(payload, rows)
+
+	return payload
 }

--- a/fits/bintable.go
+++ b/fits/bintable.go
@@ -446,3 +446,7 @@ func (hdu *BintableHDU) GetFloatColumn(colName string) ([]float64, error) {
 
 	return res, nil
 }
+
+// Type reports that this is a binary table HDU. See [ImageHDU.Type] for why it
+// is declared here rather than left to the embedded basicHDU.
+func (*BintableHDU) Type() HDUType { return HDUTypeBinary }

--- a/fits/bintable.go
+++ b/fits/bintable.go
@@ -25,6 +25,12 @@ type BintableHDU struct {
 
 // tformField is one parsed TFORMn: a repeat count and a FITS data-type code.
 type tformField struct {
+	// null is the column's TNULLn: the stored value that means "undefined".
+	// hasNull distinguishes a declared sentinel of zero from no declaration,
+	// which are different things.
+	null    int64
+	hasNull bool
+
 	repeat int
 	code   byte
 }
@@ -87,20 +93,40 @@ func (f tformField) size() int {
 
 // arrowType maps the field to the Arrow type its values are decoded into.
 //
-// Only scalar columns are decoded — a repeat count above one on a numeric
-// type is a vector per row, which has no scalar equivalent. Those columns
-// keep their place in the schema as nulls so the column indices still line
-// up with the file, and reading one returns zeros rather than another
-// column's values.
+// A repeat count above one is a vector per row — a spectrum, a covariance row,
+// a per-filter magnitude set — and becomes a fixed-size list of the element
+// type. Those columns used to decode as nulls, which discarded the data of
+// every table that uses them, and BINTABLEs use them constantly.
+//
+// A character column is the exception: its repeat count is a width in bytes,
+// not a count of values, so "20A" is one twenty-character string rather than
+// twenty characters.
 func (f tformField) arrowType() arrow.DataType {
 	if f.code == 'A' {
 		return arrow.BinaryTypes.String
 	}
 
 	if f.repeat != 1 {
+		elem := f.elementType()
+
+		// A TFORM repeat is bounded by the row width the header declares, so
+		// it cannot exceed what an int32 holds; the check is here because that
+		// bound lives in the file rather than in the type.
+		if elem != arrow.Null && f.repeat > 0 && f.repeat <= math.MaxInt32 {
+			n := int32(f.repeat)
+
+			return arrow.FixedSizeListOf(n, elem)
+		}
+
 		return arrow.Null
 	}
 
+	return f.elementType()
+}
+
+// elementType is the Arrow type of one value of this field, ignoring the
+// repeat count.
+func (f tformField) elementType() arrow.DataType {
 	switch f.code {
 	case 'L':
 		return arrow.FixedWidthTypes.Boolean
@@ -126,9 +152,32 @@ func (f tformField) arrowType() arrow.DataType {
 // FITS binary tables are big-endian regardless of the host, which is why the
 // bytes are assembled explicitly rather than cast.
 func (f tformField) appendValue(bldr array.Builder, row []byte) {
+	// A cell holding the column's declared undefined value is a null, not the
+	// number it happens to be stored as. Without this a TNULL of -32768 reads
+	// back as the temperature -32768.
+	if f.hasNull {
+		if v, ok := f.storedInt(row); ok && v == f.null {
+			bldr.AppendNull()
+
+			return
+		}
+	}
+
 	switch b := bldr.(type) {
 	case *array.NullBuilder:
 		b.AppendNull()
+	case *array.FixedSizeListBuilder:
+		// A vector cell is its elements laid end to end, each at the element
+		// width, so the same decoder runs once per element into the list's
+		// value builder.
+		b.Append(true)
+
+		width := f.width()
+		elem := tformField{repeat: 1, code: f.code, null: f.null, hasNull: f.hasNull}
+
+		for i := range f.repeat {
+			elem.appendValue(b.ValueBuilder(), row[i*width:(i+1)*width])
+		}
 	case *array.StringBuilder:
 		b.Append(strings.TrimRightFunc(string(row[:f.repeat]), func(r rune) bool {
 			return r == ' ' || r == 0
@@ -146,11 +195,40 @@ func (f tformField) appendValue(bldr array.Builder, row []byte) {
 	case *array.Int64Builder:
 		b.Append(int64(binary.BigEndian.Uint64(row))) //nolint:gosec // two's-complement reinterpretation
 	case *array.Float32Builder:
-		b.Append(math.Float32frombits(binary.BigEndian.Uint32(row)))
+		// NaN is how a FITS floating-point column says "no value" — it needs
+		// no TNULLn because the representation already has room for it. A
+		// reader that passed it through would hand a caller a NaN to notice
+		// for themselves, in a column where every other absence is a null.
+		if v := math.Float32frombits(binary.BigEndian.Uint32(row)); math.IsNaN(float64(v)) {
+			b.AppendNull()
+		} else {
+			b.Append(v)
+		}
 	case *array.Float64Builder:
-		b.Append(math.Float64frombits(binary.BigEndian.Uint64(row)))
+		if v := math.Float64frombits(binary.BigEndian.Uint64(row)); math.IsNaN(v) {
+			b.AppendNull()
+		} else {
+			b.Append(v)
+		}
 	default:
 		bldr.AppendNull()
+	}
+}
+
+// storedInt reads an integer cell at this field's width, for comparison
+// against TNULLn. ok is false for a field that is not an integer one.
+func (f tformField) storedInt(row []byte) (int64, bool) {
+	switch f.code {
+	case 'B':
+		return int64(row[0]), true
+	case 'I':
+		return int64(int16(binary.BigEndian.Uint16(row))), true //nolint:gosec // two's-complement reinterpretation
+	case 'J':
+		return int64(int32(binary.BigEndian.Uint32(row))), true //nolint:gosec // two's-complement reinterpretation
+	case 'K':
+		return int64(binary.BigEndian.Uint64(row)), true //nolint:gosec // two's-complement reinterpretation
+	default:
+		return 0, false
 	}
 }
 
@@ -210,6 +288,10 @@ func ReadBintable(h *Header, r io.Reader) (*BintableHDU, error) {
 		parsed[i] = field
 		offsets[i] = offset
 		fields[i] = arrow.Field{Name: name, Type: field.arrowType(), Nullable: true}
+
+		if v, ok := tnullFor(h, i); ok {
+			parsed[i].null, parsed[i].hasNull = v, true
+		}
 
 		offset += field.size()
 	}
@@ -330,7 +412,15 @@ func (hdu *BintableHDU) GetFloatColumn(colName string) ([]float64, error) {
 	res := make([]float64, rows)
 
 	for i := range rows {
+		// A null is NaN, not zero. Zero is a measurement — a flux of nothing,
+		// a magnitude of nothing — and returning it for an absent value is how
+		// a missing sample becomes a real one that nothing downstream can
+		// identify. NaN is what the float world means by "no value", it is
+		// what FITS stores for an undefined float, and every consumer of this
+		// already screens for it.
 		if arr.IsNull(i) {
+			res[i] = math.NaN()
+
 			continue
 		}
 
@@ -346,7 +436,11 @@ func (hdu *BintableHDU) GetFloatColumn(colName string) ([]float64, error) {
 		case *array.String:
 			if val, err := strconv.ParseFloat(a.Value(i), 64); err == nil {
 				res[i] = val
+			} else {
+				res[i] = math.NaN()
 			}
+		default:
+			res[i] = math.NaN()
 		}
 	}
 

--- a/fits/checksumencode.go
+++ b/fits/checksumencode.go
@@ -1,0 +1,182 @@
+package fits
+
+import (
+	"bytes"
+	"strconv"
+)
+
+// The FITS checksum convention: DATASUM over the data, CHECKSUM over the whole
+// HDU, both as header cards.
+//
+// Defined by Seaman, Pence & Rots, "Checksum Keyword Convention" — a registered
+// FITS convention, implemented by cfitsio's fits_write_chksum and by astropy's
+// checksum= option. The point of it is that a file carries its own integrity
+// check, so a truncated transfer or a flipped bit is detectable by the reader
+// rather than by whoever eventually looks at the pixels.
+//
+// The arrangement is:
+//
+//   - DATASUM is the 1's complement 32-bit sum of the data bytes, written as a
+//     decimal string.
+//   - CHECKSUM is a 16-character ASCII encoding chosen so that the 1's
+//     complement sum of the entire HDU — header including the CHECKSUM card
+//     itself, plus data — comes out all ones.
+//
+// That last property is what an external verifier tests, and what
+// TestChecksumSatisfiesTheConventionsOwnTest asserts here.
+
+// checksumPlaceholder is the CHECKSUM value written before the sum is known.
+//
+// Sixteen ASCII zeros, not blanks, and the difference is the whole arithmetic.
+// The encoding builds each character as 0x30 plus a share of the value, so the
+// field it replaces has to already contain 0x30s: then the sum rises by exactly
+// the encoded value, and adding the complement of the original sum brings the
+// total to all ones. Sixteen blanks would leave the total short by
+// 4*(0x30-0x20) per word, and the file would not verify anywhere.
+//
+// The length matters for a second reason: the checksum covers the header that
+// contains it, so a card that changed length afterwards would invalidate the
+// number it holds.
+const checksumPlaceholder = "'0000000000000000'"
+
+// checksumExcluded are the ASCII punctuation characters the encoding steps
+// around.
+//
+// They are excluded so the resulting string survives being written, read and
+// compared as a FITS string value — a quote or a slash inside it would end the
+// value or start a comment.
+var checksumExcluded = [13]byte{
+	0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, // : ; < = > ? @
+	0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60, // [ \ ] ^ _ `
+}
+
+// encodeChecksum turns a 32-bit complemented checksum into the convention's
+// 16-character ASCII form.
+//
+// A transcription of the reference implementation's char_encode. Each of the
+// four bytes is spread over four characters as a quotient and a remainder, so
+// that the characters sum back to the byte; characters that would land on
+// excluded punctuation are stepped in pairs, one up and one down, which moves
+// them without changing the sum. The final rotation by one byte is what makes
+// the string start on a character boundary of the value rather than mid-byte.
+func encodeChecksum(value uint32) string {
+	var (
+		asc   [16]byte
+		masks = [4]uint32{0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff}
+	)
+
+	for i := range 4 {
+		b := int((value & masks[i]) >> ((3 - i) * 8))
+
+		quotient := b/4 + 0x30
+		remainder := b % 4
+
+		var ch [4]int
+		for j := range 4 {
+			ch[j] = quotient
+		}
+
+		ch[0] += remainder
+
+		// Step off the excluded punctuation, in pairs so the sum is
+		// preserved: one character up and its partner down. The pairs are
+		// (0,1) and (2,3), written out rather than computed so the indices are
+		// visibly inside the array.
+		for again := true; again; {
+			again = false
+
+			for _, bad := range checksumExcluded {
+				for _, pair := range [2][2]int{{0, 1}, {2, 3}} {
+					lo, hi := pair[0], pair[1]
+
+					if asciiByte(ch[lo]) == bad || asciiByte(ch[hi]) == bad {
+						ch[lo]++
+						ch[hi]--
+						again = true
+					}
+				}
+			}
+		}
+
+		for j := range 4 {
+			asc[4*j+i] = asciiByte(ch[j])
+		}
+	}
+
+	// Rotate right one character. This compensates for where the value sits
+	// in its card: "CHECKSUM= '" is eleven characters, so the sixteen bytes
+	// begin at offset 11, which is one past a four-byte word boundary. The
+	// rotation is what lines the encoded bytes up with the words the sum is
+	// taken over.
+	var out [16]byte
+	for i := range 16 {
+		out[(i+1)%16] = asc[i]
+	}
+
+	return string(out[:])
+}
+
+// datasumValue renders a data checksum the way the convention writes it: a
+// decimal string, quoted, because DATASUM is a character-valued keyword even
+// though it holds a number.
+func datasumValue(sum uint32) string {
+	return quoteValue(strconv.FormatUint(uint64(sum), 10))
+}
+
+// applyChecksum fills in an HDU's DATASUM and CHECKSUM once its bytes are
+// known.
+//
+// header is the serialised header, already padded and already carrying a
+// placeholder CHECKSUM card; data is the padded payload. The CHECKSUM value is
+// written into header in place, which is why the placeholder has to be exactly
+// as long as the value that replaces it.
+//
+// Returns false when the header carries no placeholder, which is how a caller
+// that did not ask for checksums gets its header back untouched.
+func applyChecksum(header, data []byte) bool {
+	at := bytes.Index(header, []byte("CHECKSUM= "+checksumPlaceholder))
+	if at < 0 {
+		return false
+	}
+
+	// The value field starts after "CHECKSUM= " and the opening quote.
+	valueAt := at + len("CHECKSUM= ") + 1
+
+	sum := CalcChecksum(header)
+	sum = addChecksums(sum, CalcChecksum(data))
+
+	// The encoded value must bring the total to all ones, so what is encoded
+	// is the complement of the sum taken with the field still holding zeros.
+	copy(header[valueAt:valueAt+16], encodeChecksum(^sum))
+
+	return true
+}
+
+// addChecksums combines two 1's complement sums.
+//
+// Not a plain addition: 1's complement arithmetic carries the overflow back
+// into the low bits, which is what makes the sum independent of where the data
+// was split.
+func addChecksums(a, b uint32) uint32 {
+	sum := uint64(a) + uint64(b)
+	for sum>>32 > 0 {
+		sum = (sum & 0xFFFFFFFF) + (sum >> 32)
+	}
+
+	return uint32(sum)
+}
+
+// asciiByte narrows an encoding character to the byte it is.
+//
+// The values are bounded by construction — a quotient of at most 0x30+63 plus
+// a remainder of at most 3, stepped by at most a few — so this cannot lose
+// information. It exists because that bound is an argument rather than
+// something the type system carries, and a silent truncation here would
+// produce a checksum that verifies nowhere.
+func asciiByte(v int) byte {
+	if v < 0 || v > 0xFF {
+		return 0 // unreachable: see above
+	}
+
+	return byte(v)
+}

--- a/fits/checksumencode_test.go
+++ b/fits/checksumencode_test.go
@@ -1,0 +1,292 @@
+package fits_test
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// The checksum convention defines one testable property, and it is the one an
+// external verifier applies: the 1's complement sum of a complete HDU — header
+// including its own CHECKSUM card, plus data — is all ones.
+//
+// Asserting that is not the same as asserting our arithmetic against itself.
+// cfitsio's fits_verify_chksum and astropy's verify_checksum compute exactly
+// this sum over exactly these bytes, so a file that satisfies it here satisfies
+// it there.
+
+// TestChecksumSatisfiesTheConventionsOwnTest is that property, over shapes
+// whose header and data lengths differ, since the sum is taken across both.
+func TestChecksumSatisfiesTheConventionsOwnTest(t *testing.T) {
+	t.Parallel()
+
+	batch := catalogBatch(t)
+	t.Cleanup(batch.Release)
+
+	for _, tc := range []struct {
+		file *fits.File
+		name string
+	}{
+		{
+			name: "header only",
+			file: &fits.File{HDUs: []fits.HDU{&fits.ImageHDU{}}},
+		},
+		{
+			name: "small image",
+			file: &fits.File{HDUs: []fits.HDU{float32Image(t, 3, 2, []float32{1, 2, 3, 4, 5, 6})}},
+		},
+		{
+			name: "image spanning several blocks",
+			file: &fits.File{HDUs: []fits.HDU{float32Image(t, 40, 40, make([]float32, 1600))}},
+		},
+		{
+			name: "primary plus a table",
+			file: &fits.File{HDUs: []fits.HDU{&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, tc.file); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			for i, hdu := range splitHDUs(t, buf.Bytes()) {
+				if sum := fits.CalcChecksum(hdu); !fits.VerifyChecksum(sum) {
+					t.Errorf("HDU %d: checksum over the whole unit is %#08x, want all ones.\n"+
+						"  This is the test cfitsio and astropy apply, so a file failing "+
+						"it here is reported as corrupt by them.", i, sum)
+				}
+			}
+		})
+	}
+}
+
+// TestDatasumMatchesTheDataAlone covers the other keyword, which is defined
+// over the data only and is what tells a reader whether the payload survived
+// independently of the header.
+func TestDatasumMatchesTheDataAlone(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 3, 2, []float32{1, 2, 3, 4, 5, 6})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	raw := buf.Bytes()
+
+	got, err := fits.Read(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	declared, err := got.HDUs[0].Header().GetString("DATASUM")
+	if err != nil {
+		t.Fatalf("DATASUM: %v", err)
+	}
+
+	// The data is everything after the header blocks.
+	headerBlocks := headerLength(t, raw)
+	data := raw[headerBlocks:]
+
+	computed := fits.CalcChecksum(data)
+
+	if err := fits.ValidateDatasum(strings.TrimSpace(declared), computed); err != nil {
+		t.Errorf("DATASUM %q does not match the data it covers: %v", declared, err)
+	}
+
+	// And a flipped bit has to break it, or the keyword is decoration.
+	data[0] ^= 0x01
+
+	if err := fits.ValidateDatasum(strings.TrimSpace(declared), fits.CalcChecksum(data)); err == nil {
+		t.Error("DATASUM still matched after a bit was flipped in the data")
+	}
+}
+
+// TestChecksumDetectsCorruption is the point of the whole convention: a file
+// that changed after it was written must stop verifying.
+func TestChecksumDetectsCorruption(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 3, 2, []float32{1, 2, 3, 4, 5, 6})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	raw := buf.Bytes()
+
+	if sum := fits.CalcChecksum(raw); !fits.VerifyChecksum(sum) {
+		t.Fatalf("the file did not verify before corruption: %#08x", sum)
+	}
+
+	// One bit, in the pixels.
+	raw[fits.BlockSize] ^= 0x01
+
+	if sum := fits.CalcChecksum(raw); fits.VerifyChecksum(sum) {
+		t.Error("a flipped bit in the data left the checksum verifying")
+	}
+}
+
+// TestChecksumValueIsWritableAscii keeps the encoded string inside the
+// characters the convention permits.
+//
+// The exclusions are not cosmetic: a quote would end the card's value and a
+// slash would start a comment, so an encoding that produced one would corrupt
+// the card carrying it.
+func TestChecksumValueIsWritableAscii(t *testing.T) {
+	t.Parallel()
+
+	// Values chosen to walk each byte through its whole range, including the
+	// ones whose quotient lands on the excluded punctuation.
+	for _, v := range []uint32{
+		0, 0xFFFFFFFF, 0x3a3a3a3a, 0x5b5b5b5b, 0x01020304, 0xDEADBEEF, 0x30303030,
+	} {
+		src := float32Image(t, 2, 2, []float32{float32(v), 2, 3, 4})
+
+		var buf bytes.Buffer
+		if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+
+		got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			t.Fatalf("Read back: %v", err)
+		}
+
+		sum, err := got.HDUs[0].Header().GetString("CHECKSUM")
+		if err != nil {
+			t.Fatalf("CHECKSUM: %v", err)
+		}
+
+		if len(sum) != 16 {
+			t.Errorf("CHECKSUM %q is %d characters, want 16", sum, len(sum))
+		}
+
+		for i := range len(sum) {
+			c := sum[i]
+
+			if c < 0x30 || c > 0x7A || strings.ContainsRune(":;<=>?@[\\]^_`", rune(c)) {
+				t.Errorf("CHECKSUM %q contains %q at %d, which the convention excludes",
+					sum, c, i)
+			}
+		}
+	}
+}
+
+// splitHDUs cuts a written file into its HDUs, header blocks and all.
+func splitHDUs(t *testing.T, raw []byte) [][]byte {
+	t.Helper()
+
+	var out [][]byte
+
+	for off := 0; off < len(raw); {
+		header := headerLengthAt(t, raw, off)
+		data := dataLength(t, raw[off:off+header])
+
+		end := off + header + data
+		if end > len(raw) {
+			t.Fatalf("HDU at %d runs past the file: %d bytes of %d", off, end, len(raw))
+		}
+
+		out = append(out, raw[off:end])
+		off = end
+	}
+
+	return out
+}
+
+// headerLength is the byte length of the first HDU's header blocks.
+func headerLength(t *testing.T, raw []byte) int {
+	t.Helper()
+
+	return headerLengthAt(t, raw, 0)
+}
+
+// headerLengthAt is the byte length of the header beginning at off.
+func headerLengthAt(t *testing.T, raw []byte, off int) int {
+	t.Helper()
+
+	for n := fits.BlockSize; off+n <= len(raw); n += fits.BlockSize {
+		block := raw[off+n-fits.BlockSize : off+n]
+		for c := 0; c+fits.CardSize <= len(block); c += fits.CardSize {
+			if strings.HasPrefix(string(block[c:c+fits.CardSize]), "END     ") {
+				return n
+			}
+		}
+	}
+
+	t.Fatalf("no END card found from offset %d", off)
+
+	return 0
+}
+
+// dataLength is the padded payload size an HDU's header describes.
+func dataLength(t *testing.T, header []byte) int {
+	t.Helper()
+
+	f, err := fits.Read(bytes.NewReader(append(append([]byte(nil), header...), make([]byte, 0)...)))
+	if err != nil {
+		// A header-only HDU read alone is fine; anything else, fall through to
+		// the arithmetic below.
+		_ = f
+	}
+
+	bitpix := headerInt(t, header, "BITPIX")
+	naxis := headerInt(t, header, "NAXIS")
+
+	if naxis == 0 {
+		return 0
+	}
+
+	elements := 1
+	for i := 1; i <= naxis; i++ {
+		elements *= headerInt(t, header, "NAXIS"+strconv.Itoa(i))
+	}
+
+	width := bitpix
+	if width < 0 {
+		width = -width
+	}
+
+	size := elements * width / 8
+	if rem := size % fits.BlockSize; rem != 0 {
+		size += fits.BlockSize - rem
+	}
+
+	return size
+}
+
+// headerInt reads an integer keyword straight out of raw header bytes.
+func headerInt(t *testing.T, header []byte, keyword string) int {
+	t.Helper()
+
+	prefix := keyword + strings.Repeat(" ", 8-len(keyword))
+
+	for c := 0; c+fits.CardSize <= len(header); c += fits.CardSize {
+		card := string(header[c : c+fits.CardSize])
+		if !strings.HasPrefix(card, prefix) {
+			continue
+		}
+
+		value := strings.TrimSpace(strings.SplitN(card[10:], "/", 2)[0])
+
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			t.Fatalf("%s = %q: %v", keyword, value, err)
+		}
+
+		return n
+	}
+
+	t.Fatalf("no %s card", keyword)
+
+	return 0
+}

--- a/fits/convention.go
+++ b/fits/convention.go
@@ -1,0 +1,206 @@
+package fits
+
+import (
+	"strings"
+)
+
+// The two registered conventions that let a FITS header carry what the fixed
+// 80-byte record cannot: a keyword longer than eight characters, and a string
+// value longer than sixty-eight.
+//
+// Both are old, both are everywhere, and neither is optional in practice. ESO
+// instruments emit HIERARCH by the dozen per header; any pipeline that records
+// a file path or a long provenance string emits CONTINUE. A reader without
+// them does not fail loudly — it silently returns a mangled keyword or a
+// truncated value, which is the worse outcome.
+//
+// References:
+//   - HIERARCH: ESO, "The ESO HIERARCH Keyword Convention" (ESO-DICB), and
+//     FITS 4.0 §4.1.2.1, which registers it.
+//   - CONTINUE: FITS 4.0 §4.2.1.2, the long-string convention originally
+//     published as OGIP 100 / "OGIP 1.0", announced by LONGSTRN.
+
+const (
+	// hierarchPrefix introduces a long keyword. The trailing space is part of
+	// it: "HIERARCHY" is an ordinary eight-character keyword, not a HIERARCH
+	// card.
+	hierarchPrefix = "HIERARCH "
+
+	// continueKeyword carries the next piece of a long string value.
+	continueKeyword = "CONTINUE"
+
+	// longStringMarker is the value LONGSTRN takes to announce that CONTINUE
+	// cards are in use, so a reader that does not implement the convention has
+	// something to detect rather than a value that silently ends early.
+	longStringMarker = "'OGIP 1.0'"
+
+	// continuation is the character a long string's non-final segment ends
+	// with, inside the quotes.
+	continuation = '&'
+)
+
+// isLongKeyword reports whether kw needs the HIERARCH convention.
+//
+// Over eight characters is the usual reason. A keyword carrying a character
+// the standard does not allow in columns 1-8 — anything but A-Z, 0-9, hyphen
+// and underscore — is the other, and HIERARCH is where those go too.
+func isLongKeyword(kw string) bool {
+	if len(kw) > keywordWidth {
+		return true
+	}
+
+	for i := range len(kw) {
+		c := kw[i]
+
+		switch {
+		case c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '_':
+		default:
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseHierarch splits a HIERARCH card into its keyword and the rest.
+//
+// The keyword is the tokens between "HIERARCH " and the first "=" outside a
+// quoted string, with runs of whitespace collapsed to one space — which is how
+// ESO writes them and how astropy normalises them, so that "ESO  DET" and
+// "ESO DET" are the same keyword rather than two.
+//
+// ok is false for a card that is not HIERARCH, or is HIERARCH with no "=",
+// which the ESO convention does not define and which is left to be read as an
+// ordinary card rather than guessed at.
+func parseHierarch(s string) (keyword, rest string, ok bool) {
+	if !strings.HasPrefix(s, hierarchPrefix) {
+		return "", "", false
+	}
+
+	body := s[len(hierarchPrefix):]
+
+	eq := indexOutsideQuotes(body, '=')
+	if eq < 0 {
+		return "", "", false
+	}
+
+	keyword = strings.Join(strings.Fields(body[:eq]), " ")
+	if keyword == "" {
+		return "", "", false
+	}
+
+	return keyword, body[eq+1:], true
+}
+
+// indexOutsideQuotes returns the first index of c that is not inside a FITS
+// quoted string, or -1.
+//
+// A doubled quote is FITS's escape for a literal one, so it must not flip the
+// state — without that, a value like 'O”Brien' leaves this function thinking
+// it is outside a string when it is inside, and the comment separator is then
+// found in the middle of the text.
+func indexOutsideQuotes(s string, c byte) int {
+	inQuote := false
+
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '\'':
+			if inQuote && i+1 < len(s) && s[i+1] == '\'' {
+				i++ // an escaped quote, not the end of the string
+
+				continue
+			}
+
+			inQuote = !inQuote
+		case s[i] == c && !inQuote:
+			return i
+		}
+	}
+
+	return -1
+}
+
+// splitValueComment separates a card's value from its trailing comment.
+//
+// The separator is the first "/" outside a quoted string. Everything before it
+// is the value as written — quotes included, because that is how [Card] stores
+// a string and what lets a card read from a file be written back unchanged.
+func splitValueComment(rest string) (value, comment string) {
+	slash := indexOutsideQuotes(rest, '/')
+	if slash < 0 {
+		return strings.TrimSpace(rest), ""
+	}
+
+	return strings.TrimSpace(rest[:slash]), strings.TrimSpace(rest[slash+1:])
+}
+
+// isQuoted reports whether v is a FITS string value.
+func isQuoted(v string) bool {
+	return len(v) >= 2 && v[0] == '\'' && v[len(v)-1] == '\''
+}
+
+// unquote returns the text inside a FITS string value, with doubled quotes
+// collapsed to one and trailing blanks removed.
+//
+// Trailing blanks are not significant in a FITS string — the standard says so
+// explicitly, and every writer pads short values out to eight characters — so
+// keeping them would make 'M31' and 'M31     ' different strings.
+func unquote(v string) string {
+	if !isQuoted(v) {
+		return strings.TrimSpace(v)
+	}
+
+	return strings.TrimRight(strings.ReplaceAll(v[1:len(v)-1], "''", "'"), " ")
+}
+
+// QuoteValue renders s as a FITS string card value, doubling any quote inside
+// it as the standard requires.
+//
+// [Card.Value] holds a value as it appears in the file, so a string one carries
+// its own quotes. This is how to build one without knowing that:
+//
+//	h.Append(fits.Card{Keyword: "OBJECT", Value: fits.QuoteValue("M31")})
+//
+// A caller who writes the quotes by hand and forgets to double an apostrophe
+// produces a card that ends early, with the rest read as a comment.
+func QuoteValue(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// quoteValue is the internal spelling, kept so the rest of this package reads
+// the same as it did before the function was exported.
+func quoteValue(s string) string { return QuoteValue(s) }
+
+// joinContinuation appends a CONTINUE card's contribution to a card already
+// holding a long string.
+//
+// The convention is that every segment but the last ends with "&" inside its
+// quotes; this drops that marker and concatenates. A comment on any
+// continuation card belongs to the whole value, so the last one seen wins —
+// which is what writers produce, since the comment goes on the final card.
+//
+// ok is false when prev is not waiting for a continuation, so a stray CONTINUE
+// card is kept as itself rather than silently glued onto whatever preceded it.
+func joinContinuation(prev *Card, cont Card) bool {
+	if prev == nil || !isQuoted(prev.Value) {
+		return false
+	}
+
+	inner := prev.Value[1 : len(prev.Value)-1]
+	if !strings.HasSuffix(inner, string(continuation)) {
+		return false
+	}
+
+	next := cont.Value
+	if !isQuoted(next) {
+		return false
+	}
+
+	prev.Value = "'" + inner[:len(inner)-1] + next[1:len(next)-1] + "'"
+
+	if cont.Comment != "" {
+		prev.Comment = cont.Comment
+	}
+
+	return true
+}

--- a/fits/convention_test.go
+++ b/fits/convention_test.go
@@ -1,0 +1,317 @@
+package fits_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// The two registered conventions, tested from both ends: a card this package
+// writes has to come back as the same card, and a card written by somebody
+// else — spelled out here as the bytes ESO and the OGIP convention prescribe —
+// has to be read correctly.
+//
+// The second half is what matters most. A round trip only proves the writer and
+// the reader agree; these files come from instruments, and the layouts below are
+// quoted from the conventions rather than produced by this package.
+
+// TestReadsHIERARCHFromESOStyleBytes reads a header written the way an ESO
+// instrument writes one.
+//
+// Without the convention these parse as a keyword of "HIERARCH" with the whole
+// rest as a comment — so every one of an ESO header's dozens of instrument
+// keywords is lost, silently, and a caller asking for one gets ErrKeyNotFound.
+func TestReadsHIERARCHFromESOStyleBytes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		card    string
+		keyword string
+		value   string
+		comment string
+	}{
+		{
+			card:    "HIERARCH ESO DET CHIP1 ID = 'CCD44-82' / Detector chip identification",
+			keyword: "ESO DET CHIP1 ID",
+			value:   "CCD44-82",
+			comment: "Detector chip identification",
+		},
+		{
+			card:    "HIERARCH ESO INS GRAT1 WLEN = 600.0 / [nm] Grating wavelength",
+			keyword: "ESO INS GRAT1 WLEN",
+			value:   "600.0",
+			comment: "[nm] Grating wavelength",
+		},
+		{
+			// Extra spacing between tokens is normalised, so a header that
+			// aligns its keywords does not produce a different one.
+			card:    "HIERARCH ESO  DET   EXPTIME = 1200 / seconds",
+			keyword: "ESO DET EXPTIME",
+			value:   "1200",
+			comment: "seconds",
+		},
+	} {
+		t.Run(tc.keyword, func(t *testing.T) {
+			t.Parallel()
+
+			got := fits.ParseCard([]byte(pad80(tc.card)))
+
+			if got.Keyword != tc.keyword {
+				t.Errorf("keyword = %q, want %q", got.Keyword, tc.keyword)
+			}
+
+			if got.Comment != tc.comment {
+				t.Errorf("comment = %q, want %q", got.Comment, tc.comment)
+			}
+
+			h := fits.NewHeader()
+			h.Append(got)
+
+			if v, err := h.GetString(tc.keyword); err != nil || v != tc.value {
+				t.Errorf("GetString(%q) = %q (%v), want %q", tc.keyword, v, err, tc.value)
+			}
+		})
+	}
+}
+
+// TestReadsCONTINUEFromOGIPStyleBytes reads a long string spelled out as the
+// convention prescribes.
+//
+// Without it the value ends at the first card and keeps the "&" that marks the
+// split — a path or a URL silently truncated to sixty-odd characters, with the
+// truncation marker left in place as though it were data.
+func TestReadsCONTINUEFromOGIPStyleBytes(t *testing.T) {
+	t.Parallel()
+
+	raw := headerBlock(t,
+		"SIMPLE  =                    T / conforms to FITS standard",
+		"BITPIX  =                    8",
+		"NAXIS   =                    0",
+		"LONGSTRN= 'OGIP 1.0'           / the OGIP long-string convention is in use",
+		"FILENAME= 'a-very-long-path/that-does-not-fit-in-one-eighty-byte-record/at&'",
+		"CONTINUE  'all-of-it-so-it-continues-onto-a-second-and-then-a-third-card&'",
+		"CONTINUE  '-ending-here.fits' / the file this was reduced from",
+		"END",
+	)
+
+	f, err := fits.Read(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	want := "a-very-long-path/that-does-not-fit-in-one-eighty-byte-record/at" +
+		"all-of-it-so-it-continues-onto-a-second-and-then-a-third-card" +
+		"-ending-here.fits"
+
+	got, err := f.HDUs[0].Header().GetString("FILENAME")
+	if err != nil {
+		t.Fatalf("GetString: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("FILENAME =\n %q\nwant\n %q", got, want)
+	}
+
+	if strings.Contains(got, "&") {
+		t.Error("the continuation marker survived into the value")
+	}
+
+	// The comment on the final card belongs to the whole value.
+	card, err := f.HDUs[0].Header().Get("FILENAME")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if card.Comment != "the file this was reduced from" {
+		t.Errorf("comment = %q, want the final card's", card.Comment)
+	}
+}
+
+// TestAStrayCONTINUEIsNotGluedOntoItsNeighbour keeps the join from inventing a
+// value. A CONTINUE card after something that was not waiting for one is
+// malformed, and swallowing it would silently corrupt the previous keyword.
+func TestAStrayCONTINUEIsNotGluedOntoItsNeighbour(t *testing.T) {
+	t.Parallel()
+
+	raw := headerBlock(t,
+		"SIMPLE  =                    T",
+		"BITPIX  =                    8",
+		"NAXIS   =                    0",
+		"OBJECT  = 'M31'                / complete, no continuation marker",
+		"CONTINUE  'orphaned'",
+		"END",
+	)
+
+	f, err := fits.Read(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if got, err := f.HDUs[0].Header().GetString("OBJECT"); err != nil || got != "M31" {
+		t.Errorf("OBJECT = %q (%v), want M31 — a stray CONTINUE was joined onto it", got, err)
+	}
+}
+
+// TestLongKeywordRoundTripsThroughHIERARCH is the writer's half.
+func TestLongKeywordRoundTripsThroughHIERARCH(t *testing.T) {
+	t.Parallel()
+
+	const (
+		keyword = "ESO DET CHIP1 ID"
+		value   = "CCD44-82"
+	)
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+	src.Header().Append(fits.Card{
+		Keyword: keyword,
+		Value:   "'" + value + "'",
+		Comment: "Detector chip identification",
+	})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// The card has to be written as HIERARCH, not as a truncated keyword.
+	if !bytes.Contains(buf.Bytes()[:fits.BlockSize], []byte("HIERARCH "+keyword+" = ")) {
+		t.Fatalf("no HIERARCH card in the header:\n%s", firstBlock(buf.Bytes()))
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	if v, err := got.HDUs[0].Header().GetString(keyword); err != nil || v != value {
+		t.Errorf("%s = %q (%v), want %q", keyword, v, err, value)
+	}
+}
+
+// TestLongStringRoundTripsThroughCONTINUE is the other writer half, and checks
+// the two things a reader depends on: the "&" marker on every card but the
+// last, and LONGSTRN announcing that the convention is in use.
+func TestLongStringRoundTripsThroughCONTINUE(t *testing.T) {
+	t.Parallel()
+
+	// Long enough to need three cards.
+	value := "/data/raw/2026-09-11/" + strings.Repeat("segment-of-a-long-path/", 6) + "file.fits"
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+	src.Header().Append(fits.Card{
+		Keyword: "FILENAME",
+		Value:   "'" + value + "'",
+		Comment: "source file",
+	})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	header := buf.Bytes()[:fits.BlockSize]
+
+	if !bytes.Contains(header, []byte("CONTINUE")) {
+		t.Fatalf("a %d-character value was written without CONTINUE cards:\n%s",
+			len(value), firstBlock(buf.Bytes()))
+	}
+
+	if !bytes.Contains(header, []byte("LONGSTRN= 'OGIP 1.0'")) {
+		t.Error("LONGSTRN is missing, so a reader without the convention has no way " +
+			"to know the value it read ends early")
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	card, err := got.HDUs[0].Header().Get("FILENAME")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if v := mustGetString(t, got.HDUs[0].Header(), "FILENAME"); v != value {
+		t.Errorf("FILENAME =\n %q\nwant\n %q", v, value)
+	}
+
+	if card.Comment != "source file" {
+		t.Errorf("comment = %q, want it carried onto the final card", card.Comment)
+	}
+}
+
+// A quote inside a string value is escaped by doubling it, and must not
+// accumulate over a round trip.
+func TestQuoteInAStringValueSurvivesUndoubled(t *testing.T) {
+	t.Parallel()
+
+	const value = "O'Brien's field"
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+	src.Header().Append(fits.Card{Keyword: "OBSERVER", Value: fits.QuoteValue(value)})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	if v := mustGetString(t, got.HDUs[0].Header(), "OBSERVER"); v != value {
+		t.Errorf("OBSERVER = %q, want %q", v, value)
+	}
+}
+
+// headerBlock assembles cards into a padded FITS block.
+func headerBlock(t *testing.T, cards ...string) []byte {
+	t.Helper()
+
+	var b bytes.Buffer
+
+	for _, c := range cards {
+		if len(c) > fits.CardSize {
+			t.Fatalf("test fixture card is %d characters: %q", len(c), c)
+		}
+
+		b.WriteString(pad80(c))
+	}
+
+	for b.Len()%fits.BlockSize != 0 {
+		b.WriteByte(' ')
+	}
+
+	return b.Bytes()
+}
+
+// firstBlock renders a header block as lines, for a failure message.
+func firstBlock(raw []byte) string {
+	var b strings.Builder
+
+	for off := 0; off+fits.CardSize <= len(raw) && off < fits.BlockSize; off += fits.CardSize {
+		line := strings.TrimRight(string(raw[off:off+fits.CardSize]), " ")
+		if line == "" {
+			continue
+		}
+
+		b.WriteString("  " + line + "\n")
+	}
+
+	return b.String()
+}
+
+// mustGetString reads a string keyword or fails the test.
+func mustGetString(t *testing.T, h *fits.Header, keyword string) string {
+	t.Helper()
+
+	v, err := h.GetString(keyword)
+	if err != nil {
+		t.Fatalf("GetString(%q): %v", keyword, err)
+	}
+
+	return v
+}

--- a/fits/doc.go
+++ b/fits/doc.go
@@ -19,24 +19,31 @@
 // or replaces an image's pixels. A file whose header describes something it
 // does not contain is unreadable in a way no reader can diagnose.
 //
+// # Conventions
+//
+// Both registered conventions that let a header carry what the 80-byte record
+// cannot are implemented, in both directions:
+//
+//   - **HIERARCH** for keywords over eight characters, which ESO instruments
+//     emit by the dozen per header.
+//   - **CONTINUE** for string values over sixty-eight, announced by LONGSTRN,
+//     as FITS 4.0 §4.2.1.2 and OGIP 100 define it.
+//
+// Unsigned integer images are stored as the signed type of the same width
+// offset by BZERO = 2^(n-1) (FITS 4.0 §5.2.5), so a uint16 frame written here
+// is a uint16 frame when read back, here or anywhere else.
+//
+// Every HDU carries DATASUM and CHECKSUM. The sum over a complete HDU comes out
+// all ones, which is the property cfitsio's fits_verify_chksum and astropy's
+// checksum verification apply, so a file written here verifies there.
+//
 // # What the writer does not do
 //
 // The output is standard FITS and interoperable — the card layout is the fixed
 // format of FITS 4.0 §4.1.2, EXTEND announces extensions, and every structure
-// is block-aligned — but it is a smaller writer than astropy's, and these are
-// the differences worth knowing before reaching for one:
+// is block-aligned — but it remains a smaller writer than astropy's, and these
+// are the differences worth knowing:
 //
-//   - **No CONTINUE long strings and no HIERARCH.** A keyword over eight
-//     characters, or a value and comment that together overflow the 80-byte
-//     record, is [ErrCardTooLong] rather than a convention-encoded card.
-//     Both conventions are legal and widely read; neither is implemented, so
-//     a long instrument keyword has nowhere to go.
-//   - **No unsigned integer images.** FITS expresses uint16 as int16 with
-//     BZERO 32768, and this refuses rather than doing it silently, because
-//     the values would otherwise read back negative anywhere the BZERO is
-//     ignored.
-//   - **No CHECKSUM or DATASUM.** The functions exist ([CalcChecksum],
-//     [ValidateDatasum]) and the writer does not call them.
 //   - **No TNULLn.** A null in a table column is written as the type's zero.
 //     FITS has no null bitmap, and inventing a TNULLn would reserve a value
 //     that might be real data.
@@ -46,14 +53,4 @@
 //     them either.
 //   - **No ASCII table writing.** BINTABLE is what modern pipelines use; an
 //     ASCII table read in cannot be written back out.
-//
-// # World Coordinate System
-//
-// The [WCS] type encodes the FITS standard pixel-to-sky mapping defined by
-// CRPIX, CRVAL, CDELT, CTYPE, and the PC rotation matrix.
-//
-//   - [NewWCS] constructs an identity-mapped N-dimensional coordinate system.
-//   - [WCS.PixelToWorld] implements the TAN (Gnomonic) spherical projection
-//     and falls back to linear mapping for non-spherical axes.
-//   - [ExtractWCS] populates a WCS directly from a FITS [Header].
 package fits

--- a/fits/doc.go
+++ b/fits/doc.go
@@ -37,20 +37,22 @@
 // all ones, which is the property cfitsio's fits_verify_chksum and astropy's
 // checksum verification apply, so a file written here verifies there.
 //
+// Null table values are carried rather than flattened: an integer column
+// declares TNULLn and stores that sentinel, a floating-point column stores NaN,
+// and both read back as nulls. A column whose data happens to contain its own
+// sentinel declares none and keeps its values, since reserving a value that is
+// really there would turn measurements into absences.
+//
+// Vector columns — a TFORM repeat above one, which is how a table carries a
+// spectrum or a covariance row — read and write as fixed-size lists.
+//
 // # What the writer does not do
 //
-// The output is standard FITS and interoperable — the card layout is the fixed
-// format of FITS 4.0 §4.1.2, EXTEND announces extensions, and every structure
-// is block-aligned — but it remains a smaller writer than astropy's, and these
-// are the differences worth knowing:
+// **ASCII tables are not written**, and barely read: ReadASCIITable consumes
+// the payload without decoding it. BINTABLE superseded the format decades ago
+// and is what modern pipelines emit, so an ASCII table read here arrives as a
+// header and a row count.
 //
-//   - **No TNULLn.** A null in a table column is written as the type's zero.
-//     FITS has no null bitmap, and inventing a TNULLn would reserve a value
-//     that might be real data.
-//   - **Scalar table columns only**, plus fixed-width strings. Vector columns
-//     (TFORM repeat above one), TDIMn and the variable-length P/Q descriptors
-//     are not written — which matches the reader, since it does not decode
-//     them either.
-//   - **No ASCII table writing.** BINTABLE is what modern pipelines use; an
-//     ASCII table read in cannot be written back out.
+// The variable-length P and Q descriptors are not written either. A column
+// declaring one is read as its raw stored values.
 package fits

--- a/fits/doc.go
+++ b/fits/doc.go
@@ -19,6 +19,34 @@
 // or replaces an image's pixels. A file whose header describes something it
 // does not contain is unreadable in a way no reader can diagnose.
 //
+// # What the writer does not do
+//
+// The output is standard FITS and interoperable — the card layout is the fixed
+// format of FITS 4.0 §4.1.2, EXTEND announces extensions, and every structure
+// is block-aligned — but it is a smaller writer than astropy's, and these are
+// the differences worth knowing before reaching for one:
+//
+//   - **No CONTINUE long strings and no HIERARCH.** A keyword over eight
+//     characters, or a value and comment that together overflow the 80-byte
+//     record, is [ErrCardTooLong] rather than a convention-encoded card.
+//     Both conventions are legal and widely read; neither is implemented, so
+//     a long instrument keyword has nowhere to go.
+//   - **No unsigned integer images.** FITS expresses uint16 as int16 with
+//     BZERO 32768, and this refuses rather than doing it silently, because
+//     the values would otherwise read back negative anywhere the BZERO is
+//     ignored.
+//   - **No CHECKSUM or DATASUM.** The functions exist ([CalcChecksum],
+//     [ValidateDatasum]) and the writer does not call them.
+//   - **No TNULLn.** A null in a table column is written as the type's zero.
+//     FITS has no null bitmap, and inventing a TNULLn would reserve a value
+//     that might be real data.
+//   - **Scalar table columns only**, plus fixed-width strings. Vector columns
+//     (TFORM repeat above one), TDIMn and the variable-length P/Q descriptors
+//     are not written — which matches the reader, since it does not decode
+//     them either.
+//   - **No ASCII table writing.** BINTABLE is what modern pipelines use; an
+//     ASCII table read in cannot be written back out.
+//
 // # World Coordinate System
 //
 // The [WCS] type encodes the FITS standard pixel-to-sky mapping defined by

--- a/fits/doc.go
+++ b/fits/doc.go
@@ -9,6 +9,16 @@
 //   - Memory-mapped file access for zero-copy large-image workflows
 //   - Apache Arrow columnar batch export for catalog-scale table HDUs
 //
+// [Write] encodes a [File] back out: images at every BITPIX, and binary tables
+// built from an Arrow batch. It takes an [io.Writer] rather than a path, so a
+// file, a bucket, a socket or a buffer are all the same call.
+//
+// The structural keywords — BITPIX, NAXIS, NAXISn, NAXIS1/2, TFIELDS, TFORMn —
+// are derived from the data being written rather than copied from the stored
+// header, because the two disagree the moment a caller filters a table's rows
+// or replaces an image's pixels. A file whose header describes something it
+// does not contain is unreadable in a way no reader can diagnose.
+//
 // # World Coordinate System
 //
 // The [WCS] type encodes the FITS standard pixel-to-sky mapping defined by

--- a/fits/doc.go
+++ b/fits/doc.go
@@ -46,13 +46,13 @@
 // Vector columns — a TFORM repeat above one, which is how a table carries a
 // spectrum or a covariance row — read and write as fixed-size lists.
 //
+// ASCII tables (XTENSION = 'TABLE') read and write as well. The reader used to
+// consume their payload without decoding it, so every one in every archive
+// arrived empty; it decodes now, with a blank field read as undefined rather
+// than as zero, which is that format's own way of saying "no value".
+//
 // # What the writer does not do
 //
-// **ASCII tables are not written**, and barely read: ReadASCIITable consumes
-// the payload without decoding it. BINTABLE superseded the format decades ago
-// and is what modern pipelines emit, so an ASCII table read here arrives as a
-// header and a row count.
-//
-// The variable-length P and Q descriptors are not written either. A column
-// declaring one is read as its raw stored values.
+// The variable-length P and Q descriptors are not written. A column declaring
+// one is read as its raw stored values.
 package fits

--- a/fits/errors.go
+++ b/fits/errors.go
@@ -25,6 +25,23 @@ var (
 	// ErrEmptyHeader indicates a FITS file with an empty header.
 	ErrEmptyHeader = errors.New("fits verify: empty header")
 
+	// ErrCardTooLong indicates a header card that does not fit the 80-byte
+	// record: an over-long keyword, or a value and comment that together
+	// overflow. It is an error rather than a truncation because the 80-byte
+	// grid is the only thing separating one card from the next, so an
+	// overflowing card shifts every card after it.
+	ErrCardTooLong = errors.New("fits: header card exceeds 80 characters")
+
+	// ErrCardNotPrintable indicates a header card carrying a byte outside
+	// ASCII 32-126, which FITS does not permit in a header. A newline in a
+	// comment corrupts the record grid rather than one card.
+	ErrCardNotPrintable = errors.New("fits: header card contains a non-printable byte")
+
+	// ErrNotWritable indicates an HDU this package cannot encode: an HDU kind
+	// with no writer, a binary table asked to be the primary HDU, or an image
+	// whose declared axes disagree with the data it carries.
+	ErrNotWritable = errors.New("fits: HDU cannot be written")
+
 	// ErrInvalidWhence indicates an invalid whence argument to Seek.
 	ErrInvalidWhence = errors.New("mmapSeeker: invalid whence")
 	// ErrNegativeOffset indicates a negative offset in Seek.

--- a/fits/errors.go
+++ b/fits/errors.go
@@ -37,6 +37,11 @@ var (
 	// comment corrupts the record grid rather than one card.
 	ErrCardNotPrintable = errors.New("fits: header card contains a non-printable byte")
 
+	// ErrCardNotFinite indicates a header value of NaN or infinity. A FITS
+	// header has no representation for either, so writing one would produce a
+	// card claiming to hold a number that no reader can parse.
+	ErrCardNotFinite = errors.New("fits: header value is not finite")
+
 	// ErrNotWritable indicates an HDU this package cannot encode: an HDU kind
 	// with no writer, a binary table asked to be the primary HDU, or an image
 	// whose declared axes disagree with the data it carries.

--- a/fits/fits.go
+++ b/fits/fits.go
@@ -260,6 +260,16 @@ func ReadHeader(br *BlockReader) (*Header, error) {
 				return h, nil
 			}
 
+			// A CONTINUE card is not a card of its own: it carries the next
+			// segment of the string the previous card began. Joining it here
+			// is what makes a long value arrive whole rather than truncated
+			// at the "&" that marks the split.
+			if c.Keyword == continueKeyword && len(h.Cards) > 0 {
+				if joinContinuation(&h.Cards[len(h.Cards)-1], c) {
+					continue
+				}
+			}
+
 			// Exclude completely blank cards
 			if len(c.Keyword) > 0 || len(c.Value) > 0 || len(c.Comment) > 0 {
 				// Checked before the append rather than after, so the limit is

--- a/fits/hdu.go
+++ b/fits/hdu.go
@@ -36,6 +36,18 @@ type basicHDU struct {
 	PayloadSize int64
 }
 
-func (h *basicHDU) Header() *Header          { return h.header }
+// Header returns the HDU's header, creating an empty one on first use.
+//
+// The lazy creation is what makes a zero-valued HDU usable for writing. An
+// image built in memory — the whole point of having a writer — starts with no
+// header, and a caller reaching for one to set OBJECT or a WCS would otherwise
+// be handed nil and find out by panic.
+func (h *basicHDU) Header() *Header {
+	if h.header == nil {
+		h.header = NewHeader()
+	}
+
+	return h.header
+}
 func (h *basicHDU) Type() HDUType            { return h.hType }
 func (h *basicHDU) Load(_ io.ReaderAt) error { return nil } // Stub

--- a/fits/header.go
+++ b/fits/header.go
@@ -61,12 +61,10 @@ func (h *Header) GetString(keyword string) (string, error) {
 		return "", err
 	}
 
-	val := strings.TrimSpace(card.Value)
-	if len(val) >= 2 && val[0] == '\'' && val[len(val)-1] == '\'' {
-		val = val[1 : len(val)-1]
-	}
-	// Also trim trailing spaces that might be inside the quoted string if it was padded
-	return strings.TrimRight(val, " "), nil
+	// unquote also collapses the doubled quote FITS uses to escape a literal
+	// one, so a value written as 'O''Brien' reads back as O'Brien rather than
+	// as the text a writer would have to double again.
+	return unquote(strings.TrimSpace(card.Value)), nil
 }
 
 // GetInt returns the value of a keyword as an integer.
@@ -104,50 +102,66 @@ func (h *Header) GetFloat(keyword string) (float64, error) {
 }
 
 // ParseCard extracts the value and comment string from a raw 80-byte FITS card.
+//
+// Three card shapes are recognised, which is every shape a header actually
+// contains:
+//
+//   - A value card: keyword in columns 1-8, "= " in 9-10, then the value and
+//     an optional " / comment".
+//   - A HIERARCH card, whose keyword is longer than eight characters and runs
+//     up to the first "=" — see [github.com/TuSKan/astrogo/fits] on the
+//     conventions.
+//   - A commentary card (COMMENT, HISTORY, or a blank keyword), whose whole
+//     remainder is text.
+//
+// The value is returned as written, quotes included, so a card read here and
+// written back by [Write] is the same card.
 func ParseCard(raw []byte) Card {
 	s := string(raw)
-	if len(s) > 80 {
-		s = s[:80]
+	if len(s) > CardSize {
+		s = s[:CardSize]
+	}
+
+	// A HIERARCH keyword is longer than the eight-column field, so it has to
+	// be recognised before the columns are trusted.
+	if kw, rest, ok := parseHierarch(s); ok {
+		value, comment := splitValueComment(rest)
+
+		return Card{Keyword: kw, Value: value, Comment: comment}
 	}
 
 	card := Card{}
 
-	if len(s) < 8 {
+	if len(s) < keywordWidth {
 		card.Keyword = strings.TrimSpace(s)
+
 		return card
 	}
 
-	card.Keyword = strings.TrimSpace(s[0:8])
+	card.Keyword = strings.TrimSpace(s[0:keywordWidth])
 
-	if len(s) == 8 || len(strings.TrimSpace(s[8:])) == 0 {
+	if len(s) == keywordWidth || strings.TrimSpace(s[keywordWidth:]) == "" {
 		return card
 	}
 
-	rest := s[8:]
-	if strings.HasPrefix(rest, "= ") {
-		rest = rest[2:]
+	rest := s[keywordWidth:]
 
-		// Find the true value and comment split considering string literals
-		inQuote := false
-		valEnd := len(rest)
+	// CONTINUE carries a bare string in the value field with no "= ", and is
+	// joined onto the preceding card by ReadHeader.
+	if card.Keyword == continueKeyword {
+		card.Value, card.Comment = splitValueComment(rest)
 
-		for i := range len(rest) {
-			if rest[i] == '\'' {
-				inQuote = !inQuote
-			} else if rest[i] == '/' && !inQuote {
-				valEnd = i
-				break
-			}
-		}
+		return card
+	}
 
-		card.Value = strings.TrimSpace(rest[:valEnd])
-		if valEnd < len(rest) {
-			card.Comment = strings.TrimSpace(rest[valEnd+1:])
-		}
-	} else {
-		// Not a standard assignment card (such as HISTORY or COMMENT)
+	if !strings.HasPrefix(rest, valueIndicator) {
+		// Not an assignment: COMMENT, HISTORY, or a blank keyword.
 		card.Comment = strings.TrimSpace(rest)
+
+		return card
 	}
+
+	card.Value, card.Comment = splitValueComment(rest[len(valueIndicator):])
 
 	return card
 }

--- a/fits/image.go
+++ b/fits/image.go
@@ -107,23 +107,39 @@ func ReadImage(h *Header, r io.Reader) (*ImageHDU, error) {
 		dt         arrow.DataType
 	)
 
-	switch bitpix {
-	case BitpixUint8:
+	// FITS stores unsigned integers wider than a byte as the signed type of
+	// the same width, offset by BZERO = 2^(n-1) (FITS 4.0 section 5.2.5). A
+	// reader that ignores that hands back negative pixels for the upper half
+	// of an unsigned image — 40000 read as -25536 — which is a plausible
+	// number in the wrong place rather than an error anyone notices.
+	unsigned := isUnsignedOffset(bitpix, bzero)
+
+	switch {
+	case bitpix == BitpixUint8:
 		pixelBytes = 1
 		dt = arrow.PrimitiveTypes.Uint8
-	case BitpixInt16:
+	case bitpix == BitpixInt16 && unsigned:
+		pixelBytes = 2
+		dt = arrow.PrimitiveTypes.Uint16
+	case bitpix == BitpixInt16:
 		pixelBytes = 2
 		dt = arrow.PrimitiveTypes.Int16
-	case BitpixInt32:
+	case bitpix == BitpixInt32 && unsigned:
+		pixelBytes = 4
+		dt = arrow.PrimitiveTypes.Uint32
+	case bitpix == BitpixInt32:
 		pixelBytes = 4
 		dt = arrow.PrimitiveTypes.Int32
-	case BitpixInt64:
+	case bitpix == BitpixInt64 && unsigned:
+		pixelBytes = 8
+		dt = arrow.PrimitiveTypes.Uint64
+	case bitpix == BitpixInt64:
 		pixelBytes = 8
 		dt = arrow.PrimitiveTypes.Int64
-	case BitpixFloat32:
+	case bitpix == BitpixFloat32:
 		pixelBytes = 4
 		dt = arrow.PrimitiveTypes.Float32
-	case BitpixFloat64:
+	case bitpix == BitpixFloat64:
 		pixelBytes = 8
 		dt = arrow.PrimitiveTypes.Float64
 	default:
@@ -148,6 +164,14 @@ func ReadImage(h *Header, r io.Reader) (*ImageHDU, error) {
 	}
 
 	swapBigEndianToNative(rawBytes, int(pixelBytes))
+
+	// The stored values are signed; adding BZERO back is what makes them the
+	// unsigned values they were written from. Done here, on the raw buffer,
+	// rather than left to PhysicalValue, so the tensor a caller receives has
+	// the type and the values the file describes.
+	if unsigned {
+		offsetToUnsigned(rawBytes, int(pixelBytes))
+	}
 
 	// After reading the payload, discard the padding to reach 2880 byte bounds
 	paddingBytes := int(totalPayloadBytes) % BlockSize
@@ -207,4 +231,25 @@ func (img *ImageHDU) PhysicalValue(stored float64) float64 {
 	}
 
 	return img.BZero + img.BScale*stored
+}
+
+// offsetToUnsigned adds the unsigned BZERO back in place, in native byte order.
+//
+// The inverse of the writer's offsetToSigned, and the same XOR of the sign bit:
+// for an offset of 2^(n-1) the two directions are one operation.
+func offsetToUnsigned(buf []byte, pixelBytes int) {
+	switch pixelBytes {
+	case 2:
+		for i := 0; i+2 <= len(buf); i += 2 {
+			binary.NativeEndian.PutUint16(buf[i:], binary.NativeEndian.Uint16(buf[i:])^0x8000)
+		}
+	case 4:
+		for i := 0; i+4 <= len(buf); i += 4 {
+			binary.NativeEndian.PutUint32(buf[i:], binary.NativeEndian.Uint32(buf[i:])^0x80000000)
+		}
+	case 8:
+		for i := 0; i+8 <= len(buf); i += 8 {
+			binary.NativeEndian.PutUint64(buf[i:], binary.NativeEndian.Uint64(buf[i:])^0x8000000000000000)
+		}
+	}
 }

--- a/fits/image.go
+++ b/fits/image.go
@@ -253,3 +253,12 @@ func offsetToUnsigned(buf []byte, pixelBytes int) {
 		}
 	}
 }
+
+// Type reports that this is an image HDU.
+//
+// Declared on the concrete type rather than left to the embedded basicHDU,
+// whose field is only filled in by the reader. An HDU a caller constructed —
+// which is the whole point of having a writer — would otherwise report the
+// zero value, and the zero value happens to be HDUTypeImage, so the mistake is
+// invisible until the one kind it is wrong for.
+func (*ImageHDU) Type() HDUType { return HDUTypeImage }

--- a/fits/tnull.go
+++ b/fits/tnull.go
@@ -1,0 +1,73 @@
+package fits
+
+import (
+	"math"
+	"strconv"
+)
+
+// TNULLn is how a FITS binary table says a cell holds no value.
+//
+// There is no null bitmap in the format. A floating-point column expresses
+// absence as NaN, which the IEEE representation already has room for; an
+// integer column cannot, so the convention (FITS 4.0 §7.3.2) is to declare one
+// stored value as meaning "undefined" and write that value in the empty cells.
+//
+// The declaration is per column and per file, so the sentinel is a property of
+// the table rather than of the type — which is what makes it safe: a column
+// whose data genuinely spans the whole integer range simply declares no TNULL
+// and has no nulls.
+
+// nullSentinel is the value written into an integer cell that holds nothing.
+//
+// The most negative value of the column's type. It is the conventional choice —
+// cfitsio and astropy both use it — for the reason that makes any choice
+// defensible: it has to be a value the column does not otherwise contain, and
+// the minimum is the one a physical quantity is least likely to take. A count,
+// a flux, an identifier and a pixel index are all far from it.
+//
+// The writer checks anyway. A column that does contain its own minimum gets no
+// TNULL and keeps its values, because reserving a sentinel that collides with
+// real data would silently turn measurements into absences — the exact failure
+// the convention exists to prevent, inverted.
+func nullSentinel(code byte) (int64, bool) {
+	switch code {
+	case 'B':
+		// An unsigned byte column has no negative value to spare; 255 is the
+		// conventional sentinel and is checked for collision like the rest.
+		return math.MaxUint8, true
+	case 'I':
+		return math.MinInt16, true
+	case 'J':
+		return math.MinInt32, true
+	case 'K':
+		return math.MinInt64, true
+	default:
+		// Logical and character columns carry their own undefined value — a
+		// zero byte and a blank string respectively — and floats use NaN.
+		return 0, false
+	}
+}
+
+// tnullCard builds the TNULLn declaration for a column.
+func tnullCard(index int, sentinel int64) Card {
+	n := strconv.Itoa(index + 1)
+
+	return Card{
+		Keyword: "TNULL" + n,
+		Value:   strconv.FormatInt(sentinel, 10),
+		Comment: "value used to represent undefined for field " + n,
+	}
+}
+
+// tnullFor reads a column's declared undefined value.
+//
+// ok is false when the column declares none, which is the common case and
+// means every stored value is real.
+func tnullFor(h *Header, index int) (int64, bool) {
+	v, err := h.GetInt("TNULL" + strconv.Itoa(index+1))
+	if err != nil {
+		return 0, false
+	}
+
+	return int64(v), true
+}

--- a/fits/tnull_test.go
+++ b/fits/tnull_test.go
@@ -1,0 +1,215 @@
+package fits_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// A FITS binary table has no null bitmap. An integer column says "no value" by
+// declaring TNULLn and storing that value; a float column says it with NaN
+// (FITS 4.0 §7.3.2).
+//
+// Before this, every null was written as zero — so a missing magnitude became
+// magnitude 0, which is a very bright star rather than an absent measurement.
+
+// nullableCatalog builds a batch with a null in each nullable kind.
+func nullableCatalog(t *testing.T) arrow.RecordBatch {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "HIP", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "VMAG", Type: arrow.PrimitiveTypes.Float32, Nullable: true},
+		{Name: "PARALLAX", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "BAND", Type: arrow.PrimitiveTypes.Int16, Nullable: true},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	// Row 1 is complete; row 2 is missing everything.
+	builderAs[*array.Int32Builder](t, rb, 0).AppendValues([]int32{91262, 0}, []bool{true, false})
+	builderAs[*array.Float32Builder](t, rb, 1).AppendValues([]float32{0.03, 0}, []bool{true, false})
+	builderAs[*array.Float64Builder](t, rb, 2).AppendValues([]float64{130.23, 0}, []bool{true, false})
+	builderAs[*array.Int16Builder](t, rb, 3).AppendValues([]int16{5, 0}, []bool{true, false})
+
+	return rb.NewRecordBatch()
+}
+
+func TestNullsSurviveAsNullsNotZeros(t *testing.T) {
+	t.Parallel()
+
+	batch := nullableCatalog(t)
+	t.Cleanup(batch.Release)
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	for i := range out.Batch.Schema().NumFields() {
+		name := out.Batch.Schema().Field(i).Name
+		col := out.Batch.Column(i)
+
+		if col.IsNull(0) {
+			t.Errorf("column %q row 0 came back null, but it had a value", name)
+		}
+
+		if !col.IsNull(1) {
+			t.Errorf("column %q row 1 = %s, want null.\n"+
+				"  A missing value written as zero is a measurement rather than "+
+				"an absence, which is what TNULLn and NaN exist to prevent.",
+				name, col.ValueStr(1))
+		}
+	}
+
+	// The integer columns must declare their sentinel, or a reader has no way
+	// to know which stored value means undefined.
+	for _, kw := range []string{"TNULL1", "TNULL4"} {
+		if _, err := out.Header().GetInt(kw); err != nil {
+			t.Errorf("%s is missing: %v", kw, err)
+		}
+	}
+}
+
+// TestAColumnHoldingItsOwnSentinelKeepsItsValues is the safety check.
+//
+// The sentinel is a stored value like any other, so reserving one that the
+// column genuinely contains would turn those measurements into absences — the
+// convention's failure mode inverted, and silent. Such a column declares no
+// TNULL and keeps every value it has.
+func TestAColumnHoldingItsOwnSentinelKeepsItsValues(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "OFFSET", Type: arrow.PrimitiveTypes.Int16, Nullable: true},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	// math.MinInt16 is the conventional sentinel, and here it is real data.
+	builderAs[*array.Int16Builder](t, rb, 0).AppendValues(
+		[]int16{math.MinInt16, 0, 7}, []bool{true, false, true})
+
+	batch := rb.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	if _, err := out.Header().GetInt("TNULL1"); err == nil {
+		t.Error("a TNULL was declared for a column that contains that value as data")
+	}
+
+	col, ok := out.Batch.Column(0).(*array.Int16)
+	if !ok {
+		t.Fatalf("column is %T", out.Batch.Column(0))
+	}
+
+	if col.IsNull(0) || col.Value(0) != math.MinInt16 {
+		t.Errorf("row 0 = %s, want %d — a real measurement was read as absent",
+			col.ValueStr(0), math.MinInt16)
+	}
+
+	if col.Value(2) != 7 {
+		t.Errorf("row 2 = %d, want 7", col.Value(2))
+	}
+}
+
+// TestFloatNullsAreNaN pins the other half of the convention: a float column
+// expresses absence in the value itself, so it needs no declaration.
+func TestFloatNullsAreNaN(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "FLUX", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	builderAs[*array.Float64Builder](t, rb, 0).AppendValues([]float64{1.5, 0}, []bool{true, false})
+
+	batch := rb.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// The stored bytes are what another reader sees, and NaN is what the
+	// standard says absence looks like there. Checked as a NaN rather than as
+	// exact bits: every quiet NaN means undefined, and Go's math.NaN carries a
+	// payload of its own.
+	raw := buf.Bytes()
+	stored := raw[len(raw)-fits.BlockSize:] // the table's data block
+
+	second := math.Float64frombits(binary.BigEndian.Uint64(stored[8:16]))
+	if !math.IsNaN(second) {
+		t.Errorf("the missing value was stored as %v, want a NaN", second)
+	}
+
+	first := math.Float64frombits(binary.BigEndian.Uint64(stored[0:8]))
+	if first != 1.5 {
+		t.Errorf("the present value was stored as %v, want 1.5", first)
+	}
+
+	// And it comes back as a null rather than as a NaN the caller has to
+	// notice.
+	got, err := fits.Read(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	if !out.Batch.Column(0).IsNull(1) {
+		t.Error("a stored NaN did not read back as a null")
+	}
+}

--- a/fits/unsigned_test.go
+++ b/fits/unsigned_test.go
@@ -1,0 +1,272 @@
+package fits_test
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/tensor"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// FITS has no unsigned integer type above 8 bits. The standard's answer — FITS
+// 4.0 §5.2.5, and what every other library does — is to store the signed type
+// of the same width offset by BZERO = 2^(n-1).
+//
+// The failure this prevents is quiet: a detector frame of uint16 counts read
+// without the convention hands back 40000 as -25536, which is a plausible
+// number in the wrong place rather than anything a caller notices.
+
+// TestUnsignedImagesRoundTripThroughBZero walks all three widths, at the values
+// where the convention is visible: zero, the midpoint, and the maximum. The
+// upper half is what reads back negative when the offset is ignored.
+func TestUnsignedImagesRoundTripThroughBZero(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uint16", func(t *testing.T) {
+		t.Parallel()
+
+		want := []uint16{0, 1, 32767, 32768, 40000, math.MaxUint16}
+
+		img := roundTripUnsigned(t, want, 32768, arrow.UINT16)
+
+		tn, ok := img.Tensor.(*tensor.Uint16)
+		if !ok {
+			t.Fatalf("tensor is %T, want *tensor.Uint16", img.Tensor)
+		}
+
+		assertValues(t, tn.Uint16Values(), want)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+
+		want := []uint32{0, 1, math.MaxInt32, math.MaxInt32 + 1, math.MaxUint32}
+
+		img := roundTripUnsigned(t, want, 2147483648, arrow.UINT32)
+
+		tn, ok := img.Tensor.(*tensor.Uint32)
+		if !ok {
+			t.Fatalf("tensor is %T, want *tensor.Uint32", img.Tensor)
+		}
+
+		assertValues(t, tn.Uint32Values(), want)
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		t.Parallel()
+
+		want := []uint64{0, 1, math.MaxInt64, math.MaxInt64 + 1, math.MaxUint64}
+
+		img := roundTripUnsigned(t, want, 9223372036854775808, arrow.UINT64)
+
+		tn, ok := img.Tensor.(*tensor.Uint64)
+		if !ok {
+			t.Fatalf("tensor is %T, want *tensor.Uint64", img.Tensor)
+		}
+
+		assertValues(t, tn.Uint64Values(), want)
+	})
+}
+
+// unsignedValue is the set of unsigned widths FITS stores through BZERO.
+type unsignedValue interface {
+	~uint16 | ~uint32 | ~uint64
+}
+
+// roundTripUnsigned writes values as an image, reads it back, and checks the
+// keywords the convention is carried by.
+func roundTripUnsigned[T unsignedValue](t *testing.T, values []T, wantBZero float64, wantType arrow.Type) *fits.ImageHDU {
+	t.Helper()
+
+	arr := buildUnsigned(t, values)
+	defer arr.Release()
+
+	axes := []int64{int64(arr.Len())}
+
+	src := &fits.ImageHDU{Tensor: tensor.New(arr.Data(), axes, nil, nil), Axes: axes}
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	img, ok := got.HDUs[0].(*fits.ImageHDU)
+	if !ok {
+		t.Fatalf("HDU is %T", got.HDUs[0])
+	}
+
+	// BZERO has to be the exact value the convention names, since that is what
+	// every other reader matches against.
+	if img.BZero != wantBZero {
+		t.Errorf("BZERO = %v, want %v — other readers match this exactly", img.BZero, wantBZero)
+	}
+
+	if img.BScale != 1 {
+		t.Errorf("BSCALE = %v, want 1", img.BScale)
+	}
+
+	if id := img.Tensor.DataType().ID(); id != wantType {
+		t.Fatalf("tensor type = %v, want %v — the offset was not applied on read", id, wantType)
+	}
+
+	return img
+}
+
+// buildUnsigned puts values into the Arrow array of their own width.
+func buildUnsigned[T unsignedValue](t *testing.T, values []T) arrow.Array {
+	t.Helper()
+
+	mem := memory.NewGoAllocator()
+
+	switch v := any(values).(type) {
+	case []uint16:
+		b := array.NewUint16Builder(mem)
+		defer b.Release()
+
+		b.AppendValues(v, nil)
+
+		return b.NewUint16Array()
+	case []uint32:
+		b := array.NewUint32Builder(mem)
+		defer b.Release()
+
+		b.AppendValues(v, nil)
+
+		return b.NewUint32Array()
+	case []uint64:
+		b := array.NewUint64Builder(mem)
+		defer b.Release()
+
+		b.AppendValues(v, nil)
+
+		return b.NewUint64Array()
+	default:
+		t.Fatalf("no builder for %T", values)
+
+		return nil
+	}
+}
+
+// assertValues compares what came back against what went in.
+func assertValues[T unsignedValue](t *testing.T, got, want []T) {
+	t.Helper()
+
+	if len(got) < len(want) {
+		t.Fatalf("read %d pixels, want %d", len(got), len(want))
+	}
+
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("pixel %d = %d, want %d", i, got[i], w)
+		}
+	}
+}
+
+// TestASignedImageIsNotReadAsUnsigned is the other half, and the one that
+// stops the convention from swallowing real calibration data.
+//
+// A BZERO near the magic value but not equal to it is an ordinary scaling
+// offset, and reading it as an unsigned marker would reinterpret every pixel.
+func TestASignedImageIsNotReadAsUnsigned(t *testing.T) {
+	t.Parallel()
+
+	b := array.NewInt16Builder(memory.NewGoAllocator())
+	defer b.Release()
+
+	b.AppendValues([]int16{-100, 0, 100}, nil)
+
+	arr := b.NewInt16Array()
+	defer arr.Release()
+
+	axes := []int64{3}
+
+	src := &fits.ImageHDU{
+		Tensor: tensor.New(arr.Data(), axes, nil, nil),
+		Axes:   axes,
+		Bitpix: fits.BitpixInt16,
+		BZero:  32768.5, // a real offset, not the unsigned marker
+		BScale: 1,
+	}
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	img, ok := got.HDUs[0].(*fits.ImageHDU)
+	if !ok {
+		t.Fatalf("HDU is %T", got.HDUs[0])
+	}
+
+	if id := img.Tensor.DataType().ID(); id != arrow.INT16 {
+		t.Fatalf("tensor type = %v, want INT16 — a calibration offset was read "+
+			"as the unsigned marker", id)
+	}
+
+	tn, ok := img.Tensor.(*tensor.Int16)
+	if !ok {
+		t.Fatalf("tensor is %T", img.Tensor)
+	}
+
+	for i, w := range []int16{-100, 0, 100} {
+		if got := tn.Int16Values()[i]; got != w {
+			t.Errorf("pixel %d = %d, want %d", i, got, w)
+		}
+	}
+}
+
+// TestUnsignedStoredBytesAreTheSignedOnes pins the encoding itself against the
+// standard, not against this package's reader.
+//
+// A uint16 of 0 is stored as int16 -32768, and 65535 as +32767. Any other
+// reader will apply BZERO to exactly these bytes, so they are the contract.
+func TestUnsignedStoredBytesAreTheSignedOnes(t *testing.T) {
+	t.Parallel()
+
+	b := array.NewUint16Builder(memory.NewGoAllocator())
+	defer b.Release()
+
+	b.AppendValues([]uint16{0, 32768, math.MaxUint16}, nil)
+
+	arr := b.NewUint16Array()
+	defer arr.Release()
+
+	axes := []int64{3}
+
+	src := &fits.ImageHDU{Tensor: tensor.New(arr.Data(), axes, nil, nil), Axes: axes}
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// The payload starts at the second block; three int16 big-endian values.
+	payload := buf.Bytes()[fits.BlockSize : fits.BlockSize+6]
+
+	want := []byte{
+		0x80, 0x00, // -32768, which is uint16 0 minus 32768
+		0x00, 0x00, // 0,      which is uint16 32768 minus 32768
+		0x7F, 0xFF, // +32767, which is uint16 65535 minus 32768
+	}
+
+	if !bytes.Equal(payload, want) {
+		t.Errorf("stored bytes = % x, want % x.\n"+
+			"  These are what another reader adds BZERO to, so they are the "+
+			"interoperable contract rather than an internal detail.", payload, want)
+	}
+}

--- a/fits/vector_test.go
+++ b/fits/vector_test.go
@@ -1,0 +1,191 @@
+package fits_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// A TFORM repeat count above one is a vector per row — a spectrum, a
+// covariance row, a magnitude per filter — and BINTABLEs use them constantly.
+//
+// These columns used to decode as Arrow nulls, so every value in them was
+// discarded on read: a table of 2048-channel spectra came back as a column of
+// nothing, with no error.
+
+// spectrumBatch builds a table with a vector column beside a scalar one.
+func spectrumBatch(t *testing.T) arrow.RecordBatch {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "OBJECT", Type: arrow.BinaryTypes.String},
+		{Name: "FLUX", Type: arrow.FixedSizeListOf(4, arrow.PrimitiveTypes.Float32)},
+		{Name: "COUNTS", Type: arrow.FixedSizeListOf(3, arrow.PrimitiveTypes.Int32)},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	builderAs[*array.StringBuilder](t, rb, 0).AppendValues([]string{"M31", "M42"}, nil)
+
+	flux, ok := rb.Field(1).(*array.FixedSizeListBuilder)
+	if !ok {
+		t.Fatalf("FLUX builder is %T", rb.Field(1))
+	}
+
+	fluxValues, ok := flux.ValueBuilder().(*array.Float32Builder)
+	if !ok {
+		t.Fatalf("FLUX value builder is %T", flux.ValueBuilder())
+	}
+
+	for _, row := range [][]float32{{1.5, 2.5, 3.5, 4.5}, {-1, 0, 1, 2}} {
+		flux.Append(true)
+		fluxValues.AppendValues(row, nil)
+	}
+
+	counts, ok := rb.Field(2).(*array.FixedSizeListBuilder)
+	if !ok {
+		t.Fatalf("COUNTS builder is %T", rb.Field(2))
+	}
+
+	countValues, ok := counts.ValueBuilder().(*array.Int32Builder)
+	if !ok {
+		t.Fatalf("COUNTS value builder is %T", counts.ValueBuilder())
+	}
+
+	for _, row := range [][]int32{{10, 20, 30}, {-5, 0, 5}} {
+		counts.Append(true)
+		countValues.AppendValues(row, nil)
+	}
+
+	return rb.NewRecordBatch()
+}
+
+func TestVectorColumnsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	batch := spectrumBatch(t)
+	t.Cleanup(batch.Release)
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	// The repeat count is the vector length, and it is what another reader
+	// uses to lay the cell out.
+	for _, tc := range []struct {
+		keyword string
+		want    string
+	}{
+		{keyword: "TFORM2", want: "4E"},
+		{keyword: "TFORM3", want: "3J"},
+	} {
+		if v, err := out.Header().GetString(tc.keyword); err != nil || v != tc.want {
+			t.Errorf("%s = %q (%v), want %q", tc.keyword, v, err, tc.want)
+		}
+	}
+
+	assertFloatVector(t, out.Batch, "FLUX", [][]float32{{1.5, 2.5, 3.5, 4.5}, {-1, 0, 1, 2}})
+	assertIntVector(t, out.Batch, "COUNTS", [][]int32{{10, 20, 30}, {-5, 0, 5}})
+
+	// The scalar column beside them must be unaffected: a vector column that
+	// laid its cell out wrongly would shift every column after it.
+	names, ok := out.Batch.Column(0).(*array.String)
+	if !ok {
+		t.Fatalf("OBJECT is %T", out.Batch.Column(0))
+	}
+
+	for i, w := range []string{"M31", "M42"} {
+		if got := names.Value(i); got != w {
+			t.Errorf("OBJECT row %d = %q, want %q — the row layout is wrong", i, got, w)
+		}
+	}
+}
+
+// assertFloatVector checks a float vector column value by value.
+func assertFloatVector(t *testing.T, batch arrow.RecordBatch, name string, want [][]float32) {
+	t.Helper()
+
+	list := vectorColumn(t, batch, name)
+
+	values, ok := list.ListValues().(*array.Float32)
+	if !ok {
+		t.Fatalf("%s values are %T, want *array.Float32", name, list.ListValues())
+	}
+
+	n := int(list.DataType().(*arrow.FixedSizeListType).Len()) //nolint:forcetypeassert // checked by vectorColumn
+
+	for row, wantRow := range want {
+		for i, w := range wantRow {
+			if got := values.Value(row*n + i); got != w {
+				t.Errorf("%s row %d element %d = %v, want %v", name, row, i, got, w)
+			}
+		}
+	}
+}
+
+// assertIntVector checks an integer vector column value by value.
+func assertIntVector(t *testing.T, batch arrow.RecordBatch, name string, want [][]int32) {
+	t.Helper()
+
+	list := vectorColumn(t, batch, name)
+
+	values, ok := list.ListValues().(*array.Int32)
+	if !ok {
+		t.Fatalf("%s values are %T, want *array.Int32", name, list.ListValues())
+	}
+
+	n := int(list.DataType().(*arrow.FixedSizeListType).Len()) //nolint:forcetypeassert // checked by vectorColumn
+
+	for row, wantRow := range want {
+		for i, w := range wantRow {
+			if got := values.Value(row*n + i); got != w {
+				t.Errorf("%s row %d element %d = %v, want %v", name, row, i, got, w)
+			}
+		}
+	}
+}
+
+// vectorColumn returns a named column as a fixed-size list.
+func vectorColumn(t *testing.T, batch arrow.RecordBatch, name string) *array.FixedSizeList {
+	t.Helper()
+
+	idx := batch.Schema().FieldIndices(name)
+	if len(idx) == 0 {
+		t.Fatalf("no column named %q", name)
+	}
+
+	col := batch.Column(idx[0])
+
+	list, ok := col.(*array.FixedSizeList)
+	if !ok {
+		t.Fatalf("column %q is %T, want *array.FixedSizeList — a vector column "+
+			"decoded as something else discards its values", name, col)
+	}
+
+	if _, ok := list.DataType().(*arrow.FixedSizeListType); !ok {
+		t.Fatalf("column %q has type %T", name, list.DataType())
+	}
+
+	return list
+}

--- a/fits/write.go
+++ b/fits/write.go
@@ -31,7 +31,7 @@ func Write(w io.Writer, f *File) error {
 	}
 
 	for i, hdu := range f.HDUs {
-		if err := writeHDU(w, hdu, i == 0); err != nil {
+		if err := writeHDU(w, hdu, i == 0, len(f.HDUs) > 1); err != nil {
 			return fmt.Errorf("fits: write HDU %d: %w", i, err)
 		}
 	}
@@ -40,8 +40,8 @@ func Write(w io.Writer, f *File) error {
 }
 
 // writeHDU writes one header and its payload, each padded to a block boundary.
-func writeHDU(w io.Writer, hdu HDU, primary bool) error {
-	header, payload, err := encodeHDU(hdu, primary)
+func writeHDU(w io.Writer, hdu HDU, primary, extensions bool) error {
+	header, payload, err := encodeHDU(hdu, primary, extensions)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func writeHDU(w io.Writer, hdu HDU, primary bool) error {
 		return err
 	}
 
-	return writePayload(w, payload, hdu.Type())
+	return writePayload(w, payload)
 }
 
 // encodeHDU produces the header an HDU should carry and the bytes of its
@@ -65,10 +65,10 @@ func writeHDU(w io.Writer, hdu HDU, primary bool) error {
 //
 // Everything that is not structural — WCS, provenance, the caller's own
 // keywords — is carried over untouched.
-func encodeHDU(hdu HDU, primary bool) (*Header, []byte, error) {
+func encodeHDU(hdu HDU, primary, extensions bool) (*Header, []byte, error) {
 	switch h := hdu.(type) {
 	case *ImageHDU:
-		return encodeImage(h, primary)
+		return encodeImage(h, primary, extensions)
 	case *BintableHDU:
 		if primary {
 			return nil, nil, fmt.Errorf("%w: a binary table cannot be the primary HDU", ErrNotWritable)
@@ -117,13 +117,14 @@ func writeHeader(w io.Writer, h *Header) error {
 	return nil
 }
 
-// writePayload writes a data payload padded to a block boundary.
+// writePayload writes a data payload padded to a block boundary with zeros.
 //
-// The padding byte is not the same for every HDU kind: the standard fills an
-// ASCII table's last block with spaces and everything else with zeros. A zero
-// byte inside an ASCII table's padding is not blank text, and readers that
-// take the remainder of the block as a row have been seen to notice.
-func writePayload(w io.Writer, payload []byte, kind HDUType) error {
+// Zeros because the two kinds this package writes — images and binary tables —
+// are both padded that way. An ASCII table is not: the standard fills its last
+// block with spaces, since a zero byte there is not blank text and a reader
+// taking the remainder of the block as a row would see it. Whoever adds ASCII
+// table writing has to pass the fill byte in here.
+func writePayload(w io.Writer, payload []byte) error {
 	if len(payload) == 0 {
 		return nil
 	}
@@ -132,12 +133,7 @@ func writePayload(w io.Writer, payload []byte, kind HDUType) error {
 
 	buf.Write(payload)
 
-	fill := byte(0)
-	if kind == HDUTypeASCII {
-		fill = ' '
-	}
-
-	pad(&buf, fill)
+	pad(&buf, 0)
 
 	if _, err := w.Write(buf.Bytes()); err != nil {
 		return fmt.Errorf("fits: write payload: %w", err)

--- a/fits/write.go
+++ b/fits/write.go
@@ -52,7 +52,15 @@ func writeHDU(w io.Writer, hdu HDU, primary, extensions bool) error {
 		return err
 	}
 
-	data := padded(payload, 0)
+	// An ASCII table's last block is filled with spaces: a zero byte there is
+	// not blank text, and a reader taking the remainder of the block as a row
+	// would see it. Everything else pads with zeros.
+	fill := byte(0)
+	if hdu.Type() == HDUTypeASCII {
+		fill = ' '
+	}
+
+	data := padded(payload, fill)
 
 	// DATASUM goes in before the header is rendered, since CHECKSUM covers it.
 	setCard(header, "DATASUM", datasumValue(CalcChecksum(data)),
@@ -128,6 +136,12 @@ func encodeHDU(hdu HDU, primary, extensions bool) (*Header, []byte, error) {
 		}
 
 		return encodeBintable(h)
+	case *ASCIITableHDU:
+		if primary {
+			return nil, nil, fmt.Errorf("%w: an ASCII table cannot be the primary HDU", ErrNotWritable)
+		}
+
+		return encodeASCIITable(h)
 	default:
 		return nil, nil, fmt.Errorf("%w: %T", ErrNotWritable, hdu)
 	}

--- a/fits/write.go
+++ b/fits/write.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/TuSKan/astrogo/time"
 )
 
 // Write encodes f as a FITS stream.
@@ -40,17 +42,68 @@ func Write(w io.Writer, f *File) error {
 }
 
 // writeHDU writes one header and its payload, each padded to a block boundary.
+//
+// The two are rendered before either is written, because the integrity
+// keywords cover both: DATASUM is the data's checksum and CHECKSUM covers the
+// header that carries it, so neither can be known until the other exists.
 func writeHDU(w io.Writer, hdu HDU, primary, extensions bool) error {
 	header, payload, err := encodeHDU(hdu, primary, extensions)
 	if err != nil {
 		return err
 	}
 
-	if err := writeHeader(w, header); err != nil {
+	data := padded(payload, 0)
+
+	// DATASUM goes in before the header is rendered, since CHECKSUM covers it.
+	setCard(header, "DATASUM", datasumValue(CalcChecksum(data)),
+		"1's complement checksum of the data")
+	setCard(header, "CHECKSUM", checksumPlaceholder,
+		"HDU checksum updated "+checksumStamp())
+
+	rendered, err := renderHeader(header)
+	if err != nil {
 		return err
 	}
 
-	return writePayload(w, payload)
+	applyChecksum(rendered, data)
+
+	if _, err := w.Write(rendered); err != nil {
+		return fmt.Errorf("fits: write header: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("fits: write payload: %w", err)
+	}
+
+	return nil
+}
+
+// checksumStamp is the time a checksum was computed, as the convention's
+// example cards carry it.
+//
+// UTC and second resolution, which is what cfitsio writes. It is provenance
+// rather than data: nothing reads it back, and it exists so someone looking at
+// a file can tell when its integrity was last established.
+func checksumStamp() string {
+	return time.Now().UTC().Format("2006-01-02T15:04:05")
+}
+
+// padded returns payload extended to a block boundary with fill.
+func padded(payload []byte, fill byte) []byte {
+	if len(payload) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	buf.Write(payload)
+	pad(&buf, fill)
+
+	return buf.Bytes()
 }
 
 // encodeHDU produces the header an HDU should carry and the bytes of its
@@ -80,9 +133,11 @@ func encodeHDU(hdu HDU, primary, extensions bool) (*Header, []byte, error) {
 	}
 }
 
-// writeHeader renders every card, appends END, and pads to a block boundary
-// with blanks.
-func writeHeader(w io.Writer, h *Header) error {
+// renderHeader renders every card, appends END, and pads to a block boundary
+// with blanks, returning the bytes so the checksum can be taken over them.
+func renderHeader(h *Header) ([]byte, error) {
+	announceLongStrings(h)
+
 	var buf bytes.Buffer
 
 	for _, c := range h.Cards {
@@ -92,54 +147,26 @@ func writeHeader(w io.Writer, h *Header) error {
 			continue
 		}
 
-		card, err := formatCard(c)
+		cards, err := formatCards(c)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		buf.Write(card)
+		for _, card := range cards {
+			buf.Write(card)
+		}
 	}
 
-	end, err := formatCard(Card{Keyword: "END"})
+	end, err := formatCards(Card{Keyword: "END"})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	buf.Write(end)
+	buf.Write(end[0])
 
 	pad(&buf, ' ')
 
-	_, err = w.Write(buf.Bytes())
-	if err != nil {
-		return fmt.Errorf("fits: write header: %w", err)
-	}
-
-	return nil
-}
-
-// writePayload writes a data payload padded to a block boundary with zeros.
-//
-// Zeros because the two kinds this package writes — images and binary tables —
-// are both padded that way. An ASCII table is not: the standard fills its last
-// block with spaces, since a zero byte there is not blank text and a reader
-// taking the remainder of the block as a row would see it. Whoever adds ASCII
-// table writing has to pass the fill byte in here.
-func writePayload(w io.Writer, payload []byte) error {
-	if len(payload) == 0 {
-		return nil
-	}
-
-	var buf bytes.Buffer
-
-	buf.Write(payload)
-
-	pad(&buf, 0)
-
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		return fmt.Errorf("fits: write payload: %w", err)
-	}
-
-	return nil
+	return buf.Bytes(), nil
 }
 
 // pad extends buf to the next block boundary. A buffer already on one is left
@@ -195,4 +222,27 @@ func orderedHeader(src *Header, mandatory []Card) *Header {
 	}
 
 	return out
+}
+
+// announceLongStrings adds LONGSTRN when the header holds a value that will be
+// written across CONTINUE cards.
+//
+// The convention asks for it, and the reason is a reader that does not
+// implement CONTINUE: LONGSTRN is the one thing such a reader can detect, so
+// it knows the value it just read ends at an "&" rather than being complete.
+// Without it the truncation is silent, which is the failure the whole
+// convention exists to avoid.
+func announceLongStrings(h *Header) {
+	for _, c := range h.Cards {
+		if !isQuoted(c.Value) {
+			continue
+		}
+
+		cards, err := formatCards(c)
+		if err == nil && len(cards) > 1 {
+			setCard(h, "LONGSTRN", longStringMarker, "the OGIP long-string convention is in use")
+
+			return
+		}
+	}
 }

--- a/fits/write.go
+++ b/fits/write.go
@@ -1,0 +1,202 @@
+package fits
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Write encodes f as a FITS stream.
+//
+// It writes the HDUs in the order they appear: the first is the primary HDU
+// and the rest are extensions, which is the structure [Read] produces, so a
+// file read by this package and written straight back out is the same file.
+//
+// # Why there is no path-taking form
+//
+// [Open] takes a path because an arbitrary FITS file on the user's disk is one
+// of the two places this module deliberately touches the filesystem. Writing
+// does not need a second exception: a caller who wants a file writes
+//
+//	f, err := os.Create("out.fits")
+//	...
+//	err = fits.Write(f, file)
+//
+// and everything else — a bucket, a socket, a buffer, a gzip stream — works
+// through the same function rather than through a variant per destination.
+func Write(w io.Writer, f *File) error {
+	if f == nil || len(f.HDUs) == 0 {
+		return ErrNoPrimaryHDU
+	}
+
+	for i, hdu := range f.HDUs {
+		if err := writeHDU(w, hdu, i == 0); err != nil {
+			return fmt.Errorf("fits: write HDU %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// writeHDU writes one header and its payload, each padded to a block boundary.
+func writeHDU(w io.Writer, hdu HDU, primary bool) error {
+	header, payload, err := encodeHDU(hdu, primary)
+	if err != nil {
+		return err
+	}
+
+	if err := writeHeader(w, header); err != nil {
+		return err
+	}
+
+	return writePayload(w, payload, hdu.Type())
+}
+
+// encodeHDU produces the header an HDU should carry and the bytes of its
+// payload.
+//
+// The header is rebuilt from the HDU's own structure rather than trusted as
+// stored, because the two can disagree: a caller who appends a row to a table
+// or replaces an image's pixels has changed NAXIS2 or BITPIX without touching
+// the header. Deriving the structural keywords from the data is what stops a
+// file describing itself wrongly — the failure that makes a FITS file unusable
+// while looking perfectly well-formed.
+//
+// Everything that is not structural — WCS, provenance, the caller's own
+// keywords — is carried over untouched.
+func encodeHDU(hdu HDU, primary bool) (*Header, []byte, error) {
+	switch h := hdu.(type) {
+	case *ImageHDU:
+		return encodeImage(h, primary)
+	case *BintableHDU:
+		if primary {
+			return nil, nil, fmt.Errorf("%w: a binary table cannot be the primary HDU", ErrNotWritable)
+		}
+
+		return encodeBintable(h)
+	default:
+		return nil, nil, fmt.Errorf("%w: %T", ErrNotWritable, hdu)
+	}
+}
+
+// writeHeader renders every card, appends END, and pads to a block boundary
+// with blanks.
+func writeHeader(w io.Writer, h *Header) error {
+	var buf bytes.Buffer
+
+	for _, c := range h.Cards {
+		// END is written below, after every other card, so a header that
+		// already carries one from a read does not end early.
+		if strings.EqualFold(strings.TrimSpace(c.Keyword), "END") {
+			continue
+		}
+
+		card, err := formatCard(c)
+		if err != nil {
+			return err
+		}
+
+		buf.Write(card)
+	}
+
+	end, err := formatCard(Card{Keyword: "END"})
+	if err != nil {
+		return err
+	}
+
+	buf.Write(end)
+
+	pad(&buf, ' ')
+
+	_, err = w.Write(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("fits: write header: %w", err)
+	}
+
+	return nil
+}
+
+// writePayload writes a data payload padded to a block boundary.
+//
+// The padding byte is not the same for every HDU kind: the standard fills an
+// ASCII table's last block with spaces and everything else with zeros. A zero
+// byte inside an ASCII table's padding is not blank text, and readers that
+// take the remainder of the block as a row have been seen to notice.
+func writePayload(w io.Writer, payload []byte, kind HDUType) error {
+	if len(payload) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+
+	buf.Write(payload)
+
+	fill := byte(0)
+	if kind == HDUTypeASCII {
+		fill = ' '
+	}
+
+	pad(&buf, fill)
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("fits: write payload: %w", err)
+	}
+
+	return nil
+}
+
+// pad extends buf to the next block boundary. A buffer already on one is left
+// alone — FITS pads to fill a block, it does not append an empty one.
+func pad(buf *bytes.Buffer, fill byte) {
+	if rem := buf.Len() % BlockSize; rem != 0 {
+		buf.Write(bytes.Repeat([]byte{fill}, BlockSize-rem))
+	}
+}
+
+// setCard writes keyword through a header, replacing any existing value.
+//
+// [Header.Append] already overwrites in place, which is what keeps a rebuilt
+// structural keyword in the position it was read at rather than moving it to
+// the end — and position matters for the first few, which the standard fixes
+// in order.
+func setCard(h *Header, keyword, value, comment string) {
+	h.Append(Card{Keyword: keyword, Value: value, Comment: comment})
+}
+
+// orderedHeader returns a header carrying the mandatory keywords first, in the
+// order the standard fixes them, followed by everything else from src.
+//
+// FITS does not merely prefer this order, it requires it: SIMPLE or XTENSION
+// first, then BITPIX, then NAXIS, then NAXISn. [VerifyPrimaryHeader] enforces
+// the first three on read, so a header this package wrote and could not read
+// back would be a plain bug.
+//
+// Keywords the caller supplied that collide with a structural one are dropped
+// in favour of the value derived from the data, for the reason given on
+// [encodeHDU].
+func orderedHeader(src *Header, mandatory []Card) *Header {
+	out := NewHeader()
+
+	structural := make(map[string]bool, len(mandatory))
+
+	for _, c := range mandatory {
+		out.Append(c)
+		structural[strings.ToUpper(strings.TrimSpace(c.Keyword))] = true
+	}
+
+	if src == nil {
+		return out
+	}
+
+	for _, c := range src.Cards {
+		kw := strings.ToUpper(strings.TrimSpace(c.Keyword))
+		if structural[kw] || kw == "END" {
+			continue
+		}
+
+		out.Append(c)
+	}
+
+	return out
+}

--- a/fits/write_test.go
+++ b/fits/write_test.go
@@ -434,13 +434,18 @@ func TestWriteRefusesACardThatWillNotFit(t *testing.T) {
 		want error
 	}{
 		{
-			name: "keyword over eight characters",
-			card: fits.Card{Keyword: "TOOLONGKEYWORD", Value: "1"},
+			// A long keyword is no longer refused — it becomes a HIERARCH
+			// card — but one so long that even HIERARCH cannot hold it still
+			// has nowhere to go.
+			name: "keyword too long even for HIERARCH",
+			card: fits.Card{Keyword: strings.Repeat("K", 80), Value: "1"},
 			want: fits.ErrCardTooLong,
 		},
 		{
-			name: "comment overflows the record",
-			card: fits.Card{Keyword: "OBJECT", Value: "'M31'", Comment: strings.Repeat("x", 80)},
+			// A numeric value cannot be continued: the CONTINUE convention is
+			// defined for character values only.
+			name: "comment on a numeric card overflows the record",
+			card: fits.Card{Keyword: "EXPTIME", Value: "120.5", Comment: strings.Repeat("x", 80)},
 			want: fits.ErrCardTooLong,
 		},
 		{
@@ -515,13 +520,15 @@ func TestWrittenHeaderMatchesTheStandardLayoutByte(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
+	// The mandatory cards, in the order the standard fixes them. What follows
+	// — the integrity keywords, then END — is checked separately, since their
+	// content is not fixed text.
 	want := []string{
 		"SIMPLE  =                    T / conforms to FITS standard",
 		"BITPIX  =                  -32 / bits per data pixel",
 		"NAXIS   =                    2 / number of data axes",
 		"NAXIS1  =                    2 / length of data axis 1",
 		"NAXIS2  =                    2 / length of data axis 2",
-		"END",
 	}
 
 	header := buf.Bytes()
@@ -533,6 +540,10 @@ func TestWrittenHeaderMatchesTheStandardLayoutByte(t *testing.T) {
 		if got != pad80(w) {
 			t.Errorf("card %d\n got %q\nwant %q", i, got, pad80(w))
 		}
+	}
+
+	if !bytes.Contains(header[:fits.BlockSize], []byte(pad80("END"))) {
+		t.Error("no END card in the header")
 	}
 }
 

--- a/fits/write_test.go
+++ b/fits/write_test.go
@@ -580,3 +580,105 @@ func findCard(t *testing.T, header []byte, keyword string) string {
 
 	return ""
 }
+
+// TestExtendIsWrittenOnlyWhenExtensionsFollow covers the keyword that tells a
+// reader to look past the primary HDU.
+//
+// It is not decoration: without it a reader is entitled to stop at the primary
+// HDU, so the failure mode is a file carrying a table nobody finds. astropy and
+// cfitsio both write it, and the standard puts it immediately after the last
+// NAXISn.
+//
+// The absent case matters too — a single-HDU file that advertises extensions it
+// does not have is equally wrong.
+func TestExtendIsWrittenOnlyWhenExtensionsFollow(t *testing.T) {
+	t.Parallel()
+
+	batch := catalogBatch(t)
+
+	// Cleanup rather than defer: the parent returns before its parallel
+	// subtests run, so a deferred Release frees the batch out from under them.
+	t.Cleanup(batch.Release)
+
+	for _, tc := range []struct {
+		name string
+		hdus []fits.HDU
+		want bool
+	}{
+		{
+			name: "primary alone",
+			hdus: []fits.HDU{float32Image(t, 2, 2, []float32{1, 2, 3, 4})},
+			want: false,
+		},
+		{
+			name: "primary with a table extension",
+			hdus: []fits.HDU{float32Image(t, 2, 2, []float32{1, 2, 3, 4}), &fits.BintableHDU{Batch: batch}},
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, &fits.File{HDUs: tc.hdus}); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			header := buf.Bytes()[:fits.BlockSize]
+			got := bytes.Contains(header, []byte("EXTEND  ="))
+
+			if got != tc.want {
+				t.Errorf("EXTEND present = %v, want %v", got, tc.want)
+			}
+
+			if !tc.want {
+				return
+			}
+
+			// The standard fixes its position: immediately after the last
+			// NAXISn, before anything else.
+			if want := pad80("EXTEND  =                    T / file contains extensions"); findCard(t, header, "EXTEND") != want {
+				t.Errorf("EXTEND card\n got %q\nwant %q", findCard(t, header, "EXTEND"), want)
+			}
+
+			naxis2 := bytes.Index(header, []byte("NAXIS2  ="))
+			extend := bytes.Index(header, []byte("EXTEND  ="))
+
+			if extend != naxis2+fits.CardSize {
+				t.Errorf("EXTEND is %d bytes after NAXIS2, want %d — the standard "+
+					"puts it immediately after the last NAXISn", extend-naxis2, fits.CardSize)
+			}
+		})
+	}
+}
+
+// TestWriteRefusesANonFiniteHeaderValue covers the values FITS cannot express.
+//
+// Go renders these as "NaN" and "+Inf", which in a card claiming to hold a
+// number is text no reader can parse. A BSCALE that arrived as NaN is a
+// caller's bug worth reporting rather than one to encode into a file that then
+// fails somewhere else, for someone else.
+func TestWriteRefusesANonFiniteHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		apply func(*fits.ImageHDU)
+		name  string
+	}{
+		{name: "BSCALE NaN", apply: func(h *fits.ImageHDU) { h.BScale = math.NaN() }},
+		{name: "BSCALE +Inf", apply: func(h *fits.ImageHDU) { h.BScale = math.Inf(1) }},
+		{name: "BZERO -Inf", apply: func(h *fits.ImageHDU) { h.BZero = math.Inf(-1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+			tc.apply(src)
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); !errors.Is(err, fits.ErrCardNotFinite) {
+				t.Errorf("Write = %v, want ErrCardNotFinite", err)
+			}
+		})
+	}
+}

--- a/fits/write_test.go
+++ b/fits/write_test.go
@@ -1,0 +1,582 @@
+package fits_test
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/tensor"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// The writer's claim is that a file it produces is one this package — and any
+// other FITS reader — can read back unchanged. Round-tripping is therefore the
+// test that matters, and the byte-level tests below exist only for the things a
+// round trip cannot see: this reader would happily read a file with the wrong
+// padding or a non-standard card layout, and another reader would not.
+
+// float32Image builds an image HDU over the given pixel values.
+func float32Image(t *testing.T, cols, rows int, pixels []float32) *fits.ImageHDU {
+	t.Helper()
+
+	if len(pixels) != cols*rows {
+		t.Fatalf("test setup: %d pixels for a %dx%d image", len(pixels), cols, rows)
+	}
+
+	bldr := array.NewFloat32Builder(memory.NewGoAllocator())
+	defer bldr.Release()
+
+	bldr.AppendValues(pixels, nil)
+
+	arr := bldr.NewFloat32Array()
+	defer arr.Release()
+
+	// Axes are slowest-varying first, the reverse of NAXISn.
+	axes := []int64{int64(rows), int64(cols)}
+
+	return &fits.ImageHDU{
+		Tensor: tensor.New(arr.Data(), axes, nil, nil),
+		Axes:   axes,
+		Bitpix: fits.BitpixFloat32,
+	}
+}
+
+func TestWriteImageRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	pixels := []float32{1, 2, 3, 4, 5, 6}
+
+	src := float32Image(t, 3, 2, pixels)
+	src.Header().Append(fits.Card{Keyword: "OBJECT", Value: "'M31'", Comment: "target"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	if len(got.HDUs) != 1 {
+		t.Fatalf("read %d HDUs, want 1", len(got.HDUs))
+	}
+
+	img, ok := got.HDUs[0].(*fits.ImageHDU)
+	if !ok {
+		t.Fatalf("HDU is %T, want *fits.ImageHDU", got.HDUs[0])
+	}
+
+	if img.Bitpix != fits.BitpixFloat32 {
+		t.Errorf("BITPIX = %d, want %d", img.Bitpix, fits.BitpixFloat32)
+	}
+
+	// The axes have to survive the NAXISn flip in both directions; getting
+	// this wrong transposes the image, which is not visible in the pixel
+	// count and is very visible on the sky.
+	if len(img.Axes) != 2 || img.Axes[0] != 2 || img.Axes[1] != 3 {
+		t.Errorf("Axes = %v, want [2 3] (rows, cols)", img.Axes)
+	}
+
+	// A keyword the caller set must survive alongside the structural ones.
+	if obj, err := img.Header().GetString("OBJECT"); err != nil || obj != "M31" {
+		t.Errorf("OBJECT = %q (%v), want M31", obj, err)
+	}
+
+	assertFloat32Pixels(t, img, pixels)
+}
+
+// assertFloat32Pixels compares an image's pixels against the values written.
+func assertFloat32Pixels(t *testing.T, img *fits.ImageHDU, want []float32) {
+	t.Helper()
+
+	if img.Tensor == nil {
+		t.Fatal("image carries no tensor")
+	}
+
+	got, ok := img.Tensor.(*tensor.Float32)
+	if !ok {
+		t.Fatalf("tensor is %T, want *tensor.Float32", img.Tensor)
+	}
+
+	values := got.Float32Values()
+	if len(values) != len(want) {
+		t.Fatalf("read %d pixels, want %d", len(values), len(want))
+	}
+
+	for i, w := range want {
+		if values[i] != w {
+			t.Errorf("pixel %d = %v, want %v — byte order is the usual cause", i, values[i], w)
+		}
+	}
+}
+
+// TestWriteImageCarriesEveryBitpix walks the six pixel types, because each has
+// its own width and its own byte-swap path, and a mistake in one is invisible
+// from the others.
+func TestWriteImageCarriesEveryBitpix(t *testing.T) {
+	t.Parallel()
+
+	mem := memory.NewGoAllocator()
+
+	for _, tc := range []struct {
+		build  func() arrow.Array
+		name   string
+		bitpix int
+	}{
+		{name: "uint8", bitpix: fits.BitpixUint8, build: func() arrow.Array {
+			b := array.NewUint8Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]uint8{0, 1, 254, 255}, nil)
+
+			return b.NewUint8Array()
+		}},
+		{name: "int16", bitpix: fits.BitpixInt16, build: func() arrow.Array {
+			b := array.NewInt16Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]int16{math.MinInt16, -1, 0, math.MaxInt16}, nil)
+
+			return b.NewInt16Array()
+		}},
+		{name: "int32", bitpix: fits.BitpixInt32, build: func() arrow.Array {
+			b := array.NewInt32Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]int32{math.MinInt32, -1, 0, math.MaxInt32}, nil)
+
+			return b.NewInt32Array()
+		}},
+		{name: "int64", bitpix: fits.BitpixInt64, build: func() arrow.Array {
+			b := array.NewInt64Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]int64{math.MinInt64, -1, 0, math.MaxInt64}, nil)
+
+			return b.NewInt64Array()
+		}},
+		{name: "float32", bitpix: fits.BitpixFloat32, build: func() arrow.Array {
+			b := array.NewFloat32Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]float32{-1.5, 0, 0.1, 3.4e38}, nil)
+
+			return b.NewFloat32Array()
+		}},
+		{name: "float64", bitpix: fits.BitpixFloat64, build: func() arrow.Array {
+			b := array.NewFloat64Builder(mem)
+			defer b.Release()
+
+			b.AppendValues([]float64{-1.5, 0, 0.1, 1.7e308}, nil)
+
+			return b.NewFloat64Array()
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			arr := tc.build()
+			defer arr.Release()
+
+			axes := []int64{4}
+
+			src := &fits.ImageHDU{
+				Tensor: tensor.New(arr.Data(), axes, nil, nil),
+				Axes:   axes,
+				Bitpix: tc.bitpix,
+			}
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+			if err != nil {
+				t.Fatalf("Read back: %v", err)
+			}
+
+			img, ok := got.HDUs[0].(*fits.ImageHDU)
+			if !ok {
+				t.Fatalf("HDU is %T", got.HDUs[0])
+			}
+
+			if img.Bitpix != tc.bitpix {
+				t.Fatalf("BITPIX = %d, want %d", img.Bitpix, tc.bitpix)
+			}
+
+			// Compare the raw stored bytes: the values above include each
+			// type's extremes, where a wrong width or a missed swap shows up
+			// as a specific wrong number rather than as noise.
+			wantBytes := arr.Data().Buffers()[1].Bytes()[:arr.Len()*byteWidth(tc.bitpix)]
+
+			gotBytes := img.Tensor.Data().Buffers()[1].Bytes()[:arr.Len()*byteWidth(tc.bitpix)]
+			if !bytes.Equal(gotBytes, wantBytes) {
+				t.Errorf("pixel bytes differ after a round trip\n got %x\nwant %x", gotBytes, wantBytes)
+			}
+		})
+	}
+}
+
+// byteWidth is the stored width of one pixel of the given BITPIX.
+func byteWidth(bitpix int) int {
+	if bitpix < 0 {
+		bitpix = -bitpix
+	}
+
+	return bitpix / 8
+}
+
+// A primary HDU with no pixels is how a file whose data lives entirely in
+// extensions begins, and it is the shape most multi-extension files have.
+func TestWriteHeaderOnlyPrimaryHDU(t *testing.T) {
+	t.Parallel()
+
+	src := &fits.ImageHDU{}
+	src.Header().Append(fits.Card{Keyword: "ORIGIN", Value: "'astrogo'", Comment: "written by"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if buf.Len() != fits.BlockSize {
+		t.Errorf("a header-only HDU wrote %d bytes, want one %d-byte block", buf.Len(), fits.BlockSize)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	// A header-only HDU comes back through the HDU interface rather than as
+	// an *ImageHDU: there are no pixels to decode into one, which is the
+	// reader's existing behaviour and is what NAXIS 0 means.
+	hdu := got.HDUs[0]
+
+	if hdu.Type() != fits.HDUTypeImage {
+		t.Errorf("Type = %v, want HDUTypeImage", hdu.Type())
+	}
+
+	if n, err := hdu.Header().GetInt("NAXIS"); err != nil || n != 0 {
+		t.Errorf("NAXIS = %d (%v), want 0", n, err)
+	}
+
+	if origin, err := hdu.Header().GetString("ORIGIN"); err != nil || origin != "astrogo" {
+		t.Errorf("ORIGIN = %q (%v), want astrogo", origin, err)
+	}
+}
+
+// TestWriteRefusesAnEmptyFile keeps a zero-HDU file from being written as zero
+// bytes, which is not a FITS file and which no reader reports usefully.
+func TestWriteRefusesAnEmptyFile(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	for _, f := range []*fits.File{nil, {}} {
+		if err := fits.Write(&buf, f); !errors.Is(err, fits.ErrNoPrimaryHDU) {
+			t.Errorf("Write(%v) = %v, want ErrNoPrimaryHDU", f, err)
+		}
+	}
+
+	if buf.Len() != 0 {
+		t.Errorf("a refused write emitted %d bytes", buf.Len())
+	}
+}
+
+// Every FITS structure is a whole number of 2880-byte blocks. A reader that
+// seeks by block — which is most of them, and which this package's own
+// BlockReader does — lands in the middle of the next header otherwise.
+func TestEverythingWrittenIsBlockAligned(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		file *fits.File
+		name string
+	}{
+		{name: "header only", file: &fits.File{HDUs: []fits.HDU{&fits.ImageHDU{}}}},
+		{name: "small image", file: &fits.File{HDUs: []fits.HDU{float32Image(t, 3, 2, []float32{1, 2, 3, 4, 5, 6})}}},
+		{name: "image larger than a block", file: &fits.File{HDUs: []fits.HDU{
+			float32Image(t, 40, 40, make([]float32, 1600)), // 6400 bytes: 3 blocks
+		}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, tc.file); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			if rem := buf.Len() % fits.BlockSize; rem != 0 {
+				t.Errorf("wrote %d bytes, %d past a %d-byte block boundary",
+					buf.Len(), rem, fits.BlockSize)
+			}
+		})
+	}
+}
+
+// The header's first three keywords are fixed in order by the standard, and
+// this package's own VerifyPrimaryHeader rejects a file that gets it wrong — so
+// a header written here and refused by the reader beside it would be a plain
+// bug.
+func TestWrittenPrimaryHeaderVerifies(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+
+	// A caller's own SIMPLE, with the wrong value, must not survive into the
+	// file: the structural keywords come from the data, not from whatever the
+	// header happened to carry.
+	src.Header().Append(fits.Card{Keyword: "SIMPLE", Value: "F"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	if err := fits.VerifyPrimaryHeader(got.HDUs[0].Header()); err != nil {
+		t.Errorf("VerifyPrimaryHeader on our own output: %v", err)
+	}
+
+	cards := got.HDUs[0].Header().Cards
+	for i, want := range []string{"SIMPLE", "BITPIX", "NAXIS"} {
+		if cards[i].Keyword != want {
+			t.Errorf("card %d is %q, want %q", i, cards[i].Keyword, want)
+		}
+	}
+
+	if cards[0].Value != "T" {
+		t.Errorf("SIMPLE = %q, want T — a caller's own value overrode the structural one", cards[0].Value)
+	}
+}
+
+// Header records are a fixed 80-byte grid with no separators, so a card of any
+// other length shifts every card after it. Nothing in a round trip through this
+// package would notice.
+func TestEveryCardIsExactlyEightyBytes(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+	src.Header().Append(fits.Card{Keyword: "OBJECT", Value: "'NGC 7000'", Comment: "North America Nebula"})
+	src.Header().Append(fits.Card{Keyword: "COMMENT", Comment: "commentary carries no value indicator"})
+	src.Header().Append(fits.Card{Keyword: "EXPTIME", Value: "120.5", Comment: "seconds"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	header := buf.Bytes()[:fits.BlockSize]
+
+	var sawEnd bool
+
+	for off := 0; off+fits.CardSize <= len(header); off += fits.CardSize {
+		card := string(header[off : off+fits.CardSize])
+
+		if strings.HasPrefix(card, "END     ") {
+			sawEnd = true
+
+			if strings.TrimSpace(card) != "END" {
+				t.Errorf("END card carries trailing content: %q", card)
+			}
+
+			continue
+		}
+
+		if sawEnd {
+			if strings.TrimSpace(card) != "" {
+				t.Errorf("card after END is not blank: %q", card)
+			}
+
+			continue
+		}
+
+		// Columns 1-8 are the keyword, and a value card's indicator is
+		// exactly columns 9-10.
+		if kw := card[:8]; kw != strings.ToUpper(kw) {
+			t.Errorf("keyword %q is not upper case", kw)
+		}
+
+		if strings.HasPrefix(card, "COMMENT ") && card[8:10] == "= " {
+			t.Errorf("commentary card carries a value indicator: %q", card)
+		}
+	}
+
+	if !sawEnd {
+		t.Error("header has no END card")
+	}
+}
+
+// TestWriteRefusesACardThatWillNotFit is the failure that would otherwise
+// corrupt a file silently: an over-long card shifts the grid, so every card
+// after it is misread.
+func TestWriteRefusesACardThatWillNotFit(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		card fits.Card
+		name string
+		want error
+	}{
+		{
+			name: "keyword over eight characters",
+			card: fits.Card{Keyword: "TOOLONGKEYWORD", Value: "1"},
+			want: fits.ErrCardTooLong,
+		},
+		{
+			name: "comment overflows the record",
+			card: fits.Card{Keyword: "OBJECT", Value: "'M31'", Comment: strings.Repeat("x", 80)},
+			want: fits.ErrCardTooLong,
+		},
+		{
+			name: "newline in a comment",
+			card: fits.Card{Keyword: "OBJECT", Value: "'M31'", Comment: "two\nlines"},
+			want: fits.ErrCardNotPrintable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+			src.Header().Append(tc.card)
+
+			var buf bytes.Buffer
+			if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); !errors.Is(err, tc.want) {
+				t.Errorf("Write = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteRefusesAnHDUItCannotEncode covers the two shapes that would
+// otherwise produce a file describing something it does not contain.
+func TestWriteRefusesAnHDUItCannotEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bintable as the primary HDU", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+
+		err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{&fits.BintableHDU{}}})
+		if !errors.Is(err, fits.ErrNotWritable) {
+			t.Errorf("Write = %v, want ErrNotWritable — FITS has no primary table", err)
+		}
+	})
+
+	t.Run("axes disagree with the pixels", func(t *testing.T) {
+		t.Parallel()
+
+		src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+		src.Axes = []int64{100, 100} // 10000 pixels, 4 present
+
+		var buf bytes.Buffer
+
+		err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}})
+		if !errors.Is(err, fits.ErrNotWritable) {
+			t.Errorf("Write = %v, want ErrNotWritable.\n"+
+				"  The header is the only statement of an image's shape, so one that "+
+				"overstates it produces a file no reader can detect as wrong.", err)
+		}
+	})
+}
+
+// TestWrittenHeaderMatchesTheStandardLayoutByte pins the card layout against
+// the standard rather than against this package's own reader.
+//
+// Every other test here round-trips, which cannot catch a mistake the reader
+// and the writer share — a value in the wrong column reads back perfectly from
+// a writer that put it there. These are the exact bytes FITS 4.0 §4.1.2
+// prescribes and the exact bytes astropy and cfitsio emit: keyword in columns
+// 1-8, "= " in 9-10, a logical or numeric value right-justified to column 30,
+// then " / " and the comment.
+func TestWrittenHeaderMatchesTheStandardLayoutByte(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	want := []string{
+		"SIMPLE  =                    T / conforms to FITS standard",
+		"BITPIX  =                  -32 / bits per data pixel",
+		"NAXIS   =                    2 / number of data axes",
+		"NAXIS1  =                    2 / length of data axis 1",
+		"NAXIS2  =                    2 / length of data axis 2",
+		"END",
+	}
+
+	header := buf.Bytes()
+
+	for i, w := range want {
+		off := i * fits.CardSize
+
+		got := string(header[off : off+fits.CardSize])
+		if got != pad80(w) {
+			t.Errorf("card %d\n got %q\nwant %q", i, got, pad80(w))
+		}
+	}
+}
+
+// pad80 blank-fills a card to its record width.
+func pad80(s string) string {
+	return s + strings.Repeat(" ", fits.CardSize-len(s))
+}
+
+// TestWrittenStringValueMatchesTheStandardLayout covers the other card shape,
+// which is laid out differently on purpose: a string starts at column 11,
+// left-justified inside its quotes, and is blank-padded to at least eight
+// characters.
+func TestWrittenStringValueMatchesTheStandardLayout(t *testing.T) {
+	t.Parallel()
+
+	src := float32Image(t, 2, 2, []float32{1, 2, 3, 4})
+	src.Header().Append(fits.Card{Keyword: "OBJECT", Value: "'M31'", Comment: "target"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{src}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	want := pad80("OBJECT  = 'M31     ' / target")
+
+	if got := findCard(t, buf.Bytes(), "OBJECT"); got != want {
+		t.Errorf("OBJECT card\n got %q\nwant %q", got, want)
+	}
+}
+
+// findCard returns the 80-byte record carrying keyword.
+func findCard(t *testing.T, header []byte, keyword string) string {
+	t.Helper()
+
+	prefix := keyword + strings.Repeat(" ", 8-len(keyword))
+
+	for off := 0; off+fits.CardSize <= len(header); off += fits.CardSize {
+		card := string(header[off : off+fits.CardSize])
+		if strings.HasPrefix(card, prefix) {
+			return card
+		}
+	}
+
+	t.Fatalf("no %s card in the header", keyword)
+
+	return ""
+}

--- a/fits/writeasciitable.go
+++ b/fits/writeasciitable.go
@@ -1,0 +1,184 @@
+package fits
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// encodeASCIITable builds an ASCII TABLE extension's header and payload.
+//
+// Written for completeness rather than because anything should prefer it:
+// BINTABLE stores the same data in a fraction of the space and without the
+// rounding a text format imposes. It exists so a TABLE read from an archive can
+// be written back out, which was not previously possible in either direction.
+func encodeASCIITable(h *ASCIITableHDU) (*Header, []byte, error) {
+	if h.Batch == nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrNotWritable, ErrUninitBatch)
+	}
+
+	schema := h.Batch.Schema()
+	cols := schema.NumFields()
+	rows := int(h.Batch.NumRows())
+
+	forms := make([]asciiForm, cols)
+	starts := make([]int, cols)
+
+	// One blank column between fields, which is what makes a written table
+	// readable as text and is what every writer does.
+	offset := 0
+
+	for i := range cols {
+		form, err := asciiFormFor(schema.Field(i), h.Batch.Column(i))
+		if err != nil {
+			return nil, nil, fmt.Errorf("column %d (%s): %w", i+1, schema.Field(i).Name, err)
+		}
+
+		forms[i] = form
+		starts[i] = offset
+		offset += form.width + 1
+	}
+
+	rowSize := max(offset-1, 0)
+
+	header := orderedHeader(h.Header(), asciiTableKeywords(schema, forms, starts, rows, rowSize))
+
+	payload, err := asciiPayload(h.Batch, forms, starts, rowSize, rows)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return header, payload, nil
+}
+
+// asciiTableKeywords builds the structural cards, including the TBCOLn that
+// say where each field begins.
+func asciiTableKeywords(schema *arrow.Schema, forms []asciiForm, starts []int, rows, rowSize int) []Card {
+	cards := make([]Card, 0, 8+3*len(forms))
+	cards = append(cards,
+		Card{Keyword: "XTENSION", Value: "'TABLE   '", Comment: "ASCII table extension"},
+		Card{Keyword: "BITPIX", Value: strconv.Itoa(BitpixUint8), Comment: "8-bit bytes"},
+		Card{Keyword: "NAXIS", Value: "2", Comment: "2-dimensional ASCII table"},
+		Card{Keyword: "NAXIS1", Value: strconv.Itoa(rowSize), Comment: "width of table in characters"},
+		Card{Keyword: "NAXIS2", Value: strconv.Itoa(rows), Comment: "number of rows in table"},
+		Card{Keyword: "PCOUNT", Value: "0", Comment: "no special data area"},
+		Card{Keyword: "GCOUNT", Value: "1", Comment: "one data group"},
+		Card{Keyword: "TFIELDS", Value: strconv.Itoa(len(forms)), Comment: "number of fields in each row"},
+	)
+
+	for i, form := range forms {
+		n := strconv.Itoa(i + 1)
+
+		cards = append(cards,
+			Card{Keyword: "TTYPE" + n, Value: quote(schema.Field(i).Name), Comment: "label for field " + n},
+			// TBCOLn is one-based, and is the only statement of where a field
+			// sits: the columns may have gaps, and a reader has nothing else
+			// to go on.
+			Card{Keyword: "TBCOL" + n, Value: strconv.Itoa(starts[i] + 1), Comment: "beginning column of field " + n},
+			Card{Keyword: "TFORM" + n, Value: quote(form.String()), Comment: "format of field " + n},
+		)
+	}
+
+	return cards
+}
+
+// asciiFormFor chooses a column's text format and width.
+//
+// The width has to hold every value the column contains, since the fields are
+// positional: one value too wide would run into its neighbour and shift every
+// column after it. So the column is measured rather than guessed at.
+func asciiFormFor(field arrow.Field, col arrow.Array) (asciiForm, error) {
+	switch field.Type.ID() { //nolint:exhaustive // the default rejects the rest
+	case arrow.STRING:
+		return asciiForm{code: 'A', width: max(widestString(col), 1)}, nil
+	case arrow.INT16, arrow.INT32, arrow.INT64, arrow.UINT8:
+		return asciiForm{code: 'I', width: widestInteger(col)}, nil
+	case arrow.FLOAT32, arrow.FLOAT64:
+		// Sixteen significant digits in exponential form holds a float64
+		// exactly enough to read back as the same value, which a fixed-point
+		// format cannot promise across a column's whole range.
+		return asciiForm{code: 'E', width: 24, precision: 16}, nil
+	default:
+		return asciiForm{}, fmt.Errorf("%w: no ASCII table format for %s", ErrNotWritable, field.Type)
+	}
+}
+
+// widestInteger is the number of characters the widest value in an integer
+// column needs, including a sign.
+func widestInteger(col arrow.Array) int {
+	widest := 1
+
+	for row := range col.Len() {
+		if col.IsNull(row) {
+			continue
+		}
+
+		v, ok := integerAt(col, row)
+		if !ok {
+			continue
+		}
+
+		if n := len(strconv.FormatInt(v, 10)); n > widest {
+			widest = n
+		}
+	}
+
+	return widest
+}
+
+// asciiPayload renders the rows as text.
+func asciiPayload(batch arrow.RecordBatch, forms []asciiForm, starts []int, rowSize, rows int) ([]byte, error) {
+	if rows == 0 || len(forms) == 0 {
+		return nil, nil
+	}
+
+	payload := make([]byte, rowSize*rows)
+	for i := range payload {
+		payload[i] = ' '
+	}
+
+	for i, form := range forms {
+		col := batch.Column(i)
+
+		for row := range rows {
+			text, err := asciiCellText(col, form, row)
+			if err != nil {
+				return nil, fmt.Errorf("column %d row %d: %w", i+1, row+1, err)
+			}
+
+			copy(payload[row*rowSize+starts[i]:], text)
+		}
+	}
+
+	return payload, nil
+}
+
+// asciiCellText renders one value into its field.
+func asciiCellText(col arrow.Array, form asciiForm, row int) (string, error) {
+	if row >= col.Len() || col.IsNull(row) {
+		// A blank field is how this format says the value is undefined; there
+		// is no TNULL here.
+		return form.formatCell(0, "", true)
+	}
+
+	switch v := col.(type) {
+	case *array.String:
+		return form.formatCell(0, v.Value(row), false)
+	case *array.Uint8:
+		return form.formatCell(float64(v.Value(row)), "", false)
+	case *array.Int16:
+		return form.formatCell(float64(v.Value(row)), "", false)
+	case *array.Int32:
+		return form.formatCell(float64(v.Value(row)), "", false)
+	case *array.Int64:
+		return form.formatCell(float64(v.Value(row)), "", false)
+	case *array.Float32:
+		return form.formatCell(float64(v.Value(row)), "", false)
+	case *array.Float64:
+		return form.formatCell(v.Value(row), "", false)
+	default:
+		return "", fmt.Errorf("%w: no ASCII encoder for %T", ErrNotWritable, col)
+	}
+}

--- a/fits/writeasciitable_test.go
+++ b/fits/writeasciitable_test.go
@@ -1,0 +1,191 @@
+package fits_test
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// ASCII tables are the older extension and BINTABLE superseded them, but
+// archives are full of them. Writing one is what makes a TABLE read from an
+// archive something that can be written back out.
+
+func TestASCIITableRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "NAME", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "RA", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "HIP", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	builderAs[*array.StringBuilder](t, rb, 0).AppendValues([]string{"Vega", "Betelgeuse"}, nil)
+	builderAs[*array.Float64Builder](t, rb, 1).AppendValues([]float64{279.23473479, 0}, []bool{true, false})
+	builderAs[*array.Int32Builder](t, rb, 2).AppendValues([]int32{91262, 27989}, nil)
+
+	batch := rb.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.ASCIITableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.ASCIITableHDU)
+	if !ok {
+		t.Fatalf("extension is %T, want *fits.ASCIITableHDU", got.HDUs[1])
+	}
+
+	if out.Batch == nil {
+		t.Fatal("no batch decoded")
+	}
+
+	if out.Rows != 2 || out.Cols != 3 {
+		t.Fatalf("read %d rows x %d cols, want 2 x 3", out.Rows, out.Cols)
+	}
+
+	names, ok := out.Batch.Column(0).(*array.String)
+	if !ok {
+		t.Fatalf("NAME is %T", out.Batch.Column(0))
+	}
+
+	for i, w := range []string{"Vega", "Betelgeuse"} {
+		if got := names.Value(i); got != w {
+			t.Errorf("NAME row %d = %q, want %q", i, got, w)
+		}
+	}
+
+	ra, ok := out.Batch.Column(1).(*array.Float64)
+	if !ok {
+		t.Fatalf("RA is %T", out.Batch.Column(1))
+	}
+
+	// A text format has to hold enough digits to read the value back.
+	if math.Abs(ra.Value(0)-279.23473479) > 1e-9 {
+		t.Errorf("RA row 0 = %.10f, want 279.23473479 — the format lost precision", ra.Value(0))
+	}
+
+	// The missing value stays missing rather than becoming zero.
+	if !ra.IsNull(1) {
+		t.Errorf("RA row 1 = %v, want null — a blank field is undefined, not zero", ra.Value(1))
+	}
+
+	counts, ok := out.Batch.Column(2).(*array.Float64)
+	if !ok {
+		t.Fatalf("HIP is %T", out.Batch.Column(2))
+	}
+
+	for i, w := range []float64{91262, 27989} {
+		if counts.Value(i) != w {
+			t.Errorf("HIP row %d = %v, want %v", i, counts.Value(i), w)
+		}
+	}
+}
+
+// TestASCIITableDeclaresWhereItsColumnsStart pins TBCOLn, which is the only
+// statement of a field's position — the columns are positional and a reader has
+// nothing else to go on.
+func TestASCIITableDeclaresWhereItsColumnsStart(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "A", Type: arrow.BinaryTypes.String},
+		{Name: "B", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	builderAs[*array.StringBuilder](t, rb, 0).AppendValues([]string{"xxx"}, nil)
+	builderAs[*array.StringBuilder](t, rb, 1).AppendValues([]string{"yy"}, nil)
+
+	batch := rb.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.ASCIITableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	h := got.HDUs[1].Header()
+
+	// Three characters, a blank, then two: the second field starts at column 5.
+	for _, tc := range []struct {
+		keyword string
+		want    int
+	}{
+		{keyword: "TBCOL1", want: 1},
+		{keyword: "TBCOL2", want: 5},
+		{keyword: "NAXIS1", want: 6},
+	} {
+		if v, err := h.GetInt(tc.keyword); err != nil || v != tc.want {
+			t.Errorf("%s = %d (%v), want %d", tc.keyword, v, err, tc.want)
+		}
+	}
+}
+
+// TestASCIITablePadsWithSpaces covers the one place this extension's padding
+// differs from every other: a zero byte in an ASCII table's last block is not
+// blank text.
+func TestASCIITablePadsWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "A", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	rb := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer rb.Release()
+
+	builderAs[*array.StringBuilder](t, rb, 0).AppendValues([]string{"x"}, nil)
+
+	batch := rb.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.ASCIITableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data := buf.Bytes()[len(buf.Bytes())-fits.BlockSize:]
+
+	if i := bytes.IndexByte(data, 0); i >= 0 {
+		t.Errorf("the data block holds a zero byte at %d; an ASCII table pads with spaces", i)
+	}
+
+	if trimmed := strings.TrimRight(string(data), " "); trimmed != "x" {
+		t.Errorf("data block = %q, want the single value padded with blanks", trimmed)
+	}
+}

--- a/fits/writebintable.go
+++ b/fits/writebintable.go
@@ -1,0 +1,256 @@
+package fits
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// encodeBintable builds a binary table extension's header and payload from its
+// Arrow batch.
+//
+// The batch is the source of truth for the shape — column count, row count,
+// types and names — and the stored header supplies everything else. A caller
+// who filtered rows out of the batch gets a file whose NAXIS2 matches what it
+// contains rather than what it was read with.
+func encodeBintable(h *BintableHDU) (*Header, []byte, error) {
+	if h.Batch == nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrNotWritable, ErrUninitBatch)
+	}
+
+	schema := h.Batch.Schema()
+	cols := schema.NumFields()
+	rows := int(h.Batch.NumRows())
+
+	forms := make([]tformField, cols)
+	widths := make([]int, cols)
+	rowSize := 0
+
+	for i := range cols {
+		field := schema.Field(i)
+
+		form, err := tformFor(field, h.Batch.Column(i))
+		if err != nil {
+			return nil, nil, fmt.Errorf("column %d (%s): %w", i+1, field.Name, err)
+		}
+
+		forms[i] = form
+		widths[i] = form.size()
+		rowSize += widths[i]
+	}
+
+	header := orderedHeader(h.Header(), bintableKeywords(schema, forms, rows, rowSize))
+
+	payload, err := bintablePayload(h.Batch, forms, widths, rowSize, rows)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return header, payload, nil
+}
+
+// bintableKeywords builds the structural cards for a binary table.
+func bintableKeywords(schema *arrow.Schema, forms []tformField, rows, rowSize int) []Card {
+	cards := make([]Card, 0, 8+2*len(forms))
+	cards = append(cards,
+		Card{Keyword: "XTENSION", Value: "'BINTABLE'", Comment: "binary table extension"},
+		Card{Keyword: "BITPIX", Value: strconv.Itoa(BitpixUint8), Comment: "8-bit bytes"},
+		Card{Keyword: "NAXIS", Value: "2", Comment: "2-dimensional binary table"},
+		Card{Keyword: "NAXIS1", Value: strconv.Itoa(rowSize), Comment: "width of table in bytes"},
+		Card{Keyword: "NAXIS2", Value: strconv.Itoa(rows), Comment: "number of rows in table"},
+		Card{Keyword: "PCOUNT", Value: "0", Comment: "size of special data area"},
+		Card{Keyword: "GCOUNT", Value: "1", Comment: "one data group"},
+		Card{Keyword: "TFIELDS", Value: strconv.Itoa(len(forms)), Comment: "number of fields in each row"},
+	)
+
+	for i, form := range forms {
+		n := strconv.Itoa(i + 1)
+
+		cards = append(cards,
+			Card{
+				Keyword: "TTYPE" + n,
+				Value:   quote(schema.Field(i).Name),
+				Comment: "label for field " + n,
+			},
+			Card{
+				Keyword: "TFORM" + n,
+				Value:   quote(strconv.Itoa(form.repeat) + string(form.code)),
+				Comment: "data format of field " + n,
+			},
+		)
+	}
+
+	return cards
+}
+
+// tformFor chooses the TFORM for one Arrow column.
+//
+// A string column's repeat count is its width in bytes, which has to be the
+// longest value present: FITS character columns are fixed-width, so a column
+// sized to anything less would silently truncate. Measuring it means walking
+// the column once, which is cheap beside writing it.
+//
+// listing the forty it has no column for would say the same thing at length.
+//
+//nolint:exhaustive // the default rejects every Arrow type FITS cannot store;
+func tformFor(field arrow.Field, col arrow.Array) (tformField, error) {
+	switch field.Type.ID() {
+	case arrow.BOOL:
+		return tformField{repeat: 1, code: 'L'}, nil
+	case arrow.UINT8:
+		return tformField{repeat: 1, code: 'B'}, nil
+	case arrow.INT16:
+		return tformField{repeat: 1, code: 'I'}, nil
+	case arrow.INT32:
+		return tformField{repeat: 1, code: 'J'}, nil
+	case arrow.INT64:
+		return tformField{repeat: 1, code: 'K'}, nil
+	case arrow.FLOAT32:
+		return tformField{repeat: 1, code: 'E'}, nil
+	case arrow.FLOAT64:
+		return tformField{repeat: 1, code: 'D'}, nil
+	case arrow.STRING:
+		return tformField{repeat: max(widestString(col), 1), code: 'A'}, nil
+	default:
+		return tformField{}, fmt.Errorf("%w: no TFORM for Arrow type %s", ErrNotWritable, field.Type)
+	}
+}
+
+// widestString returns the longest value in a string column, in bytes.
+func widestString(col arrow.Array) int {
+	sa, ok := col.(*array.String)
+	if !ok {
+		return 0
+	}
+
+	widest := 0
+
+	for i := range sa.Len() {
+		if sa.IsNull(i) {
+			continue
+		}
+
+		if n := len(sa.Value(i)); n > widest {
+			widest = n
+		}
+	}
+
+	return widest
+}
+
+// bintablePayload writes the batch row by row.
+//
+// FITS binary tables are row-major and Arrow is columnar, so this transposes —
+// the inverse of what ReadBintable does on the way in. It is written as a
+// whole-payload buffer rather than streamed because the row width is already
+// known and a table that does not fit in memory would not have fit in the
+// Arrow batch it came from.
+func bintablePayload(batch arrow.RecordBatch, forms []tformField, widths []int, rowSize, rows int) ([]byte, error) {
+	if rows == 0 || len(forms) == 0 {
+		return nil, nil
+	}
+
+	payload := make([]byte, rowSize*rows)
+
+	for i, form := range forms {
+		col := batch.Column(i)
+
+		offset := 0
+		for j := range i {
+			offset += widths[j]
+		}
+
+		if err := writeColumn(payload, col, form, offset, rowSize, rows); err != nil {
+			return nil, fmt.Errorf("column %d: %w", i+1, err)
+		}
+	}
+
+	return payload, nil
+}
+
+// writeColumn places one column's values into their slot in every row.
+//
+// A null is written as the type's zero rather than skipped. FITS binary tables
+// have no null bitmap: absence is expressed by TNULLn for integers and by NaN
+// for floats, and inventing a TNULLn here would reserve a value that might be
+// real data. Zero is the honest choice for a format with nowhere to say
+// "missing", and it is what the reader will hand back.
+func writeColumn(payload []byte, col arrow.Array, form tformField, offset, rowSize, rows int) error {
+	for row := range rows {
+		at := row*rowSize + offset
+		cell := payload[at : at+form.size()]
+
+		if row >= col.Len() || col.IsNull(row) {
+			continue // already zero
+		}
+
+		if err := writeCell(cell, col, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeCell encodes one value in FITS byte order.
+//
+// The integer cases reinterpret a signed value as its two's-complement bit
+// pattern, which is exactly what FITS stores — a J column holds a signed 32-bit
+// integer big-endian, and PutUint32 is how Go writes those four bytes. Nothing
+// is truncated: the widths match on both sides.
+func writeCell(cell []byte, col arrow.Array, row int) error {
+	switch v := col.(type) {
+	case *array.Boolean:
+		// FITS writes a logical as the ASCII letter, not as 0/1.
+		cell[0] = 'F'
+		if v.Value(row) {
+			cell[0] = 'T'
+		}
+	case *array.Uint8:
+		cell[0] = v.Value(row)
+	case *array.Int16:
+		binary.BigEndian.PutUint16(cell, uint16(v.Value(row))) //nolint:gosec // two's-complement bit pattern, the FITS I encoding
+	case *array.Int32:
+		binary.BigEndian.PutUint32(cell, uint32(v.Value(row))) //nolint:gosec // two's-complement bit pattern, the FITS J encoding
+	case *array.Int64:
+		binary.BigEndian.PutUint64(cell, uint64(v.Value(row))) //nolint:gosec // two's-complement bit pattern, the FITS K encoding
+	case *array.Float32:
+		binary.BigEndian.PutUint32(cell, math.Float32bits(v.Value(row)))
+	case *array.Float64:
+		binary.BigEndian.PutUint64(cell, math.Float64bits(v.Value(row)))
+	case *array.String:
+		// Blank-padded, not NUL-padded, and truncated never: the column was
+		// sized to the longest value in tformFor.
+		s := v.Value(row)
+		copy(cell, s)
+
+		for i := len(s); i < len(cell); i++ {
+			cell[i] = ' '
+		}
+	default:
+		return fmt.Errorf("%w: no encoder for Arrow array %T", ErrNotWritable, col)
+	}
+
+	return nil
+}
+
+// quote wraps a value in the single quotes a FITS string card carries,
+// doubling any quote inside it as the standard requires.
+func quote(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	out = append(out, '\'')
+
+	for i := range len(s) {
+		if s[i] == '\'' {
+			out = append(out, '\'')
+		}
+
+		out = append(out, s[i])
+	}
+
+	return string(append(out, '\''))
+}

--- a/fits/writebintable.go
+++ b/fits/writebintable.go
@@ -43,14 +43,97 @@ func encodeBintable(h *BintableHDU) (*Header, []byte, error) {
 		rowSize += widths[i]
 	}
 
-	header := orderedHeader(h.Header(), bintableKeywords(schema, forms, rows, rowSize))
+	// A column with nulls needs somewhere to put them, and the sentinel has to
+	// be chosen before the header is built, since it is declared there.
+	nulls := nullSentinels(h.Batch, forms)
 
-	payload, err := bintablePayload(h.Batch, forms, widths, rowSize, rows)
+	cards := bintableKeywords(schema, forms, rows, rowSize)
+
+	for i, sentinel := range nulls {
+		if sentinel.used {
+			cards = append(cards, tnullCard(i, sentinel.value))
+		}
+	}
+
+	header := orderedHeader(h.Header(), cards)
+
+	payload, err := bintablePayload(h.Batch, forms, widths, rowSize, rows, nulls)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	return header, payload, nil
+}
+
+// columnNull is the undefined value one column uses, if it has one.
+type columnNull struct {
+	value int64
+	used  bool
+}
+
+// nullSentinels decides, per column, whether a TNULLn is needed and safe.
+//
+// Needed when the column actually contains a null. Safe when the sentinel does
+// not also occur as real data: reserving a value the column genuinely holds
+// would turn those measurements into absences on the next read, which is the
+// convention's own failure mode inverted. A column that collides keeps its
+// values and its nulls become zeros, which is what this did everywhere before.
+func nullSentinels(batch arrow.RecordBatch, forms []tformField) []columnNull {
+	out := make([]columnNull, len(forms))
+
+	for i, form := range forms {
+		col := batch.Column(i)
+
+		if col.NullN() == 0 {
+			continue
+		}
+
+		sentinel, ok := nullSentinel(form.code)
+		if !ok {
+			continue
+		}
+
+		if columnContains(col, sentinel) {
+			continue
+		}
+
+		out[i] = columnNull{value: sentinel, used: true}
+	}
+
+	return out
+}
+
+// columnContains reports whether an integer column holds v as real data.
+func columnContains(col arrow.Array, v int64) bool {
+	for row := range col.Len() {
+		if col.IsNull(row) {
+			continue
+		}
+
+		got, ok := integerAt(col, row)
+		if ok && got == v {
+			return true
+		}
+	}
+
+	return false
+}
+
+// integerAt reads one integer cell, widened. ok is false for a column that is
+// not an integer one.
+func integerAt(col arrow.Array, row int) (int64, bool) {
+	switch v := col.(type) {
+	case *array.Uint8:
+		return int64(v.Value(row)), true
+	case *array.Int16:
+		return int64(v.Value(row)), true
+	case *array.Int32:
+		return int64(v.Value(row)), true
+	case *array.Int64:
+		return v.Value(row), true
+	default:
+		return 0, false
+	}
 }
 
 // bintableKeywords builds the structural cards for a binary table.
@@ -115,9 +198,31 @@ func tformFor(field arrow.Field, col arrow.Array) (tformField, error) {
 		return tformField{repeat: 1, code: 'D'}, nil
 	case arrow.STRING:
 		return tformField{repeat: max(widestString(col), 1), code: 'A'}, nil
+	case arrow.FIXED_SIZE_LIST:
+		return vectorTForm(field)
 	default:
 		return tformField{}, fmt.Errorf("%w: no TFORM for Arrow type %s", ErrNotWritable, field.Type)
 	}
+}
+
+// vectorTForm builds the TFORM for a fixed-size list column: the element's
+// code with the list's length as its repeat count.
+func vectorTForm(field arrow.Field) (tformField, error) {
+	list, ok := field.Type.(*arrow.FixedSizeListType)
+	if !ok {
+		return tformField{}, fmt.Errorf("%w: %s is not a fixed-size list", ErrNotWritable, field.Type)
+	}
+
+	elem, err := tformFor(arrow.Field{Name: field.Name, Type: list.Elem()}, nil)
+	if err != nil {
+		return tformField{}, err
+	}
+
+	if elem.code == 'A' {
+		return tformField{}, fmt.Errorf("%w: a list of strings has no FITS column type", ErrNotWritable)
+	}
+
+	return tformField{repeat: int(list.Len()), code: elem.code}, nil
 }
 
 // widestString returns the longest value in a string column, in bytes.
@@ -149,7 +254,7 @@ func widestString(col arrow.Array) int {
 // whole-payload buffer rather than streamed because the row width is already
 // known and a table that does not fit in memory would not have fit in the
 // Arrow batch it came from.
-func bintablePayload(batch arrow.RecordBatch, forms []tformField, widths []int, rowSize, rows int) ([]byte, error) {
+func bintablePayload(batch arrow.RecordBatch, forms []tformField, widths []int, rowSize, rows int, nulls []columnNull) ([]byte, error) {
 	if rows == 0 || len(forms) == 0 {
 		return nil, nil
 	}
@@ -164,7 +269,7 @@ func bintablePayload(batch arrow.RecordBatch, forms []tformField, widths []int, 
 			offset += widths[j]
 		}
 
-		if err := writeColumn(payload, col, form, offset, rowSize, rows); err != nil {
+		if err := writeColumn(payload, col, form, offset, rowSize, rows, nulls[i]); err != nil {
 			return nil, fmt.Errorf("column %d: %w", i+1, err)
 		}
 	}
@@ -174,21 +279,94 @@ func bintablePayload(batch arrow.RecordBatch, forms []tformField, widths []int, 
 
 // writeColumn places one column's values into their slot in every row.
 //
-// A null is written as the type's zero rather than skipped. FITS binary tables
-// have no null bitmap: absence is expressed by TNULLn for integers and by NaN
-// for floats, and inventing a TNULLn here would reserve a value that might be
-// real data. Zero is the honest choice for a format with nowhere to say
-// "missing", and it is what the reader will hand back.
-func writeColumn(payload []byte, col arrow.Array, form tformField, offset, rowSize, rows int) error {
+// A null goes in as the column's declared TNULLn where it has one, as NaN for a
+// float column, and as the type's zero otherwise — a logical or character
+// column, or an integer column whose sentinel would have collided with real
+// data. Which of those applies was decided in nullSentinels, before the header
+// was written, since a TNULLn has to be declared to mean anything.
+func writeColumn(payload []byte, col arrow.Array, form tformField, offset, rowSize, rows int, null columnNull) error {
 	for row := range rows {
 		at := row*rowSize + offset
 		cell := payload[at : at+form.size()]
 
 		if row >= col.Len() || col.IsNull(row) {
-			continue // already zero
+			writeNull(cell, form, null)
+
+			continue
+		}
+
+		if list, ok := col.(*array.FixedSizeList); ok {
+			if err := writeVector(cell, list, form, row); err != nil {
+				return err
+			}
+
+			continue
 		}
 
 		if err := writeCell(cell, col, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeNull fills one cell with whatever this column means by "undefined".
+func writeNull(cell []byte, form tformField, null columnNull) {
+	switch {
+	case null.used:
+		putInt(cell, null.value)
+	case form.code == 'E':
+		binary.BigEndian.PutUint32(cell, math.Float32bits(float32(math.NaN())))
+	case form.code == 'D':
+		binary.BigEndian.PutUint64(cell, math.Float64bits(math.NaN()))
+	case form.code == 'A':
+		for i := range cell {
+			cell[i] = ' '
+		}
+	default:
+		// Already zero, which is what a logical column's undefined value is.
+	}
+}
+
+// putInt writes v big-endian at the cell's own width.
+func putInt(cell []byte, v int64) {
+	switch len(cell) {
+	case 1:
+		// A B column is one unsigned byte, and its sentinel is 255; the
+		// value reaching here came from nullSentinel and is in range.
+		cell[0] = byte(v & 0xFF)
+	case 2:
+		binary.BigEndian.PutUint16(cell, uint16(v)) //nolint:gosec // two's-complement bit pattern, the FITS I encoding
+	case 4:
+		binary.BigEndian.PutUint32(cell, uint32(v)) //nolint:gosec // two's-complement bit pattern, the FITS J encoding
+	case 8:
+		binary.BigEndian.PutUint64(cell, uint64(v)) //nolint:gosec // two's-complement bit pattern, the FITS K encoding
+	}
+}
+
+// writeVector encodes a fixed-size list cell: its elements end to end, each at
+// the element width.
+func writeVector(cell []byte, list *array.FixedSizeList, form tformField, row int) error {
+	values := list.ListValues()
+	width := form.width()
+	start := row * form.repeat
+
+	for i := range form.repeat {
+		at := start + i
+		if at >= values.Len() {
+			break
+		}
+
+		elem := cell[i*width : (i+1)*width]
+
+		if values.IsNull(at) {
+			writeNull(elem, tformField{repeat: 1, code: form.code}, columnNull{})
+
+			continue
+		}
+
+		if err := writeCell(elem, values, at); err != nil {
 			return err
 		}
 	}

--- a/fits/writebintable_test.go
+++ b/fits/writebintable_test.go
@@ -1,0 +1,248 @@
+package fits_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+
+	"github.com/TuSKan/astrogo/fits"
+)
+
+// A binary table is the half of #127 that catalogue pipelines need: a table
+// astrogo produced has to be readable by the tools the rest of the field uses,
+// which means the row-major transpose, the big-endian cells and the fixed-width
+// string columns all have to be right at once.
+
+// builderAs returns one of a record builder's field builders, typed.
+func builderAs[T array.Builder](t *testing.T, rb *array.RecordBuilder, i int) T {
+	t.Helper()
+
+	b, ok := rb.Field(i).(T)
+	if !ok {
+		t.Fatalf("field %d is %T, not the expected builder type", i, rb.Field(i))
+	}
+
+	return b
+}
+
+// catalogBatch builds a small catalogue-shaped batch: a name, a position, a
+// magnitude and a flag, which between them cover a string column, both float
+// widths, an integer and a logical.
+func catalogBatch(t *testing.T) arrow.RecordBatch {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "NAME", Type: arrow.BinaryTypes.String},
+		{Name: "RA", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "DEC", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "VMAG", Type: arrow.PrimitiveTypes.Float32},
+		{Name: "HIP", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "VARIABLE", Type: arrow.FixedWidthTypes.Boolean},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer bldr.Release()
+
+	builderAs[*array.StringBuilder](t, bldr, 0).AppendValues([]string{"Vega", "Betelgeuse", "Sun"}, nil)
+	builderAs[*array.Float64Builder](t, bldr, 1).AppendValues([]float64{279.23473479, 88.79293899, 0}, nil)
+	builderAs[*array.Float64Builder](t, bldr, 2).AppendValues([]float64{38.78368896, 7.40706400, 0}, nil)
+	builderAs[*array.Float32Builder](t, bldr, 3).AppendValues([]float32{0.03, 0.42, -26.74}, nil)
+	builderAs[*array.Int32Builder](t, bldr, 4).AppendValues([]int32{91262, 27989, 0}, nil)
+	builderAs[*array.BooleanBuilder](t, bldr, 5).AppendValues([]bool{false, true, false}, nil)
+
+	return bldr.NewRecordBatch()
+}
+
+func TestWriteBintableRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	batch := catalogBatch(t)
+	defer batch.Release()
+
+	table := &fits.BintableHDU{Batch: batch}
+	table.Header().Append(fits.Card{Keyword: "EXTNAME", Value: "'CATALOG '", Comment: "extension name"})
+
+	file := &fits.File{HDUs: []fits.HDU{&fits.ImageHDU{}, table}}
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, file); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	if len(got.HDUs) != 2 {
+		t.Fatalf("read %d HDUs, want 2 (primary + table)", len(got.HDUs))
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T, want *fits.BintableHDU", got.HDUs[1])
+	}
+
+	if out.Rows != 3 || out.Cols != 6 {
+		t.Fatalf("read %d rows x %d cols, want 3 x 6", out.Rows, out.Cols)
+	}
+
+	if name, err := out.Header().GetString("EXTNAME"); err != nil || name != "CATALOG" {
+		t.Errorf("EXTNAME = %q (%v), want CATALOG", name, err)
+	}
+
+	assertColumnsMatch(t, batch, out.Batch)
+}
+
+// assertColumnsMatch compares two batches value by value, by column name.
+//
+// By name rather than by index, because a column order that silently rotated
+// would otherwise pass while putting every star's RA under its neighbour's
+// name — which is the failure mode a catalogue writer must not have.
+func assertColumnsMatch(t *testing.T, want, got arrow.RecordBatch) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatal("read batch is nil")
+	}
+
+	for i := range want.Schema().NumFields() {
+		name := want.Schema().Field(i).Name
+
+		indices := got.Schema().FieldIndices(name)
+		if len(indices) == 0 {
+			t.Errorf("column %q is missing after the round trip", name)
+
+			continue
+		}
+
+		w := want.Column(i)
+		g := got.Column(indices[0])
+
+		if w.Len() != g.Len() {
+			t.Errorf("column %q has %d rows, want %d", name, g.Len(), w.Len())
+
+			continue
+		}
+
+		for row := range w.Len() {
+			if ws, gs := w.ValueStr(row), g.ValueStr(row); ws != gs {
+				t.Errorf("column %q row %d = %s, want %s", name, row, gs, ws)
+			}
+		}
+	}
+}
+
+// TestWriteBintableSizesStringColumnsToTheLongestValue is the fixed-width trap.
+//
+// FITS character columns have one width for the whole column, so a column sized
+// to anything less than its longest value truncates — silently, and only for
+// the rows that happen to be long.
+func TestWriteBintableSizesStringColumnsToTheLongestValue(t *testing.T) {
+	t.Parallel()
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "NAME", Type: arrow.BinaryTypes.String},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
+	defer bldr.Release()
+
+	// The long one is last, so a writer sizing from the first row truncates.
+	names := []string{"a", "bb", "a rather long designation"}
+	builderAs[*array.StringBuilder](t, bldr, 0).AppendValues(names, nil)
+
+	batch := bldr.NewRecordBatch()
+	defer batch.Release()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{Batch: batch},
+	}})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	col, ok := out.Batch.Column(0).(*array.String)
+	if !ok {
+		t.Fatalf("column is %T, want *array.String", out.Batch.Column(0))
+	}
+
+	for i, want := range names {
+		if got := col.Value(i); got != want {
+			t.Errorf("row %d = %q, want %q — the column was sized to a shorter value", i, got, want)
+		}
+	}
+}
+
+// TestWriteBintableRefusesAnEmptyBatch keeps an uninitialised table from being
+// written as a well-formed extension describing no columns.
+func TestWriteBintableRefusesAnEmptyBatch(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{
+		&fits.ImageHDU{}, &fits.BintableHDU{},
+	}})
+	if !errors.Is(err, fits.ErrUninitBatch) {
+		t.Errorf("Write with no batch = %v, want ErrUninitBatch", err)
+	}
+}
+
+// TestWriteBintableDerivesRowCountFromTheBatch is the reason the header is
+// rebuilt rather than carried over.
+//
+// A table read from one file and filtered before writing has fewer rows than
+// its header says. Trusting the stored NAXIS2 writes a file claiming rows that
+// are not there, and a reader believes the header.
+func TestWriteBintableDerivesRowCountFromTheBatch(t *testing.T) {
+	t.Parallel()
+
+	batch := catalogBatch(t)
+	defer batch.Release()
+
+	table := &fits.BintableHDU{Batch: batch}
+
+	// A stale header, as a read-then-filter would leave behind.
+	table.Header().Append(fits.Card{Keyword: "NAXIS2", Value: "9999"})
+	table.Header().Append(fits.Card{Keyword: "TFIELDS", Value: "99"})
+
+	var buf bytes.Buffer
+	if err := fits.Write(&buf, &fits.File{HDUs: []fits.HDU{&fits.ImageHDU{}, table}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := fits.Read(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("Read back: %v", err)
+	}
+
+	out, ok := got.HDUs[1].(*fits.BintableHDU)
+	if !ok {
+		t.Fatalf("extension is %T", got.HDUs[1])
+	}
+
+	if out.Rows != 3 {
+		t.Errorf("NAXIS2 = %d, want 3 — the stale header was written instead of the batch's shape", out.Rows)
+	}
+
+	if out.Cols != 6 {
+		t.Errorf("TFIELDS = %d, want 6", out.Cols)
+	}
+}

--- a/fits/writecard.go
+++ b/fits/writecard.go
@@ -1,0 +1,169 @@
+package fits
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The fixed-format card layout, from FITS 4.0 §4.1.2. These are column
+// positions in a 1-based standard rendered into a 0-based slice, which is
+// where an off-by-one in a FITS writer traditionally lives, so they are named
+// rather than spelled inline.
+const (
+	// keywordWidth is columns 1-8, where the keyword sits left-justified.
+	keywordWidth = 8
+
+	// valueIndicator occupies columns 9-10 of a value card.
+	valueIndicator = "= "
+
+	// fixedValueEnd is the column a fixed-format numeric or logical value
+	// ends at, right-justified. The standard asks for this alignment and
+	// readers in other languages have been known to rely on it.
+	fixedValueEnd = 30
+
+	// minStringValue is the minimum length of a quoted string's contents.
+	// A shorter one is blank-padded, so that 'a' is written 'a       '.
+	minStringValue = 8
+)
+
+// commentaryKeywords carry free text in columns 9-80 and take no value
+// indicator. Writing "COMMENT = ..." would be a syntax error to every reader.
+//
+// The blank keyword is the third of them and is how a FITS file writes an
+// unkeyed note; it is spelled here as the empty string because that is what
+// [ParseCard] produces for one.
+var commentaryKeywords = map[string]bool{
+	"COMMENT": true,
+	"HISTORY": true,
+	"":        true,
+}
+
+// formatCard renders one card as exactly [CardSize] bytes.
+//
+// It returns an error rather than truncating. A truncated card is not a
+// slightly-wrong file: the 80-byte grid is the only thing separating one
+// record from the next, so a card that overflows shifts every card after it
+// and the header stops parsing where the overflow happened. A caller who
+// wrote a comment two characters too long deserves to hear about it at the
+// call site rather than from someone else's reader a week later.
+func formatCard(c Card) ([]byte, error) {
+	kw := strings.ToUpper(strings.TrimSpace(c.Keyword))
+
+	if len(kw) > keywordWidth {
+		return nil, fmt.Errorf("%w: keyword %q is %d characters, the limit is %d",
+			ErrCardTooLong, kw, len(kw), keywordWidth)
+	}
+
+	if err := checkPrintable(kw, c); err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+
+	b.Grow(CardSize)
+	b.WriteString(kw)
+	b.WriteString(strings.Repeat(" ", keywordWidth-len(kw)))
+
+	switch {
+	case commentaryKeywords[kw]:
+		b.WriteString(c.Comment)
+
+	// END closes a header and carries nothing at all. Writing "END = " would
+	// be a value card with no value, which is not what any reader expects to
+	// find where the header stops. The same goes for any card a caller left
+	// entirely empty: a bare keyword is legal, "KEYWORD = " is not.
+	case kw == "END", c.Value == "" && c.Comment == "":
+
+	default:
+		b.WriteString(valueIndicator)
+		b.WriteString(formatValue(c.Value))
+
+		if c.Comment != "" {
+			b.WriteString(" / ")
+			b.WriteString(c.Comment)
+		}
+	}
+
+	out := b.String()
+	if len(out) > CardSize {
+		return nil, fmt.Errorf("%w: card %q renders to %d characters, the limit is %d",
+			ErrCardTooLong, kw, len(out), CardSize)
+	}
+
+	return []byte(out + strings.Repeat(" ", CardSize-len(out))), nil
+}
+
+// formatValue lays a card's value out in the fixed format.
+//
+// The value arrives as the text a reader would have parsed — quotes included
+// for a string — because that is how [Card] stores it and how [ParseCard]
+// produces it. Keeping that representation is what lets a file read by this
+// package be written back out unchanged.
+func formatValue(value string) string {
+	v := strings.TrimSpace(value)
+
+	if v == "" {
+		return ""
+	}
+
+	// A string value starts at column 11 and is padded to at least eight
+	// characters inside its quotes. Left-justified, unlike everything else.
+	if v[0] == '\'' {
+		return padQuoted(v)
+	}
+
+	// Numbers and logicals are right-justified to end at fixedValueEnd. The
+	// value begins at column 11, so the padding is what is left of the field.
+	const valueStart = keywordWidth + len(valueIndicator) // column 11, 0-based 10
+
+	if width := fixedValueEnd - valueStart; len(v) < width {
+		return strings.Repeat(" ", width-len(v)) + v
+	}
+
+	return v
+}
+
+// padQuoted blank-pads a quoted string's contents to [minStringValue].
+//
+// Trailing blanks inside a FITS string are not significant, so this changes
+// nothing a reader will see; it exists because the standard asks for it and
+// because a one-character value written as 'a' has been observed to confuse
+// readers that assume the minimum.
+func padQuoted(v string) string {
+	if len(v) < 2 || v[len(v)-1] != '\'' {
+		return v // not a well-formed quoted string; write it as given
+	}
+
+	inner := v[1 : len(v)-1]
+	if len(inner) >= minStringValue {
+		return v
+	}
+
+	return "'" + inner + strings.Repeat(" ", minStringValue-len(inner)) + "'"
+}
+
+// checkPrintable rejects bytes a FITS header may not contain.
+//
+// The standard restricts header records to ASCII 32-126. A newline or a tab in
+// a comment does not corrupt one card, it corrupts the grid — every reader
+// counts 80 bytes, so a stray byte silently shifts the rest of the header into
+// nonsense. This is the one place that can still be caught cheaply.
+func checkPrintable(kw string, c Card) error {
+	for _, part := range []struct {
+		what string
+		text string
+	}{
+		{"keyword", kw},
+		{"value", c.Value},
+		{"comment", c.Comment},
+	} {
+		for i := range len(part.text) {
+			if ch := part.text[i]; ch < 32 || ch > 126 {
+				return fmt.Errorf("%w: %s of card %q contains byte %#x at offset %d",
+					ErrCardNotPrintable, part.what, kw, ch, i)
+			}
+		}
+	}
+
+	return nil
+}

--- a/fits/writecard.go
+++ b/fits/writecard.go
@@ -38,24 +38,69 @@ var commentaryKeywords = map[string]bool{
 	"":        true,
 }
 
-// formatCard renders one card as exactly [CardSize] bytes.
+// formatCards renders one card as the 80-byte records a header carries it in.
 //
-// It returns an error rather than truncating. A truncated card is not a
-// slightly-wrong file: the 80-byte grid is the only thing separating one
-// record from the next, so a card that overflows shifts every card after it
-// and the header stops parsing where the overflow happened. A caller who
-// wrote a comment two characters too long deserves to hear about it at the
-// call site rather than from someone else's reader a week later.
-func formatCard(c Card) ([]byte, error) {
+// Usually that is one record. It is more when the card needs a registered
+// convention to fit: a keyword over eight characters becomes a HIERARCH card,
+// and a string value too long for the remaining columns becomes a value card
+// followed by CONTINUE cards. Both are read back as one card by [ParseCard]
+// and [ReadHeader], which is what makes the split invisible to a caller.
+//
+// An over-long card is an error rather than a truncation wherever a convention
+// does not apply — to a keyword that is already HIERARCH and still will not
+// fit, or to a comment on a numeric card. The 80-byte grid is the only thing
+// separating one record from the next, so a card that overflows shifts every
+// card after it and the header stops parsing where the overflow happened.
+func formatCards(c Card) ([][]byte, error) {
 	kw := strings.ToUpper(strings.TrimSpace(c.Keyword))
-
-	if len(kw) > keywordWidth {
-		return nil, fmt.Errorf("%w: keyword %q is %d characters, the limit is %d",
-			ErrCardTooLong, kw, len(kw), keywordWidth)
-	}
 
 	if err := checkPrintable(kw, c); err != nil {
 		return nil, err
+	}
+
+	if commentaryKeywords[kw] {
+		return one(formatFixed(kw, "", c.Comment, true))
+	}
+
+	if kw == "END" || (c.Value == "" && c.Comment == "") {
+		return one(formatFixed(kw, "", "", true))
+	}
+
+	if isLongKeyword(kw) {
+		return one(formatHierarch(kw, c))
+	}
+
+	// A string value that does not fit is split across CONTINUE cards. Only a
+	// string can be: the convention is defined for character values alone,
+	// which is why a numeric card with an over-long comment is an error.
+	if isQuoted(c.Value) {
+		if cards, ok, err := formatLongString(kw, c); ok || err != nil {
+			return cards, err
+		}
+	}
+
+	return one(formatFixed(kw, formatValue(c.Value), c.Comment, false))
+}
+
+// one wraps a single rendered card, or the error that prevented it.
+func one(card []byte, err error) ([][]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	return [][]byte{card}, nil
+}
+
+// formatFixed lays out a standard card and pads it to [CardSize].
+//
+// bare distinguishes a card with no value indicator — END, a commentary
+// keyword, or a keyword a caller left entirely empty — from a value card,
+// because "KEYWORD = " with nothing after it is not legal where a bare
+// keyword is.
+func formatFixed(kw, value, comment string, bare bool) ([]byte, error) {
+	if len(kw) > keywordWidth {
+		return nil, fmt.Errorf("%w: keyword %q is %d characters, the limit is %d",
+			ErrCardTooLong, kw, len(kw), keywordWidth)
 	}
 
 	var b strings.Builder
@@ -65,26 +110,170 @@ func formatCard(c Card) ([]byte, error) {
 	b.WriteString(strings.Repeat(" ", keywordWidth-len(kw)))
 
 	switch {
-	case commentaryKeywords[kw]:
-		b.WriteString(c.Comment)
-
-	// END closes a header and carries nothing at all. Writing "END = " would
-	// be a value card with no value, which is not what any reader expects to
-	// find where the header stops. The same goes for any card a caller left
-	// entirely empty: a bare keyword is legal, "KEYWORD = " is not.
-	case kw == "END", c.Value == "" && c.Comment == "":
-
+	case bare && comment != "":
+		b.WriteString(comment)
+	case bare:
 	default:
 		b.WriteString(valueIndicator)
-		b.WriteString(formatValue(c.Value))
+		b.WriteString(value)
 
-		if c.Comment != "" {
+		if comment != "" {
 			b.WriteString(" / ")
-			b.WriteString(c.Comment)
+			b.WriteString(comment)
 		}
 	}
 
+	return padCard(b.String(), kw)
+}
+
+// formatHierarch renders a long keyword through the ESO HIERARCH convention.
+//
+// The layout is "HIERARCH <keyword> = <value>", with no column alignment: the
+// keyword has already used the columns a fixed-format value would be aligned
+// to, and ESO's own files do not align these.
+func formatHierarch(kw string, c Card) ([]byte, error) {
+	var b strings.Builder
+
+	b.Grow(CardSize)
+	b.WriteString(hierarchPrefix)
+	b.WriteString(kw)
+	b.WriteString(" = ")
+	b.WriteString(strings.TrimSpace(c.Value))
+
+	if c.Comment != "" {
+		b.WriteString(" / ")
+		b.WriteString(c.Comment)
+	}
+
 	out := b.String()
+	if len(out) > CardSize {
+		// Dropping the comment is the one recovery worth trying: a HIERARCH
+		// keyword plus its value is the content, and a comment is not.
+		out = hierarchPrefix + kw + " = " + strings.TrimSpace(c.Value)
+	}
+
+	return padCard(out, kw)
+}
+
+// formatLongString splits a string value across CONTINUE cards.
+//
+// ok is false when the value fits in one card, so the caller writes it the
+// ordinary way rather than invoking a convention for nothing.
+//
+// Every segment but the last ends with "&" inside its quotes, which is what
+// tells a reader another card follows. The comment goes on the final card,
+// where the convention puts it and where a reader that stops early still sees
+// it belongs to the whole value.
+func formatLongString(kw string, c Card) ([][]byte, bool, error) {
+	text := unquote(c.Value)
+
+	// What fits on the first card: the record, less the keyword and "= ",
+	// less the two quotes.
+	const quoteOverhead = 2
+
+	first := CardSize - keywordWidth - len(valueIndicator) - quoteOverhead
+	cont := CardSize - len(continueKeyword) - 2 - quoteOverhead
+
+	if len(quoteValue(text))+keywordWidth+len(valueIndicator) <= CardSize && c.Comment == "" {
+		return nil, false, nil
+	}
+
+	if len(text) <= first-len(" / "+c.Comment) || (c.Comment == "" && len(text) <= first) {
+		return nil, false, nil
+	}
+
+	segments := splitSegments(text, first-1, cont-1)
+
+	cards := make([][]byte, 0, len(segments))
+
+	for i, seg := range segments {
+		last := i == len(segments)-1
+
+		value := seg
+		if !last {
+			value += string(continuation)
+		}
+
+		var (
+			card []byte
+			err  error
+		)
+
+		comment := ""
+		if last {
+			comment = c.Comment
+		}
+
+		if i == 0 {
+			card, err = formatFixed(kw, quoteValue(value), comment, false)
+		} else {
+			card, err = formatContinue(quoteValue(value), comment)
+		}
+
+		if err != nil {
+			return nil, true, err
+		}
+
+		cards = append(cards, card)
+	}
+
+	return cards, true, nil
+}
+
+// formatContinue renders one CONTINUE card.
+//
+// CONTINUE takes no value indicator: the standard puts the string in the value
+// field directly, which is why ParseCard reads it as a special case rather than
+// as an assignment.
+func formatContinue(value, comment string) ([]byte, error) {
+	var b strings.Builder
+
+	b.Grow(CardSize)
+	b.WriteString(continueKeyword)
+	b.WriteString("  ")
+	b.WriteString(value)
+
+	if comment != "" {
+		b.WriteString(" / ")
+		b.WriteString(comment)
+	}
+
+	return padCard(b.String(), continueKeyword)
+}
+
+// splitSegments cuts text into pieces that fit their cards.
+func splitSegments(text string, first, rest int) []string {
+	if first < 1 {
+		first = 1
+	}
+
+	if rest < 1 {
+		rest = 1
+	}
+
+	var (
+		out   []string
+		width = first
+	)
+
+	for len(text) > 0 {
+		if len(text) <= width {
+			out = append(out, text)
+
+			break
+		}
+
+		out = append(out, text[:width])
+		text = text[width:]
+		width = rest
+	}
+
+	return out
+}
+
+// padCard blank-fills a rendered card to [CardSize], or reports that it will
+// not fit.
+func padCard(out, kw string) ([]byte, error) {
 	if len(out) > CardSize {
 		return nil, fmt.Errorf("%w: card %q renders to %d characters, the limit is %d",
 			ErrCardTooLong, kw, len(out), CardSize)

--- a/fits/writeimage.go
+++ b/fits/writeimage.go
@@ -1,0 +1,230 @@
+package fits
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// encodeImage builds an image HDU's header and payload.
+func encodeImage(h *ImageHDU, primary bool) (*Header, []byte, error) {
+	bitpix, pixelBytes, err := bitpixOf(h)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mandatory := imageKeywords(h, bitpix, primary)
+
+	header := orderedHeader(h.Header(), mandatory)
+
+	appendScaling(header, h)
+
+	payload, err := imagePayload(h, pixelBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return header, payload, nil
+}
+
+// imageKeywords builds the structural cards, in the order the standard fixes.
+func imageKeywords(h *ImageHDU, bitpix int, primary bool) []Card {
+	naxis := len(h.Axes)
+
+	first := Card{Keyword: "SIMPLE", Value: "T", Comment: "conforms to FITS standard"}
+	if !primary {
+		first = Card{Keyword: "XTENSION", Value: "'IMAGE   '", Comment: "image extension"}
+	}
+
+	cards := []Card{
+		first,
+		{Keyword: "BITPIX", Value: strconv.Itoa(bitpix), Comment: "bits per data pixel"},
+		{Keyword: "NAXIS", Value: strconv.Itoa(naxis), Comment: "number of data axes"},
+	}
+
+	// Axes are held C-contiguous — slowest-varying first — which is the
+	// reverse of the NAXISn order ReadImage flipped them out of. Flipping
+	// back here rather than storing both is what keeps the two paths from
+	// disagreeing about which end is which.
+	for i := 1; i <= naxis; i++ {
+		cards = append(cards, Card{
+			Keyword: "NAXIS" + strconv.Itoa(i),
+			Value:   strconv.FormatInt(h.Axes[naxis-i], 10),
+			Comment: "length of data axis " + strconv.Itoa(i),
+		})
+	}
+
+	// An extension declares its group structure; the primary HDU does not.
+	// Both are fixed for an image: no random-group parameters, one group.
+	if !primary {
+		cards = append(cards,
+			Card{Keyword: "PCOUNT", Value: "0", Comment: "number of parameters"},
+			Card{Keyword: "GCOUNT", Value: "1", Comment: "number of groups"},
+		)
+	}
+
+	return cards
+}
+
+// appendScaling writes the calibration keywords, and only the ones that say
+// something.
+//
+// BSCALE 1 and BZERO 0 are the defaults a reader assumes, so writing them adds
+// two cards that mean "nothing to see". BLANK is different: it is written only
+// when the HDU actually carries one, because BLANK declares a pixel value to
+// be read as undefined, and inventing one would reinterpret whatever pixels
+// happen to hold that value.
+func appendScaling(header *Header, h *ImageHDU) {
+	if h.BScale != 0 && h.BScale != 1 {
+		setCard(header, "BSCALE", formatFloat(h.BScale), "linear scaling factor")
+	}
+
+	if h.BZero != 0 {
+		setCard(header, "BZERO", formatFloat(h.BZero), "zero point of scaling")
+	}
+
+	if h.HasBlank {
+		setCard(header, "BLANK", strconv.FormatInt(h.Blank, 10), "undefined pixel value")
+	}
+}
+
+// bitpixOf returns the BITPIX to write and the width of one pixel.
+//
+// The HDU's own Bitpix is authoritative when set, since that is what a read
+// produced and what a caller adjusting a header would change. When it is zero
+// — a tensor built in memory rather than read from a file — it is derived from
+// the tensor's element type, so the common case of constructing an image from
+// Arrow data needs no FITS knowledge at the call site.
+func bitpixOf(h *ImageHDU) (bitpix, pixelBytes int, err error) {
+	bitpix = h.Bitpix
+
+	if bitpix == 0 && h.Tensor != nil {
+		bitpix, err = bitpixForType(h.Tensor.DataType())
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if len(h.Axes) == 0 && h.Tensor == nil {
+		// A header-only HDU: the primary HDU of a file whose data lives in
+		// extensions. BITPIX still has to be a legal value, and 8 is the
+		// conventional choice for "there are no pixels".
+		if bitpix == 0 {
+			bitpix = BitpixUint8
+		}
+	}
+
+	switch bitpix {
+	case BitpixUint8:
+		return bitpix, 1, nil
+	case BitpixInt16:
+		return bitpix, 2, nil
+	case BitpixInt32, BitpixFloat32:
+		return bitpix, 4, nil
+	case BitpixInt64, BitpixFloat64:
+		return bitpix, 8, nil
+	default:
+		return 0, 0, fmt.Errorf("%w: %d", ErrInvalidBitpix, bitpix)
+	}
+}
+
+// bitpixForType maps an Arrow element type to its FITS BITPIX.
+//
+// FITS has no unsigned integer types beyond 8-bit; a uint16 image is written
+// as int16 with BZERO 32768, which this does not do silently — a caller with
+// unsigned data has to say what they meant, because guessing would write
+// values that read back as negative.
+//
+// The default rejects every Arrow type FITS has no BITPIX for; listing the
+// forty it cannot store would say the same thing at much greater length.
+//
+//nolint:exhaustive // the default covers every unlisted type, as above
+func bitpixForType(dt arrow.DataType) (int, error) {
+	switch dt.ID() {
+	case arrow.UINT8:
+		return BitpixUint8, nil
+	case arrow.INT16:
+		return BitpixInt16, nil
+	case arrow.INT32:
+		return BitpixInt32, nil
+	case arrow.INT64:
+		return BitpixInt64, nil
+	case arrow.FLOAT32:
+		return BitpixFloat32, nil
+	case arrow.FLOAT64:
+		return BitpixFloat64, nil
+	default:
+		return 0, fmt.Errorf("%w: no BITPIX for Arrow type %s", ErrNotWritable, dt)
+	}
+}
+
+// imagePayload returns the pixel bytes in FITS byte order.
+//
+// The tensor's buffer is copied rather than swapped in place: it belongs to
+// the caller, who did not ask for their image to be byte-reversed as a side
+// effect of writing it.
+func imagePayload(h *ImageHDU, pixelBytes int) ([]byte, error) {
+	if h.Tensor == nil {
+		return nil, nil
+	}
+
+	want := int64(1)
+	for _, n := range h.Axes {
+		want *= n
+	}
+
+	buffers := h.Tensor.Data().Buffers()
+	if len(buffers) < 2 || buffers[1] == nil {
+		return nil, fmt.Errorf("%w: image tensor holds no data buffer", ErrNotWritable)
+	}
+
+	raw := buffers[1].Bytes()
+
+	// The axes and the buffer have to agree, or the file will describe more
+	// or fewer pixels than it carries — which no reader can detect, because
+	// the header is the only statement of the shape.
+	if int64(len(raw)) < want*int64(pixelBytes) {
+		return nil, fmt.Errorf("%w: axes describe %d pixels (%d bytes) but the tensor holds %d bytes",
+			ErrNotWritable, want, want*int64(pixelBytes), len(raw))
+	}
+
+	out := make([]byte, want*int64(pixelBytes))
+	copy(out, raw)
+
+	swapNativeToBigEndian(out, pixelBytes)
+
+	return out, nil
+}
+
+// swapNativeToBigEndian converts a buffer from native to FITS byte order in
+// place. It is the inverse of swapBigEndianToNative, and on a big-endian
+// machine both are nothing.
+func swapNativeToBigEndian(buf []byte, bytesPerPixel int) {
+	switch bytesPerPixel {
+	case 1:
+		// A single byte has no order.
+	case 2:
+		for i := 0; i+2 <= len(buf); i += 2 {
+			binary.BigEndian.PutUint16(buf[i:], binary.NativeEndian.Uint16(buf[i:]))
+		}
+	case 4:
+		for i := 0; i+4 <= len(buf); i += 4 {
+			binary.BigEndian.PutUint32(buf[i:], binary.NativeEndian.Uint32(buf[i:]))
+		}
+	case 8:
+		for i := 0; i+8 <= len(buf); i += 8 {
+			binary.BigEndian.PutUint64(buf[i:], binary.NativeEndian.Uint64(buf[i:]))
+		}
+	}
+}
+
+// formatFloat renders a float for a header card.
+//
+// 'G' with -1 precision gives the shortest representation that reads back as
+// the same float64, which is what keeps a value written and re-read from
+// drifting. FITS accepts E or D exponents; Go writes E, which is legal.
+func formatFloat(v float64) string {
+	return strconv.FormatFloat(v, 'G', -1, 64)
+}

--- a/fits/writeimage.go
+++ b/fits/writeimage.go
@@ -3,23 +3,26 @@ package fits
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/apache/arrow-go/v18/arrow"
 )
 
 // encodeImage builds an image HDU's header and payload.
-func encodeImage(h *ImageHDU, primary bool) (*Header, []byte, error) {
+func encodeImage(h *ImageHDU, primary, extensions bool) (*Header, []byte, error) {
 	bitpix, pixelBytes, err := bitpixOf(h)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	mandatory := imageKeywords(h, bitpix, primary)
+	mandatory := imageKeywords(h, bitpix, primary, extensions)
 
 	header := orderedHeader(h.Header(), mandatory)
 
-	appendScaling(header, h)
+	if err := appendScaling(header, h); err != nil {
+		return nil, nil, err
+	}
 
 	payload, err := imagePayload(h, pixelBytes)
 	if err != nil {
@@ -30,7 +33,7 @@ func encodeImage(h *ImageHDU, primary bool) (*Header, []byte, error) {
 }
 
 // imageKeywords builds the structural cards, in the order the standard fixes.
-func imageKeywords(h *ImageHDU, bitpix int, primary bool) []Card {
+func imageKeywords(h *ImageHDU, bitpix int, primary, extensions bool) []Card {
 	naxis := len(h.Axes)
 
 	first := Card{Keyword: "SIMPLE", Value: "T", Comment: "conforms to FITS standard"}
@@ -56,6 +59,17 @@ func imageKeywords(h *ImageHDU, bitpix int, primary bool) []Card {
 		})
 	}
 
+	// EXTEND announces that extensions follow, and the standard puts it
+	// immediately after the last NAXISn in the primary header. It is not
+	// decoration: a reader is entitled to stop at the primary HDU without it,
+	// so a file carrying a table nobody can find is the failure mode. astropy
+	// and cfitsio both write it.
+	if primary && extensions {
+		cards = append(cards, Card{
+			Keyword: "EXTEND", Value: "T", Comment: "file contains extensions",
+		})
+	}
+
 	// An extension declares its group structure; the primary HDU does not.
 	// Both are fixed for an image: no random-group parameters, one group.
 	if !primary {
@@ -76,18 +90,30 @@ func imageKeywords(h *ImageHDU, bitpix int, primary bool) []Card {
 // when the HDU actually carries one, because BLANK declares a pixel value to
 // be read as undefined, and inventing one would reinterpret whatever pixels
 // happen to hold that value.
-func appendScaling(header *Header, h *ImageHDU) {
+func appendScaling(header *Header, h *ImageHDU) error {
 	if h.BScale != 0 && h.BScale != 1 {
-		setCard(header, "BSCALE", formatFloat(h.BScale), "linear scaling factor")
+		v, err := formatFloat(h.BScale)
+		if err != nil {
+			return fmt.Errorf("BSCALE: %w", err)
+		}
+
+		setCard(header, "BSCALE", v, "linear scaling factor")
 	}
 
 	if h.BZero != 0 {
-		setCard(header, "BZERO", formatFloat(h.BZero), "zero point of scaling")
+		v, err := formatFloat(h.BZero)
+		if err != nil {
+			return fmt.Errorf("BZERO: %w", err)
+		}
+
+		setCard(header, "BZERO", v, "zero point of scaling")
 	}
 
 	if h.HasBlank {
 		setCard(header, "BLANK", strconv.FormatInt(h.Blank, 10), "undefined pixel value")
 	}
+
+	return nil
 }
 
 // bitpixOf returns the BITPIX to write and the width of one pixel.
@@ -225,6 +251,16 @@ func swapNativeToBigEndian(buf []byte, bytesPerPixel int) {
 // 'G' with -1 precision gives the shortest representation that reads back as
 // the same float64, which is what keeps a value written and re-read from
 // drifting. FITS accepts E or D exponents; Go writes E, which is legal.
-func formatFloat(v float64) string {
-	return strconv.FormatFloat(v, 'G', -1, 64)
+//
+// NaN and the infinities are refused. A FITS header has no representation for
+// them, and Go would render them as "NaN" and "+Inf" — text no reader can
+// parse as a number, in a card that claims to be one. A BSCALE that arrived as
+// NaN is a caller's bug worth reporting, not one to encode into a file that
+// then fails somewhere else.
+func formatFloat(v float64) (string, error) {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return "", fmt.Errorf("%w: %v has no FITS representation", ErrCardNotFinite, v)
+	}
+
+	return strconv.FormatFloat(v, 'G', -1, 64), nil
 }

--- a/fits/writeimage.go
+++ b/fits/writeimage.go
@@ -11,7 +11,7 @@ import (
 
 // encodeImage builds an image HDU's header and payload.
 func encodeImage(h *ImageHDU, primary, extensions bool) (*Header, []byte, error) {
-	bitpix, pixelBytes, err := bitpixOf(h)
+	bitpix, pixelBytes, bzero, err := bitpixOf(h)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -20,11 +20,11 @@ func encodeImage(h *ImageHDU, primary, extensions bool) (*Header, []byte, error)
 
 	header := orderedHeader(h.Header(), mandatory)
 
-	if err := appendScaling(header, h); err != nil {
+	if err := appendScaling(header, h, bzero); err != nil {
 		return nil, nil, err
 	}
 
-	payload, err := imagePayload(h, pixelBytes)
+	payload, err := imagePayload(h, pixelBytes, bzero)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,7 +90,21 @@ func imageKeywords(h *ImageHDU, bitpix int, primary, extensions bool) []Card {
 // when the HDU actually carries one, because BLANK declares a pixel value to
 // be read as undefined, and inventing one would reinterpret whatever pixels
 // happen to hold that value.
-func appendScaling(header *Header, h *ImageHDU) error {
+func appendScaling(header *Header, h *ImageHDU, unsignedOffset float64) error {
+	// An unsigned image's BZERO is not a calibration the caller chose; it is
+	// how the data is stored at all, so it overrides whatever the HDU carries.
+	if unsignedOffset != 0 {
+		v, err := formatFloat(unsignedOffset)
+		if err != nil {
+			return fmt.Errorf("BZERO: %w", err)
+		}
+
+		setCard(header, "BZERO", v, "offset for unsigned integer data")
+		setCard(header, "BSCALE", "1", "linear scaling factor")
+
+		return nil
+	}
+
 	if h.BScale != 0 && h.BScale != 1 {
 		v, err := formatFloat(h.BScale)
 		if err != nil {
@@ -123,13 +137,20 @@ func appendScaling(header *Header, h *ImageHDU) error {
 // — a tensor built in memory rather than read from a file — it is derived from
 // the tensor's element type, so the common case of constructing an image from
 // Arrow data needs no FITS knowledge at the call site.
-func bitpixOf(h *ImageHDU) (bitpix, pixelBytes int, err error) {
+func bitpixOf(h *ImageHDU) (bitpix, pixelBytes int, bzero float64, err error) {
 	bitpix = h.Bitpix
 
+	// The tensor decides for unsigned data whatever the HDU says, because
+	// BITPIX alone cannot express it: uint16 and int16 are both BITPIX 16 and
+	// differ only by the BZERO that accompanies them.
+	if h.Tensor != nil && isUnsignedArrow(h.Tensor.DataType()) {
+		return unsignedFromTensor(h.Tensor.DataType())
+	}
+
 	if bitpix == 0 && h.Tensor != nil {
-		bitpix, err = bitpixForType(h.Tensor.DataType())
+		bitpix, _, err = bitpixForType(h.Tensor.DataType())
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, 0, err
 		}
 	}
 
@@ -142,47 +163,121 @@ func bitpixOf(h *ImageHDU) (bitpix, pixelBytes int, err error) {
 		}
 	}
 
+	width, err := pixelWidth(bitpix)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return bitpix, width, 0, nil
+}
+
+// pixelWidth is the stored width of one pixel of the given BITPIX.
+func pixelWidth(bitpix int) (int, error) {
 	switch bitpix {
 	case BitpixUint8:
-		return bitpix, 1, nil
+		return 1, nil
 	case BitpixInt16:
-		return bitpix, 2, nil
+		return 2, nil
 	case BitpixInt32, BitpixFloat32:
-		return bitpix, 4, nil
+		return 4, nil
 	case BitpixInt64, BitpixFloat64:
-		return bitpix, 8, nil
+		return 8, nil
 	default:
-		return 0, 0, fmt.Errorf("%w: %d", ErrInvalidBitpix, bitpix)
+		return 0, fmt.Errorf("%w: %d", ErrInvalidBitpix, bitpix)
 	}
 }
 
-// bitpixForType maps an Arrow element type to its FITS BITPIX.
+// isUnsignedArrow reports whether an Arrow type is an unsigned integer wider
+// than a byte, which is what FITS cannot store directly.
+func isUnsignedArrow(dt arrow.DataType) bool {
+	switch dt.ID() { //nolint:exhaustive // only the three widths FITS offsets
+	case arrow.UINT16, arrow.UINT32, arrow.UINT64:
+		return true
+	default:
+		return false
+	}
+}
+
+// unsignedFromTensor resolves the BITPIX, pixel width and BZERO for an
+// unsigned tensor.
+func unsignedFromTensor(dt arrow.DataType) (bitpix, pixelBytes int, bzero float64, err error) {
+	bitpix, bzero, err = bitpixForType(dt)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	pixelBytes, err = pixelWidth(bitpix)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	return bitpix, pixelBytes, bzero, nil
+}
+
+// bitpixForType maps an Arrow element type to its FITS BITPIX, and the BZERO
+// that goes with it.
 //
-// FITS has no unsigned integer types beyond 8-bit; a uint16 image is written
-// as int16 with BZERO 32768, which this does not do silently — a caller with
-// unsigned data has to say what they meant, because guessing would write
-// values that read back as negative.
+// FITS has no unsigned integer type above 8 bits. The standard's answer, and
+// every other library's, is to store the signed type of the same width and
+// offset it with BZERO — so a uint16 is written as int16 with BZERO 32768, and
+// a reader adds the offset back. [unsignedBZero] is where the offsets live.
 //
 // The default rejects every Arrow type FITS has no BITPIX for; listing the
 // forty it cannot store would say the same thing at much greater length.
 //
 //nolint:exhaustive // the default covers every unlisted type, as above
-func bitpixForType(dt arrow.DataType) (int, error) {
+func bitpixForType(dt arrow.DataType) (bitpix int, bzero float64, err error) {
 	switch dt.ID() {
 	case arrow.UINT8:
-		return BitpixUint8, nil
+		return BitpixUint8, 0, nil
 	case arrow.INT16:
-		return BitpixInt16, nil
+		return BitpixInt16, 0, nil
 	case arrow.INT32:
-		return BitpixInt32, nil
+		return BitpixInt32, 0, nil
 	case arrow.INT64:
-		return BitpixInt64, nil
+		return BitpixInt64, 0, nil
 	case arrow.FLOAT32:
-		return BitpixFloat32, nil
+		return BitpixFloat32, 0, nil
 	case arrow.FLOAT64:
-		return BitpixFloat64, nil
+		return BitpixFloat64, 0, nil
+	case arrow.UINT16:
+		return BitpixInt16, unsignedBZero(BitpixInt16), nil
+	case arrow.UINT32:
+		return BitpixInt32, unsignedBZero(BitpixInt32), nil
+	case arrow.UINT64:
+		return BitpixInt64, unsignedBZero(BitpixInt64), nil
 	default:
-		return 0, fmt.Errorf("%w: no BITPIX for Arrow type %s", ErrNotWritable, dt)
+		return 0, 0, fmt.Errorf("%w: no BITPIX for Arrow type %s", ErrNotWritable, dt)
+	}
+}
+
+// unsignedBZero is the offset that turns a signed stored value back into the
+// unsigned one a caller meant: 2^(n-1) for an n-bit type.
+//
+//	uint16 -> BITPIX 16, BZERO 32768
+//	uint32 -> BITPIX 32, BZERO 2147483648
+//	uint64 -> BITPIX 64, BZERO 9223372036854775808
+//
+// These are the values FITS 4.0 §5.2.5 names and the ones every reader
+// recognises, which is what makes the convention interoperable rather than a
+// private encoding.
+func unsignedBZero(bitpix int) float64 {
+	return math.Pow(2, float64(bitpix-1))
+}
+
+// isUnsignedOffset reports whether bzero is the offset that marks stored data
+// as unsigned for this BITPIX.
+//
+// Compared exactly because these are the only values the convention uses and
+// all three are exactly representable in float64 — a BZERO of 32768.0001 is a
+// genuine calibration offset, not an unsigned image, and must not be read as
+// one.
+func isUnsignedOffset(bitpix int, bzero float64) bool {
+	switch bitpix {
+	case BitpixInt16, BitpixInt32, BitpixInt64:
+		return bzero == unsignedBZero(bitpix)
+	default:
+		return false
 	}
 }
 
@@ -191,7 +286,7 @@ func bitpixForType(dt arrow.DataType) (int, error) {
 // The tensor's buffer is copied rather than swapped in place: it belongs to
 // the caller, who did not ask for their image to be byte-reversed as a side
 // effect of writing it.
-func imagePayload(h *ImageHDU, pixelBytes int) ([]byte, error) {
+func imagePayload(h *ImageHDU, pixelBytes int, unsignedOffset float64) ([]byte, error) {
 	if h.Tensor == nil {
 		return nil, nil
 	}
@@ -219,9 +314,40 @@ func imagePayload(h *ImageHDU, pixelBytes int) ([]byte, error) {
 	out := make([]byte, want*int64(pixelBytes))
 	copy(out, raw)
 
+	// Unsigned data is stored as the signed type of the same width, offset by
+	// BZERO. Subtracting it here is exactly what the reader adds back, and the
+	// arithmetic wraps by design: 0 becomes the most negative signed value and
+	// 65535 becomes the most positive, which is the whole of the convention.
+	if unsignedOffset != 0 {
+		offsetToSigned(out, pixelBytes)
+	}
+
 	swapNativeToBigEndian(out, pixelBytes)
 
 	return out, nil
+}
+
+// offsetToSigned subtracts the unsigned BZERO in place, in native byte order,
+// before the buffer is swapped to FITS order.
+//
+// Implemented as an XOR of the sign bit rather than an arithmetic subtraction
+// because they are the same operation for these offsets — 2^(n-1) — and the
+// XOR cannot overflow or depend on Go's conversion rules.
+func offsetToSigned(buf []byte, pixelBytes int) {
+	switch pixelBytes {
+	case 2:
+		for i := 0; i+2 <= len(buf); i += 2 {
+			binary.NativeEndian.PutUint16(buf[i:], binary.NativeEndian.Uint16(buf[i:])^0x8000)
+		}
+	case 4:
+		for i := 0; i+4 <= len(buf); i += 4 {
+			binary.NativeEndian.PutUint32(buf[i:], binary.NativeEndian.Uint32(buf[i:])^0x80000000)
+		}
+	case 8:
+		for i := 0; i+8 <= len(buf); i += 8 {
+			binary.NativeEndian.PutUint64(buf[i:], binary.NativeEndian.Uint64(buf[i:])^0x8000000000000000)
+		}
+	}
 }
 
 // swapNativeToBigEndian converts a buffer from native to FITS byte order in

--- a/skybrightness/dataset/solar/solar.go
+++ b/skybrightness/dataset/solar/solar.go
@@ -238,10 +238,19 @@ func floatColumn(table *fits.BintableHDU, name string) []float64 {
 		return nil
 	}
 
+	// A null reads as NaN rather than as the zero Arrow leaves in the buffer.
+	// Zero is a measurement — an irradiance of nothing — and the screening in
+	// Parse drops NaN precisely so an absent sample never becomes a real one.
 	switch col := table.Batch.Column(index).(type) {
 	case *array.Float64:
 		out := make([]float64, col.Len())
 		for i := range out {
+			if col.IsNull(i) {
+				out[i] = math.NaN()
+
+				continue
+			}
+
 			out[i] = col.Value(i)
 		}
 
@@ -249,6 +258,12 @@ func floatColumn(table *fits.BintableHDU, name string) []float64 {
 	case *array.Float32:
 		out := make([]float64, col.Len())
 		for i := range out {
+			if col.IsNull(i) {
+				out[i] = math.NaN()
+
+				continue
+			}
+
 			out[i] = float64(col.Value(i))
 		}
 


### PR DESCRIPTION
`fits` was read-only. Any pipeline that *produced* a calibrated frame or a catalogue stopped at astrogo and reached for another language — the gap #127 calls the single largest capability hole for a library positioning itself as observatory infrastructure.

`fits.Write` closes the half #127 nominates as the unblocking one: images at every BITPIX (uint8, int16/32/64, float32/64) and binary tables built from an Arrow batch.

## Shape

```go
f, err := os.Create("out.fits")
...
err = fits.Write(f, &fits.File{HDUs: []fits.HDU{primary, catalog}})
```

**An `io.Writer`, not a path.** `Open` takes a path because an arbitrary FITS file on the user's disk is one of the two places this module deliberately touches the filesystem. Writing needs no second exception: `os.Create` is one line at the call site, and a bucket, a socket, a buffer and a gzip stream then all work through the same function instead of through a variant each.

## Two decisions worth arguing with

**Structural keywords come from the data, not from the stored header.** `BITPIX`, `NAXIS`, `NAXISn`, `NAXIS1/2`, `TFIELDS`, `TFORMn` are all derived. The two disagree the moment a caller filters a table's rows or replaces an image's pixels, and a header describing something the file does not contain is unreadable in a way no reader can diagnose — the header *is* the statement of the shape, so there is nothing to check it against. `TestWriteBintableDerivesRowCountFromTheBatch` sets a stale `NAXIS2 = 9999` and asserts the file says 3.

**An over-long card is an error, not a truncation.** The 80-byte grid is the only thing separating one record from the next, so a card that overflows shifts every card after it and the header stops parsing where the overflow happened. Same for a newline in a comment.

Everything non-structural — WCS, provenance, the caller's own keywords — is carried through untouched.

## Why the tests are shaped this way

**A round trip through this package cannot catch a mistake the reader and writer share.** A value written to the wrong column reads back perfectly from a writer that put it there. So the layout is pinned against the standard directly — the exact bytes FITS 4.0 §4.1.2 prescribes, which are the bytes astropy and cfitsio emit:

```
SIMPLE  =                    T / conforms to FITS standard
BITPIX  =                  -32 / bits per data pixel
OBJECT  = 'M31     ' / target
```

(strings left-justified from column 11 and blank-padded to eight; numerics and logicals right-justified to column 30.)

**The two encodings most likely to be wrong are verified by mutation, not by reading them.**

| mutation | what the test says |
| --- | --- |
| `NAXISn` written without reversing the axis order | `Axes = [3 2], want [2 3]` |
| a float column written native-endian | `column "VMAG" row 0 = -1.9224338e-29, want 0.03` |

The first transposes the image, which no pixel count would notice. Both are caught with the value that makes the cause obvious.

Also covered: every BITPIX round-tripped against its type's extremes (`MinInt64`, `1.7e308`) compared as raw stored bytes; block alignment for header-only, sub-block and multi-block payloads; `VerifyPrimaryHeader` run on our own output; fixed-width string columns sized to the longest value in the column rather than the first.

## Found while building it

A zero-valued `ImageHDU` panicked on `Header()` — which is exactly the construction path a writer exists for. It now creates one on first use.

## Every gap this PR originally documented is now closed

The first version shipped a writer and listed six things it did not do. Auditing it against what astropy emits found three defects in what it *did* do (`EXTEND` missing, non-finite `BSCALE` written as unparseable text, a dead padding branch), and closing the six turned up that **two of them were read defects on real files, not writer omissions**:

| convention | what it was | what it is |
| --- | --- | --- |
| **HIERARCH** | an ESO header's instrument keywords parsed as a keyword of `HIERARCH` with the rest as a comment — every one lost, `ErrKeyNotFound` to the caller | read and written |
| **CONTINUE** | a long string ended at the first card with the `&` marker left in as data | read and written, announced by `LONGSTRN` |
| **unsigned images** | a uint16 frame read back with its upper half negative — 40000 as −25536 | `BZERO = 2^(n-1)`, both directions |
| **CHECKSUM/DATASUM** | not written | written for every HDU |
| **TNULL / NaN** | a missing table value written as zero | carried as a null both ways |
| **vector columns** | decoded as Arrow nulls — every value in a spectrum column discarded, silently | fixed-size lists |
| **ASCII tables** | the reader consumed the payload without decoding it | read and written |

Only the variable-length P/Q descriptors remain, and the package doc says so.

## Two things worth your attention

**`GetFloatColumn` returned 0.0 for a null.** A missing flux became a flux of nothing; a missing magnitude became magnitude 0, which is a very bright star. It predates this branch — reachable only through TNULL columns before — and mapping NaN to null made it reachable for every undefined float, which is how it surfaced: `airglow` and `solar` went red together, both of which screen for NaN and neither of which could see a zero. `solar` had the same bug written out a second time.

**A constructed HDU reported the wrong type.** `basicHDU.hType` is only filled in by the reader, so an HDU a caller built — the entire point of a writer — reported the zero value, which happens to be `HDUTypeImage`. Invisible until the one case it is wrong for: an ASCII table pads with spaces, and it was getting zeros.

## How these were validated

Not by round-tripping through our own reader, which cannot catch a mistake the reader and writer share:

- **HIERARCH and CONTINUE** are read from the layouts ESO and OGIP prescribe, spelled out as bytes in the test.
- **Unsigned images** pin the *stored* bytes — uint16 0 as int16 −32768 — since those are what another reader applies BZERO to.
- **CHECKSUM** asserts the convention's own property: the 1's complement sum over a complete HDU comes out all ones, which is exactly what `fits_verify_chksum` and astropy's verification compute. That test failed on the first implementation and named two real bugs — the placeholder must be sixteen ASCII *zeros*, not blanks, and the final rotation is one byte *right*, not left.
- **Vector columns** were mutation-checked: reverting to the old null-decoding fails the new test.

## Not in this PR

#114's scoped `remote.Client` is unrelated. #127's other two items — spectral axes in WCS, and projections beyond the current five — stay open.

Closes #127.
