### PR TITLE
coord: add the FK5 J2000 frame, and expose FK4 to FK5

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ What `astrogo` is: **the only SOFA-rigorous astronomy engine that deploys like s
 One static binary, no Python runtime, no C FFI, an explicit and consent-gated I/O boundary,
 an event solver, an observation scheduler, and a spectral sky-brightness engine.
 
-What it is not, and the honest list matters more than the flattering one: it has no FITS
-writer, no general frame graph, and of the frames astropy carries only FK4/B1950 has
-arrived — no ITRS, HCRS, TETE, LSR or Galactocentric. If you need those today, astropy
+What it is not, and the honest list matters more than the flattering one: it has no general
+frame graph — transforms are point-to-point functions, so each new frame costs its own
+implementation — and of the frames astropy carries only FK4/B1950 and FK5/J2000 have
+arrived, with no ITRS, HCRS, TETE, LSR or Galactocentric. If you need those today, astropy
 has them and this does not — see [Known Limitations & Scope](#known-limitations--scope)
 and the [open issues](https://github.com/TuSKan/astrogo/issues).
 

--- a/coord/doc.go
+++ b/coord/doc.go
@@ -26,6 +26,17 @@
 // Pure frame rotations ([ICRSToGalactic], [ICRSToEcliptic]) are available as
 // standalone functions.
 //
+// # Catalogue frames
+//
+// [FK4] (B1950.0) and [FK5] (J2000.0) are the fundamental catalogues the IAU
+// used before the ICRS, and are what most archival positions are actually in:
+// [FK4ToFK5] is the classic B1950 → J2000 conversion, and [FK4ToICRS] carries
+// it the rest of the way. Neither is a rotation — FK4's E-terms of aberration
+// and both catalogues' non-inertial drift mean a star at rest in one is moving
+// in the next — so each has two constructors, one for a recorded proper motion
+// and one for a catalogue that recorded none. Confusing FK5 J2000 with ICRS
+// costs about 20 mas; confusing FK4 B1950 with either costs about 0.7°.
+//
 // The [Reducer] provides a lightweight topocentric reduction pipeline that
 // also handles chromatic atmospheric dispersion.
 //

--- a/coord/fk4.go
+++ b/coord/fk4.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/TuSKan/astrogo/angle"
 	"github.com/TuSKan/astrogo/internal/gofaext"
-	"github.com/TuSKan/astrogo/time"
 )
 
 // FK4 is a position in the FK4 system, the pre-1984 fundamental catalogue
@@ -108,27 +107,24 @@ func (c FK4) String() string {
 	return fmt.Sprintf("FK4 B%.1f RA %s Dec %s", c.bepoch, c.ra, c.dec)
 }
 
-// FK4ToICRS converts an FK4 (B1950.0) position to ICRS, via FK5.
+// FK4ToFK5 converts an FK4 (B1950.0) position to FK5 (J2000.0).
 //
-// The route is FK4 → FK5 (J2000.0) → Hipparcos, which is what defines the
-// ICRS realisation; astropy takes the same one. A position with no recorded
-// proper motion goes through SOFA's position-only routines at each step, so
-// the fictitious motion FK4's drifting equinox implies is supplied rather than
-// assumed away.
+// This is the classic B1950 → J2000 conversion, and the one most published
+// coordinates were converted *with*: a plate-survey position quoted as "J2000"
+// is almost always an FK5 J2000 position obtained this way, not an ICRS one.
+// [FK4ToICRS] is this followed by [FK5ToICRS].
 //
-// Kinematics survive the conversion when the catalogue recorded them: the
-// returned ICRS carries proper motion, parallax and radial velocity, and
-// [Context.ICRSToAltAz] will use them for rigorous space-motion propagation.
-func FK4ToICRS(c FK4) ICRS {
+// A position with no recorded proper motion goes through SOFA's position-only
+// routine at its own Besselian epoch, so the fictitious motion FK4's drifting
+// equinox implies is accounted for rather than assumed away. The result is a
+// position-only FK5, because that routine reports where the star is and not
+// how fast the new frame sees it moving — [FK5ToFK4] is the direction that
+// hands back a motion.
+func FK4ToFK5(c FK4) FK5 {
 	if !c.hasProperMotion {
-		// Position only. Fk45z supplies the fictitious proper motion FK4's
-		// non-inertial equinox implies, then Fk5hz carries the position into
-		// the Hipparcos frame at J2000.0.
 		r5, d5 := gofaext.Fk45z(c.ra.Radians(), c.dec.Radians(), c.bepoch)
-		jd1, jd2 := j2000TT()
-		rh, dh := gofaext.Fk5hz(r5, d5, jd1, jd2)
 
-		return NewICRS(angle.Rad(rh).Wrap360(), angle.Rad(dh))
+		return NewFK5(angle.Rad(r5).Wrap360(), angle.Rad(d5), J2000Epoch)
 	}
 
 	r5, d5, dr5, dd5, px5, rv5 := gofaext.Fk425(
@@ -137,13 +133,60 @@ func FK4ToICRS(c FK4) ICRS {
 		c.parallax.Arcseconds(), c.rv,
 	)
 
-	rh, dh, drh, ddh, pxh, rvh := gofaext.Fk52h(r5, d5, dr5, dd5, px5, rv5)
-
-	return NewICRSWithKinematics(
-		angle.Rad(rh).Wrap360(), angle.Rad(dh),
-		angle.Rad(drh), angle.Rad(ddh),
-		angle.Arcsec(pxh), rvh,
+	return NewFK5WithProperMotion(
+		angle.Rad(r5).Wrap360(), angle.Rad(d5),
+		angle.Rad(dr5), angle.Rad(dd5),
+		angle.Arcsec(px5), rv5,
 	)
+}
+
+// FK5ToFK4 converts an FK5 (J2000.0) position to FK4 at the given Besselian
+// epoch of observation — [B1950] for the catalogue equinox itself.
+//
+// The inverse of [FK4ToFK5]: the E-terms of aberration are put back and the
+// fictitious proper motion is restored. A position with no recorded motion
+// comes back carrying the one FK4's drifting equinox gives it, which is the
+// honest answer — a star at rest in FK5 is not at rest in FK4.
+func FK5ToFK4(c FK5, bepoch float64) FK4 {
+	if !c.hasProperMotion {
+		r1950, d1950, dr1950, dd1950 := gofaext.Fk54z(c.ra.Radians(), c.dec.Radians(), bepoch)
+
+		return FK4{
+			ra: angle.Rad(r1950).Wrap360(), dec: angle.Rad(d1950),
+			pmRA: angle.Rad(dr1950), pmDec: angle.Rad(dd1950),
+			bepoch:          bepoch,
+			hasProperMotion: true,
+		}
+	}
+
+	r1950, d1950, dr1950, dd1950, px1950, rv1950 := gofaext.Fk524(
+		c.ra.Radians(), c.dec.Radians(),
+		c.pmRA.Radians(), c.pmDec.Radians(),
+		c.parallax.Arcseconds(), c.rv,
+	)
+
+	return FK4{
+		ra: angle.Rad(r1950).Wrap360(), dec: angle.Rad(d1950),
+		pmRA: angle.Rad(dr1950), pmDec: angle.Rad(dd1950),
+		parallax:        angle.Arcsec(px1950),
+		rv:              rv1950,
+		bepoch:          bepoch,
+		hasProperMotion: true,
+	}
+}
+
+// FK4ToICRS converts an FK4 (B1950.0) position to ICRS, via FK5.
+//
+// The route is FK4 → FK5 (J2000.0) → Hipparcos, which is what defines the
+// ICRS realisation; astropy takes the same one. Both legs are the exported
+// [FK4ToFK5] and [FK5ToICRS], so the intermediate J2000 position a caller may
+// actually want is reachable rather than buried here.
+//
+// Kinematics survive the conversion when the catalogue recorded them: the
+// returned ICRS carries proper motion, parallax and radial velocity, and
+// [Context.ICRSToAltAz] will use them for rigorous space-motion propagation.
+func FK4ToICRS(c FK4) ICRS {
+	return FK5ToICRS(FK4ToFK5(c))
 }
 
 // ICRSToFK4 converts an ICRS position to FK4 at the given Besselian epoch of
@@ -154,10 +197,24 @@ func FK4ToICRS(c FK4) ICRS {
 // position with no kinematics attached comes back carrying the proper motion
 // FK4's drifting equinox gives it, which is the honest answer — a star at rest
 // in ICRS is not at rest in FK4.
+//
+// # Why this is not simply [FK5ToFK4] after [ICRSToFK5]
+//
+// [FK4ToICRS] is written as its two legs and this one is not, which looks like
+// an oversight and is not. For a position with no kinematics the two routes
+// genuinely differ: composing would hand the FK5 spin motion that [ICRSToFK5]
+// supplies to SOFA's six-element routine, along with the zero parallax and
+// zero radial velocity that are absences rather than measurements. The direct
+// route uses Fk54z, which is SOFA's routine for exactly this input, and is
+// what astropy's FK5 → FK4 does for a coordinate carrying no differentials.
+//
+// The price is that Fk54z assumes the star is at rest in FK5 while the caller
+// said it is at rest in ICRS; those differ by FK5's spin, about 0.3 mas/yr in
+// the *returned proper motion* and nothing at all in the returned position.
 func ICRSToFK4(c ICRS, bepoch float64) FK4 {
 	if c.PmRA() == angle.Zero() && c.PmDec() == angle.Zero() &&
 		c.Parallax() == angle.Zero() && c.RV() == 0 {
-		jd1, jd2 := j2000TT()
+		jd1, jd2 := ttAtJulianEpoch(J2000Epoch)
 		r5, d5, _, _ := gofaext.Hfk5z(c.RA().Radians(), c.Dec().Radians(), jd1, jd2)
 		r1950, d1950, dr1950, dd1950 := gofaext.Fk54z(r5, d5, bepoch)
 
@@ -185,14 +242,4 @@ func ICRSToFK4(c ICRS, bepoch float64) FK4 {
 		bepoch:          bepoch,
 		hasProperMotion: true,
 	}
-}
-
-// j2000TT is the two-part Julian date of J2000.0 on the TT scale, which is the
-// epoch the FK5 ↔ Hipparcos rotation is defined at.
-//
-// Taken from time.J2000 rather than written as 2451545.0 so the two cannot
-// drift apart, and split the way SOFA wants it: the integral part carries the
-// magnitude and the fraction carries the precision.
-func j2000TT() (jd1, jd2 float64) {
-	return time.J2000.JDParts()
 }

--- a/coord/fk4_test.go
+++ b/coord/fk4_test.go
@@ -410,3 +410,147 @@ func TestFK4CarriesTheKinematicsItWasGiven(t *testing.T) {
 			empty.Parallax(), empty.RV())
 	}
 }
+
+// TestFK4ToFK5MatchesSOFAExactly is the intermediate step
+// [TestFK4ToICRSAgreesWithSOFAsPublishedVector] could only bound.
+//
+// That test compares an ICRS result against SOFA's FK5 answer and therefore
+// has to allow the ~25 mas the second stage adds. This one stops where SOFA
+// stops, so it can assert SOFA's published Fk425 vector outright — every one
+// of the six elements, at SOFA's own tolerances.
+func TestFK4ToFK5MatchesSOFAExactly(t *testing.T) {
+	t.Parallel()
+
+	// SOFA's Fk425 test vector from t_sofa_c.c, in radians, radians/year,
+	// arcseconds and km/s.
+	src := coord.NewFK4WithProperMotion(
+		angle.Rad(0.07626899753879587532), angle.Rad(-1.137405378399605780),
+		angle.Rad(0.1973749217849087460e-4), angle.Rad(0.5659714913272723189e-5),
+		angle.Arcsec(0.134), 8.7,
+	)
+
+	got := coord.FK4ToFK5(src)
+
+	pmRA, pmDec, ok := got.ProperMotion()
+	if !ok {
+		t.Fatal("the six-element conversion came back with no recorded proper motion")
+	}
+
+	testutil.AssertNear(t, "RA (rad)", got.RA().Radians(), 0.08757989933556446040, 1e-14)
+	testutil.AssertNear(t, "Dec (rad)", got.Dec().Radians(), -1.132279113042091895, 1e-12)
+	testutil.AssertNear(t, "pmRA (rad/yr)", pmRA.Radians(), 0.1953670614474396139e-4, 1e-17)
+	testutil.AssertNear(t, "pmDec (rad/yr)", pmDec.Radians(), 0.5637686678659640164e-5, 1e-18)
+	testutil.AssertNear(t, "parallax (arcsec)", got.Parallax().Arcseconds(), 0.1339919950582767871, 1e-13)
+	testutil.AssertNear(t, "radial velocity (km/s)", got.RV(), 8.736999669183529069, 1e-12)
+
+	if got.Epoch() != coord.J2000Epoch {
+		t.Errorf("epoch = %v, want J2000.0 — Fk425 produces J2000 data by definition", got.Epoch())
+	}
+}
+
+// TestFK4ToFK5PositionOnlyMatchesSOFA is the other route, against SOFA's
+// Fk45z vector, at a Besselian epoch that is deliberately not B1950 — the
+// epoch is the only thing distinguishing this routine from a fixed rotation.
+func TestFK4ToFK5PositionOnlyMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewFK4(
+		angle.Rad(0.01602284975382960982), angle.Rad(-0.1164347929099906024),
+		1954.677617625256806,
+	)
+
+	got := coord.FK4ToFK5(src)
+
+	testutil.AssertNear(t, "RA (rad)", got.RA().Radians(), 0.02719295911606862303, 1e-15)
+	testutil.AssertNear(t, "Dec (rad)", got.Dec().Radians(), -0.1115766001565926892, 1e-13)
+
+	// Fk45z reports where the star is and not how fast FK5 sees it move, so
+	// the result carries no recorded motion. Claiming a measured zero here
+	// would send the next conversion down the wrong branch.
+	if _, _, ok := got.ProperMotion(); ok {
+		t.Error("the position-only route reported a recorded proper motion; " +
+			"Fk45z returns a position and nothing else")
+	}
+}
+
+// TestFK5ToFK4MatchesSOFAExactly is the inverse, against SOFA's Fk524 vector.
+func TestFK5ToFK4MatchesSOFAExactly(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewFK5WithProperMotion(
+		angle.Rad(0.8723503576487275595), angle.Rad(-0.7517076365138887672),
+		angle.Rad(0.2019447755430472323e-4), angle.Rad(0.3541563940505160433e-5),
+		angle.Arcsec(0.1559), 86.87,
+	)
+
+	got := coord.FK5ToFK4(src, coord.B1950)
+
+	pmRA, pmDec, ok := got.ProperMotion()
+	if !ok {
+		t.Fatal("the six-element conversion came back with no recorded proper motion")
+	}
+
+	testutil.AssertNear(t, "RA (rad)", got.RA().Radians(), 0.8636359659799603487, 1e-13)
+	testutil.AssertNear(t, "Dec (rad)", got.Dec().Radians(), -0.7550281733160843059, 1e-13)
+	testutil.AssertNear(t, "pmRA (rad/yr)", pmRA.Radians(), 0.2023628192747172486e-4, 1e-17)
+	testutil.AssertNear(t, "pmDec (rad/yr)", pmDec.Radians(), 0.3624459754935334718e-5, 1e-18)
+	testutil.AssertNear(t, "parallax (arcsec)", got.Parallax().Arcseconds(), 0.1560079963299390241, 1e-13)
+	testutil.AssertNear(t, "radial velocity (km/s)", got.RV(), 86.79606353469163751, 1e-11)
+}
+
+// TestFK5ToFK4PositionOnlyMatchesSOFA checks the direction that does hand back
+// a motion, against SOFA's Fk54z vector.
+//
+// The two proper-motion components are the whole point: they are the motion
+// FK4's drifting equinox gives a star that is not moving in FK5, and they are
+// of order 1e-8 rad/yr — about 2 milliarcseconds a year, or a fifth of an
+// arcsecond over the century between the two catalogues.
+func TestFK5ToFK4PositionOnlyMatchesSOFA(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewFK5(
+		angle.Rad(0.02719026625066316119), angle.Rad(-0.1115815170738754813),
+		coord.J2000Epoch,
+	)
+
+	got := coord.FK5ToFK4(src, 1954.677308160316374)
+
+	pmRA, pmDec, ok := got.ProperMotion()
+	if !ok {
+		t.Fatal("the fictitious proper motion was not supplied")
+	}
+
+	testutil.AssertNear(t, "RA (rad)", got.RA().Radians(), 0.01602015588390065476, 1e-14)
+	testutil.AssertNear(t, "Dec (rad)", got.Dec().Radians(), -0.1164397101110765346, 1e-13)
+	testutil.AssertNear(t, "pmRA (rad/yr)", pmRA.Radians(), -0.1175712648471090704e-7, 1e-20)
+	testutil.AssertNear(t, "pmDec (rad/yr)", pmDec.Radians(), 0.2108109051316431056e-7, 1e-20)
+
+	if got.Epoch() != 1954.677308160316374 {
+		t.Errorf("epoch = %v, want the one it was converted to", got.Epoch())
+	}
+}
+
+// TestFK4ToICRSIsItsTwoLegs states the relationship the doc comments claim, so
+// that splitting the conversion in two cannot quietly stop being equivalent to
+// doing it in one.
+func TestFK4ToICRSIsItsTwoLegs(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []coord.FK4{
+		coord.NewFK4(angle.Deg(101.2871), angle.Deg(-16.7161), coord.B1950),
+		coord.NewFK4(angle.Deg(359.999), angle.Deg(-89.5), 1954.6776),
+		coord.NewFK4WithProperMotion(
+			angle.Rad(0.07626899753879587532), angle.Rad(-1.137405378399605780),
+			angle.Rad(0.1973749217849087460e-4), angle.Rad(0.5659714913272723189e-5),
+			angle.Arcsec(0.134), 8.7),
+	} {
+		direct := coord.FK4ToICRS(src)
+		legs := coord.FK5ToICRS(coord.FK4ToFK5(src))
+
+		if direct.RA() != legs.RA() || direct.Dec() != legs.Dec() ||
+			direct.PmRA() != legs.PmRA() || direct.PmDec() != legs.PmDec() ||
+			direct.Parallax() != legs.Parallax() || direct.RV() != legs.RV() {
+			t.Errorf("%s:\n  FK4ToICRS       = %+v\n  FK5ToICRS∘FK4ToFK5 = %+v", src, direct, legs)
+		}
+	}
+}

--- a/coord/fk5.go
+++ b/coord/fk5.go
@@ -1,0 +1,200 @@
+package coord
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/internal/gofaext"
+	"github.com/TuSKan/astrogo/time"
+)
+
+// FK5 is a position in the FK5 system, the fundamental catalogue the IAU used
+// from 1984 until the ICRS replaced it in 1998.
+//
+// # Why it is not simply ICRS with a different name
+//
+// FK5 and ICRS agree to about 20 milliarcseconds, which is nothing for most
+// purposes and is not nothing at all for astrometry. Two effects separate
+// them:
+//
+//   - A **frame bias**: the FK5 axes are tilted from the ICRS axes by a fixed
+//     rotation of order 20 mas, measured rather than defined, since FK5 was
+//     realised from observations of stars and ICRS from VLBI of quasars.
+//   - A **spin**: FK5's realisation rotates slowly against the extragalactic
+//     frame, so the bias between them depends on the epoch of the position.
+//     That is why [FK5ToICRS] takes an epoch and not only a direction.
+//
+// A catalogue that says "J2000" is usually FK5, not ICRS. The difference does
+// not matter at arcsecond precision and does matter at the precision this
+// library otherwise claims, which is why the two are separate types here
+// rather than one type with a note in its doc comment.
+//
+// # What a catalogue records
+//
+// The same distinction [FK4] draws: a star with no recorded proper motion is
+// not a star measured to have none. FK5's spin means a star at rest in FK5 has
+// a real motion in ICRS, so a position-only entry goes through SOFA's
+// position-only routine, which supplies that motion rather than assuming it
+// away. See [NewFK5] and [NewFK5WithProperMotion].
+type FK5 struct {
+	ra, dec         angle.Angle
+	pmRA, pmDec     angle.Angle // per Julian year; zero when hasProperMotion is false
+	parallax        angle.Angle
+	rv              float64 // km/s
+	jepoch          float64 // Julian epoch of observation, e.g. 2000.0
+	hasProperMotion bool
+}
+
+// J2000Epoch is the Julian epoch of the FK5 equinox, and the epoch of
+// observation for a catalogue that records none.
+const J2000Epoch = 2000.0
+
+// NewFK5 builds an FK5 position from a catalogue that records no proper
+// motion, at the Julian epoch its positions were determined for — J2000.0
+// unless the catalogue says otherwise.
+//
+// "No proper motion recorded" is not "proper motion is zero". FK5's frame
+// spins slowly against the extragalactic one, so a star genuinely at rest in
+// FK5 acquires a small motion in ICRS; SOFA supplies that through a different
+// routine than the one for a star with a measured motion. Passing zeroes to
+// [NewFK5WithProperMotion] asserts the star really is at rest in the inertial
+// sense, which is a claim almost no catalogue makes.
+func NewFK5(ra, dec angle.Angle, jepoch float64) FK5 {
+	return FK5{ra: ra, dec: dec, jepoch: jepoch}
+}
+
+// NewFK5WithProperMotion builds an FK5 position from a catalogue that records
+// the full six elements: proper motions per Julian year, parallax as an angle,
+// and radial velocity in km/s.
+//
+// There is no epoch parameter, and that is not an omission: SOFA's six-element
+// routines are defined for FK5 data at the catalogue equinox J2000.0, and a
+// position carrying its own motion already says where it will be at any other
+// date. The epoch matters only for the position-only form, which has nothing
+// else to go on — see [NewFK5].
+//
+// Use this only for a genuinely measured proper motion. See [NewFK5].
+func NewFK5WithProperMotion(ra, dec, pmRA, pmDec, parallax angle.Angle, rv float64) FK5 {
+	return FK5{
+		ra: ra, dec: dec,
+		pmRA: pmRA, pmDec: pmDec,
+		parallax: parallax, rv: rv,
+		jepoch:          J2000Epoch,
+		hasProperMotion: true,
+	}
+}
+
+// RA returns the FK5 right ascension.
+func (c FK5) RA() angle.Angle { return c.ra }
+
+// Dec returns the FK5 declination.
+func (c FK5) Dec() angle.Angle { return c.dec }
+
+// ProperMotion returns the recorded proper motion per Julian year, and whether
+// the catalogue recorded one at all.
+//
+// The bool is what separates a star with no measurement from one measured at
+// zero — see [NewFK5] for why those are different positions after conversion.
+func (c FK5) ProperMotion() (pmRA, pmDec angle.Angle, ok bool) {
+	return c.pmRA, c.pmDec, c.hasProperMotion
+}
+
+// Parallax returns the recorded annual parallax.
+func (c FK5) Parallax() angle.Angle { return c.parallax }
+
+// RV returns the recorded radial velocity in km/s.
+func (c FK5) RV() float64 { return c.rv }
+
+// Epoch returns the Julian epoch of observation.
+func (c FK5) Epoch() float64 { return c.jepoch }
+
+// String renders the position for logs and errors.
+func (c FK5) String() string {
+	return fmt.Sprintf("FK5 J%.1f RA %s Dec %s", c.jepoch, c.ra, c.dec)
+}
+
+// FK5ToICRS converts an FK5 position to ICRS.
+//
+// ICRS is realised here by the Hipparcos frame, which is what defines it and
+// what [FK4ToICRS] already routes through; astropy takes the same one.
+//
+// A position with no recorded proper motion goes through SOFA's position-only
+// routine at the position's own epoch, because the frame spin makes the answer
+// epoch-dependent — the same position quoted at 1990 and at 2020 is not the
+// same ICRS direction.
+//
+// Kinematics survive the conversion when the catalogue recorded them: the
+// returned ICRS carries proper motion, parallax and radial velocity, and
+// [Context.ICRSToAltAz] will use them for rigorous space-motion propagation.
+func FK5ToICRS(c FK5) ICRS {
+	if !c.hasProperMotion {
+		jd1, jd2 := ttAtJulianEpoch(c.jepoch)
+		rh, dh := gofaext.Fk5hz(c.ra.Radians(), c.dec.Radians(), jd1, jd2)
+
+		return NewICRS(angle.Rad(rh).Wrap360(), angle.Rad(dh))
+	}
+
+	rh, dh, drh, ddh, pxh, rvh := gofaext.Fk52h(
+		c.ra.Radians(), c.dec.Radians(),
+		c.pmRA.Radians(), c.pmDec.Radians(),
+		c.parallax.Arcseconds(), c.rv,
+	)
+
+	return NewICRSWithKinematics(
+		angle.Rad(rh).Wrap360(), angle.Rad(dh),
+		angle.Rad(drh), angle.Rad(ddh),
+		angle.Arcsec(pxh), rvh,
+	)
+}
+
+// ICRSToFK5 converts an ICRS position to FK5 at the given Julian epoch of
+// observation — [J2000Epoch] for the catalogue equinox itself.
+//
+// The inverse of [FK5ToICRS]. A position with no kinematics attached comes
+// back carrying the proper motion FK5's spin gives it, which is the honest
+// answer: a star at rest in ICRS is not at rest in FK5.
+func ICRSToFK5(c ICRS, jepoch float64) FK5 {
+	if c.PmRA() == angle.Zero() && c.PmDec() == angle.Zero() &&
+		c.Parallax() == angle.Zero() && c.RV() == 0 {
+		jd1, jd2 := ttAtJulianEpoch(jepoch)
+		r5, d5, dr5, dd5 := gofaext.Hfk5z(c.RA().Radians(), c.Dec().Radians(), jd1, jd2)
+
+		return FK5{
+			ra: angle.Rad(r5).Wrap360(), dec: angle.Rad(d5),
+			pmRA: angle.Rad(dr5), pmDec: angle.Rad(dd5),
+			jepoch:          jepoch,
+			hasProperMotion: true,
+		}
+	}
+
+	r5, d5, dr5, dd5, px5, rv5 := gofaext.H2fk5(
+		c.RA().Radians(), c.Dec().Radians(),
+		c.PmRA().Radians(), c.PmDec().Radians(),
+		c.Parallax().Arcseconds(), c.RV(),
+	)
+
+	return FK5{
+		ra: angle.Rad(r5).Wrap360(), dec: angle.Rad(d5),
+		pmRA: angle.Rad(dr5), pmDec: angle.Rad(dd5),
+		parallax: angle.Arcsec(px5), rv: rv5,
+		jepoch:          jepoch,
+		hasProperMotion: true,
+	}
+}
+
+// ttAtJulianEpoch returns the two-part TT Julian date of a Julian epoch.
+//
+// A Julian year is 365.25 days exactly, by definition, so this is arithmetic
+// rather than a calendar conversion. The offset goes into the second part so
+// the first keeps the magnitude and the second keeps the precision, which is
+// the whole reason SOFA takes a two-part date at all.
+//
+// The origin comes from [time.J2000] rather than a written-out 2451545.0, so
+// the two cannot drift apart.
+func ttAtJulianEpoch(jepoch float64) (jd1, jd2 float64) {
+	const daysPerJYear = 365.25
+
+	jd1, jd2 = time.J2000.JDParts()
+
+	return jd1, jd2 + (jepoch-J2000Epoch)*daysPerJYear
+}

--- a/coord/fk5_test.go
+++ b/coord/fk5_test.go
@@ -1,0 +1,211 @@
+package coord_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+)
+
+// FK5 and ICRS agree to about 20 milliarcseconds, which is why they are easy
+// to conflate and why conflating them costs exactly that much. The values below
+// are SOFA's own, from the published tests for iauFk52h and iauFk5hz, so these
+// check the transformation rather than checking a round trip against itself.
+
+// masTolerance is a tenth of a milliarcsecond, well inside the ~20 mas the
+// transformation is about and well outside float noise.
+const masTolerance = 1e-4 / 3600 * math.Pi / 180
+
+// TestFK5ToICRSMatchesSOFAWithKinematics is the six-element case, against
+// iauFk52h's published result.
+func TestFK5ToICRSMatchesSOFAWithKinematics(t *testing.T) {
+	t.Parallel()
+
+	// SOFA's inputs, in radians, radians/year, arcseconds and km/s.
+	src := coord.NewFK5WithProperMotion(
+		angle.Rad(1.76779433),
+		angle.Rad(-0.2917517103),
+		angle.Rad(-1.91851572e-7),
+		angle.Rad(-5.8468475e-6),
+		angle.Arcsec(0.379210),
+		-7.6,
+	)
+
+	got := coord.FK5ToICRS(src)
+
+	// iauFk52h -> ra 1.767794226299947632, dec -0.2917516070530391757
+	assertRadians(t, got.RA().Radians(), 1.767794226299947632, "RA")
+	assertRadians(t, got.Dec().Radians(), -0.2917516070530391757, "Dec")
+
+	// The kinematics come through too, or a caller loses the space motion the
+	// catalogue recorded.
+	assertClose(t, got.PmRA().Radians(), -0.1961874125605721270e-6, 1e-18, "pmRA")
+	assertClose(t, got.PmDec().Radians(), -0.58459905176693911e-5, 1e-18, "pmDec")
+	assertClose(t, got.Parallax().Arcseconds(), 0.37921, 1e-12, "parallax")
+
+	// Not the -7.6 that went in. The rotation acts on the whole space-motion
+	// vector, so a little of the transverse motion lands in the radial
+	// component; SOFA publishes -7.6000000940000254 for exactly that reason.
+	// Asserting the input here would have passed for a transformation that
+	// copied the field across and skipped the rotation.
+	assertClose(t, got.RV(), -7.6000000940000254, 1e-11, "RV")
+}
+
+// TestFK5ToICRSMatchesSOFAPositionOnly is the other constructor, against
+// iauFk5hz, and is the one where the epoch matters.
+func TestFK5ToICRSMatchesSOFAPositionOnly(t *testing.T) {
+	t.Parallel()
+
+	// SOFA evaluates at JD 2400000.5 + 54479.0, which is MJD 54479 — Julian
+	// epoch 2008.0189...; the epoch is passed as such here and converted back
+	// inside, so this also pins that conversion.
+	const mjd = 54479.0
+
+	jepoch := 2000.0 + ((2400000.5+mjd)-2451545.0)/365.25
+
+	src := coord.NewFK5(angle.Rad(1.76779433), angle.Rad(-0.2917517103), jepoch)
+
+	got := coord.FK5ToICRS(src)
+
+	// iauFk5hz -> ra 1.767794191464423978, dec -0.2917516001679884419
+	assertRadians(t, got.RA().Radians(), 1.767794191464423978, "RA")
+	assertRadians(t, got.Dec().Radians(), -0.2917516001679884419, "Dec")
+}
+
+// TestFK5DiffersFromICRSByAboutTwentyMilliarcseconds states the size of the
+// thing, because "FK5 is basically ICRS" is true right up to the precision
+// this library claims.
+func TestFK5DiffersFromICRSByAboutTwentyMilliarcseconds(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewFK5(angle.Deg(101.2871), angle.Deg(-16.7161), coord.J2000Epoch) // Sirius
+
+	got := coord.FK5ToICRS(src)
+
+	sep := coord.Separation(
+		coord.NewICRS(src.RA(), src.Dec()),
+		got,
+	)
+
+	mas := sep.Arcseconds() * 1000
+
+	if mas < 1 || mas > 100 {
+		t.Errorf("FK5 to ICRS moved the position by %.2f mas, want the tens of mas "+
+			"the frame bias is.\n"+
+			"  Far less would mean the transformation is doing nothing; far more "+
+			"would mean it is doing something else.", mas)
+	}
+}
+
+// TestFK5RoundTripsThroughICRS covers the inverse, and is written so that a
+// transformation doing nothing would fail it: the position-only form comes back
+// carrying the proper motion FK5's spin gives it, which a no-op cannot produce.
+func TestFK5RoundTripsThroughICRS(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewFK5WithProperMotion(
+		angle.Deg(101.2871), angle.Deg(-16.7161),
+		angle.Arcsec(-0.5460), angle.Arcsec(-1.2231),
+		angle.Arcsec(0.37921), -5.5,
+	)
+
+	back := coord.ICRSToFK5(coord.FK5ToICRS(src), coord.J2000Epoch)
+
+	assertRadians(t, back.RA().Radians(), src.RA().Radians(), "RA round trip")
+	assertRadians(t, back.Dec().Radians(), src.Dec().Radians(), "Dec round trip")
+
+	pmRA, pmDec, ok := back.ProperMotion()
+	if !ok {
+		t.Fatal("the round trip lost the recorded proper motion")
+	}
+
+	assertClose(t, pmRA.Arcseconds(), -0.5460, 1e-6, "pmRA round trip")
+	assertClose(t, pmDec.Arcseconds(), -1.2231, 1e-6, "pmDec round trip")
+}
+
+// TestICRSToFK5MatchesSOFAWithKinematics covers the inverse against iauH2fk5's
+// published result.
+func TestICRSToFK5MatchesSOFAWithKinematics(t *testing.T) {
+	t.Parallel()
+
+	src := coord.NewICRSWithKinematics(
+		angle.Rad(1.767794352),
+		angle.Rad(-0.2917512594),
+		angle.Rad(-2.76413026e-6),
+		angle.Rad(-5.92994449e-6),
+		angle.Arcsec(0.379210),
+		-7.6,
+	)
+
+	got := coord.ICRSToFK5(src, coord.J2000Epoch)
+
+	pmRA, pmDec, ok := got.ProperMotion()
+	if !ok {
+		t.Fatal("the six-element conversion came back with no recorded proper motion")
+	}
+
+	// iauH2fk5 -> ra 1.767794455700065506, dec -0.2917513626469638890
+	assertRadians(t, got.RA().Radians(), 1.767794455700065506, "RA")
+	assertRadians(t, got.Dec().Radians(), -0.2917513626469638890, "Dec")
+
+	assertClose(t, pmRA.Radians(), -0.27597945024511204e-5, 1e-18, "pmRA")
+	assertClose(t, pmDec.Radians(), -0.59308014093262838e-5, 1e-18, "pmDec")
+	assertClose(t, got.Parallax().Arcseconds(), 0.37921, 1e-13, "parallax")
+	assertClose(t, got.RV(), -7.6000001309071126, 1e-11, "RV")
+}
+
+// TestICRSToFK5SuppliesTheSpinMotion pins the claim [NewFK5] makes: a star at
+// rest in ICRS is not at rest in FK5, so converting a position with no
+// kinematics returns one that has them — and the values are iauHfk5z's own,
+// not merely "something nonzero".
+func TestICRSToFK5SuppliesTheSpinMotion(t *testing.T) {
+	t.Parallel()
+
+	// SOFA evaluates at JD 2400000.5 + 54479.0; the epoch goes in as the
+	// Julian epoch that is, so this pins the conversion as well.
+	const mjd = 54479.0
+
+	jepoch := 2000.0 + ((2400000.5+mjd)-2451545.0)/365.25
+
+	got := coord.ICRSToFK5(coord.NewICRS(angle.Rad(1.767794352), angle.Rad(-0.2917512594)), jepoch)
+
+	pmRA, pmDec, ok := got.ProperMotion()
+	if !ok {
+		t.Fatal("no proper motion was supplied; a star at rest in ICRS is not at rest in FK5")
+	}
+
+	// iauHfk5z -> ra 1.767794490535581026, dec -0.2917513695320114258
+	assertRadians(t, got.RA().Radians(), 1.767794490535581026, "RA")
+	assertRadians(t, got.Dec().Radians(), -0.2917513695320114258, "Dec")
+
+	// The spin, in full. About 0.9 mas/yr in RA here — small, and an order of
+	// magnitude larger than the 0.1 mas this library's other tests resolve, so
+	// "too small to matter" is not available as an excuse for dropping it.
+	assertClose(t, pmRA.Radians(), 0.4335890983539243029e-8, 1e-22, "pmRA")
+	assertClose(t, pmDec.Radians(), -0.8569648841237745902e-9, 1e-23, "pmDec")
+
+	if pmRA == angle.Zero() && pmDec == angle.Zero() {
+		t.Error("the supplied proper motion is exactly zero, which is the answer " +
+			"a transformation that did nothing would give")
+	}
+}
+
+// assertRadians compares two angles to a tenth of a milliarcsecond.
+func assertRadians(t *testing.T, got, want float64, what string) {
+	t.Helper()
+
+	if diff := math.Abs(got - want); diff > masTolerance {
+		t.Errorf("%s = %.15f rad, want %.15f (differ by %.4f mas)",
+			what, got, want, diff*180/math.Pi*3600*1000)
+	}
+}
+
+// assertClose compares two numbers to an explicit tolerance.
+func assertClose(t *testing.T, got, want, tol float64, what string) {
+	t.Helper()
+
+	if diff := math.Abs(got - want); diff > tol {
+		t.Errorf("%s = %g, want %g (differ by %g)", what, got, want, diff)
+	}
+}

--- a/docs/changelog.d/277-fk5-j2000.md
+++ b/docs/changelog.d/277-fk5-j2000.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 277
+---
+`coord.FK5`, `coord.FK5ToICRS` and `coord.ICRSToFK5` read and write FK5 J2000
+positions, and `coord.FK4ToFK5`/`coord.FK5ToFK4` expose the classic B1950 ↔
+J2000 conversion that was previously buried inside `FK4ToICRS`. A catalogue
+that says "J2000" is usually FK5, not ICRS, and the two differ by the ~20 mas
+frame bias plus an epoch-dependent spin — so, like FK4, each direction has a
+position-only route and a six-element one (#126).


### PR DESCRIPTION
Advances #126 — the FK5 / J2000 frame. The issue stays open: ITRS, HCRS, TETE,
LSR/LSRK, Supergalactic, Galactocentric, `SkyOffsetFrame` and the absence of a
general transform graph are all still outstanding.

## Why FK5 is not just ICRS with a different name

A catalogue that says "J2000" is usually FK5, not ICRS. They agree to about
**20 milliarcseconds**, from two separate effects:

- a **frame bias** — the FK5 axes are tilted from the ICRS axes by a fixed
  rotation of order 20 mas, *measured* rather than defined, since FK5 was
  realised from star observations and ICRS from VLBI of quasars;
- a **spin** — FK5's realisation rotates slowly against the extragalactic
  frame, so the bias depends on the epoch of the position.

Nothing at arcsecond precision. Not nothing at the precision the rest of this
library works to, and not something a caller can correct for after the fact.

## What lands

| | position only | six elements |
| :--- | :--- | :--- |
| `FK5ToICRS` | `Fk5hz` at the position's own epoch | `Fk52h` |
| `ICRSToFK5` | `Hfk5z` | `H2fk5` |
| `FK4ToFK5` | `Fk45z` | `Fk425` |
| `FK5ToFK4` | `Fk54z` | `Fk524` |

Two constructors, as with `FK4`, because **"the catalogue recorded no proper
motion" is not "the proper motion is zero"**: FK5 spins, so a star genuinely at
rest in FK5 has a real motion in ICRS, and SOFA supplies that through a
different routine than the one for a measured motion. Passing zeroes to
`NewFK5WithProperMotion` asserts the star really is inertially at rest, which is
a claim almost no catalogue makes.

`NewFK5WithProperMotion` takes no epoch, and that is not an omission — SOFA's
six-element routines are defined for FK5 data at the catalogue equinox J2000.0,
and a position carrying its own motion already says where it will be at any
other date. The epoch matters only for the position-only form, which has nothing
else to go on.

### `FK4ToFK5` / `FK5ToFK4` were already here, unexported

`FK4ToICRS` has always gone FK4 → FK5 → Hipparcos; the intermediate was just
inaccessible. It is the conversion most archival "J2000" positions were actually
*made* with, so it is now a pair of exported functions and `FK4ToICRS` is
written as `FK5ToICRS(FK4ToFK5(c))`.

Before deleting the old direct implementation I kept a copy alongside the new
one and asserted **bit equality** (`!=` on the raw values, not a tolerance)
across six inputs including the pole, the RA 0/360 boundary and SOFA's own
Fk425 vector. `TestFK4ToICRSIsItsTwoLegs` is that probe made permanent, so the
two cannot quietly diverge later.

## Validation

Every transformation is checked against **SOFA's own published test values** —
`iauFk52h`, `iauFk5hz`, `iauH2fk5`, `iauHfk5z`, `iauFk425`, `iauFk45z`,
`iauFk524`, `iauFk54z` — at SOFA's own tolerances, rather than round-tripping
through this package. A round trip cannot catch a mistake that both directions
share, which is the whole failure mode worth worrying about here.

That caught a real defect in the tests themselves. The first draft asserted that
`FK5ToICRS` returns the radial velocity it was given, `-7.6` km/s. SOFA's
published answer is **`-7.6000000940000254`**: the rotation acts on the whole
space-motion vector, so a little of the transverse motion lands in the radial
component. Asserting the input passes for an implementation that copies the
field across and never rotates it.

It also closes something the existing FK4 test could only bound.
`TestFK4ToICRSAgreesWithSOFAsPublishedVector` compares an ICRS result against
SOFA's *FK5* answer, so it has to allow the ~25 mas the second stage adds — it
asserts the gap is under 0.1″ and over 0.1 mas. With FK5 as a type the
intermediate is now asserted outright, at 1e-14 rad in RA.

Both new functions were mutation-checked: making `FK5ToICRS` a no-op fails four
of the five FK5 tests, dropping the spin motion from `ICRSToFK5` fails the
fifth, and making `ICRSToFK5` ignore its epoch argument fails the epoch test.

## One thing deliberately left alone

`ICRSToFK4` stays a direct route rather than becoming
`FK5ToFK4(ICRSToFK5(...))`, and now says why in its doc comment. Composing would
hand SOFA's six-element routine the FK5 spin motion together with a zero
parallax and zero radial velocity that are *absences* rather than measurements;
`Fk54z` is the routine written for exactly that input, and is what astropy's
FK5 → FK4 uses for a coordinate carrying no differentials.

The price is real and small: `Fk54z` assumes the star is at rest in FK5 while the
caller said it is at rest in ICRS, and those differ by FK5's spin — about
0.3 mas/yr in the **returned proper motion**, and nothing at all in the returned
position. Filed separately rather than changed here, since it alters the output
of a shipped function.

## Also

- README's "no FITS writer" claim is dropped — #127 landed it. The frames half
  of that sentence is updated for FK5, and the "no general frame graph" point is
  spelled out rather than just named.

## Verification

- `gofmt -l .`, `go vet ./...`, `go mod tidy` — clean, no go.mod/go.sum change
- `golangci-lint run` and `golangci-lint run --build-tags="integration,network,validation"` — **0 issues**
- `go test ./...` — pass
- `go test -race -short -count=1 ./...` — pass
- `go test -tags="integration,network,validation" ./...` — pass
