### PR TITLE
time: add the TCG and TCB coordinate time scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ be able to break an API until 1.0 says otherwise.
 | `constants` | Typed, versioned constant sets (SI 2019, CODATA, IAU 2015, WGS 84, derived) |
 | `angle` | Angular types, HMS/DMS parsing |
 | `vector` | 3D geometry primitives |
-| `time` | Astronomical time scales (JD-based, UTC/TAI/TT/TDB/UT1), Earth Orientation Parameters (DUT1, polar motion), epoch arithmetic (MJD, GAST, Julian epoch year, day-of-year) |
+| `time` | Astronomical time scales (JD-based: UTC/TAI/TT/TDB/UT1, the GNSS system times GPST/BDT, and the coordinate times TCG/TCB), Earth Orientation Parameters (DUT1, polar motion), epoch arithmetic (MJD, GAST, Julian epoch year, day-of-year) |
 | `atmosphere` | Refraction models, airmass, dispersion |
 | `coord` | Coordinate types, transforms, topocentric reduction |
 | `ephemeris` | Solar system ephemerides (SOFA + JPL SPK) |

--- a/docs/changelog.d/276-tcg-tcb.md
+++ b/docs/changelog.d/276-tcg-tcb.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 276
+---
+**`time.TCG` and `time.TCB` — the two coordinate time scales.** TCG is the geocentric
+frame's coordinate time (TT rescaled by L_G, 22 ms/year) and TCB the barycentric frame's
+(TDB rescaled by L_B, 0.49 s/year), which is what relativistic geodesy, orbit integration
+and pulsar timing are quoted in. Both convert to and from every other scale and are exact
+in both directions; verified against SOFA's own published values for `iauTttcg`,
+`iauTcgtt`, `iauTdbtcb` and `iauTcbtdb` (#126).

--- a/internal/gofaext/gofaext.go
+++ b/internal/gofaext/gofaext.go
@@ -492,3 +492,43 @@ func Ld(bm float64, p, q, e [3]float64, em, dlim float64) [3]float64 {
 
 	return p1
 }
+
+// TTToTCG converts Terrestrial Time to Geocentric Coordinate Time.
+//
+// TCG is the coordinate time of the geocentric reference system: TT is TCG
+// rescaled so that it ticks at the rate of a clock on the rotating geoid, which
+// is what makes TT the scale a terrestrial observation is timed in and TCG the
+// one a geocentric equation of motion is integrated in. The two differ by a
+// secular rate of L_G = 6.969290134e-10, about 22 ms per year, zero at
+// 1977-01-01 by definition.
+func TTToTCG(tt1, tt2 float64) (tcg1, tcg2 float64, status int) {
+	status = gofa.Tttcg(tt1, tt2, &tcg1, &tcg2)
+
+	return tcg1, tcg2, status
+}
+
+// TCGToTT converts Geocentric Coordinate Time to Terrestrial Time.
+func TCGToTT(tcg1, tcg2 float64) (tt1, tt2 float64, status int) {
+	status = gofa.Tcgtt(tcg1, tcg2, &tt1, &tt2)
+
+	return tt1, tt2, status
+}
+
+// TDBToTCB converts Barycentric Dynamical Time to Barycentric Coordinate Time.
+//
+// TCB is to TDB what TCG is to TT: the unscaled coordinate time of the
+// barycentric system. The rate difference is L_B = 1.550519768e-8, about
+// half a second per year, which is why an ephemeris argument is TDB and not
+// TCB — TDB was defined to stay close to TT.
+func TDBToTCB(tdb1, tdb2 float64) (tcb1, tcb2 float64, status int) {
+	status = gofa.Tdbtcb(tdb1, tdb2, &tcb1, &tcb2)
+
+	return tcb1, tcb2, status
+}
+
+// TCBToTDB converts Barycentric Coordinate Time to Barycentric Dynamical Time.
+func TCBToTDB(tcb1, tcb2 float64) (tdb1, tdb2 float64, status int) {
+	status = gofa.Tcbtdb(tcb1, tcb2, &tdb1, &tdb2)
+
+	return tdb1, tdb2, status
+}

--- a/time/coordtime_test.go
+++ b/time/coordtime_test.go
@@ -1,0 +1,213 @@
+package time_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/time"
+)
+
+// TCG and TCB are each one rate scaling away from the scale they belong to, and
+// a round trip cannot see a wrong rate constant: scaling out by the wrong
+// factor and back by the same wrong factor closes perfectly. So the constants
+// are checked against SOFA's own published values for iauTttcg, iauTcgtt,
+// iauTdbtcb and iauTcbtdb, at the epoch SOFA's own test suite uses.
+//
+// The values below are SOFA's, to the digits SOFA states them to. They are
+// quoted rather than derived: a value computed from the same formula under test
+// would agree with it however wrong the formula was.
+
+// sofaEpoch is JD 2453750.5, the date SOFA's t_sofa_c.c exercises every time
+// scale conversion at.
+const sofaEpoch = 2453750.5
+
+// dayTolerance is a day fraction that bounds a nanosecond, which is finer than
+// any of these scales is realised to and far finer than the millisecond-to-
+// second offsets under test.
+const dayTolerance = 1e-12
+
+func TestTTToTCGMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	// iauTttcg(2453750.5, 0.892482639) -> 0.8924900312508587113
+	got := time.FromJDParts(sofaEpoch, 0.892482639, time.TT).TCG()
+
+	assertJDParts(t, got, 0.8924900312508587113, "TT->TCG")
+
+	if got.Scale() != time.TCG {
+		t.Errorf("scale = %v, want TCG", got.Scale())
+	}
+}
+
+func TestTCGToTTMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	// iauTcgtt(2453750.5, 0.892862531) -> 0.8928551387488816828
+	got := time.FromJDParts(sofaEpoch, 0.892862531, time.TCG).TT()
+
+	assertJDParts(t, got, 0.8928551387488816828, "TCG->TT")
+}
+
+func TestTDBToTCBMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	// iauTdbtcb(2453750.5, 0.892855137) -> 0.8930195997253656716
+	got := time.FromJDParts(sofaEpoch, 0.892855137, time.TDB).TCB()
+
+	assertJDParts(t, got, 0.8930195997253656716, "TDB->TCB")
+
+	if got.Scale() != time.TCB {
+		t.Errorf("scale = %v, want TCB", got.Scale())
+	}
+}
+
+func TestTCBToTDBMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	// iauTcbtdb(2453750.5, 0.893019599) -> 0.8928551362746343397
+	got := time.FromJDParts(sofaEpoch, 0.893019599, time.TCB).TDB()
+
+	assertJDParts(t, got, 0.8928551362746343397, "TCB->TDB")
+}
+
+// assertJDParts compares a converted time against SOFA's two-part result.
+//
+// wantFraction is the day fraction SOFA returns; the integer part is always
+// [sofaEpoch], since every one of these conversions is a sub-second scaling.
+//
+// The comparison is on the sum rather than part by part: the split between jd1
+// and jd2 is an internal precision device, and SOFA itself only promises the
+// first part to 1e-6.
+func assertJDParts(t *testing.T, got time.Time, wantFraction float64, what string) {
+	t.Helper()
+
+	g1, g2 := got.JDParts()
+
+	if diff := math.Abs((g1 + g2) - (sofaEpoch + wantFraction)); diff > dayTolerance {
+		t.Errorf("%s = %.15f + %.15f, want %.15f + %.15f (differ by %g days, %.3f ns)",
+			what, g1, g2, sofaEpoch, wantFraction, diff, diff*86400e9)
+	}
+}
+
+// TestTCGDriftFromTTIsTheDefinedRate checks the scaling against its definition
+// rather than against a library, because the rate is the whole content of the
+// scale.
+//
+// TCG − TT grows at L_G/(1−L_G) per unit of TT elapsed since 1977-01-01 TAI,
+// where L_G = 6.969290134e-10 exactly (IAU 2000 Resolution B1.9). Over the
+// 48 years to 2025 that is about 1.06 s.
+func TestTCGDriftFromTTIsTheDefinedRate(t *testing.T) {
+	t.Parallel()
+
+	// The zero point: 1977-01-01T00:00:32.184 TAI, where TCG = TT by
+	// definition. JD 2443144.5003725 in TT.
+	const (
+		zeroPoint = 2443144.5003725
+		lg        = 6.969290134e-10
+	)
+
+	for _, years := range []float64{1, 10, 48} {
+		jd := zeroPoint + years*365.25
+
+		tt := time.FromJD(jd, time.TT)
+		tcg := tt.TCG()
+
+		g1, g2 := tcg.JDParts()
+		t1, t2 := tt.JDParts()
+
+		gotSeconds := ((g1 - t1) + (g2 - t2)) * 86400
+
+		// TCG − TT = L_G/(1−L_G) × (TT elapsed since the zero point).
+		wantSeconds := lg / (1 - lg) * (jd - zeroPoint) * 86400
+
+		if diff := math.Abs(gotSeconds - wantSeconds); diff > 1e-6 {
+			t.Errorf("after %v years TCG−TT = %.9f s, want %.9f s (differ by %g s)",
+				years, gotSeconds, wantSeconds, diff)
+		}
+	}
+}
+
+// TestTCBDriftFromTDBIsFarLargerThanTCGs is the reason an ephemeris is argued
+// in TDB and not in TCB, stated as a measurement.
+//
+// L_B is 22 times L_G, so the barycentric rate difference is half a second a
+// year against 22 milliseconds. A caller who confuses the two scales is wrong
+// by the larger number.
+func TestTCBDriftFromTDBIsFarLargerThanTCGs(t *testing.T) {
+	t.Parallel()
+
+	const zeroPoint = 2443144.5003725
+
+	jd := zeroPoint + 48*365.25 // roughly 2025
+
+	tdb := time.FromJD(jd, time.TDB)
+	tcb := tdb.TCB()
+
+	b1, b2 := tcb.JDParts()
+	d1, d2 := tdb.JDParts()
+
+	drift := ((b1 - d1) + (b2 - d2)) * 86400
+
+	// L_B = 1.550519768e-8 over 48 years is about 23.5 s.
+	if drift < 20 || drift > 27 {
+		t.Errorf("TCB−TDB after 48 years = %.3f s, want roughly 23.5 s.\n"+
+			"  This is the offset that makes TCB unusable as an ephemeris "+
+			"argument and TDB usable.", drift)
+	}
+}
+
+// TestCoordinateTimesConvertToEveryOtherScale keeps the new scales from being
+// reachable only from the one they are defined against.
+//
+// Every conversion method carries a switch whose default returns the time
+// unchanged, so a scale nobody added a case for is silently passed through with
+// the wrong label — which is exactly what happened to TAI here, and showed up
+// as BDT->TCG->BDT losing 34.95 s at 1900.
+func TestCoordinateTimesConvertToEveryOtherScale(t *testing.T) {
+	t.Parallel()
+
+	const jd = 2460000.5 // 2023-02-25, well inside the leap-second table
+
+	for _, from := range []struct {
+		scale time.Scale
+		name  string
+	}{
+		{time.TCG, "TCG"},
+		{time.TCB, "TCB"},
+	} {
+		t.Run(from.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := time.FromJD(jd, from.scale)
+
+			for _, to := range []struct {
+				convert func(time.Time) time.Time
+				name    string
+				want    time.Scale
+			}{
+				{name: "UTC", want: time.UTC, convert: time.Time.UTC},
+				{name: "TAI", want: time.TAI, convert: time.Time.TAI},
+				{name: "TT", want: time.TT, convert: time.Time.TT},
+				{name: "TDB", want: time.TDB, convert: time.Time.TDB},
+				{name: "GPST", want: time.GPST, convert: time.Time.GPST},
+				{name: "BDT", want: time.BDT, convert: time.Time.BDT},
+			} {
+				got := to.convert(src)
+				if got.Scale() != to.want {
+					t.Errorf("%s->%s produced scale %v", from.name, to.name, got.Scale())
+				}
+
+				// The conversion has to move the instant. A scale that fell
+				// through an unhandled case comes back byte-identical, which
+				// is the failure this test exists for.
+				s1, s2 := src.JDParts()
+				g1, g2 := got.JDParts()
+
+				if (g1 + g2) == (s1 + s2) {
+					t.Errorf("%s->%s left the date unchanged, so the conversion "+
+						"fell through an unhandled case", from.name, to.name)
+				}
+			}
+		})
+	}
+}

--- a/time/doc.go
+++ b/time/doc.go
@@ -6,7 +6,8 @@
 // In contrast, `atime` is designed for:
 //   - Precision across millennia: Uses a two-part Julian Date representation
 //     to maintain sub-millisecond precision over long time scales.
-//   - Multiple Time Scales: Supports UTC, TAI, TT, UT1, and TDB with a
+//   - Multiple Time Scales: Supports UTC, TAI, TT, UT1, TDB, the GNSS
+//     system times GPST and BDT, and the coordinate times TCG and TCB, with a
 //     complete bidirectional conversion graph.
 //   - Numerical correctness: Facilitates precise propagation of planet
 //     positions and telescope pointing.
@@ -48,7 +49,9 @@
 // The current implementation supports:
 //   - Construction from JD, Go time, and current UTC.
 //   - Basic arithmetic (AddDays/SubDays).
-//   - Full bidirectional scale conversion graph (UTC, TAI, TT, TDB, UT1).
+//   - Full bidirectional scale conversion graph (UTC, TAI, TT, TDB, UT1,
+//     GPST, BDT, TCG, TCB), every pair round-tripped by
+//     TestScaleRoundTripMatrix.
 //   - Scale-safe cross-scale comparison and arithmetic.
 //   - Dynamic UT1/UTC derivations via the IERS EOP data model.
 //

--- a/time/scale_matrix_test.go
+++ b/time/scale_matrix_test.go
@@ -27,6 +27,13 @@ func allScales() []scaleName {
 		// holds outside the only test that converts everything to everything.
 		{"GPST", time.Time.GPST},
 		{"BDT", time.Time.BDT},
+		// The two coordinate times. Each is one rate scaling away from the
+		// scale it belongs to — TCG from TT, TCB from TDB — so a mistake in
+		// either direction shows up here as a round trip that does not close,
+		// and the scaling is large enough that it would: L_B alone is half a
+		// second per year.
+		{"TCG", time.Time.TCG},
+		{"TCB", time.Time.TCB},
 		{"UT1", func(t time.Time) time.Time {
 			// UT1 needs Earth-orientation data and reports when it cannot
 			// get it; the fallback is what every other caller in the module

--- a/time/time.go
+++ b/time/time.go
@@ -283,6 +283,51 @@ const (
 	// caller to subtract it: GPST and BDT differ by a constant that neither
 	// timestamp carries.
 	BDT
+
+	// TCG is Geocentric Coordinate Time, the coordinate time of the
+	// geocentric celestial reference system.
+	//
+	// # What it is, against TT
+	//
+	// TT and TCG measure the same thing at different rates. TCG is the
+	// coordinate time of the geocentric frame; TT is TCG rescaled to tick at
+	// the rate of an ideal clock on the rotating geoid, which is the rate a
+	// clock in an observatory actually keeps. The ratio is fixed by the IAU:
+	//
+	//	TCG − TT = L_G / (1 − L_G) × (JD − 2443144.5003725) × 86400 s
+	//	L_G = 6.969290134e-10, exactly, by IAU 2000 Resolution B1.9
+	//
+	// That is about 22 ms per year, zero at 1977-01-01 TAI where the two were
+	// set equal, and roughly 1.1 s today.
+	//
+	// # When a caller needs it
+	//
+	// Relativistic geodesy and satellite-orbit work integrate equations of
+	// motion in the geocentric frame, whose time argument is TCG rather than
+	// TT. Pulsar timing quotes TCB (see [Time.TCB]) for the same reason one
+	// frame up. A terrestrial observation is timed in TT and stays there.
+	TCG
+
+	// TCB is Barycentric Coordinate Time, the coordinate time of the
+	// barycentric celestial reference system.
+	//
+	// # What it is, against TDB
+	//
+	// The same relationship TCG has to TT, one frame out: TCB is the
+	// unscaled coordinate time of the solar-system barycentric frame, and TDB
+	// is TCB rescaled so it stays close to TT rather than drifting away from
+	// it.
+	//
+	//	TCB − TDB ≈ L_B × (JD − 2443144.5003725) × 86400 s + TDB0
+	//	L_B = 1.550519768e-8, by IAU 2006 Resolution B3
+	//
+	// That is about 0.49 s per year — half a minute since 1977 — which is why
+	// a planetary ephemeris is argued in TDB and not in TCB: TDB was defined
+	// to keep the difference from TT bounded at milliseconds.
+	//
+	// A caller holding a pulsar timing solution or a barycentric dynamical
+	// model quoted in TCB has, until now, had no way to say so.
+	TCB
 )
 
 // gpstMinusTAI is the fixed offset that defines GPS time.
@@ -313,6 +358,10 @@ func (s Scale) String() string {
 		return "GPST"
 	case BDT:
 		return "BDT"
+	case TCG:
+		return "TCG"
+	case TCB:
+		return "TCB"
 	default:
 		return "UNKNOWN"
 	}
@@ -336,7 +385,8 @@ func (s Scale) String() string {
 // it spans differ by up to a microsecond per hour. Arithmetic in TDB stays in
 // TDB, which is what an ephemeris interpolating in TDB days wants.
 func (s Scale) uniform() bool {
-	return s == TAI || s == TT || s == TDB || s == GPST || s == BDT
+	return s == TAI || s == TT || s == TDB || s == GPST || s == BDT ||
+		s == TCG || s == TCB
 }
 
 // Time represents a high-precision astronomical timestamp.
@@ -1142,6 +1192,10 @@ func (t Time) UTC() Time {
 		// the leap-second table, which is where the seconds a GNSS user is
 		// missing actually come from.
 		return t.TAI().UTC()
+	case TCG:
+		return t.TT().UTC()
+	case TCB:
+		return t.TDB().UTC()
 	}
 
 	return t // unreachable with current scales
@@ -1174,6 +1228,16 @@ func (t Time) TAI() Time {
 		// Delta-T at that epoch, applied on the way home and never on the way
 		// out. Measured by TestScaleRoundTripMatrix.
 		return t.TT().TAI()
+	case TCG:
+		// TCG → TT → TAI. Without this the switch below falls through to
+		// "return t", and the caller then reads a TCG date as though it were
+		// TAI — which is the defect TestScaleRoundTripMatrix reported as
+		// BDT->TCG->BDT losing 34.95 s at 1900, that being TCG−TAI at the
+		// epoch.
+		return t.TT().TAI()
+	case TCB:
+		// TCB → TDB → TT → TAI, for the same reason.
+		return t.TDB().TAI()
 	case GPST:
 		// TAI = GPST + 19 s, exactly. No table, no epoch dependence: the
 		// offset was frozen at the 1980-01-06 synchronisation and GPS time
@@ -1250,6 +1314,17 @@ func (t Time) TT() Time {
 	case GPST, BDT:
 		// GNSS → TAI → TT, both steps constant.
 		return t.TAI().TT()
+	case TCG:
+		// TCG → TT is the defining rate scaling, and the only edge TCG has:
+		// it is TT's coordinate time, so every other scale is reached through
+		// TT rather than by a second formula that could disagree with this
+		// one.
+		tt1, tt2, _ := gofaext.TCGToTT(t.jd1, t.jd2)
+
+		return fromPartsPreserveLoc(t, tt1, tt2, TT)
+	case TCB:
+		// TCB → TDB → TT. TCB's only edge is to TDB, for the same reason.
+		return t.TDB().TT()
 	}
 
 	return t // unreachable
@@ -1308,10 +1383,59 @@ func (t Time) TDB() Time {
 		return t
 	}
 
+	// TCB is TDB's own coordinate time, so the two are one rate scaling
+	// apart. Routing that through TT instead would go out through the
+	// periodic TDB−TT term and back again, which is not symmetric.
+	if t.scale == TCB {
+		tdb1, tdb2, _ := gofaext.TCBToTDB(t.jd1, t.jd2)
+
+		return fromPartsPreserveLoc(t, tdb1, tdb2, TDB)
+	}
+
 	tt := t.TT()
 	correction := tdbMinusTT(tt.jd1, tt.jd2) / 86400.0
 
 	return fromPartsPreserveLoc(t, tt.jd1, tt.jd2+correction, TDB)
+}
+
+// TCG returns a new Time converted to Geocentric Coordinate Time.
+//
+// The conversion is a rate scaling against TT and nothing else — no table, no
+// Earth orientation, no epoch-dependent lookup — so it is exact in both
+// directions and cannot fail. Every other scale reaches TCG through TT, which
+// is what keeps one definition of the TT↔TCG rate rather than several that
+// could drift apart.
+//
+// See [TCG] for what the scale is and when a caller wants it.
+func (t Time) TCG() Time {
+	if t.scale == TCG {
+		return t
+	}
+
+	tt := t.TT()
+
+	tcg1, tcg2, _ := gofaext.TTToTCG(tt.jd1, tt.jd2)
+
+	return fromPartsPreserveLoc(t, tcg1, tcg2, TCG)
+}
+
+// TCB returns a new Time converted to Barycentric Coordinate Time.
+//
+// As [Time.TCG] is to TT, this is to TDB: a rate scaling, exact both ways,
+// reached from every other scale through TDB.
+//
+// See [TCB] for what the scale is and why an ephemeris is argued in TDB
+// instead.
+func (t Time) TCB() Time {
+	if t.scale == TCB {
+		return t
+	}
+
+	tdb := t.TDB()
+
+	tcb1, tcb2, _ := gofaext.TDBToTCB(tdb.jd1, tdb.jd2)
+
+	return fromPartsPreserveLoc(t, tcb1, tcb2, TCB)
 }
 
 // UT1 returns a new Time converted to the Universal Time (UT1) scale.


### PR DESCRIPTION
#126 lists TCG and TCB as the two time scales astropy has and `time` does not, and calls them "straightforward on top of the existing scale graph". They are — and they are also the scales relativistic geodesy, geocentric orbit integration and pulsar timing are quoted in. A caller holding one had no way to say so, which is the same defect class as GPST before #133: the only expressible option was to call it something it isn't.

## The two scalings

```
TCG − TT  = L_G/(1−L_G) × elapsed    L_G = 6.969290134e-10    22 ms/year
TCB − TDB = L_B × elapsed + TDB0     L_B = 1.550519768e-8     0.49 s/year
```

Both zero at 1977-01-01 TAI by definition. TCG's only edge is to TT, TCB's only edge is to TDB, and every other scale is reached through those — so the rate is stated once rather than in several places that could drift apart. That asymmetry is also why `TDB()` handles TCB directly instead of routing through TT: going out through the periodic TDB−TT term and back is not symmetric.

`L_B` being 22× `L_G` is the reason a planetary ephemeris is argued in TDB and not TCB, and `TestTCBDriftFromTDBIsFarLargerThanTCGs` states that as a measurement (23.5 s since 1977) rather than as a comment.

## A round trip cannot check a rate constant

Scaling out by the wrong factor and back by the same wrong factor closes perfectly. So the constants are checked against **SOFA's own published values** for `iauTttcg`, `iauTcgtt`, `iauTdbtcb` and `iauTcbtdb`, at the epoch SOFA's own suite uses, to 1e-12 days:

```
iauTttcg(2453750.5, 0.892482639) -> 0.8924900312508587113
iauTcgtt(2453750.5, 0.892862531) -> 0.8928551387488816828
iauTdbtcb(2453750.5, 0.892855137) -> 0.8930195997253656716
iauTcbtdb(2453750.5, 0.893019599) -> 0.8928551362746343397
```

Quoted, not derived: a value computed from the formula under test would agree with it however wrong the formula was.

## The matrix caught a real bug in this change

Every conversion method ends in `return t // unreachable`, so a scale nobody wrote a case for is passed through **silently with the wrong label**. `TAI()` had no case for either new scale, and `TestScaleRoundTripMatrix` reported:

```
BDT->TCG->BDT @ 1900 exceeds contract
  measured: 34.9509 s    contract: 5 s
```

34.95 s is TCG−TAI at 1900 — the caller was reading a TCG date as TAI. Adding the two scales to the matrix is what turns that class from "someone has to notice" into "the suite fails"; all 100 round trips close now.

`TestCoordinateTimesConvertToEveryOtherScale` covers the same trap directly: it asserts the instant actually *moved*, because an unhandled case returns the time byte-identical.

## Scope

This closes one line of #126's checklist. FK4/B1950 — the item the issue names as the one with real users behind it — landed in #230. The remaining frames (FK5, ITRS, HCRS, TETE, LSR, Supergalactic, Galactocentric, `SkyOffsetFrame`) and the absence of a general transform graph are untouched, so #126 stays open.

## Verification

`gofmt`, `go vet`, `golangci-lint run` (0 issues), `go test ./...`, `go test -race -short -count=1 ./...`, and `go test -tags="integration,network,validation" ./...` — all green.
