### PR TITLE
chore(ci): review dependency vulnerabilities on pull requests

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,31 @@
+name: Dependency Review
+
+# Run on every PR so this check can later be required without path-filter gaps.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime, development, unknown
+          license-check: false
+          comment-summary-in-pr: never
+          show-openssf-scorecard: false
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120


### PR DESCRIPTION
CodeQL analyzes source code, while Dependabot alerts identify vulnerable dependencies already present. This adds a PR check for newly introduced dependency vulnerabilities, so dependency changes can be reviewed before they reach main.

## What changed

Add `.github/workflows/dependency-review.yml` with the stable check name `Dependency Review`.

- Run on every pull request, including stacked PRs, with no path filters.
- Fail for newly introduced high or critical vulnerabilities across runtime, development, and unknown dependency scopes.
- Use only `contents: read` permissions and disable persisted checkout credentials.
- Pin checkout v7 and dependency-review-action v5.0.0 to verified upstream commits.
- Report through the job summary, with PR comments disabled.
- Retry dependency snapshot warnings for up to 120 seconds within a 10-minute job limit.

License-policy and Scorecard checks are disabled so this workflow enforces the vulnerability policy defined here.

## Verification

Passed locally:
- YAML parsing.
- Full 40-character commit pins for both Actions.
- All configured review inputs exist in the pinned Action's metadata.
- Read-only workflow permissions and an unfiltered `pull_request` trigger.

Full Go verification remains unavailable: Go, gofmt, and golangci-lint are not installed in the editing environment. The required tagged tests, tidy/format checks, and both linter configurations have not run for this branch. This PR is a draft pending verification.

The first GitHub run will validate dependency-review access, the current Actions allowlist, SHA enforcement, and compatibility with normal PR CI. After a successful run and merge, add `Dependency Review` to main-protection's required status checks, keeping the branch-up-to-date requirement disabled.

The action depends on GitHub's dependency graph and advisory coverage. It does not determine whether vulnerable functions are reachable from astrogo; that is a separate role for govulncheck. Lower-severity findings do not fail this check.

This is a CI-only change covered by `no-changelog`.


## First GitHub run

[Dependency Review run 34694030830](https://github.com/TuSKan/astrogo/actions/runs/34694030830) passed on `09c1579a9a6224b91ee2742eeb55f40567602db7`. The Changelog Fragment check also passed with `no-changelog`. Existing CI and CodeQL checks are still running. This verifies the new workflow can execute under the repository's current permissions and Action policies; it does not replace the full Go verification gate documented above.
