### PR TITLE
coord: add SkyOffset, a frame centred on a target

### DIFF
--- a/coord/doc.go
+++ b/coord/doc.go
@@ -29,6 +29,16 @@
 // The [Reducer] provides a lightweight topocentric reduction pipeline that
 // also handles chromatic atmospheric dispersion.
 //
+// # Offsets from a target
+//
+// [SkyOffset] is a frame centred on a chosen position, so nearby objects are
+// described by how far they are from it rather than by absolute coordinates —
+// dither and mosaic patterns, offset guide stars, slit layouts, finder charts.
+// It is a rotation of the sphere rather than a projection onto a plane, which
+// is what separates it from subtracting coordinates: at δ = 80° a point one
+// degree due east of a target differs from it by 5.7° of right ascension and
+// by three arcminutes of declination.
+//
 // # Earth Orientation
 //
 // Both [Context] and [Reducer] query the global IERS EOP model for DUT1 and

--- a/coord/example_skyoffset_test.go
+++ b/coord/example_skyoffset_test.go
@@ -1,0 +1,66 @@
+package coord_test
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+)
+
+// A five-point dither pattern around a target: the offsets are what an
+// observer writes down, and the frame turns each one into the sky position the
+// telescope is actually sent to.
+func ExampleSkyOffset() {
+	target := coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911)) // M42
+	f := coord.NewSkyOffset(target, 0)
+
+	// 20 arcseconds, centre plus the four corners.
+	const d = 20.0 / 3600
+
+	for _, p := range []struct{ lon, lat float64 }{
+		{0, 0}, {+d, +d}, {-d, +d}, {-d, -d}, {+d, -d},
+	} {
+		pointing := f.ToICRS(angle.Deg(p.lon), angle.Deg(p.lat))
+
+		fmt.Printf("offset (%+.0f\", %+.0f\") -> RA %s Dec %s\n",
+			p.lon*3600, p.lat*3600,
+			pointing.RA().HMSString(2), pointing.Dec().DMSString(1))
+	}
+	// The east-west pairs differ by 2.68 seconds of right ascension rather
+	// than by 2.67, because 40 arcseconds of arc is 40/cos(dec) arcseconds of
+	// right ascension. Applying that is the frame's job, not the caller's.
+
+	// Output:
+	// offset (+0", +0") -> RA 05h35m17.30s Dec -05°23'28.0"
+	// offset (+20", +20") -> RA 05h35m18.64s Dec -05°23'08.0"
+	// offset (-20", +20") -> RA 05h35m15.96s Dec -05°23'08.0"
+	// offset (-20", -20") -> RA 05h35m15.96s Dec -05°23'48.0"
+	// offset (+20", -20") -> RA 05h35m18.64s Dec -05°23'48.0"
+}
+
+// The frame's rotation is the position angle its +lat axis points at, so
+// setting it to a slit's position angle makes lat the along-slit coordinate
+// and lon the across-slit one.
+func ExampleSkyOffset_rotation() {
+	target := coord.NewICRS(angle.Deg(210.8023), angle.Deg(54.3488))
+
+	// A companion 12 arcseconds from the target at position angle 145°. In a
+	// frame turned to that position angle it lies straight up the +lat axis,
+	// which is what makes the rotation worth having: a slit laid at 145° has
+	// the companion on axis and nothing to resolve across it.
+	slit := coord.NewSkyOffset(target, angle.Deg(145))
+	companion := slit.ToICRS(0, angle.Arcsec(12))
+
+	across, along := slit.FromICRS(companion)
+	fmt.Printf("across the slit %+.2f\", along it %+.2f\"\n",
+		across.Arcseconds(), along.Arcseconds())
+
+	// The same star seen north-up, where 145° is mostly south and a little
+	// east: 12·sin 145° and 12·cos 145°.
+	east, north := coord.NewSkyOffset(target, 0).FromICRS(companion)
+	fmt.Printf("east %+.2f\", north %+.2f\"\n", east.Arcseconds(), north.Arcseconds())
+
+	// Output:
+	// across the slit +0.00", along it +12.00"
+	// east +6.88", north -9.83"
+}

--- a/coord/skyoffset.go
+++ b/coord/skyoffset.go
@@ -1,0 +1,125 @@
+package coord
+
+import (
+	"fmt"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/vector"
+)
+
+// SkyOffset is a spherical frame whose origin sits on a chosen target, so that
+// positions near it are expressed as offsets from it rather than as absolute
+// right ascension and declination.
+//
+// # Why the obvious arithmetic is wrong
+//
+// The usual first attempt at "how far is this from my target" is to subtract:
+// Δα = α − α₀ and Δδ = δ − δ₀. That is wrong in two ways at once, and both
+// grow with declination:
+//
+//   - A degree of right ascension is a degree of arc only at the equator. At
+//     δ = 60° it is half that, and at δ = 89° it is a sixtieth. Quoting Δα as
+//     an offset overstates it by 1/cos δ.
+//   - Multiplying by cos δ fixes the scale and not the geometry. The lines of
+//     constant declination are small circles, not great circles, so a grid
+//     built from (Δα·cos δ, Δδ) is sheared — enough to matter across a
+//     wide-field detector, and badly wrong anywhere near a pole.
+//
+// A [SkyOffset] is the rotation that actually moves the target to the origin,
+// so offsets are measured on the sphere the whole way out and there is no
+// small-angle assumption to outgrow.
+//
+// # What it is for
+//
+// Dither and mosaic patterns, offset guide stars, slit and detector layouts,
+// finder charts, and any "put the target at the centre and tell me where
+// everything else falls" question. The frame is a value: build one per target
+// and apply it to as many positions as needed.
+//
+// # Orientation
+//
+// With a zero rotation the frame's +lat axis points north and its +lon axis
+// points east, matching the position-angle convention [PositionAngle] uses. A
+// non-zero rotation turns the frame so that **+lat points at that position
+// angle** — set it to an instrument's position angle and lat becomes the
+// along-slit coordinate, lon the across-slit one.
+type SkyOffset struct {
+	origin   ICRS
+	rotation angle.Angle
+}
+
+// NewSkyOffset returns the offset frame centred on origin, with the frame's
+// +lat axis pointing at the given position angle (north through east).
+//
+// Pass a zero rotation for a north-up, east-left frame.
+func NewSkyOffset(origin ICRS, rotation angle.Angle) SkyOffset {
+	return SkyOffset{origin: origin, rotation: rotation}
+}
+
+// Origin returns the position the frame is centred on.
+func (f SkyOffset) Origin() ICRS { return f.origin }
+
+// Rotation returns the position angle the frame's +lat axis points at.
+func (f SkyOffset) Rotation() angle.Angle { return f.rotation }
+
+// FromICRS returns the offsets of c from the frame's origin.
+//
+// lon is in (-180°, 180°] and increases eastward; lat is in [-90°, 90°] and
+// increases northward, both turned by the frame's rotation. The origin itself
+// maps to (0, 0).
+//
+// These are true spherical coordinates in a rotated frame, not a projection
+// onto a plane, so they stay exact out to the antipode. The relations back to
+// [Separation] and [PositionAngle] are
+//
+//	Separation(origin, c)    = acos(cos lat · cos lon)
+//	PositionAngle(origin, c) = atan2(sin lon · cos lat, sin lat) + rotation
+//
+// and both hold at any separation. Note the second one: near the origin it
+// degenerates to atan2(lon, lat), which is the form worth being careful about,
+// since it is right to a part in 10⁸ at an arcminute and visibly wrong at a
+// degree.
+func (f SkyOffset) FromICRS(c ICRS) (lon, lat angle.Angle) {
+	x, y := f.toFrame(c.ToUnitVector()).ToSpherical()
+
+	return angle.Rad(x).Wrap180(), angle.Rad(y)
+}
+
+// ToICRS returns the ICRS position at the given offsets from the frame's
+// origin. It is the exact inverse of [SkyOffset.FromICRS].
+func (f SkyOffset) ToICRS(lon, lat angle.Angle) ICRS {
+	v := f.toSky(vector.FromSpherical(lon.Radians(), lat.Radians()))
+
+	var c ICRS
+	c.FromUnitVector(v)
+
+	return c
+}
+
+// String renders the frame for logs and errors.
+func (f SkyOffset) String() string {
+	return fmt.Sprintf("SkyOffset origin %s rotation %s", f.origin, f.rotation)
+}
+
+// toFrame rotates an ICRS unit vector into the offset frame.
+//
+// Three rotations, each of the frame rather than of the vector, which is why
+// the signs are the negatives of the ones that would move a point the same
+// way: about z by the origin's right ascension, bringing it into the x–z
+// plane; about y by its declination, bringing it onto the x axis; then about
+// x by the frame's rotation.
+func (f SkyOffset) toFrame(v vector.Vec3) vector.Vec3 {
+	return v.
+		RotateZ(-f.origin.RA().Radians()).
+		RotateY(f.origin.Dec().Radians()).
+		RotateX(f.rotation.Radians())
+}
+
+// toSky is the inverse of [SkyOffset.toFrame]: the same three rotations
+// negated and applied in the opposite order.
+func (f SkyOffset) toSky(v vector.Vec3) vector.Vec3 {
+	return v.
+		RotateX(-f.rotation.Radians()).
+		RotateY(-f.origin.Dec().Radians()).
+		RotateZ(f.origin.RA().Radians())
+}

--- a/coord/skyoffset_test.go
+++ b/coord/skyoffset_test.go
@@ -1,0 +1,353 @@
+package coord_test
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/TuSKan/astrogo/angle"
+	"github.com/TuSKan/astrogo/coord"
+	"github.com/TuSKan/astrogo/internal/testutil"
+)
+
+// The offset frame is a rotation, so nothing in it can be checked by comparing
+// it against itself. Every test below pins it against something that already
+// existed and was implemented a different way: coord.Separation, which works
+// from the cross and dot products of two unit vectors, and coord.PositionAngle,
+// which works from spherical trigonometry on the two declinations. Neither
+// shares a line of code with the rotation under test.
+
+// exactTolerance is a nanoradian, about 0.2 microarcseconds. The relations
+// below are identities rather than approximations, so the only thing that
+// should separate the two sides is float rounding.
+const exactTolerance = 1e-9
+
+// skyOffsetOrigins spans the declinations where the naive alternative to this
+// frame goes wrong, plus the pole, where it has no answer at all.
+var skyOffsetOrigins = []struct {
+	name string
+	ra   float64
+	dec  float64
+}{
+	{"equator", 0, 0},
+	{"mid-northern", 83.8221, -5.3911},
+	{"high-northern", 120, 80},
+	{"near the south pole", 200, -89.5},
+	{"north pole", 45, 90},
+	{"just past the RA wrap", 359.99, 12},
+}
+
+// TestSkyOffsetPlacesTheOriginAtZero is the defining property: the frame is
+// centred on its origin, so the origin has no offset from itself.
+func TestSkyOffsetPlacesTheOriginAtZero(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range skyOffsetOrigins {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			origin := coord.NewICRS(angle.Deg(tc.ra), angle.Deg(tc.dec))
+
+			// A non-zero rotation must not move the origin either — it turns
+			// the frame about that point, it does not shift it.
+			lon, lat := coord.NewSkyOffset(origin, angle.Deg(37)).FromICRS(origin)
+
+			testutil.AssertNear(t, "lon of the origin",
+				lon.Radians(), 0, exactTolerance)
+			testutil.AssertNear(t, "lat of the origin",
+				lat.Radians(), 0, exactTolerance)
+		})
+	}
+}
+
+// TestSkyOffsetAgreesWithSeparationAndPositionAngle is the main check.
+//
+// Each case names a separation and a position angle, places a point there
+// using nothing but the spherical destination formula from the frame's own
+// origin, and then asks [Separation] and [PositionAngle] — neither of which
+// knows this frame exists — whether the point really ended up there.
+//
+// It is exact rather than a small-angle check: the separations run from an
+// arcsecond to 170°, because a frame that was only locally right would pass a
+// test that only looked nearby. That is not hypothetical — the first draft of
+// this test built its points as (sep·sin pa, sep·cos pa), the tangent-plane
+// approximation, and was already wrong by 1e-8 radians at one arcminute.
+func TestSkyOffsetAgreesWithSeparationAndPositionAngle(t *testing.T) {
+	t.Parallel()
+
+	separations := []float64{1.0 / 3600, 1.0 / 60, 1, 15, 90, 170}
+	angles := []float64{0, 37, 90, 143, 180, 251, 315}
+	rotations := []float64{0, 30, -75}
+
+	for _, tc := range skyOffsetOrigins {
+		for _, rot := range rotations {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				origin := coord.NewICRS(angle.Deg(tc.ra), angle.Deg(tc.dec))
+				f := coord.NewSkyOffset(origin, angle.Deg(rot))
+
+				for _, sepDeg := range separations {
+					for _, paDeg := range angles {
+						sep, pa := angle.Deg(sepDeg).Radians(), angle.Deg(paDeg).Radians()
+
+						// Where a point at that separation and bearing lands,
+						// measured from the frame's origin at (0, 0). This is
+						// the great-circle destination formula, not a
+						// projection onto a plane.
+						lat := angle.Rad(math.Asin(math.Sin(sep) * math.Cos(pa)))
+						lon := angle.Rad(math.Atan2(math.Sin(pa)*math.Sin(sep), math.Cos(sep)))
+
+						where := fmt.Sprintf("%s, sep %g deg, pa %g deg, rotation %g deg",
+							tc.name, sepDeg, paDeg, rot)
+
+						c := f.ToICRS(lon, lat)
+
+						testutil.AssertNear(t, "separation at "+where,
+							coord.Separation(origin, c).Radians(), sep, exactTolerance)
+
+						// The offsets have to survive the trip back, or the
+						// frame is not a frame.
+						gotLon, gotLat := f.FromICRS(c)
+
+						testutil.AssertNear(t, "lat at "+where,
+							gotLat.Radians(), lat.Radians(), exactTolerance)
+
+						// Every longitude names the same point at the frame's
+						// own poles, so there is nothing there to compare.
+						if math.Abs(lat.Degrees()) < 90-1e-9 {
+							assertAngle(t, gotLon, lon, exactTolerance, "lon at "+where)
+						}
+
+						// PositionAngle divides by the cosine of the origin's
+						// declination, so it has nothing to say when the
+						// origin is a pole, and nothing useful when the two
+						// points coincide.
+						if math.Abs(tc.dec) > 89 || sepDeg == 0 {
+							continue
+						}
+
+						gotPA := coord.PositionAngle(origin, c)
+						wantPA := angle.Deg(paDeg).Add(f.Rotation()).Wrap360()
+
+						if diff := math.Abs(gotPA.Sub(wantPA).Wrap180().Radians()); diff > 1e-8 {
+							t.Errorf("position angle at %s, sep %g deg, pa %g deg, rotation %g: "+
+								"got %v, want %v (differ by %g rad)",
+								tc.name, sepDeg, paDeg, rot, gotPA, wantPA, diff)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestSkyOffsetRoundTrips checks the inverse, including at separations where a
+// tangent-plane approximation would have diverged long ago.
+func TestSkyOffsetRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	f := coord.NewSkyOffset(coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911)), angle.Deg(42))
+
+	for _, tc := range []struct {
+		name     string
+		lon, lat float64
+	}{
+		{"the origin", 0, 0},
+		{"an arcsecond away", 1.0 / 3600, -1.0 / 3600},
+		{"a detector away", 0.25, 0.18},
+		{"a quadrant away", 60, -30},
+		{"the frame's own pole", 0, 90},
+		{"the antipode", 180, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lon, lat := angle.Deg(tc.lon), angle.Deg(tc.lat)
+
+			gotLon, gotLat := f.FromICRS(f.ToICRS(lon, lat))
+
+			// At the frame's own pole every longitude names the same point, so
+			// only the latitude is meaningful there.
+			if math.Abs(tc.lat) < 90 {
+				assertAngle(t, gotLon, lon, exactTolerance, "lon")
+			}
+
+			testutil.AssertNear(t, "lat",
+				gotLat.Radians(), lat.Radians(), exactTolerance)
+		})
+	}
+}
+
+// TestSkyOffsetSignsPointEastAndNorth pins the two things a caller reads off
+// an offset without thinking about them: which way is positive, and that a
+// point to the west reports a small negative longitude rather than a number
+// just under 360.
+//
+// The wrap matters more than it sounds. A dither pattern that averages its
+// offsets, or a plot that scales to them, turns a 359.99° into nonsense while
+// a -0.01° behaves.
+func TestSkyOffsetSignsPointEastAndNorth(t *testing.T) {
+	t.Parallel()
+
+	origin := coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911))
+	f := coord.NewSkyOffset(origin, 0)
+
+	for _, tc := range []struct {
+		name    string
+		pa      float64
+		wantLon func(float64) bool
+		wantLat func(float64) bool
+	}{
+		{"east", 90, func(l float64) bool { return l > 0 }, func(b float64) bool { return math.Abs(b) < 1e-9 }},
+		{"west", 270, func(l float64) bool { return l < 0 && l > -1 }, func(b float64) bool { return math.Abs(b) < 1e-9 }},
+		{"north", 0, func(l float64) bool { return math.Abs(l) < 1e-9 }, func(b float64) bool { return b > 0 }},
+		{"south", 180, func(l float64) bool { return math.Abs(l) < 1e-9 }, func(b float64) bool { return b < 0 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pa := angle.Deg(tc.pa).Radians()
+			sep := angle.Deg(0.5).Radians()
+
+			c := f.ToICRS(
+				angle.Rad(math.Atan2(math.Sin(pa)*math.Sin(sep), math.Cos(sep))),
+				angle.Rad(math.Asin(math.Sin(sep)*math.Cos(pa))),
+			)
+
+			lon, lat := f.FromICRS(c)
+
+			if !tc.wantLon(lon.Degrees()) || !tc.wantLat(lat.Degrees()) {
+				t.Errorf("half a degree %s of the origin reads as lon %v, lat %v",
+					tc.name, lon, lat)
+			}
+		})
+	}
+}
+
+// TestSkyOffsetRotationAimsLatAtThePositionAngle pins the orientation the doc
+// comment promises, which is the part a caller setting an instrument angle
+// depends on being right.
+func TestSkyOffsetRotationAimsLatAtThePositionAngle(t *testing.T) {
+	t.Parallel()
+
+	origin := coord.NewICRS(angle.Deg(210.8), angle.Deg(54.35))
+
+	for _, rot := range []float64{0, 15, 90, 180, 275, -60} {
+		f := coord.NewSkyOffset(origin, angle.Deg(rot))
+
+		// A point one degree along the frame's +lat axis.
+		c := f.ToICRS(0, angle.Deg(1))
+
+		got := coord.PositionAngle(origin, c)
+		want := angle.Deg(rot).Wrap360()
+
+		if diff := math.Abs(got.Sub(want).Wrap180().Radians()); diff > 1e-9 {
+			t.Errorf("with rotation %g deg the +lat axis points at position angle %v, want %v",
+				rot, got, want)
+		}
+	}
+}
+
+// TestSubtractingCoordinatesIsNotAnOffset is the reason this frame exists,
+// stated as numbers.
+//
+// Each case takes a point exactly one degree due east of its origin — due
+// east, on the sphere, at a position angle of 90° — and asks what the usual
+// shortcuts make of it. Both fail, and the second fails much worse than the
+// first:
+//
+//   - Δα·cos δ is offered as the "cos-δ correction" for the scale of right
+//     ascension. It is wrong by 12 arcseconds at δ = 80° and by 13 arcminutes
+//     at δ = 89°.
+//   - Δδ is expected to be zero, because the offset was purely eastward. It is
+//     3 arcminutes at δ = 80° and 25 arcminutes at δ = 89°. That is the shear
+//     no scale factor can remove, and it is the larger error of the two.
+func TestSubtractingCoordinatesIsNotAnOffset(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		dec float64
+		// Lower bounds on how wrong the two shortcuts are, in arcminutes.
+		minScaleError float64
+		minShear      float64
+	}{
+		{dec: 0, minScaleError: 0, minShear: 0},
+		{dec: 60, minScaleError: 0.01, minShear: 0.8},
+		{dec: 80, minScaleError: 0.15, minShear: 2.5},
+		{dec: 89, minScaleError: 10, minShear: 20},
+	} {
+		origin := coord.NewICRS(angle.Deg(120), angle.Deg(tc.dec))
+		f := coord.NewSkyOffset(origin, 0)
+
+		c := f.ToICRS(angle.Deg(1), 0)
+
+		// The frame's own answer is exactly right, which is the control: the
+		// numbers below are the shortcuts being wrong, not this being wrong.
+		testutil.AssertNear(t, "separation of the constructed point",
+			coord.Separation(origin, c).Degrees(), 1, 1e-9)
+
+		scaleError := (c.RA().Sub(origin.RA()).Wrap180().Degrees()*
+			math.Cos(origin.Dec().Radians()) - 1) * 60
+		shear := c.Dec().Sub(origin.Dec()).Degrees() * 60
+
+		t.Logf("dec %+5.1f: a 1 deg eastward offset has dRA %.4f deg; "+
+			"dRA*cos(dec) is off by %+.4f arcmin and dDec is %+.4f arcmin",
+			tc.dec, c.RA().Sub(origin.RA()).Wrap180().Degrees(), scaleError, shear)
+
+		if math.Abs(scaleError) < tc.minScaleError {
+			t.Errorf("dec %g: dRA*cos(dec) is off by only %g arcmin, want at least %g",
+				tc.dec, math.Abs(scaleError), tc.minScaleError)
+		}
+
+		if math.Abs(shear) < tc.minShear {
+			t.Errorf("dec %g: a purely eastward offset changed the declination by only "+
+				"%g arcmin, want at least %g", tc.dec, math.Abs(shear), tc.minShear)
+		}
+	}
+}
+
+// TestSkyOffsetAccessorsReportWhatItWasBuiltWith keeps the frame's parameters
+// readable, since a caller handed a frame has no other way to ask what it is.
+func TestSkyOffsetAccessorsReportWhatItWasBuiltWith(t *testing.T) {
+	t.Parallel()
+
+	origin := coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911))
+	f := coord.NewSkyOffset(origin, angle.Deg(42))
+
+	if f.Origin() != origin {
+		t.Errorf("Origin() = %v, want %v", f.Origin(), origin)
+	}
+
+	if f.Rotation() != angle.Deg(42) {
+		t.Errorf("Rotation() = %v, want 42 deg", f.Rotation())
+	}
+
+	if s := f.String(); !strings.Contains(s, "SkyOffset") {
+		t.Errorf("String() = %q, want it to name the frame", s)
+	}
+}
+
+func BenchmarkSkyOffsetFromICRS(b *testing.B) {
+	f := coord.NewSkyOffset(coord.NewICRS(angle.Deg(83.8221), angle.Deg(-5.3911)), angle.Deg(42))
+	c := coord.NewICRS(angle.Deg(83.9), angle.Deg(-5.3))
+
+	b.ReportAllocs()
+
+	for range b.N {
+		lon, lat := f.FromICRS(c)
+		_, _ = lon, lat
+	}
+}
+
+// assertAngle compares two angles as directions rather than as numbers, so
+// that +180 degrees and -180 degrees count as the same longitude. They are the
+// same place, and a plain subtraction makes them look a full turn apart.
+func assertAngle(t *testing.T, got, want angle.Angle, tol float64, what string) {
+	t.Helper()
+
+	if diff := math.Abs(got.Sub(want).Wrap180().Radians()); diff > tol {
+		t.Errorf("%s = %v, want %v (differ by %g rad)", what, got, want, diff)
+	}
+}

--- a/docs/changelog.d/279-skyoffset.md
+++ b/docs/changelog.d/279-skyoffset.md
@@ -1,0 +1,10 @@
+---
+type: Added
+pr: 279
+---
+`coord.SkyOffset` is a frame centred on a target, so positions near it can be
+given as offsets — dither and mosaic patterns, offset guide stars, slit
+layouts, finder charts. It is a rotation of the sphere rather than a projection
+onto a plane, which is the difference between it and subtracting coordinates: a
+point one degree due east of a target at δ = 80° differs from it by 5.7° of
+right ascension and by three arcminutes of declination (#126).


### PR DESCRIPTION
Advances #126 — `SkyOffsetFrame`. The issue stays open for ITRS, HCRS, TETE,
LSR/LSRK, Supergalactic, Galactocentric and the absence of a general transform
graph.

Independent of #277 (FK5) — both branch from `main` and touch different files,
except for adjacent doc sections in `coord/doc.go` that merge cleanly.

## What it is

A frame whose origin sits on a chosen target, so nearby objects are described
by how far they are **from it**: dither and mosaic patterns, offset guide stars,
slit and detector layouts, finder charts.

```go
f := coord.NewSkyOffset(target, 0)
pointing := f.ToICRS(angle.Arcsec(20), angle.Arcsec(20)) // 20" NE of the target
east, north := f.FromICRS(companion)                     // and back
```

## Why not just subtract the coordinates

Because it is wrong in two ways at once, and the second one is worse than the
one everybody knows about. These numbers are measured in the test, not asserted
from theory — each row is a point placed **exactly one degree due east** of its
target, on the sphere:

| dec | ΔRA | ΔRA·cos δ error | ΔDec |
| ---: | ---: | ---: | ---: |
| 0° | 1.0000° | 0.0000′ | 0.0000′ |
| 60° | 1.9994° | −0.0183′ | **−0.9067′** |
| 80° | 5.7401° | −0.1948′ | **−2.9622′** |
| 89° | 45.0044° | −12.8739′ | **−24.8507′** |

- **ΔRA·cos δ** is the correction everyone reaches for, and it is still wrong by
  12 arcseconds at δ = 80°.
- **ΔDec** is the one no scale factor can fix. The offset was *purely eastward*
  and the declination moved by three arcminutes at δ = 80° and twenty-five at
  δ = 89°. Lines of constant declination are small circles, not great circles,
  so a grid built from (ΔRA·cos δ, ΔDec) is sheared.

`SkyOffset` is the rotation that actually moves the target to the origin, so
there is no small-angle assumption to outgrow and it stays exact out to the
antipode.

## Orientation

With a zero rotation the frame is north-up, east-left, matching
`coord.PositionAngle`. A non-zero rotation turns it so that **+lat points at
that position angle** — set it to an instrument's position angle and `lat`
becomes the along-slit coordinate, `lon` the across-slit one. There is a
runnable example of exactly that.

## Validation

Against `coord.Separation` and `coord.PositionAngle`, which predate this frame
and share no code with it — one works from the cross and dot products of two
unit vectors, the other from spherical trigonometry on two declinations. Points
are placed with the great-circle destination formula and then handed to those
two functions to confirm they landed where they were sent:

- separations from **1″ to 170°**, so a frame that was only locally right cannot
  pass;
- six origins: the equator, mid-latitude, δ = 80°, δ = −89.5°, the north pole
  itself, and one just past the RA wrap at 359.99°;
- three frame rotations, including a negative one.

### The test found a bug in this change's own doc comment

The first draft claimed

```
PositionAngle = atan2(lon, lat) + rotation
```

which is only the **small-angle limit**. The exact relation is

```
PositionAngle = atan2(sin lon · cos lat, sin lat) + rotation
```

and the first draft of the test made the matching mistake in its fixture,
placing points at `(sep·sin pa, sep·cos pa)` — the tangent-plane approximation.
That is already wrong by 1e-8 radians at **one arcminute**. Both are fixed, and
the doc comment now says which form is which and where the approximate one
stops being usable, because it is exactly the shortcut a reader would otherwise
take from it.

### Mutation testing

Five mutations, all five caught:

| mutation | caught by |
| :--- | :--- |
| drop the frame rotation from `toFrame` | round trips, the main suite |
| drop it from `toSky` | the orientation test, round trips, the main suite |
| flip the sign of the declination rotation | all four property tests |
| swap the order of the first two rotations | all four property tests |
| drop the longitude wrap | the origin test, the sign test |

### Examples

Both `ExampleSkyOffset` and `ExampleSkyOffset_rotation` were verified to
actually run, by corrupting their expected output and watching them fail — an
Example whose final comment block does not *begin* with `Output:` is silently
never executed, and the first draft of one of them had explanatory prose above
the marker.

The rotation example's expected numbers were written from the trigonometry
before the code was run (12·sin 145° = +6.88″, 12·cos 145° = −9.83″) and matched
on the first execution.

## Performance

**120 ns/op, 0 allocations** — about a third of a cached `ICRS → AltAz`. The
three rotations are written out rather than composed into a cached matrix: at
that cost the sines saved are worth less than the code being readable against
the geometry it implements. The benchmark is checked in so that stays a
measured claim.

## Verification

- `gofmt -l .`, `go vet ./...` — clean
- `golangci-lint run` and `--build-tags="integration,network,validation"` — **0 issues**
- `go test ./...` — pass
- `go test -race -short -count=1 ./...` — pass
- `go test -tags="integration,network,validation" ./...` — pass
