### PR TITLE
chore(ci): pin GitHub Actions to immutable commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 2
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # '1.27' rather than go-version-file: go.mod, still deliberately —
           # though the reason is now insurance rather than a live problem.
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run golangci-lint
         if: matrix.os == 'ubuntu-latest'
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           # v2.13+: .golangci.yml disables exhaustruct_v5, which does not
           # exist before it - v2.12 rejects the whole config with exit 3.
@@ -135,7 +135,7 @@ jobs:
       # the wrong directory would silently stop excluding.
       - name: Run golangci-lint (examples)
         if: matrix.os == 'ubuntu-latest'
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.13
           working-directory: examples
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Require a changelog fragment naming this pull request
         shell: bash
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # The script reads the base commit out of this clone, so the history
           # has to be here. A shallow clone leaves it with nothing to compare
@@ -224,7 +224,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.27'
           cache: true
@@ -248,10 +248,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
@@ -286,10 +286,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
@@ -365,7 +365,7 @@ jobs:
           } | summary
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmarks-${{ github.sha }}
           path: bench.txt
@@ -385,13 +385,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history: the job merges other branches into this commit.
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).
@@ -410,10 +410,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # See the Setup Go step in the lint-and-test job for why this is a
           # minor-version spec rather than go-version-file: go.mod (#109).

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           # Track go.mod rather than a hardcoded version, so this workflow
           # cannot drift onto a different toolchain from ci.yml.
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload network results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: network-${{ github.sha }}
           path: ${{ env.ASTROGO_METROLOGY_OUT }}
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.27'
           cache: true
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload validation results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: validation-${{ github.sha }}
           path: ${{ env.ASTROGO_METROLOGY_OUT }}


### PR DESCRIPTION
Mutable Action tags can change the code executed by CI without a repository change. Pinning the resolved commits makes workflow dependency changes explicit and reviewable, and prepares these workflows for mandatory SHA pinning.

## What changed

Pin all 23 external Action references across two workflows, with the original major tags retained as same-line comments for readability and Dependabot updates:

- `.github/workflows/ci.yml`: 17 references.
- `.github/workflows/pre-release.yml`: 6 references.

The branch incorporates `main` through `efadd6ddf9f5839ad3a640ecf0ddef7fc23c6b9e` and preserves the checkout v7 and setup-go v7 upgrades.

| Action tag | Pinned upstream commit |
| --- | --- |
| actions/checkout@v7 | 3d3c42e5aac5ba805825da76410c181273ba90b1 |
| actions/setup-go@v7 | b7ad1dad31e06c5925ef5d2fc7ad053ef454303e |
| actions/upload-artifact@v6 | b7c566a772e6b6bfb58ed0dc250532a479d7789f |
| golangci/golangci-lint-action@v9 | ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a |
| codecov/codecov-action@v6 | fb8b3582c8e4def4969c97caa2f19720cb33a72f |

## Verification

Passed:
- Parsed both proposed workflow files as YAML.
- Compared parsed workflows after normalizing the pinned references back to their original tags: triggers, permissions, jobs, steps, and inputs are identical.
- Checked the line diff: exactly 23 Action-reference lines changed.
- Resolved all five commit hashes against the upstream Action repositories.

The full local verification gate could not run. The following attempted commands failed because Go, gofmt, and golangci-lint are not installed in the editing environment:

```sh
go test -tags="integration,network,validation" ./...
go mod tidy
gofmt -l .
golangci-lint run
golangci-lint run --build-tags="integration,network,validation"
```

A repository archive download also timed out. The full local verification gate remains unverified; the existing PR CI does not cover every command in that gate.

This is a CI-only change, covered by the `no-changelog` label. Mandatory SHA enforcement should be enabled after the workflow change is verified and merged.


## Conflict resolution

Merged the setup-go v7 update from main into this branch in `20ce67db172831b40d12985100f5a692a68d404f`. All eight setup-go references now pin upstream commit `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` with `# v7` comments. YAML validation and comparison against the latest main passed; the resolution changes only those eight lines relative to the previous PR head. GitHub reports no merge conflicts, and the new CI run is [34670780167](https://github.com/TuSKan/astrogo/actions/runs/34670780167).
